### PR TITLE
[FLINK-31380][table] Support enhanced show catalogs syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -548,10 +548,52 @@ Flink SQL> SHOW JARS;
 ## SHOW CATALOGS
 
 ```sql
-SHOW CATALOGS
+SHOW CATALOGS [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-展示所有的 catalog。
+展示所有的 catalog。另外返回的结果能被一个可选的匹配字符串过滤。
+
+**LIKE**
+根据可选的 `LIKE` 语句与 `<sql_like_pattern>` 是否模糊匹配的所有 catalog。
+
+`LIKE` 子句中 SQL 正则式的语法与 `MySQL` 方言中的语法相同。
+* `%` 匹配任意数量的字符, 也包括0数量字符, `\%` 匹配一个 `%` 字符.
+* `_` 只匹配一个字符, `\_` 匹配一个 `_` 字符.
+
+**ILIKE**
+它的行为和 LIKE 相同，只是对于大小写是不敏感的。
+
+### SHOW CATALOGS 示例
+
+假定我们在当前 flink session 中有 `catalog1` 和 `catalog2`。
+
+- 显示所有的 catalog。
+
+```sql
+show catalogs;
++-----------------+
+|    catalog name |
++-----------------+
+|        catalog1 |
+|        catalog2 |
+| default_catalog |
++-----------------+
+3 rows in set
+```
+
+- 显示模糊匹配指定 SQL 正则式的所有catalog。
+
+```sql
+show catalogs like '%log1';
+-- show catalogs ilike '%log1';
+-- show catalogs ilike '%LOG1';
++--------------+
+| catalog name |
++--------------+
+|     catalog1 |
++--------------+
+1 row in set
+```
 
 ## SHOW CURRENT CATALOG
 

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -548,10 +548,52 @@ Flink SQL> SHOW JARS;
 ## SHOW CATALOGS
 
 ```sql
