### PR TITLE
[BP-1.16][FLINK-31420][test] Fix unstable test ThreadInfoRequestCoordinatorTest#testShutDown.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
@@ -181,7 +181,9 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
-                                CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
+                                // request future will only be completed after all gateways
+                                // successfully return thread infos.
+                                CompletionType.SUCCESSFULLY, CompletionType.NEVER_COMPLETE);
 
         List<CompletableFuture<JobVertexThreadInfoStats>> requestFutures = new ArrayList<>();
 


### PR DESCRIPTION
Backport FLINK-31420 to release-1.16.