### PR TITLE
[FLINK-31445][runtime]Split resource allocate/release related logic from FineGrainedSlotManager to TaskManagerTracker

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -83,7 +83,13 @@ public class ResourceManagerRuntimeServices {
                     slotManagerConfiguration,
                     slotManagerMetricGroup,
                     new DefaultResourceTracker(),
-                    new FineGrainedTaskManagerTracker(),
+                    new FineGrainedTaskManagerTracker(
+                            slotManagerConfiguration.getMaxTotalCpu(),
+                            slotManagerConfiguration.getMaxTotalMem(),
+                            slotManagerConfiguration.isWaitResultConsumedBeforeRelease(),
+                            slotManagerConfiguration.getTaskManagerTimeout(),
+                            slotManagerConfiguration.getDeclareNeededResourceDelay(),
+                            scheduledExecutor),
                     new DefaultSlotStatusSyncer(
                             slotManagerConfiguration.getTaskManagerRequestTimeout()),
                     new DefaultResourceAllocationStrategy(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -217,6 +217,8 @@ public class FineGrainedSlotManager implements SlotManager {
         slotStatusSyncer.initialize(
                 taskManagerTracker, resourceTracker, resourceManagerId, mainThreadExecutor);
         blockedTaskManagerChecker = Preconditions.checkNotNull(newBlockedTaskManagerChecker);
+        taskManagerTracker.initialize(
+                Preconditions.checkNotNull(newResourceAllocator), mainThreadExecutor);
 
         started = true;
 
@@ -255,7 +257,7 @@ public class FineGrainedSlotManager implements SlotManager {
         }
 
         slotStatusSyncer.close();
-        taskManagerTracker.clear();
+        taskManagerTracker.close();
         resourceTracker.clear();
 
         unfulfillableJobs.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceDeclaration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceDeclaration.java
@@ -21,9 +21,9 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /** ResourceDeclaration for {@link ResourceAllocator}. */
 public class ResourceDeclaration {
@@ -34,13 +34,13 @@ public class ResourceDeclaration {
      * workers that {@link SlotManager} does not wanted. This is just a hint for {@link
      * ResourceAllocator} to decide which worker should be release.
      */
-    private final Collection<InstanceID> unwantedWorkers;
+    private final Set<InstanceID> unwantedWorkers;
 
     public ResourceDeclaration(
-            WorkerResourceSpec spec, int numNeeded, Collection<InstanceID> unwantedWorkers) {
+            WorkerResourceSpec spec, int numNeeded, Set<InstanceID> unwantedWorkers) {
         this.spec = spec;
         this.numNeeded = numNeeded;
-        this.unwantedWorkers = Collections.unmodifiableCollection(unwantedWorkers);
+        this.unwantedWorkers = Collections.unmodifiableSet(unwantedWorkers);
     }
 
     public WorkerResourceSpec getSpec() {
@@ -51,7 +51,7 @@ public class ResourceDeclaration {
         return numNeeded;
     }
 
-    public Collection<InstanceID> getUnwantedWorkers() {
+    public Set<InstanceID> getUnwantedWorkers() {
         return unwantedWorkers;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
@@ -21,12 +21,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
-import org.apache.flink.runtime.util.ResourceCounter;
 
 import java.util.Collection;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 /**
@@ -62,48 +60,33 @@ interface TaskManagerTracker
     // ---------------------------------------------------------------------------------------------
 
     /**
+     * Allocate pending task managers according to allocation result.
+     *
+     * @param result of the slot allocation
+     * @return the ids of pending task managers that can not be allocated.
+     */
+    Set<PendingTaskManagerId> allocateTaskManagersAccordingTo(ResourceAllocationResult result);
+
+    /**
      * Register a new task manager.
      *
      * @param taskExecutorConnection of the new task manager
      * @param totalResourceProfile of the new task manager
      * @param defaultSlotResourceProfile of the new task manager
+     * @return whether register successfully
      */
-    void addTaskManager(
+    boolean registerTaskManager(
             TaskExecutorConnection taskExecutorConnection,
             ResourceProfile totalResourceProfile,
-            ResourceProfile defaultSlotResourceProfile);
+            ResourceProfile defaultSlotResourceProfile,
+            PendingTaskManagerId matchedPendingTaskManagerId);
 
     /**
      * Unregister a task manager with the given instance id.
      *
      * @param instanceId of the task manager
      */
-    void removeTaskManager(InstanceID instanceId);
-
-    /**
-     * Add a new pending task manager.
-     *
-     * @param pendingTaskManager to be added
-     */
-    void addPendingTaskManager(PendingTaskManager pendingTaskManager);
-
-    /**
-     * Remove a pending task manager and it associated allocation records.
-     *
-     * @param pendingTaskManagerId of the pending task manager
-     * @return the allocation records associated to the removed pending task manager
-     */
-    Map<JobID, ResourceCounter> removePendingTaskManager(PendingTaskManagerId pendingTaskManagerId);
-
-    /**
-     * Add an unwanted task manager.
-     *
-     * @param instanceId identifier of task manager.
-     */
-    void addUnWantedTaskManager(InstanceID instanceId);
-
-    /** Get unwanted task managers. */
-    Map<InstanceID, WorkerResourceSpec> getUnWantedTaskManager();
+    void unregisterTaskManager(InstanceID instanceId);
 
     /**
      * Returns all task managers that have at least 1 allocation for the given job.
@@ -133,14 +116,8 @@ interface TaskManagerTracker
             ResourceProfile resourceProfile,
             SlotState slotState);
 
-    /**
-     * Clear all previous pending slot allocation records if any, and record new pending slot
-     * allocations.
-     *
-     * @param pendingSlotAllocations new pending slot allocations be recorded
-     */
-    void replaceAllPendingAllocations(
-            Map<PendingTaskManagerId, Map<JobID, ResourceCounter>> pendingSlotAllocations);
+    /** Clear all previous pending slot allocation records if any. */
+    void clearAllPendingAllocations();
 
     /**
      * Clear all previous pending slot allocation records for the given job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
@@ -27,13 +27,38 @@ import org.apache.flink.runtime.util.ResourceCounter;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
-/** Tracks TaskManager's resource and slot status. */
+/**
+ * Allocates/Releases/Tracks TaskManager's resource and slot status.
+ *
+ * <ul>
+ *   <li>tracks TaskManager's resource and slot status
+ *   <li>allocating new task executors
+ *   <li>releasing idle task executors
+ *   <li>tracking pending task executors
+ * </ul>
+ */
 interface TaskManagerTracker
         extends TaskManagerResourceInfoProvider, ClusterResourceStatisticsProvider {
 
     // ---------------------------------------------------------------------------------------------
-    // Add / Remove (pending) Resource
+    // initialize / close
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Initialize the TaskManagerTracker.
+     *
+     * @param resourceAllocator to use for resource (de-)allocations
+     * @param mainThreadExecutor to use to run code in the ResourceManager's main thread
+     */
+    void initialize(ResourceAllocator resourceAllocator, Executor mainThreadExecutor);
+
+    /** Removes all state from the tracker. */
+    void close();
+
+    // ---------------------------------------------------------------------------------------------
+    // Add / Remove Resource
     // ---------------------------------------------------------------------------------------------
 
     /**
@@ -123,7 +148,4 @@ interface TaskManagerTracker
      * @param jobId of the given job
      */
     void clearPendingAllocationsOfJob(JobID jobId);
-
-    /** Removes all state from the tracker. */
-    void clear();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
@@ -33,41 +33,34 @@ import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link DefaultSlotStatusSyncer}. */
-public class DefaultSlotStatusSyncerTest extends TestLogger {
+class DefaultSlotStatusSyncerTest {
     private static final Time TASK_MANAGER_REQUEST_TIMEOUT = Time.seconds(10);
     private static final TaskExecutorConnection TASK_EXECUTOR_CONNECTION =
             new TaskExecutorConnection(
                     ResourceID.generate(),
                     new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
 
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     @Test
-    public void testAllocateSlot() throws Exception {
+    void testAllocateSlot() throws Exception {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final CompletableFuture<
@@ -109,23 +102,20 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                         "address",
                         ResourceProfile.ANY);
         final AllocationID allocationId = requestFuture.get().f2;
-        assertThat(
-                resourceTracker.getAcquiredResources(jobId),
-                contains(ResourceRequirement.create(ResourceProfile.ANY, 1)));
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId).isPresent());
-        assertThat(
-                taskManagerTracker.getAllocatedOrPendingSlot(allocationId).get().getJobId(),
-                is(jobId));
-        assertThat(
-                taskManagerTracker.getAllocatedOrPendingSlot(allocationId).get().getState(),
-                is(SlotState.PENDING));
+        assertThat(resourceTracker.getAcquiredResources(jobId))
+                .contains(ResourceRequirement.create(ResourceProfile.ANY, 1));
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId))
+                .hasValueSatisfying(slot -> assertThat(slot.getJobId()).isEqualTo(jobId));
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId))
+                .hasValueSatisfying(
+                        slot -> assertThat(slot.getState()).isEqualTo(SlotState.PENDING));
 
         responseFuture.complete(Acknowledge.get());
-        assertFalse(allocatedFuture.isCompletedExceptionally());
+        assertThat(allocatedFuture).isNotCompletedExceptionally();
     }
 
     @Test
-    public void testAllocateSlotFailsWithException() {
+    void testAllocateSlotFailsWithException() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final TestingTaskExecutorGateway taskExecutorGateway =
@@ -155,23 +145,19 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                         jobId,
                         "address",
                         ResourceProfile.ANY);
-        try {
-            allocatedFuture.get();
-        } catch (Exception e) {
-            assertThat(e.getCause(), instanceOf(TimeoutException.class));
-        }
-        assertThat(resourceTracker.getAcquiredResources(jobId), is(empty()));
+
+        assertThatThrownBy(allocatedFuture::get).hasCauseInstanceOf(TimeoutException.class);
+        assertThat(resourceTracker.getAcquiredResources(jobId)).isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(taskExecutorConnection.getInstanceID())
-                        .get()
-                        .getAllocatedSlots()
-                        .keySet(),
-                is(empty()));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                taskExecutorConnection.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAllocatedSlots()).isEmpty());
     }
 
     @Test
-    public void testFreeSlot() {
+    void testFreeSlot() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
@@ -195,18 +181,17 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
         resourceTracker.notifyAcquiredResource(jobId, ResourceProfile.ANY);
 
         slotStatusSyncer.freeSlot(allocationId);
-        assertThat(resourceTracker.getAcquiredResources(jobId), is(empty()));
+        assertThat(resourceTracker.getAcquiredResources(jobId)).isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAllocatedSlots()
-                        .keySet(),
-                is(empty()));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAllocatedSlots()).isEmpty());
     }
 
     @Test
