### PR TITLE
[FLINK-31441][runtime]FineGrainedSlotManager support evenly slot selection.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -89,7 +89,8 @@ public class ResourceManagerRuntimeServices {
                     new DefaultResourceAllocationStrategy(
                             SlotManagerUtils.generateTaskManagerTotalResourceProfile(
                                     slotManagerConfiguration.getDefaultWorkerResourceSpec()),
-                            slotManagerConfiguration.getNumSlotsPerWorker()));
+                            slotManagerConfiguration.getNumSlotsPerWorker(),
+                            slotManagerConfiguration.isEvenlySpreadOutSlots()));
         } else {
             return new DeclarativeSlotManager(
                     scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -247,6 +248,9 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                 ResourceProfile totalProfile,
                 ResourceProfile availableProfile,
                 BiConsumer<JobID, ResourceProfile> allocationConsumer) {
+            Preconditions.checkState(!defaultSlotProfile.equals(ResourceProfile.UNKNOWN));
+            Preconditions.checkState(!totalProfile.equals(ResourceProfile.UNKNOWN));
+            Preconditions.checkState(!availableProfile.equals(ResourceProfile.UNKNOWN));
             this.defaultSlotProfile = defaultSlotProfile;
             this.totalProfile = totalProfile;
             this.availableProfile = availableProfile;
@@ -274,11 +278,6 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
         }
 
         private double updateUtilization() {
-            if (totalProfile.equals(ResourceProfile.UNKNOWN)
-                    || availableProfile.equals(ResourceProfile.UNKNOWN)) {
-                return 1;
-            }
-
             double cpuUtilization =
                     totalProfile
                                     .getCpuCores()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -63,7 +63,6 @@ public class SlotManagerConfiguration {
             Duration requirementCheckDelay,
             Duration declareNeededResourceDelay,
             boolean waitResultConsumedBeforeRelease,
-            SlotMatchingStrategy slotMatchingStrategy,
             boolean evenlySpreadOutSlots,
             WorkerResourceSpec defaultWorkerResourceSpec,
             int numSlotsPerWorker,
@@ -78,7 +77,10 @@ public class SlotManagerConfiguration {
         this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
         this.declareNeededResourceDelay = Preconditions.checkNotNull(declareNeededResourceDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
-        this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
+        this.slotMatchingStrategy =
+                evenlySpreadOutSlots
+                        ? LeastUtilizationSlotMatchingStrategy.INSTANCE
+                        : AnyMatchingSlotMatchingStrategy.INSTANCE;
         this.evenlySpreadOutSlots = evenlySpreadOutSlots;
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
         Preconditions.checkState(numSlotsPerWorker > 0);
@@ -171,10 +173,6 @@ public class SlotManagerConfiguration {
 
         boolean evenlySpreadOutSlots =
                 configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
-        final SlotMatchingStrategy slotMatchingStrategy =
-                evenlySpreadOutSlots
-                        ? LeastUtilizationSlotMatchingStrategy.INSTANCE
-                        : AnyMatchingSlotMatchingStrategy.INSTANCE;
 
         int numSlotsPerWorker = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 
@@ -190,7 +188,6 @@ public class SlotManagerConfiguration {
                 requirementCheckDelay,
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
-                slotMatchingStrategy,
                 evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -48,6 +48,7 @@ public class SlotManagerConfiguration {
     private final Duration declareNeededResourceDelay;
     private final boolean waitResultConsumedBeforeRelease;
     private final SlotMatchingStrategy slotMatchingStrategy;
+    private final boolean evenlySpreadOutSlots;
     private final WorkerResourceSpec defaultWorkerResourceSpec;
     private final int numSlotsPerWorker;
     private final int maxSlotNum;
@@ -63,6 +64,7 @@ public class SlotManagerConfiguration {
             Duration declareNeededResourceDelay,
             boolean waitResultConsumedBeforeRelease,
             SlotMatchingStrategy slotMatchingStrategy,
+            boolean evenlySpreadOutSlots,
             WorkerResourceSpec defaultWorkerResourceSpec,
             int numSlotsPerWorker,
             int maxSlotNum,
@@ -77,6 +79,7 @@ public class SlotManagerConfiguration {
         this.declareNeededResourceDelay = Preconditions.checkNotNull(declareNeededResourceDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
         this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
+        this.evenlySpreadOutSlots = evenlySpreadOutSlots;
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
         Preconditions.checkState(numSlotsPerWorker > 0);
         Preconditions.checkState(maxSlotNum > 0);
@@ -114,6 +117,10 @@ public class SlotManagerConfiguration {
 
     public SlotMatchingStrategy getSlotMatchingStrategy() {
         return slotMatchingStrategy;
+    }
+
+    public boolean isEvenlySpreadOutSlots() {
+        return evenlySpreadOutSlots;
     }
 
     public WorkerResourceSpec getDefaultWorkerResourceSpec() {
@@ -184,6 +191,7 @@ public class SlotManagerConfiguration {
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
                 slotMatchingStrategy,
+                evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,
                 maxSlotNum,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AnyMatchingSlotMatchingStrategyTest.java
@@ -20,31 +20,27 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link AnyMatchingSlotMatchingStrategy}. */
-public class AnyMatchingSlotMatchingStrategyTest extends TestLogger {
+class AnyMatchingSlotMatchingStrategyTest {
 
     private final InstanceID instanceId = new InstanceID();
 
     private TestingTaskManagerSlotInformation largeTaskManagerSlotInformation = null;
     private Collection<TestingTaskManagerSlotInformation> freeSlots = null;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         final ResourceProfile largeResourceProfile = ResourceProfile.fromResources(10.2, 42);
         final ResourceProfile smallResourceProfile = ResourceProfile.fromResources(1, 1);
 
@@ -64,28 +60,29 @@ public class AnyMatchingSlotMatchingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void findMatchingSlot_withFulfillableRequest_returnsFulfillingSlot() {
+    void findMatchingSlot_withFulfillableRequest_returnsFulfillingSlot() {
         final Optional<TestingTaskManagerSlotInformation> optionalMatchingSlot =
                 AnyMatchingSlotMatchingStrategy.INSTANCE.findMatchingSlot(
                         largeTaskManagerSlotInformation.getResourceProfile(),
                         freeSlots,
                         countSlotsPerInstance(freeSlots));
 
-        assertTrue(optionalMatchingSlot.isPresent());
-        assertThat(
-                optionalMatchingSlot.get().getSlotId(),
-                is(largeTaskManagerSlotInformation.getSlotId()));
+        assertThat(optionalMatchingSlot)
+                .hasValueSatisfying(
+                        slot ->
+                                assertThat(slot.getSlotId())
+                                        .isEqualTo(largeTaskManagerSlotInformation.getSlotId()));
     }
 
     @Test
-    public void findMatchingSlot_withUnfulfillableRequest_returnsEmptyResult() {
+    void findMatchingSlot_withUnfulfillableRequest_returnsEmptyResult() {
         final Optional<TestingTaskManagerSlotInformation> optionalMatchingSlot =
                 AnyMatchingSlotMatchingStrategy.INSTANCE.findMatchingSlot(
                         ResourceProfile.fromResources(Double.MAX_VALUE, Integer.MAX_VALUE),
                         freeSlots,
                         countSlotsPerInstance(freeSlots));
 
-        assertFalse(optionalMatchingSlot.isPresent());
+        assertThat(optionalMatchingSlot).isNotPresent();
     }
 
     private Function<InstanceID, Integer> countSlotsPerInstance(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Executor;
 
 /** Builder for {@link DeclarativeSlotManager}. */
 public class DeclarativeSlotManagerBuilder {
-    private SlotMatchingStrategy slotMatchingStrategy;
+    private boolean evenlySpreadOutSlots;
     private final ScheduledExecutor scheduledExecutor;
     private Time taskManagerRequestTimeout;
     private Time slotRequestTimeout;
@@ -53,7 +53,7 @@ public class DeclarativeSlotManagerBuilder {
     private Duration declareNeededResourceDelay;
 
     private DeclarativeSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
-        this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
+        this.evenlySpreadOutSlots = false;
         this.scheduledExecutor = scheduledExecutor;
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
         this.slotRequestTimeout = TestingUtils.infiniteTime();
@@ -98,9 +98,8 @@ public class DeclarativeSlotManagerBuilder {
         return this;
     }
 
-    public DeclarativeSlotManagerBuilder setSlotMatchingStrategy(
-            SlotMatchingStrategy slotMatchingStrategy) {
-        this.slotMatchingStrategy = slotMatchingStrategy;
+    public DeclarativeSlotManagerBuilder setEvenlySpreadOutSlots(boolean evenlySpreadOutSlots) {
+        this.evenlySpreadOutSlots = evenlySpreadOutSlots;
         return this;
     }
 
@@ -161,8 +160,7 @@ public class DeclarativeSlotManagerBuilder {
                         requirementCheckDelay,
                         declareNeededResourceDelay,
                         waitResultConsumedBeforeRelease,
-                        slotMatchingStrategy,
-                        false,
+                        evenlySpreadOutSlots,
                         defaultWorkerResourceSpec,
                         numSlotsPerWorker,
                         maxSlotNum,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -162,6 +162,7 @@ public class DeclarativeSlotManagerBuilder {
                         declareNeededResourceDelay,
                         waitResultConsumedBeforeRelease,
                         slotMatchingStrategy,
+                        false,
                         defaultWorkerResourceSpec,
                         numSlotsPerWorker,
                         maxSlotNum,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -1121,7 +1121,7 @@ class DeclarativeSlotManagerTest {
     void testSpreadOutSlotAllocationStrategy() throws Exception {
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
-                        .setSlotMatchingStrategy(LeastUtilizationSlotMatchingStrategy.INSTANCE)
+                        .setEvenlySpreadOutSlots(true)
                         .buildAndStartWithDirectExec()) {
 
             final List<CompletableFuture<JobID>> requestSlotFutures = new ArrayList<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -39,7 +39,7 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
     protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy() {
         return Optional.of(
                 new DefaultResourceAllocationStrategy(
-                        DEFAULT_TOTAL_RESOURCE_PROFILE, DEFAULT_NUM_SLOTS_PER_WORKER));
+                        DEFAULT_TOTAL_RESOURCE_PROFILE, DEFAULT_NUM_SLOTS_PER_WORKER, false));
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -36,10 +36,13 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
             DEFAULT_TOTAL_RESOURCE_PROFILE.multiply(2);
 
     @Override
-    protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy() {
+    protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy(
+            SlotManagerConfiguration slotManagerConfiguration) {
         return Optional.of(
                 new DefaultResourceAllocationStrategy(
-                        DEFAULT_TOTAL_RESOURCE_PROFILE, DEFAULT_NUM_SLOTS_PER_WORKER, false));
+                        DEFAULT_TOTAL_RESOURCE_PROFILE,
+                        DEFAULT_NUM_SLOTS_PER_WORKER,
+                        slotManagerConfiguration.isEvenlySpreadOutSlots()));
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -65,7 +65,8 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
             LARGE_SLOT_RESOURCE_PROFILE.multiply(2);
 
     @Override
-    protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy() {
+    protected Optional<ResourceAllocationStrategy> getResourceAllocationStrategy(
+            SlotManagerConfiguration slotManagerConfiguration) {
         return Optional.empty();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -79,7 +79,8 @@ abstract class FineGrainedSlotManagerTestBase {
             SlotManagerUtils.generateDefaultSlotResourceProfile(
                     DEFAULT_WORKER_RESOURCE_SPEC, DEFAULT_NUM_SLOTS_PER_WORKER);
 
-    protected abstract Optional<ResourceAllocationStrategy> getResourceAllocationStrategy();
+    protected abstract Optional<ResourceAllocationStrategy> getResourceAllocationStrategy(
+            SlotManagerConfiguration slotManagerConfiguration);
 
     static SlotStatus createAllocatedSlotStatus(
             AllocationID allocationID, ResourceProfile resourceProfile) {
@@ -203,15 +204,16 @@ abstract class FineGrainedSlotManagerTestBase {
         }
 
         protected final void runTest(RunnableWithException testMethod) throws Exception {
+            SlotManagerConfiguration configuration = slotManagerConfigurationBuilder.build();
             slotManager =
                     new FineGrainedSlotManager(
                             scheduledExecutor,
-                            slotManagerConfigurationBuilder.build(),
+                            configuration,
                             slotManagerMetricGroup,
                             resourceTracker,
                             taskManagerTracker,
                             slotStatusSyncer,
-                            getResourceAllocationStrategy()
+                            getResourceAllocationStrategy(configuration)
                                     .orElse(resourceAllocationStrategyBuilder.build()));
             runInMainThreadAndWait(
                     () ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/LeastUtilizationSlotMatchingStrategyTest.java
@@ -20,11 +20,10 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,15 +31,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link LeastUtilizationSlotMatchingStrategy}. */
-public class LeastUtilizationSlotMatchingStrategyTest extends TestLogger {
+class LeastUtilizationSlotMatchingStrategyTest {
 
     @Test
-    public void findMatchingSlot_multipleMatchingSlots_returnsSlotWithLeastUtilization() {
+    void findMatchingSlot_multipleMatchingSlots_returnsSlotWithLeastUtilization() {
         final ResourceProfile requestedResourceProfile = ResourceProfile.fromResources(2.0, 2);
 
         final TestingTaskManagerSlotInformation leastUtilizedSlot =
@@ -71,8 +68,11 @@ public class LeastUtilizationSlotMatchingStrategyTest extends TestLogger {
                         freeSlots,
                         createRegisteredSlotsLookupFunction(registeredSlotPerTaskExecutor));
 
-        assertTrue(matchingSlot.isPresent());
-        assertThat(matchingSlot.get().getSlotId(), is(leastUtilizedSlot.getSlotId()));
+        assertThat(matchingSlot)
+                .hasValueSatisfying(
+                        slot ->
+                                assertThat(slot.getSlotId())
+                                        .isEqualTo(leastUtilizedSlot.getSlotId()));
     }
 
     private Function<InstanceID, Integer> createRegisteredSlotsLookupFunction(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -137,6 +137,7 @@ public class SlotManagerConfigurationBuilder {
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
                 AnyMatchingSlotMatchingStrategy.INSTANCE,
+                false,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,
                 maxSlotNum,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -41,6 +41,7 @@ public class SlotManagerConfigurationBuilder {
     private CPUResource maxTotalCpu;
     private MemorySize maxTotalMem;
     private int redundantTaskManagerNum;
+    private boolean evenlySpreadOutSlots;
 
     private SlotManagerConfigurationBuilder() {
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
@@ -57,6 +58,7 @@ public class SlotManagerConfigurationBuilder {
         this.maxTotalMem = MemorySize.MAX_VALUE;
         this.redundantTaskManagerNum =
                 ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
+        this.evenlySpreadOutSlots = false;
     }
 
     public static SlotManagerConfigurationBuilder newBuilder() {
@@ -128,6 +130,11 @@ public class SlotManagerConfigurationBuilder {
         return this;
     }
 
+    public SlotManagerConfigurationBuilder setEvenlySpreadOutSlots(boolean evenlySpreadOutSlots) {
+        this.evenlySpreadOutSlots = evenlySpreadOutSlots;
+        return this;
+    }
+
     public SlotManagerConfiguration build() {
         return new SlotManagerConfiguration(
                 taskManagerRequestTimeout,
@@ -136,8 +143,7 @@ public class SlotManagerConfigurationBuilder {
                 requirementCheckDelay,
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
-                AnyMatchingSlotMatchingStrategy.INSTANCE,
-                false,
+                evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,
                 maxSlotNum,


### PR DESCRIPTION
## What is the purpose of the change
Support evenly slot selection in FineGrainedSlotManager.

## Brief change log
  - *SlotMatchingStrategy add new interface to find the matching instances*
  - *DefaultResourceAllocationStrategy use SlotMatchingStrategy to find best instance to allocate resource*

## Verifying this change
  - *Added unit test for SlotMatchingStrategy and DefaultResourceAllocationStrategy*
  - *Manually verified running 4 TaskManagers, each have 4 slots. task parallelism set to 4. When evenly enabled, each TaskManager run 1 task, when evenly disabled, 4 tasks running on single TaskManager*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
