### PR TITLE
[FLINK-31485][Confluent Avro] Change packaging of Avro Confluent Schema Registry 

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -156,12 +156,6 @@ under the License.
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
-		<!-- Needed by Schema Registry -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>30.1.1-jre</version>
-		</dependency>
 	</dependencies>
 
 	<build>
@@ -242,14 +236,6 @@ under the License.
 							<artifactId>kafka-clients</artifactId>
 							<version>3.2.3</version>
 							<destFileName>kafka-clients.jar</destFileName>
-							<type>jar</type>
-							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-						</artifactItem>
-						<artifactItem>
-							<groupId>com.google.guava</groupId>
-							<artifactId>guava</artifactId>
-							<version>30.1.1-jre</version>
-							<destFileName>guava.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
 						</artifactItem>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -71,8 +71,6 @@ public class SQLClientSchemaRegistryITCase {
     private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
     private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.jar");
 
-    private final Path guavaJar = ResourceTestUtils.getResource(".*guava.jar");
-
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 
     @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
@@ -256,11 +254,7 @@ public class SQLClientSchemaRegistryITCase {
         flink.submitSQLJob(
                 new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
                         .addJars(
-                                sqlAvroJar,
-                                sqlAvroRegistryJar,
-                                sqlConnectorKafkaJar,
-                                sqlToolBoxJar,
-                                guavaJar)
+                                sqlAvroJar, sqlAvroRegistryJar, sqlConnectorKafkaJar, sqlToolBoxJar)
                         .build());
     }
 }

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -65,6 +65,34 @@ under the License.
 					<groupId>io.swagger</groupId>
 					<artifactId>swagger-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>listenablefuture</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.swagger.core.v3</groupId>
+					<artifactId>swagger-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.j2objc</groupId>
+					<artifactId>j2objc-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>jsr305</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -67,21 +67,11 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes>
-									<include>io.confluent:*</include>
-									<!--we include only kafka-clients which is used in
-									schema-registry-client (e.g. configuration classes). -->
-									<include>org.apache.kafka:kafka-clients</include>
-									<include>org.apache.flink:flink-avro</include>
-									<include>org.apache.flink:flink-avro-confluent-registry</include>
-									<include>org.apache.avro:avro</include>
-									<include>com.fasterxml.jackson.core:*</include>
-									<include>jakarta.ws.rs:jakarta.ws.rs-api</include>
-									<include>jakarta.annotation:jakarta.annotation-api</include>
-									<include>org.glassfish.jersey.core:jersey-common</include>
-									<include>org.glassfish.hk2.external:jakarta.inject</include>
-									<include>org.glassfish.hk2:osgi-resource-locator</include>
-									<include>org.apache.commons:commons-compress</include>
+									<include>*:*</include>
 								</includes>
+								<excludes>
+									<exclude>com.google.code.findbugs:jsr305</exclude>
+								</excludes>
 							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
@@ -108,13 +98,6 @@ under the License.
 								</relocation>
 							</relocations>
 							<filters>
-								<filter>
-									<artifact>org.glassfish.jersey.core:jersey-common</artifact>
-									<excludes>
-										<!-- exclude Java 9+ specific classes as otherwise the shade-plugin crashes -->
-										<exclude>META-INF/versions/**</exclude>
-									</excludes>
-								</filter>
 								<filter>
 									<artifact>org.apache.kafka:*</artifact>
 									<excludes>

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -16,6 +16,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.confluent:common-config:7.2.2
 - io.confluent:common-utils:7.2.2
 - org.glassfish.jersey.core:jersey-common:2.30
+- com.google.guava:guava:30.1.1-jre
+- org.xerial.snappy:snappy-java:1.1.8.3
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 
@@ -23,3 +25,8 @@ The binary distribution of this product bundles these dependencies under the Ecl
 - jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
 - org.glassfish.hk2.external:jakarta.inject:2.6.1
 - org.glassfish.hk2:osgi-resource-locator:1.0.3
+
+This project bundles the following dependencies under the BSD license.
+See bundled license files for details.
+
+- com.github.luben:zstd-jni:1.5.2-1

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -6,17 +6,17 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.avro:avro:1.11.1
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.fasterxml.jackson.core:jackson-databind:2.13.4.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- org.apache.commons:commons-compress:1.21
-- io.confluent:kafka-schema-registry-client:7.2.2
-- org.apache.kafka:kafka-clients:7.2.2-ccs
+- com.google.guava:guava:30.1.1-jre
 - io.confluent:common-config:7.2.2
 - io.confluent:common-utils:7.2.2
+- io.confluent:kafka-schema-registry-client:7.2.2
+- org.apache.avro:avro:1.11.1
+- org.apache.commons:commons-compress:1.21
+- org.apache.kafka:kafka-clients:7.2.2-ccs
 - org.glassfish.jersey.core:jersey-common:2.30
-- com.google.guava:guava:30.1.1-jre
 - org.xerial.snappy:snappy-java:1.1.8.3
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/licenses/LICENSE.zstd-jni
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/licenses/LICENSE.zstd-jni
@@ -1,0 +1,26 @@
+Zstd-jni: JNI bindings to Zstd Library
+
+Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+
+BSD License
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## What is the purpose of the change

* This fixes `ClassNotFoundException` when trying to connect with the SQL Client using Avro Confluent Schema Registry

## Brief change log

* Changed the packaging of `flink-sql-avro-confluent-registry` to include all dependencies by default, instead of a case-by-case situation. This avoids that we accidentally miss a dependency when creating a fat JAR.
* Excluded all annotations and quality tools from the `kafka-schema-registry-client`
* Removed the manual inclusion of Guava in the Kafka E2E tests 

## Verifying this change

This change is already covered by existing tests, such as *SQLClientSchemaRegistryITCase*.

Also verified this locally by:

1. Building this PR
2. Copying the flink-sql-avro, flink-sql-avro-confluent-registry and flink-sql-connector-kafka to the lib folder
3. Running the SQL Client
4. Create a table which connects to Confluent Cloud, with format 'format' = 'avro-confluent' and successfully querying a topic. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