-    public void testSlotStatusProcessing() {
+    void testSlotStatusProcessing() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
@@ -245,29 +230,29 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
         taskManagerTracker.addTaskManager(taskExecutorConnection, totalResource, totalResource);
 
         slotStatusSyncer.reportSlotStatus(taskExecutorConnection.getInstanceID(), slotReport1);
+        assertThat(resourceTracker.getAcquiredResources(jobId))
+                .contains(ResourceRequirement.create(resource, 2));
         assertThat(
-                resourceTracker.getAcquiredResources(jobId),
-                contains(ResourceRequirement.create(resource, 2)));
-        assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(taskExecutorConnection.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                equalTo(ResourceProfile.fromResources(3, 12)));
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
+                        taskManagerTracker.getRegisteredTaskManager(
+                                taskExecutorConnection.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(3, 12)));
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isPresent();
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isPresent();
 
         slotStatusSyncer.allocateSlot(
                 taskExecutorConnection.getInstanceID(), jobId, "address", resource);
+        assertThat(resourceTracker.getAcquiredResources(jobId))
+                .contains(ResourceRequirement.create(resource, 3));
         assertThat(
-                resourceTracker.getAcquiredResources(jobId),
-                contains(ResourceRequirement.create(resource, 3)));
-        assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(taskExecutorConnection.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                equalTo(ResourceProfile.fromResources(2, 8)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                taskExecutorConnection.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(2, 8)));
         final AllocationID allocationId3 =
                 taskManagerTracker.getRegisteredTaskManager(taskExecutorConnection.getInstanceID())
                         .get().getAllocatedSlots().keySet().stream()