-SHOW CATALOGS
+SHOW CATALOGS [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-Show all catalogs.
+Show all catalogs. Additionally, the output of this statement may be filtered by an optional matching pattern.
+
+**LIKE**
+Show all catalogs with a `LIKE` clause, whose name is similar to the `<sql_like_pattern>`.
+
+The syntax of the SQL pattern in the `LIKE` clause is the same as that of the `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, and `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
+
+**ILIKE**
+The same behavior as `LIKE` but the SQL pattern is case-insensitive.
+
+### SHOW CATALOGS EXAMPLES
+
+Assumes that we have `catalog1` and `catalog2` in the session.
+
+- Show all catalogs.
+
+```sql
+show catalogs;
++-----------------+
+|    catalog name |
++-----------------+
+|        catalog1 |
+|        catalog2 |
+| default_catalog |
++-----------------+
+3 rows in set
+```
+
+- Show all catalogs, which are similar to the given SQL pattern.
+
+```sql
+show catalogs like '%log1';
+-- show catalogs ilike '%log1';
+-- show catalogs ilike '%LOG1';
++--------------+
+| catalog name |
++--------------+
+|     catalog1 |
++--------------+
+1 row in set
+```
 
 ## SHOW CURRENT CATALOG
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -62,6 +62,42 @@ show catalogs;
 2 rows in set
 !ok
 
+show catalogs like '%c1';
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs not like 'default%';
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs ilike '%c1';
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs not ilike 'default%';
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
 show current catalog;
 +----------------------+
 | current catalog name |

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -69,6 +69,46 @@ show catalogs;
 2 rows in set
 !ok
 
+show catalogs like '%c1';
+!output
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs not like 'default%';
+!output
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs ilike '%c1';
+!output
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
+show catalogs not ilike 'default%';
+!output
++--------------+
+| catalog name |
++--------------+
+|           c1 |
++--------------+
+1 row in set
+!ok
+
 show current catalog;
 !output
 +----------------------+

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -50,11 +50,40 @@ boolean IfNotExistsOpt() :
 */
 SqlShowCatalogs SqlShowCatalogs() :
 {
+    SqlParserPos pos;
+    String likeType = null;
+    SqlCharStringLiteral likeLiteral = null;
+    boolean notLike = false;
 }
 {
     <SHOW> <CATALOGS>
+    { pos = getPos(); }
+    [
+        [
+            <NOT>
+            {
+                notLike = true;
+            }
+        ]
+        (
+            <LIKE>
+            {
+                likeType = "LIKE";
+            }
+        |
+            <ILIKE>
+            {
+                likeType = "ILIKE";
+            }
+        )
+        <QUOTED_STRING>
+        {
+            String likeCondition = SqlParserUtil.parseString(token.image);
+            likeLiteral = SqlLiteral.createCharString(likeCondition, getPos());
+        }
+    ]
     {
-        return new SqlShowCatalogs(getPos());
+        return new SqlShowCatalogs(pos.plus(getPos()), likeType, likeLiteral, notLike);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
@@ -18,25 +18,27 @@
 
 package org.apache.flink.sql.parser.dql;
 
-import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
-import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
-import java.util.List;
-
-/** SHOW CATALOGS sql call. */
-public class SqlShowCatalogs extends SqlCall {
+/**
+ * SHOW Catalogs sql call. The full syntax for show catalogs is as followings:
+ *
+ * <pre>{@code
+ * SHOW CATALOGS [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
+ * }</pre>
+ */
+public class SqlShowCatalogs extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("SHOW CATALOGS", SqlKind.OTHER);
 
-    public SqlShowCatalogs(SqlParserPos pos) {
-        super(pos);
+    public SqlShowCatalogs(
+            SqlParserPos pos, String likeType, SqlCharStringLiteral likeLiteral, boolean notLike) {
+        super(pos, null, null, likeType, likeLiteral, notLike);
     }
 
     @Override
@@ -45,12 +47,7 @@ public class SqlShowCatalogs extends SqlCall {
     }
 
     @Override
-    public List<SqlNode> getOperandList() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-        writer.keyword("SHOW CATALOGS");
+    String getOperationName() {
+        return "SHOW CATALOGS";
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -52,6 +52,24 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testShowCatalogs() {
         sql("show catalogs").ok("SHOW CATALOGS");
+
+        // ----------- The following cases are used to detect LIKE -----------
+
+        sql("show catalogs like '%'").ok("SHOW CATALOGS LIKE '%'");
+        sql("show catalogs not like '%'").ok("SHOW CATALOGS NOT LIKE '%'");
+
+        // ----------- The following cases are used to detect ILIKE -----------
+
+        sql("show catalogs ilike '%'").ok("SHOW CATALOGS ILIKE '%'");
+        sql("show catalogs not ilike '%'").ok("SHOW CATALOGS NOT ILIKE '%'");
+
+        sql("show catalogs ^likes^").fails("(?s).*Encountered \"likes\" at line 1, column 15.\n.*");
+        sql("show catalogs not ^likes^")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 19" + ".\n" + ".*");
+        sql("show catalogs ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 15.\n.*");
+        sql("show catalogs not ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 19" + ".\n" + ".*");
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -53,12 +53,8 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     void testShowCatalogs() {
         sql("show catalogs").ok("SHOW CATALOGS");
 
-        // ----------- The following cases are used to detect LIKE -----------
-
         sql("show catalogs like '%'").ok("SHOW CATALOGS LIKE '%'");
         sql("show catalogs not like '%'").ok("SHOW CATALOGS NOT LIKE '%'");
-
-        // ----------- The following cases are used to detect ILIKE -----------
 
         sql("show catalogs ilike '%'").ok("SHOW CATALOGS ILIKE '%'");
         sql("show catalogs not ilike '%'").ok("SHOW CATALOGS NOT ILIKE '%'");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCatalogsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCatalogsOperation.java
@@ -19,23 +19,41 @@
 package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.operations.utils.ShowLikeOperator;
 
-import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
+import javax.annotation.Nullable;
 
-/** Operation to describe a SHOW CATALOGS statement. */
+import java.util.Collection;
+
+/**
+ * Operation to describe a SHOW CATALOGS statement. The full syntax for SHOW CATALOGS is as
+ * followings:
+ *
+ * <pre>{@code
+ * SHOW CATALOGS [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
+ * }</pre>
+ */
 @Internal
-public class ShowCatalogsOperation implements ShowOperation {
+public class ShowCatalogsOperation extends AbstractShowOperation {
+
+    public ShowCatalogsOperation(@Nullable ShowLikeOperator likeOp) {
+        super(null, null, likeOp);
+    }
 
     @Override
-    public String asSummaryString() {
+    protected String getOperationName() {
         return "SHOW CATALOGS";
     }
 
     @Override
-    public TableResultInternal execute(Context ctx) {
-        String[] catalogs =
-                ctx.getCatalogManager().listCatalogs().stream().sorted().toArray(String[]::new);
-        return buildStringArrayResult("catalog name", catalogs);
+    protected String getColumnName() {
+        return "catalog name";
+    }
+
+    @Override
+    protected Collection<String> retrieveDataForTableResult(Context ctx) {
+        final CatalogManager catalogManager = ctx.getCatalogManager();
+        return catalogManager.listCatalogs();
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -65,7 +65,6 @@ import org.apache.flink.sql.parser.dml.SqlStatementSet;
 import org.apache.flink.sql.parser.dql.SqlLoadModule;
 import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
 import org.apache.flink.sql.parser.dql.SqlRichExplain;
-import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowColumns;
 import org.apache.flink.sql.parser.dql.SqlShowCreateTable;
 import org.apache.flink.sql.parser.dql.SqlShowCreateView;
@@ -125,7 +124,6 @@ import org.apache.flink.table.operations.ModifyType;
 import org.apache.flink.table.operations.NopOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
-import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowColumnsOperation;
 import org.apache.flink.table.operations.ShowCreateTableOperation;
 import org.apache.flink.table.operations.ShowCreateViewOperation;
@@ -280,8 +278,6 @@ public class SqlNodeToOperationConversion {
             return Optional.of(converter.convertDropCatalog((SqlDropCatalog) validated));
         } else if (validated instanceof SqlLoadModule) {
             return Optional.of(converter.convertLoadModule((SqlLoadModule) validated));
-        } else if (validated instanceof SqlShowCatalogs) {
-            return Optional.of(converter.convertShowCatalogs((SqlShowCatalogs) validated));
         } else if (validated instanceof SqlShowCurrentCatalog) {
             return Optional.of(
                     converter.convertShowCurrentCatalog((SqlShowCurrentCatalog) validated));
@@ -909,11 +905,6 @@ public class SqlNodeToOperationConversion {
         CatalogDatabase catalogDatabase =
                 new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
         return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
-    }
-
-    /** Convert SHOW CATALOGS statement. */
-    private Operation convertShowCatalogs(SqlShowCatalogs sqlShowCatalogs) {
-        return new ShowCatalogsOperation();
     }
 
     /** Convert SHOW CURRENT CATALOG statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -66,6 +66,7 @@ public class SqlNodeConverters {
         register(new SqlDropMaterializedTableConverter());
         register(new SqlShowTablesConverter());
         register(new SqlShowViewsConverter());
+        register(new SqlShowCatalogsConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCatalogsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCatalogsConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCatalogsOperation;
+import org.apache.flink.table.operations.utils.LikeType;
+import org.apache.flink.table.operations.utils.ShowLikeOperator;
+
+/** A converter for {@link SqlShowCatalogs}. */
+public class SqlShowCatalogsConverter implements SqlNodeConverter<SqlShowCatalogs> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowCatalogs sqlShowCatalogs, ConvertContext context) {
+        final ShowLikeOperator likeOp =
+                ShowLikeOperator.of(
+                        LikeType.of(sqlShowCatalogs.getLikeType(), sqlShowCatalogs.isNotLike()),
+                        sqlShowCatalogs.getLikeSqlPattern());
+        return new ShowCatalogsOperation(likeOp);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.operations.DescribeCatalogOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowCreateCatalogOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
@@ -183,8 +184,37 @@ public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversion
         assertThat(useModulesOperation.asSummaryString()).isEqualTo("USE MODULES: [x, y, z]");
     }
 
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("inputForShowCatalogsTest")
+    void testShowCatalogs(String sql, ShowCatalogsOperation expected, String expectedSummary) {
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(ShowCatalogsOperation.class).isEqualTo(expected);
+        assertThat(operation.asSummaryString()).isEqualTo(expectedSummary);
+    }
+
+    private static Stream<Arguments> inputForShowCatalogsTest() {
+        return Stream.of(
+                Arguments.of("show catalogs", new ShowCatalogsOperation(null), "SHOW CATALOGS"),
+                Arguments.of(
+                        "show catalogs like 'c%'",
+                        new ShowCatalogsOperation(ShowLikeOperator.of(LikeType.LIKE, "c%")),
+                        "SHOW CATALOGS LIKE 'c%'"),
+                Arguments.of(
+                        "show catalogs not like 'c%'",
+                        new ShowCatalogsOperation(ShowLikeOperator.of(LikeType.NOT_LIKE, "c%")),
+                        "SHOW CATALOGS NOT LIKE 'c%'"),
+                Arguments.of(
+                        "show catalogs ilike 'c%'",
+                        new ShowCatalogsOperation(ShowLikeOperator.of(LikeType.ILIKE, "c%")),
+                        "SHOW CATALOGS ILIKE 'c%'"),
+                Arguments.of(
+                        "show catalogs not ilike 'c%'",
+                        new ShowCatalogsOperation(ShowLikeOperator.of(LikeType.NOT_ILIKE, "c%")),
+                        "SHOW CATALOGS NOT ILIKE 'c%'"));
+    }
+
     @Test
-    void testShowModules() {
+    public void testShowModules() {
         final String sql = "SHOW MODULES";
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(ShowModulesOperation.class);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -214,7 +214,7 @@ public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversion
     }
 
     @Test
-    public void testShowModules() {
+    void testShowModules() {
         final String sql = "SHOW MODULES";
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(ShowModulesOperation.class);


### PR DESCRIPTION
## What is the purpose of the change

Support enhanced show catalogs syntax for [FLIP-297](https://cwiki.apache.org/confluence/display/FLINK/FLIP-297%3A+Improve+Auxiliary+Sql+Statements)


## Brief change log
Support enhanced show catalogs syntax:
```sql
SHOW CATALOGS [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
```

## Verifying this change

Add cases in FlinkSqlParserImplTest:
- testShowCatalogs

Add cases in SqlOtherOperationConverterTest:
- testShowCatalogs

sql-client & sql-client-gateway:
catalog_databases.q

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  yes
- If yes, how is the feature documented? docs