### PR TITLE
[FLINK-31444][runtime]FineGrainedSlotManager reclaims slots when job is finished

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -310,11 +309,15 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
     }
 
     @Override
-    public void freeInactiveSlots(JobID jobId, TaskExecutorConnection taskExecutorConnection) {
+    public void freeInactiveSlots(JobID jobId) {
         checkStarted();
-        taskExecutorConnection
-                .getTaskExecutorGateway()
-                .freeInactiveSlots(jobId, taskManagerRequestTimeout);
+        for (TaskManagerInfo taskManagerInfo :
+                taskManagerTracker.getTaskManagersWithAllocatedSlotsForJob(jobId)) {
+            taskManagerInfo
+                    .getTaskExecutorConnection()
+                    .getTaskExecutorGateway()
+                    .freeInactiveSlots(jobId, taskManagerRequestTimeout);
+        }
     }
 
     private void checkStarted() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncer.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -306,6 +307,14 @@ public class DefaultSlotStatusSyncer implements SlotStatusSyncer {
             resourceTracker.notifyAcquiredResource(jobId, resourceProfile);
             return false;
         }
+    }
+
+    @Override
+    public void freeInactiveSlots(JobID jobId, TaskExecutorConnection taskExecutorConnection) {
+        checkStarted();
+        taskExecutorConnection
+                .getTaskExecutorGateway()
+                .freeInactiveSlots(jobId, taskManagerRequestTimeout);
     }
 
     private void checkStarted() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -293,11 +293,11 @@ public class FineGrainedSlotManager implements SlotManager {
     }
 
     private void maybeReclaimInactiveSlots(JobID jobId) {
+        // We don't notify the task manager tracker and resource tracker about the freeing of these
+        // slots early, and rely on task managers to report the slots becoming available later to
+        // keep the states consistent.
         if (!resourceTracker.getAcquiredResources(jobId).isEmpty()) {
-            for (TaskExecutorConnection taskExecutorConnection :
-                    taskManagerTracker.getTaskExecutorsWithAllocatedSlotsForJob(jobId)) {
-                slotStatusSyncer.freeInactiveSlots(jobId, taskExecutorConnection);
-            }
+            slotStatusSyncer.freeInactiveSlots(jobId);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
@@ -187,11 +187,12 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
     }
 
     @Override
-    public Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(
-            JobID jobId) {
-        return slots.values().stream()
-                .filter(slot -> jobId.equals(slot.getJobId()))
-                .map(FineGrainedTaskManagerSlot::getTaskManagerConnection)
+    public Collection<TaskManagerInfo> getTaskManagersWithAllocatedSlotsForJob(JobID jobId) {
+        return taskManagerRegistrations.values().stream()
+                .filter(
+                        taskManager ->
+                                taskManager.getAllocatedSlots().values().stream()
+                                        .anyMatch(slot -> jobId.equals(slot.getJobId())))
                 .collect(Collectors.toList());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
@@ -186,6 +186,15 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
                 .orElse(Collections.emptyMap());
     }
 
+    @Override
+    public Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(
+            JobID jobId) {
+        return slots.values().stream()
+                .filter(slot -> jobId.equals(slot.getJobId()))
+                .map(FineGrainedTaskManagerSlot::getTaskManagerConnection)
+                .collect(Collectors.toList());
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Core state transitions
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotStatusSyncer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotStatusSyncer.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.concurrent.CompletableFuture;
@@ -85,10 +84,9 @@ public interface SlotStatusSyncer {
     boolean reportSlotStatus(InstanceID instanceId, SlotReport slotReport);
 
     /**
-     * Frees all currently inactive slot allocated for the given job and task executor.
+     * Frees all currently inactive slot allocated for the given job.
      *
      * @param jobId of the job
-     * @param taskExecutorConnection of the task manager
      */
-    void freeInactiveSlots(JobID jobId, TaskExecutorConnection taskExecutorConnection);
+    void freeInactiveSlots(JobID jobId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotStatusSyncer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotStatusSyncer.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.concurrent.CompletableFuture;
@@ -82,4 +83,12 @@ public interface SlotStatusSyncer {
      * @return whether the previous allocations can be applied
      */
     boolean reportSlotStatus(InstanceID instanceId, SlotReport slotReport);
+
+    /**
+     * Frees all currently inactive slot allocated for the given job and task executor.
+     *
+     * @param jobId of the job
+     * @param taskExecutorConnection of the task manager
+     */
+    void freeInactiveSlots(JobID jobId, TaskExecutorConnection taskExecutorConnection);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.util.ResourceCounter;
 
+import java.util.Collection;
 import java.util.Map;
 
 /** Tracks TaskManager's resource and slot status. */
@@ -78,6 +79,15 @@ interface TaskManagerTracker
 
     /** Get unwanted task managers. */
     Map<InstanceID, WorkerResourceSpec> getUnWantedTaskManager();
+
+    /**
+     * Returns all task executors that have at least 1 pending/completed allocation for the given
+     * job.
+     *
+     * @param jobId the job for which the task executors must have a slot
+     * @return task executors with at least 1 slot for the job
+     */
+    Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(JobID jobId);
 
     // ---------------------------------------------------------------------------------------------
     // Slot status updates

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
@@ -81,13 +81,12 @@ interface TaskManagerTracker
     Map<InstanceID, WorkerResourceSpec> getUnWantedTaskManager();
 
     /**
-     * Returns all task executors that have at least 1 pending/completed allocation for the given
-     * job.
+     * Returns all task managers that have at least 1 allocation for the given job.
      *
      * @param jobId the job for which the task executors must have a slot
-     * @return task executors with at least 1 slot for the job
+     * @return task managers with at least 1 slot for the job
      */
-    Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(JobID jobId);
+    Collection<TaskManagerInfo> getTaskManagersWithAllocatedSlotsForJob(JobID jobId);
 
     // ---------------------------------------------------------------------------------------------
     // Slot status updates

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
@@ -777,6 +777,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
                                                             taskExecutionConnection.getInstanceID(),
                                                             new SlotReport(
                                                                     createAllocatedSlotStatus(
+                                                                            new JobID(),
                                                                             allocationId,
                                                                             DEFAULT_SLOT_RESOURCE_PROFILE))));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -147,7 +148,8 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final AllocationID allocationId = new AllocationID();
         final SlotReport slotReport =
                 new SlotReport(
-                        createAllocatedSlotStatus(allocationId, DEFAULT_SLOT_RESOURCE_PROFILE));
+                        createAllocatedSlotStatus(
+                                new JobID(), allocationId, DEFAULT_SLOT_RESOURCE_PROFILE));
         new Context() {
             {
                 runTest(
@@ -205,7 +207,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final SlotReport slotReportWithAllocatedSlot =
                 new SlotReport(
                         createAllocatedSlotStatus(
-                                new AllocationID(), DEFAULT_SLOT_RESOURCE_PROFILE));
+                                new JobID(), new AllocationID(), DEFAULT_SLOT_RESOURCE_PROFILE));
         new Context() {
             {
                 resourceAllocationStrategyBuilder.setTryFulfillRequirementsFunction(
@@ -691,6 +693,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     taskExecutionConnection,
                                                                     new SlotReport(
                                                                             createAllocatedSlotStatus(
+                                                                                    new JobID(),
                                                                                     allocationId,
                                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
@@ -995,5 +998,68 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             });
                     assertThat(registeredMetrics.get()).isEqualTo(0);
                 });
+    }
+
+    @Test
+    void testReclaimInactiveSlotsOnClearRequirements() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            final CompletableFuture<JobID> freeInactiveSlotsJobIdFuture =
+                                    new CompletableFuture<>();
+
+                            final JobID jobId = new JobID();
+                            final TestingTaskExecutorGateway taskExecutorGateway =
+                                    new TestingTaskExecutorGatewayBuilder()
+                                            .setFreeInactiveSlotsConsumer(
+                                                    freeInactiveSlotsJobIdFuture::complete)
+                                            .createTestingTaskExecutorGateway();
+                            final TaskExecutorConnection taskExecutionConnection =
+                                    createTaskExecutorConnection(taskExecutorGateway);
+
+                            final CompletableFuture<SlotManager.RegistrationResult>
+                                    registerTaskManagerFuture = new CompletableFuture<>();
+                            runInMainThread(
+                                    () ->
+                                            registerTaskManagerFuture.complete(
+                                                    getSlotManager()
+                                                            .registerTaskManager(
+                                                                    taskExecutionConnection,
+                                                                    new SlotReport(
+                                                                            createAllocatedSlotStatus(
+                                                                                    jobId,
+                                                                                    new AllocationID(),
+                                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)),
+                                                                    DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
+                                    .isEqualTo(SlotManager.RegistrationResult.SUCCESS);
+
+                            // setup initial requirements, which should not trigger slots being
+                            // reclaimed
+                            runInMainThreadAndWait(
+                                    () ->
+                                            getSlotManager()
+                                                    .processResourceRequirements(
+                                                            createResourceRequirements(jobId, 2)));
+                            assertFutureNotComplete(freeInactiveSlotsJobIdFuture);
+
+                            // set requirements to 0, which should not trigger slots being reclaimed
+                            runInMainThreadAndWait(
+                                    () ->
+                                            getSlotManager()
+                                                    .processResourceRequirements(
+                                                            ResourceRequirements.empty(
+                                                                    jobId, "foobar")));
+                            assertFutureNotComplete(freeInactiveSlotsJobIdFuture);
+
+                            // clear requirements, which should trigger slots being reclaimed
+                            runInMainThreadAndWait(
+                                    () -> getSlotManager().clearResourceRequirements(jobId));
+                            assertThat(freeInactiveSlotsJobIdFuture.get()).isEqualTo(jobId);
+                        });
+            }
+        };
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnect
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
@@ -82,9 +83,9 @@ abstract class FineGrainedSlotManagerTestBase {
     protected abstract Optional<ResourceAllocationStrategy> getResourceAllocationStrategy();
 
     static SlotStatus createAllocatedSlotStatus(
-            AllocationID allocationID, ResourceProfile resourceProfile) {
+            JobID jobId, AllocationID allocationID, ResourceProfile resourceProfile) {
         return new SlotStatus(
-                new SlotID(ResourceID.generate(), 0), resourceProfile, new JobID(), allocationID);
+                new SlotID(ResourceID.generate(), 0), resourceProfile, jobId, allocationID);
     }
 
     static int getTotalResourceCount(Collection<ResourceRequirement> resources) {
@@ -121,6 +122,11 @@ abstract class FineGrainedSlotManagerTestBase {
         return new TaskExecutorConnection(
                 ResourceID.generate(),
                 new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
+    }
+
+    static TaskExecutorConnection createTaskExecutorConnection(
+            TestingTaskExecutorGateway taskExecutorGateway) {
+        return new TaskExecutorConnection(ResourceID.generate(), taskExecutorGateway);
     }
 
     static <T> T assertFutureCompleteAndReturn(CompletableFuture<T> completableFuture)


### PR DESCRIPTION
## What is the purpose of the change
When a job shuts down there is a race condition between slots being freed and requirements being set to 0. If the slot release arrives first at the RM then it will immediately try to re-allocate slots, since the requirements are not 0 yet.

This change try to free all inactive slots in task executor when job finished(clear requirements). 

## Verifying this change
  - *Added unit test testReclaimInactiveSlotsOnClearRequirements to verify reclaim only invoked on clear requirements*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature?(no)