@@ -281,23 +266,21 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
         // allocationId1 should still be allocated; allocationId2 should be freed; allocationId3
         // should continue to be in a pending state;
         slotStatusSyncer.reportSlotStatus(taskExecutorConnection.getInstanceID(), slotReport2);
+        assertThat(resourceTracker.getAcquiredResources(jobId))
+                .contains(ResourceRequirement.create(resource, 2));
         assertThat(
-                resourceTracker.getAcquiredResources(jobId),
-                contains(ResourceRequirement.create(resource, 2)));
-        assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(taskExecutorConnection.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                equalTo(ResourceProfile.fromResources(3, 12)));
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
-        assertFalse(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId3).isPresent());
-        assertThat(
-                taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).get().getState(),
-                is(SlotState.ALLOCATED));
-        assertThat(
-                taskManagerTracker.getAllocatedOrPendingSlot(allocationId3).get().getState(),
-                is(SlotState.PENDING));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                taskExecutorConnection.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(3, 12)));
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isNotPresent();
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1))
+                .hasValueSatisfying(
+                        slot -> assertThat(slot.getState()).isEqualTo(SlotState.ALLOCATED));
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId3))
+                .hasValueSatisfying(
+                        slot -> assertThat(slot.getState()).isEqualTo(SlotState.PENDING));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -18,7 +18,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -648,101 +647,6 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                     .processResourceRequirements(
                                                             resourceRequirements3));
                             assertFutureCompleteAndReturn(checkRequirementFutures.get(1));
-                        });
-            }
-        };
-    }
-
-    // ---------------------------------------------------------------------------------------------
-    // Task manager timeout
-    // ---------------------------------------------------------------------------------------------
-
-    /**
-     * Tests that formerly used task managers can timeout after all of their slots have been freed.
-     */
-    @Test
-    void testTimeoutForUnusedTaskManager() throws Exception {
-        final Time taskManagerTimeout = Time.milliseconds(50L);
-
-        final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
-        final AllocationID allocationId = new AllocationID();
-        final TaskExecutorConnection taskExecutionConnection = createTaskExecutorConnection();
-        final InstanceID instanceId = taskExecutionConnection.getInstanceID();
-        new Context() {
-            {
-                resourceAllocatorBuilder.setDeclareResourceNeededConsumer(
-                        (resourceDeclarations) -> {
-                            assertThat(resourceDeclarations.size()).isEqualTo(1);
-                            ResourceDeclaration resourceDeclaration =
-                                    resourceDeclarations.iterator().next();
-                            assertThat(resourceDeclaration.getNumNeeded()).isEqualTo(0);
-                            assertThat(resourceDeclaration.getUnwantedWorkers().size())
-                                    .isEqualTo(1);
-                            releaseResourceFuture.complete(
-                                    resourceDeclaration.getUnwantedWorkers().iterator().next());
-                        });
-                slotManagerConfigurationBuilder.setTaskManagerTimeout(taskManagerTimeout);
-                runTest(
-                        () -> {
-                            final CompletableFuture<SlotManager.RegistrationResult>
-                                    registerTaskManagerFuture = new CompletableFuture<>();
-                            runInMainThread(
-                                    () ->
-                                            registerTaskManagerFuture.complete(
-                                                    getSlotManager()
-                                                            .registerTaskManager(
-                                                                    taskExecutionConnection,
-                                                                    new SlotReport(
-                                                                            createAllocatedSlotStatus(
-                                                                                    new JobID(),
-                                                                                    allocationId,
-                                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)),
-                                                                    DEFAULT_TOTAL_RESOURCE_PROFILE,
-                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
-                                    .isEqualTo(SlotManager.RegistrationResult.SUCCESS);
-                            assertThat(getSlotManager().getTaskManagerIdleSince(instanceId))
-                                    .isEqualTo(Long.MAX_VALUE);
-
-                            final CompletableFuture<Long> idleSinceFuture =
-                                    new CompletableFuture<>();
-                            runInMainThread(
-                                    () -> {
-                                        getSlotManager()
-                                                .freeSlot(
-                                                        new SlotID(
-                                                                taskExecutionConnection
-                                                                        .getResourceID(),
-                                                                0),
-                                                        allocationId);
-                                        idleSinceFuture.complete(
-                                                getSlotManager()
-                                                        .getTaskManagerIdleSince(instanceId));
-                                    });
-
-                            assertThat(assertFutureCompleteAndReturn(idleSinceFuture))
-                                    .isNotEqualTo(Long.MAX_VALUE);
-                            assertThat(assertFutureCompleteAndReturn(releaseResourceFuture))
-                                    .isEqualTo(instanceId);
-                            // A task manager timeout does not remove the slots from the
-                            // SlotManager. The receiver of the callback can then decide what to do
-                            // with the TaskManager.
-                            assertThat(getSlotManager().getNumberRegisteredSlots())
-                                    .isEqualTo(DEFAULT_NUM_SLOTS_PER_WORKER);
-
-                            final CompletableFuture<Boolean> unregisterTaskManagerFuture =
-                                    new CompletableFuture<>();
-                            runInMainThread(
-                                    () ->
-                                            unregisterTaskManagerFuture.complete(
-                                                    getSlotManager()
-                                                            .unregisterTaskManager(
-                                                                    taskExecutionConnection
-                                                                            .getInstanceID(),
-                                                                    TEST_EXCEPTION)));
-                            assertThat(assertFutureCompleteAndReturn(unregisterTaskManagerFuture))
-                                    .isTrue();
-                            assertThat(getSlotManager().getNumberRegisteredSlots()).isEqualTo(0);
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -148,7 +148,10 @@ abstract class FineGrainedSlotManagerTestBase {
     protected class Context {
         private final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
         private final ResourceTracker resourceTracker = new DefaultResourceTracker();
-        private final TaskManagerTracker taskManagerTracker = new FineGrainedTaskManagerTracker();
+        private TaskManagerTracker taskManagerTracker;
+        private final FineGrainedTaskManagerTrackerBuilder taskManagerTrackerBuilder =
+                new FineGrainedTaskManagerTrackerBuilder(
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
         private final SlotStatusSyncer slotStatusSyncer =
                 new DefaultSlotStatusSyncer(Time.seconds(10L));
         private SlotManagerMetricGroup slotManagerMetricGroup =
@@ -211,6 +214,9 @@ abstract class FineGrainedSlotManagerTestBase {
 
         protected final void runTest(RunnableWithException testMethod) throws Exception {
             SlotManagerConfiguration configuration = slotManagerConfigurationBuilder.build();
+            taskManagerTracker =
+                    taskManagerTrackerBuilder.updateConfiguration(configuration).build();
+
             slotManager =
                     new FineGrainedSlotManager(
                             scheduledExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
+import java.time.Duration;
+
+/** Builder for {@link FineGrainedTaskManagerTracker}. */
+public class FineGrainedTaskManagerTrackerBuilder {
+    private final ScheduledExecutor scheduledExecutor;
+    private Time taskManagerTimeout = Time.seconds(5);
+    private Duration declareNeededResourceDelay = Duration.ofMillis(0);
+    private boolean waitResultConsumedBeforeRelease = true;
+    private CPUResource maxTotalCpu = new CPUResource(Double.MAX_VALUE);
+    private MemorySize maxTotalMem = MemorySize.MAX_VALUE;
+
+    public FineGrainedTaskManagerTrackerBuilder(ScheduledExecutor scheduledExecutor) {
+        this.scheduledExecutor = scheduledExecutor;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder setTaskManagerTimeout(Time taskManagerTimeout) {
+        this.taskManagerTimeout = taskManagerTimeout;
+        return this;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder setDeclareNeededResourceDelay(
+            Duration declareNeededResourceDelay) {
+        this.declareNeededResourceDelay = declareNeededResourceDelay;
+        return this;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder setWaitResultConsumedBeforeRelease(
+            boolean waitResultConsumedBeforeRelease) {
+        this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+        return this;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder setMaxTotalCpu(CPUResource maxTotalCpu) {
+        this.maxTotalCpu = maxTotalCpu;
+        return this;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder setMaxTotalMem(MemorySize maxTotalMem) {
+        this.maxTotalMem = maxTotalMem;
+        return this;
+    }
+
+    public FineGrainedTaskManagerTrackerBuilder updateConfiguration(
+            SlotManagerConfiguration slotManagerConfiguration) {
+        this.maxTotalCpu = slotManagerConfiguration.getMaxTotalCpu();
+        this.maxTotalMem = slotManagerConfiguration.getMaxTotalMem();
+        this.waitResultConsumedBeforeRelease =
+                slotManagerConfiguration.isWaitResultConsumedBeforeRelease();
+        this.taskManagerTimeout = slotManagerConfiguration.getTaskManagerTimeout();
+        this.declareNeededResourceDelay = slotManagerConfiguration.getDeclareNeededResourceDelay();
+        return this;
+    }
+
+    public FineGrainedTaskManagerTracker build() {
+        return new FineGrainedTaskManagerTracker(
+                maxTotalCpu,
+                maxTotalMem,
+                waitResultConsumedBeforeRelease,
+                taskManagerTimeout,
+                declareNeededResourceDelay,
+                scheduledExecutor);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
@@ -25,63 +25,62 @@ import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link FineGrainedTaskManagerTracker}. */
-public class FineGrainedTaskManagerTrackerTest extends TestLogger {
+class FineGrainedTaskManagerTrackerTest {
     private static final TaskExecutorConnection TASK_EXECUTOR_CONNECTION =
             new TaskExecutorConnection(
                     ResourceID.generate(),
                     new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
 
     @Test
-    public void testInitState() {
+    void testInitState() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
-        assertThat(taskManagerTracker.getPendingTaskManagers(), is(empty()));
-        assertThat(taskManagerTracker.getRegisteredTaskManagers(), is(empty()));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).isEmpty();
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).isEmpty();
     }
 
     @Test
-    public void testAddAndRemoveTaskManager() {
+    void testAddAndRemoveTaskManager() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
 
         // Add task manager
         taskManagerTracker.addTaskManager(
                 TASK_EXECUTOR_CONNECTION, ResourceProfile.ANY, ResourceProfile.ANY);
-        assertThat(taskManagerTracker.getRegisteredTaskManagers().size(), is(1));
-        assertTrue(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .isPresent());
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).hasSize(1);
+        assertThat(
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .isPresent();
 
         // Remove task manager
         taskManagerTracker.removeTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID());
-        assertThat(taskManagerTracker.getRegisteredTaskManagers().size(), is(0));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testRemoveUnknownTaskManager() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.removeTaskManager(new InstanceID());
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).isEmpty();
     }
 
     @Test
-    public void testAddAndRemovePendingTaskManager() {
+    void testRemoveUnknownTaskManager() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+                            taskManagerTracker.removeTaskManager(new InstanceID());
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testAddAndRemovePendingTaskManager() {
         final PendingTaskManager pendingTaskManager =
                 new PendingTaskManager(ResourceProfile.ANY, 1);
         final FineGrainedTaskManagerTracker taskManagerTracker =
@@ -96,45 +95,46 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 Collections.singletonMap(
                         pendingTaskManager.getPendingTaskManagerId(),
                         Collections.singletonMap(jobId, resourceCounter)));
-        assertThat(taskManagerTracker.getPendingTaskManagers().size(), is(1));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).hasSize(1);
         assertThat(
-                taskManagerTracker
-                        .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
-                                ResourceProfile.ANY, ResourceProfile.ANY)
-                        .size(),
-                is(1));
+                        taskManagerTracker
+                                .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
+                                        ResourceProfile.ANY, ResourceProfile.ANY))
+                .hasSize(1);
 
         // Remove pending task manager
         final Map<JobID, ResourceCounter> records =
                 taskManagerTracker.removePendingTaskManager(
                         pendingTaskManager.getPendingTaskManagerId());
-        assertThat(taskManagerTracker.getPendingTaskManagers(), is(empty()));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager.getPendingTaskManagerId())
-                        .size(),
-                is(0));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager.getPendingTaskManagerId()))
+                .isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
-                                ResourceProfile.ANY, ResourceProfile.ANY)
-                        .size(),
-                is(0));
-        assertTrue(records.containsKey(jobId));
-        assertThat(records.get(jobId).getResourceCount(ResourceProfile.ANY), is(1));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testRemoveUnknownPendingTaskManager() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.removePendingTaskManager(PendingTaskManagerId.generate());
+                        taskManagerTracker
+                                .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
+                                        ResourceProfile.ANY, ResourceProfile.ANY))
+                .isEmpty();
+        assertThat(records).containsKey(jobId);
+        assertThat(records.get(jobId).getResourceCount(ResourceProfile.ANY)).isEqualTo(1);
     }
 
     @Test
-    public void testSlotAllocation() {
+    void testRemoveUnknownPendingTaskManager() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+
+                            taskManagerTracker.removePendingTaskManager(
+                                    PendingTaskManagerId.generate());
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testSlotAllocation() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -149,13 +149,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.PENDING);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(7, 800)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(7, 800)));
 
         // Notify pending slot is now allocated
         taskManagerTracker.notifySlotStatus(
@@ -164,13 +165,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.ALLOCATED);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(7, 800)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(7, 800)));
 
         // Notify free slot is now allocated
         taskManagerTracker.notifySlotStatus(
@@ -179,17 +181,18 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(2, 300),
                 SlotState.ALLOCATED);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(5, 500)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(5, 500)));
     }
 
     @Test
-    public void testFreeSlot() {
+    void testFreeSlot() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -217,13 +220,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.FREE);
-        assertFalse(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isNotPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(8, 700)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(8, 700)));
         // Free allocated slot
         taskManagerTracker.notifySlotStatus(
                 allocationId2,
@@ -231,30 +235,35 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(2, 300),
                 SlotState.FREE);
-        assertFalse(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isNotPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(totalResource));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFreeUnknownSlot() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.notifySlotStatus(
-                new AllocationID(),
-                new JobID(),
-                new InstanceID(),
-                ResourceProfile.ANY,
-                SlotState.FREE);
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(totalResource));
     }
 
     @Test
-    public void testRecordPendingAllocations() {
+    void testFreeUnknownSlot() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+
+                            taskManagerTracker.notifySlotStatus(
+                                    new AllocationID(),
+                                    new JobID(),
+                                    new InstanceID(),
+                                    ResourceProfile.ANY,
+                                    SlotState.FREE);
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testRecordPendingAllocations() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final PendingTaskManager pendingTaskManager1 =
@@ -277,27 +286,24 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                         pendingTaskManager2.getPendingTaskManagerId(),
                         Collections.singletonMap(jobId, resourceCounter)));
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager1.getPendingTaskManagerId())
-                        .size(),
-                is(0));
-        assertTrue(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager2.getPendingTaskManagerId())
-                        .containsKey(jobId));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager1.getPendingTaskManagerId()))
+                .isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager2.getPendingTaskManagerId())
-                        .get(jobId)
-                        .getResourceCount(ResourceProfile.ANY),
-                is(1));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager2.getPendingTaskManagerId()))
+                .containsKey(jobId);
+        assertThat(
+                        taskManagerTracker
+                                .getPendingAllocationsOfPendingTaskManager(
+                                        pendingTaskManager2.getPendingTaskManagerId())
+                                .get(jobId)
+                                .getResourceCount(ResourceProfile.ANY))
+                .isEqualTo(1);
     }
 
     @Test
-    public void testGetStatistics() {
+    void testGetStatistics() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -322,11 +328,12 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
         taskManagerTracker.addPendingTaskManager(
                 new PendingTaskManager(ResourceProfile.fromResources(4, 200), 1));
 
-        assertThat(taskManagerTracker.getFreeResource(), is(ResourceProfile.fromResources(6, 700)));
-        assertThat(taskManagerTracker.getRegisteredResource(), is(totalResource));
-        assertThat(taskManagerTracker.getNumberRegisteredSlots(), is(10));
-        assertThat(taskManagerTracker.getNumberFreeSlots(), is(8));
-        assertThat(
-                taskManagerTracker.getPendingResource(), is(ResourceProfile.fromResources(4, 200)));
+        assertThat(taskManagerTracker.getFreeResource())
+                .isEqualTo(ResourceProfile.fromResources(6, 700));
+        assertThat(taskManagerTracker.getRegisteredResource()).isEqualTo(totalResource);
+        assertThat(taskManagerTracker.getNumberRegisteredSlots()).isEqualTo(10);
+        assertThat(taskManagerTracker.getNumberFreeSlots()).isEqualTo(8);
+        assertThat(taskManagerTracker.getPendingResource())
+                .isEqualTo(ResourceProfile.fromResources(4, 200));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Currently the FineGrainedSlotManager is response to slots allocations and resources request/release. This makes the logical of FineGrainedSlotManager complicated, So we will move task manager related work from FineGrainedSlotManager to TaskManagerTracker, which already tracks task managers but not including request/release.


## Brief change log

  - *migrate tests to Junit5*
  - *move resource allocation/ resource declaration to TaskManagerTracker*
  - *move (un-)register task manager to TaskManagerTracker*
  - *move task manager idle release check to TaskManagerTracker*


## Verifying this change
  - *Add unit tests in FineGrainedTaskManagerTrackerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
