### PR TITLE
 [FLINK-31487][table-planner] Add targetColumns to DynamicTableSink#Context

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
@@ -340,6 +340,7 @@ public class HiveParserDMLHelper {
                 catalogManager.getTableOrError(insertOperationInfo.f0),
                 insertOperationInfo.f1,
                 insertOperationInfo.f2,
+                new int[0][], // targetColumns
                 insertOperationInfo.f3,
                 Collections.emptyMap());
     }
@@ -392,6 +393,7 @@ public class HiveParserDMLHelper {
                         plannerQueryOperation.getResolvedSchema(), props),
                 plannerQueryOperation,
                 Collections.emptyMap(),
+                new int[0][], // targetColumns
                 true, // insert into directory is always for overwrite
                 Collections.emptyMap());
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
@@ -340,7 +340,7 @@ public class HiveParserDMLHelper {
                 catalogManager.getTableOrError(insertOperationInfo.f0),
                 insertOperationInfo.f1,
                 insertOperationInfo.f2,
-                new int[0][], // targetColumns
+                null, // targetColumns
                 insertOperationInfo.f3,
                 Collections.emptyMap());
     }
@@ -393,7 +393,7 @@ public class HiveParserDMLHelper {
                         plannerQueryOperation.getResolvedSchema(), props),
                 plannerQueryOperation,
                 Collections.emptyMap(),
-                new int[0][], // targetColumns
+                null, // targetColumns
                 true, // insert into directory is always for overwrite
                 Collections.emptyMap());
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -467,6 +467,7 @@ public class TableImpl implements Table {
                         contextResolvedTable,
                         getQueryOperation(),
                         Collections.emptyMap(),
+                        new int[0][],
                         overwrite,
                         Collections.emptyMap()));
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -467,7 +467,7 @@ public class TableImpl implements Table {
                         contextResolvedTable,
                         getQueryOperation(),
                         Collections.emptyMap(),
-                        new int[0][],
+                        null, // targetColumns
                         overwrite,
                         Collections.emptyMap()));
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
@@ -56,6 +56,7 @@ public class CreateTableASOperation implements ModifyOperation {
                 catalogManager.getTableOrError(createTableOperation.getTableIdentifier()),
                 sinkModifyQuery,
                 sinkModifyStaticPartitions,
+                new int[0][],
                 sinkModifyOverwrite,
                 Collections.emptyMap());
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
@@ -56,7 +56,7 @@ public class CreateTableASOperation implements ModifyOperation {
                 catalogManager.getTableOrError(createTableOperation.getTableIdentifier()),
                 sinkModifyQuery,
                 sinkModifyStaticPartitions,
-                new int[0][],
+                null, // targetColumns
                 sinkModifyOverwrite,
                 Collections.emptyMap());
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
@@ -42,7 +42,7 @@ public class DeleteFromFilterOperation extends SinkModifyOperation {
             ContextResolvedTable contextResolvedTable,
             @Nonnull SupportsDeletePushDown supportsDeletePushDownSink,
             @Nonnull List<ResolvedExpression> filters) {
-        super(contextResolvedTable, null, ModifyType.DELETE);
+        super(contextResolvedTable, null, new int[0][], ModifyType.DELETE);
         this.supportsDeletePushDownSink = Preconditions.checkNotNull(supportsDeletePushDownSink);
         this.filters = Preconditions.checkNotNull(filters);
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
@@ -42,7 +42,7 @@ public class DeleteFromFilterOperation extends SinkModifyOperation {
             ContextResolvedTable contextResolvedTable,
             @Nonnull SupportsDeletePushDown supportsDeletePushDownSink,
             @Nonnull List<ResolvedExpression> filters) {
-        super(contextResolvedTable, null, new int[0][], ModifyType.DELETE);
+        super(contextResolvedTable, null, null, ModifyType.DELETE);
         this.supportsDeletePushDownSink = Preconditions.checkNotNull(supportsDeletePushDownSink);
         this.filters = Preconditions.checkNotNull(filters);
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
@@ -52,7 +52,7 @@ public class SinkModifyOperation implements ModifyOperation {
                 contextResolvedTable,
                 child,
                 Collections.emptyMap(),
-                new int[0][],
+                null,
                 false,
                 Collections.emptyMap());
     }
@@ -165,9 +165,6 @@ public class SinkModifyOperation implements ModifyOperation {
     /** The type of sink modification. */
     public enum ModifyType {
         INSERT,
-
-        // TODO should we introduce this? not necessary?
-        //        UPSERT,
 
         UPDATE,
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
@@ -45,18 +45,28 @@ public class SinkModifyOperation implements ModifyOperation {
     private final Map<String, String> dynamicOptions;
     private final ModifyType modifyType;
 
+    private final int[][] targetColumns;
+
     public SinkModifyOperation(ContextResolvedTable contextResolvedTable, QueryOperation child) {
-        this(contextResolvedTable, child, Collections.emptyMap(), false, Collections.emptyMap());
+        this(
+                contextResolvedTable,
+                child,
+                Collections.emptyMap(),
+                new int[0][],
+                false,
+                Collections.emptyMap());
     }
 
     public SinkModifyOperation(
             ContextResolvedTable contextResolvedTable,
             QueryOperation child,
+            int[][] targetColumns,
             ModifyType modifyType) {
         this(
                 contextResolvedTable,
                 child,
                 Collections.emptyMap(),
+                targetColumns,
                 false,
                 Collections.emptyMap(),
                 modifyType);
@@ -66,12 +76,14 @@ public class SinkModifyOperation implements ModifyOperation {
             ContextResolvedTable contextResolvedTable,
             QueryOperation child,
             Map<String, String> staticPartitions,
+            int[][] targetColumns,
             boolean overwrite,
             Map<String, String> dynamicOptions) {
         this(
                 contextResolvedTable,
                 child,
                 staticPartitions,
+                targetColumns,
                 overwrite,
                 dynamicOptions,
                 ModifyType.INSERT);
@@ -81,12 +93,14 @@ public class SinkModifyOperation implements ModifyOperation {
             ContextResolvedTable contextResolvedTable,
             QueryOperation child,
             Map<String, String> staticPartitions,
+            int[][] targetColumns,
             boolean overwrite,
             Map<String, String> dynamicOptions,
             ModifyType modifyType) {
         this.contextResolvedTable = contextResolvedTable;
         this.child = child;
         this.staticPartitions = staticPartitions;
+        this.targetColumns = targetColumns;
         this.overwrite = overwrite;
         this.dynamicOptions = dynamicOptions;
         this.modifyType = modifyType;
@@ -121,6 +135,11 @@ public class SinkModifyOperation implements ModifyOperation {
         return child;
     }
 
+    /** return an empty array when no column list specified. */
+    public int[][] getTargetColumns() {
+        return targetColumns;
+    }
+
     @Override
     public <T> T accept(ModifyOperationVisitor<T> visitor) {
         return visitor.visit(this);
@@ -132,6 +151,7 @@ public class SinkModifyOperation implements ModifyOperation {
         params.put("identifier", getContextResolvedTable().getIdentifier().asSummaryString());
         params.put("modifyType", modifyType);
         params.put("staticPartitions", staticPartitions);
+        params.put("targetColumns", targetColumns);
         params.put("overwrite", overwrite);
         params.put("dynamicOptions", dynamicOptions);
 
@@ -145,6 +165,9 @@ public class SinkModifyOperation implements ModifyOperation {
     /** The type of sink modification. */
     public enum ModifyType {
         INSERT,
+
+        // TODO should we introduce this? not necessary?
+        //        UPSERT,
 
         UPDATE,
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -44,8 +46,7 @@ public class SinkModifyOperation implements ModifyOperation {
     private final boolean overwrite;
     private final Map<String, String> dynamicOptions;
     private final ModifyType modifyType;
-
-    private final int[][] targetColumns;
+    @Nullable private final int[][] targetColumns;
 
     public SinkModifyOperation(ContextResolvedTable contextResolvedTable, QueryOperation child) {
         this(
@@ -93,7 +94,7 @@ public class SinkModifyOperation implements ModifyOperation {
             ContextResolvedTable contextResolvedTable,
             QueryOperation child,
             Map<String, String> staticPartitions,
-            int[][] targetColumns,
+            @Nullable int[][] targetColumns,
             boolean overwrite,
             Map<String, String> dynamicOptions,
             ModifyType modifyType) {
@@ -135,7 +136,8 @@ public class SinkModifyOperation implements ModifyOperation {
         return child;
     }
 
-    /** return an empty array when no column list specified. */
+    /** return null when no column list specified. */
+    @Nullable
     public int[][] getTargetColumns() {
         return targetColumns;
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -35,6 +35,7 @@ import org.apache.flink.types.RowKind;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * Sink of a dynamic table to an external storage system.
@@ -167,6 +168,26 @@ public interface DynamicTableSink {
          * @see LogicalType#supportsOutputConversion(Class)
          */
         DataStructureConverter createDataStructureConverter(DataType consumedDataType);
+
+        /**
+         * Returns an {@link Optional} array of column index paths related to user specified target
+         * column list or {@link Optional#empty()} when not specified. The array indices are 0-based
+         * and support composite columns within (possibly nested) structures.
+         *
+         * <p>This information comes from the column list of the DML clause, e.g., for a sink table
+         * t1 which schema is: {@code a STRING, b ROW < b1 INT, b2 STRING>, c BIGINT}
+         *
+         * <ul>
+         *   <li>insert: 'insert into t1(a, b.b2) ...', the column list will be 'a, b.b2', and will
+         *       return {@code [[0], [1, 1]]}. The statement 'insert into target select ...' without
+         *       specifying a column list will return {@link Optional#empty()}.
+         *   <li>update: 'update target set a=1, b.b1=2 where ...', the column list will be 'a,
+         *       b.b1', will return {@code [[0], [1, 0]]}.
+         * </ul>
+         *
+         * <p>Note: will always return empty for the delete statement because it has no column list.
+         */
+        Optional<int[][]> getTargetColumns();
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -179,10 +179,10 @@ public interface DynamicTableSink {
          *
          * <ul>
          *   <li>insert: 'insert into t1(a, b.b2) ...', the column list will be 'a, b.b2', and will
-         *       return {@code [[0], [1, 1]]}. The statement 'insert into target select ...' without
+         *       return {@code [[0], [1, 1]]}. The statement 'insert into t1 select ...' without
          *       specifying a column list will return {@link Optional#empty()}.
-         *   <li>update: 'update target set a=1, b.b1=2 where ...', the column list will be 'a,
-         *       b.b1', will return {@code [[0], [1, 0]]}.
+         *   <li>update: 'update t1 set a=1, b.b1=2 where ...', the column list will be 'a, b.b1',
+         *       and will return {@code [[0], [1, 0]]}.
          * </ul>
          *
          * <p>Note: will always return empty for the delete statement because it has no column list.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -157,6 +157,7 @@ public final class DynamicSinkUtils {
                 Collections.emptyMap(), // dynamicOptions
                 contextResolvedTable,
                 Collections.emptyMap(), // staticPartitions
+                new int[0][],
                 false,
                 tableSink);
     }
@@ -179,6 +180,7 @@ public final class DynamicSinkUtils {
                 Collections.emptyMap(),
                 externalModifyOperation.getContextResolvedTable(),
                 Collections.emptyMap(),
+                new int[0][],
                 false,
                 tableSink);
     }
@@ -198,6 +200,7 @@ public final class DynamicSinkUtils {
                 sinkModifyOperation.getDynamicOptions(),
                 sinkModifyOperation.getContextResolvedTable(),
                 sinkModifyOperation.getStaticPartitions(),
+                sinkModifyOperation.getTargetColumns(),
                 sinkModifyOperation.isOverwrite(),
                 sink);
     }
@@ -208,6 +211,7 @@ public final class DynamicSinkUtils {
             Map<String, String> dynamicOptions,
             ContextResolvedTable contextResolvedTable,
             Map<String, String> staticPartitions,
+            int[][] targetColumns,
             boolean isOverwrite,
             DynamicTableSink sink) {
         final DataTypeFactory dataTypeFactory =
@@ -289,6 +293,7 @@ public final class DynamicSinkUtils {
                 contextResolvedTable,
                 sink,
                 staticPartitions,
+                targetColumns,
                 sinkAbilitySpecs.toArray(new SinkAbilitySpec[0]));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -157,7 +157,7 @@ public final class DynamicSinkUtils {
                 Collections.emptyMap(), // dynamicOptions
                 contextResolvedTable,
                 Collections.emptyMap(), // staticPartitions
-                new int[0][],
+                null, // targetColumns
                 false,
                 tableSink);
     }
@@ -180,7 +180,7 @@ public final class DynamicSinkUtils {
                 Collections.emptyMap(),
                 externalModifyOperation.getContextResolvedTable(),
                 Collections.emptyMap(),
-                new int[0][],
+                null, // targetColumns
                 false,
                 tableSink);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -707,7 +707,7 @@ public class SqlNodeToOperationConversion {
                     contextResolvedTable,
                     child,
                     partitionSpec.getPartitionSpec(),
-                    new int[0][],
+                    null, // targetColumns
                     false,
                     compactOptions);
         }
@@ -1563,7 +1563,7 @@ public class SqlNodeToOperationConversion {
         return new SinkModifyOperation(
                 contextResolvedTable,
                 queryOperation,
-                new int[0][],
+                null, // targetColumns
                 SinkModifyOperation.ModifyType.DELETE);
     }
 
@@ -1589,7 +1589,7 @@ public class SqlNodeToOperationConversion {
         return new SinkModifyOperation(
                 contextResolvedTable,
                 queryOperation,
-                new int[0][],
+                null, // targetColumns
                 SinkModifyOperation.ModifyType.UPDATE);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -155,7 +155,9 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             int[] inputUpsertKey) {
         final ResolvedSchema schema = tableSinkSpec.getContextResolvedTable().getResolvedSchema();
         final SinkRuntimeProvider runtimeProvider =
-                tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(isBounded));
+                tableSink.getSinkRuntimeProvider(
+                        new SinkRuntimeProviderContext(
+                                isBounded, tableSinkSpec.getTargetColumns()));
         final RowType physicalRowType = getPhysicalRowType(schema);
         final int[] primaryKeys = getPrimaryKeyIndices(physicalRowType, schema);
         final int sinkParallelism = deriveSinkParallelism(inputTransform, runtimeProvider);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -47,18 +47,23 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
     public static final String FIELD_NAME_CATALOG_TABLE = "table";
     public static final String FIELD_NAME_SINK_ABILITIES = "abilities";
 
+    public static final String FIELD_NAME_TARGET_COLUMNS = "targetColumns";
+
     private final ContextResolvedTable contextResolvedTable;
     private final @Nullable List<SinkAbilitySpec> sinkAbilities;
+
+    private final @Nullable int[][] targetColumns;
 
     private DynamicTableSink tableSink;
 
     @JsonCreator
     public DynamicTableSinkSpec(
             @JsonProperty(FIELD_NAME_CATALOG_TABLE) ContextResolvedTable contextResolvedTable,
-            @Nullable @JsonProperty(FIELD_NAME_SINK_ABILITIES)
-                    List<SinkAbilitySpec> sinkAbilities) {
+            @Nullable @JsonProperty(FIELD_NAME_SINK_ABILITIES) List<SinkAbilitySpec> sinkAbilities,
+            @Nullable @JsonProperty(FIELD_NAME_TARGET_COLUMNS) int[][] targetColumns) {
         this.contextResolvedTable = contextResolvedTable;
         this.sinkAbilities = sinkAbilities;
+        this.targetColumns = targetColumns;
     }
 
     @JsonGetter(FIELD_NAME_CATALOG_TABLE)
@@ -94,6 +99,13 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
         return tableSink;
     }
 
+    @JsonGetter(FIELD_NAME_TARGET_COLUMNS)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Nullable
+    public int[][] getTargetColumns() {
+        return targetColumns;
+    }
+
     public void setTableSink(DynamicTableSink tableSink) {
         this.tableSink = tableSink;
     }
@@ -109,12 +121,13 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
         DynamicTableSinkSpec that = (DynamicTableSinkSpec) o;
         return Objects.equals(contextResolvedTable, that.contextResolvedTable)
                 && Objects.equals(sinkAbilities, that.sinkAbilities)
-                && Objects.equals(tableSink, that.tableSink);
+                && Objects.equals(tableSink, that.tableSink)
+                && Objects.equals(targetColumns, that.targetColumns);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contextResolvedTable, sinkAbilities, tableSink);
+        return Objects.hash(contextResolvedTable, sinkAbilities, targetColumns, tableSink);
     }
 
     @Override
@@ -124,6 +137,8 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
                 + contextResolvedTable
                 + ", sinkAbilities="
                 + sinkAbilities
+                + ", targetColumns="
+                + targetColumns
                 + ", tableSink="
                 + tableSink
                 + '}';

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -408,7 +408,8 @@ object PreValidateReWriter {
     assert(id != null)
     if (!id.isSimple) {
       val pos = id.getParserPosition
-      // TODO add accurate msg s"column name must be a simple identifier, composite column name '${id.toString}' is not supported yet"
+      // TODO no suitable error message from current CalciteResource, just use this one temporarily,
+      // we will remove this after composite column name is supported.
       throw SqlUtil.newContextException(pos, RESOURCE.unknownTargetColumn(id.toString))
     }
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -139,6 +139,7 @@ object PreValidateReWriter {
     for (node <- partitions.getList) {
       val sqlProperty = node.asInstanceOf[SqlProperty]
       val id = sqlProperty.getKey
+      validateUnsupportedCompositeColumn(id)
       val targetField = SqlValidatorUtil.getTargetField(
         targetRowType,
         typeFactory,
@@ -163,10 +164,12 @@ object PreValidateReWriter {
         sqlInsert.getTargetColumnList.getList
           .map(
             id => {
+              val identifier = id.asInstanceOf[SqlIdentifier]
+              validateUnsupportedCompositeColumn(identifier)
               val targetField = SqlValidatorUtil.getTargetField(
                 targetRowType,
                 typeFactory,
-                id.asInstanceOf[SqlIdentifier],
+                identifier,
                 calciteCatalogReader,
                 relOptTable)
               validateField(targetFields.add, id.asInstanceOf[SqlIdentifier], targetField)
@@ -399,6 +402,15 @@ object PreValidateReWriter {
     assert(node != null)
     val pos = node.getParserPosition
     SqlUtil.newContextException(pos, e)
+  }
+
+  private def validateUnsupportedCompositeColumn(id: SqlIdentifier): Unit = {
+    assert(id != null)
+    if (!id.isSimple) {
+      val pos = id.getParserPosition
+      // TODO add accurate msg s"column name must be a simple identifier, composite column name '${id.toString}' is not supported yet"
+      throw SqlUtil.newContextException(pos, RESOURCE.unknownTargetColumn(id.toString))
+    }
   }
 
   // This code snippet is copied from the SqlValidatorImpl.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.planner.plan.nodes.calcite
 
-import org.apache.flink.table.catalog.{CatalogTable, ContextResolvedTable, ObjectIdentifier, ResolvedCatalogTable}
+import org.apache.flink.table.catalog.ContextResolvedTable
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
 
@@ -40,9 +40,10 @@ final class LogicalSink(
     hints: util.List[RelHint],
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
+    targetColumns: Array[Array[Int]],
     val staticPartitions: Map[String, String],
     val abilitySpecs: Array[SinkAbilitySpec])
-  extends Sink(cluster, traitSet, input, hints, contextResolvedTable, tableSink) {
+  extends Sink(cluster, traitSet, input, hints, targetColumns, contextResolvedTable, tableSink) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new LogicalSink(
@@ -52,6 +53,7 @@ final class LogicalSink(
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       staticPartitions,
       abilitySpecs)
   }
@@ -65,6 +67,7 @@ object LogicalSink {
       contextResolvedTable: ContextResolvedTable,
       tableSink: DynamicTableSink,
       staticPartitions: util.Map[String, String],
+      targetColumns: Array[Array[Int]],
       abilitySpecs: Array[SinkAbilitySpec]): LogicalSink = {
     val traits = input.getCluster.traitSetOf(Convention.NONE)
     new LogicalSink(
@@ -74,6 +77,7 @@ object LogicalSink {
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       staticPartitions.toMap,
       abilitySpecs)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
@@ -73,7 +73,7 @@ abstract class Sink(
           .getOrElse(Array.empty[Array[Int]])
           .map(_.mkString("[", ",", "]"))
           .mkString(","),
-        targetColumns != null
+        targetColumns != null && targetColumns.length > 0
       )
       .item("fields", getRowType.getFieldNames.mkString(", "))
       .itemIf("hints", RelExplainUtil.hintsToString(hints), !hints.isEmpty)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
@@ -53,6 +53,7 @@ abstract class Sink(
     traitSet: RelTraitSet,
     input: RelNode,
     val hints: util.List[RelHint],
+    val targetColumns: Array[Array[Int]],
     val contextResolvedTable: ContextResolvedTable,
     val tableSink: DynamicTableSink)
   extends SingleRel(cluster, traitSet, input) {
@@ -65,6 +66,10 @@ abstract class Sink(
     super
       .explainTerms(pw)
       .item("table", contextResolvedTable.getIdentifier.asSummaryString())
+      .itemIf(
+        "targetColumns",
+        targetColumns.map(_.mkString("[", ",", "]")).mkString(","),
+        targetColumns.length > 0)
       .item("fields", getRowType.getFieldNames.mkString(", "))
       .itemIf("hints", RelExplainUtil.hintsToString(hints), !hints.isEmpty)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
@@ -37,14 +37,14 @@ import scala.collection.JavaConversions._
  *   cluster that this relational expression belongs to
  * @param traitSet
  *   the traits of this rel
- * @param hints
- *   the hints
  * @param input
  *   input relational expression
+ * @param hints
+ *   the hints
+ * @param targetColumns
+ *   the specified target columns.
  * @param contextResolvedTable
  *   the table definition.
- * @param catalogTable
- *   Resolved catalog table where this table source table comes from
  * @param tableSink
  *   the [[DynamicTableSink]] for which to write into
  */
@@ -68,8 +68,13 @@ abstract class Sink(
       .item("table", contextResolvedTable.getIdentifier.asSummaryString())
       .itemIf(
         "targetColumns",
-        targetColumns.map(_.mkString("[", ",", "]")).mkString(","),
-        targetColumns.length > 0)
+        Option
+          .apply(targetColumns)
+          .getOrElse(Array.empty[Array[Int]])
+          .map(_.mkString("[", ",", "]"))
+          .mkString(","),
+        targetColumns != null
+      )
       .item("fields", getRowType.getFieldNames.mkString(", "))
       .itemIf("hints", RelExplainUtil.hintsToString(hints), !hints.isEmpty)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
@@ -44,9 +44,10 @@ class FlinkLogicalSink(
     hints: util.List[RelHint],
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
+    targetColumns: Array[Array[Int]],
     val staticPartitions: Map[String, String],
     val abilitySpecs: Array[SinkAbilitySpec])
-  extends Sink(cluster, traitSet, input, hints, contextResolvedTable, tableSink)
+  extends Sink(cluster, traitSet, input, hints, targetColumns, contextResolvedTable, tableSink)
   with FlinkLogicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
@@ -57,6 +58,7 @@ class FlinkLogicalSink(
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       staticPartitions,
       abilitySpecs)
   }
@@ -74,6 +76,7 @@ private class FlinkLogicalSinkConverter(config: Config) extends ConverterRule(co
       sink.contextResolvedTable,
       sink.tableSink,
       sink.staticPartitions,
+      sink.targetColumns,
       sink.abilitySpecs)
   }
 }
@@ -92,6 +95,7 @@ object FlinkLogicalSink {
       contextResolvedTable: ContextResolvedTable,
       tableSink: DynamicTableSink,
       staticPartitions: Map[String, String] = Map(),
+      targetColumns: Array[Array[Int]],
       abilitySpecs: Array[SinkAbilitySpec] = Array.empty): FlinkLogicalSink = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
@@ -102,6 +106,7 @@ object FlinkLogicalSink {
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       staticPartitions,
       abilitySpecs)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
@@ -43,8 +43,9 @@ class BatchPhysicalSink(
     hints: util.List[RelHint],
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
+    targetColumns: Array[Array[Int]],
     abilitySpecs: Array[SinkAbilitySpec])
-  extends Sink(cluster, traitSet, inputRel, hints, contextResolvedTable, tableSink)
+  extends Sink(cluster, traitSet, inputRel, hints, targetColumns, contextResolvedTable, tableSink)
   with BatchPhysicalRel {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
@@ -55,12 +56,16 @@ class BatchPhysicalSink(
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       abilitySpecs)
   }
 
   override def translateToExecNode(): ExecNode[_] = {
     val tableSinkSpec =
-      new DynamicTableSinkSpec(contextResolvedTable, util.Arrays.asList(abilitySpecs: _*))
+      new DynamicTableSinkSpec(
+        contextResolvedTable,
+        util.Arrays.asList(abilitySpecs: _*),
+        targetColumns)
     tableSinkSpec.setTableSink(tableSink)
 
     new BatchExecSink(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -45,9 +45,10 @@ class StreamPhysicalSink(
     hints: util.List[RelHint],
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
+    targetColumns: Array[Array[Int]],
     abilitySpecs: Array[SinkAbilitySpec],
     val upsertMaterialize: Boolean = false)
-  extends Sink(cluster, traitSet, inputRel, hints, contextResolvedTable, tableSink)
+  extends Sink(cluster, traitSet, inputRel, hints, targetColumns, contextResolvedTable, tableSink)
   with StreamPhysicalRel {
 
   override def requireWatermark: Boolean = false
@@ -60,6 +61,7 @@ class StreamPhysicalSink(
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       abilitySpecs,
       upsertMaterialize)
   }
@@ -72,6 +74,7 @@ class StreamPhysicalSink(
       hints,
       contextResolvedTable,
       tableSink,
+      targetColumns,
       abilitySpecs,
       newUpsertMaterialize)
   }
@@ -80,7 +83,10 @@ class StreamPhysicalSink(
     val inputChangelogMode =
       ChangelogPlanUtils.getChangelogMode(getInput.asInstanceOf[StreamPhysicalRel]).get
     val tableSinkSpec =
-      new DynamicTableSinkSpec(contextResolvedTable, util.Arrays.asList(abilitySpecs: _*))
+      new DynamicTableSinkSpec(
+        contextResolvedTable,
+        util.Arrays.asList(abilitySpecs: _*),
+        targetColumns)
     tableSinkSpec.setTableSink(tableSink)
     // no need to call getUpsertKeysInKeyGroupRange here because there's no exchange before sink,
     // and only add exchange in exec sink node.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSinkRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSinkRule.scala
@@ -109,6 +109,7 @@ class BatchPhysicalSinkRule(config: Config) extends ConverterRule(config) {
       sink.hints,
       sink.contextResolvedTable,
       sink.tableSink,
+      sink.targetColumns,
       abilitySpecs.toArray)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalSinkRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalSinkRule.scala
@@ -99,6 +99,7 @@ class StreamPhysicalSinkRule(config: Config) extends ConverterRule(config) {
       sink.hints,
       sink.contextResolvedTable,
       sink.tableSink,
+      sink.targetColumns,
       abilitySpecs.toArray
     )
   }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1959,15 +1959,6 @@ public final class TestValuesTableFactory
             }
         }
 
-        private static int[] getIndexArray(List<String> targetColumns, String[] allColumns) {
-            Map<String, Integer> stringToIndexMap = new HashMap<>();
-            for (int i = 0; i < allColumns.length; i++) {
-                stringToIndexMap.put(allColumns[i], i);
-            }
-
-            return targetColumns.stream().mapToInt(str -> stringToIndexMap.get(str)).toArray();
-        }
-
         @Override
         public DynamicTableSink copy() {
             return new TestValuesTableSink(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -598,6 +598,8 @@ public final class TestValuesTableFactory
 
         final int[] primaryKeyIndices =
                 TableSchemaUtils.getPrimaryKeyIndices(context.getCatalogTable().getSchema());
+        TableSchema tableSchema =
+                TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
 
         if (sinkClass.equals("DEFAULT")) {
             int rowTimeIndex =
@@ -613,7 +615,8 @@ public final class TestValuesTableFactory
                     writableMetadata,
                     parallelism,
                     changelogMode,
-                    rowTimeIndex);
+                    rowTimeIndex,
+                    tableSchema);
         } else {
             try {
                 return InstantiationUtil.instantiate(
@@ -1813,6 +1816,7 @@ public final class TestValuesTableFactory
         private final Integer parallelism;
         private final ChangelogMode changelogModeEnforced;
         private final int rowtimeIndex;
+        private final TableSchema tableSchema;
 
         private TestValuesTableSink(
                 DataType consumedDataType,
@@ -1824,7 +1828,8 @@ public final class TestValuesTableFactory
                 Map<String, DataType> writableMetadata,
                 @Nullable Integer parallelism,
                 @Nullable ChangelogMode changelogModeEnforced,
-                int rowtimeIndex) {
+                int rowtimeIndex,
+                TableSchema tableSchema) {
             this.consumedDataType = consumedDataType;
             this.primaryKeyIndices = primaryKeyIndices;
             this.tableName = tableName;
@@ -1835,6 +1840,7 @@ public final class TestValuesTableFactory
             this.parallelism = parallelism;
             this.changelogModeEnforced = changelogModeEnforced;
             this.rowtimeIndex = rowtimeIndex;
+            this.tableSchema = tableSchema;
         }
 
         @Override
@@ -1927,9 +1933,20 @@ public final class TestValuesTableFactory
                 assertThat(runtimeSink.equals("SinkFunction")).isTrue();
                 SinkFunction<RowData> sinkFunction;
                 if (primaryKeyIndices.length > 0) {
+                    // TODO FLINK-31301 currently partial-insert composite columns are not supported
+                    int[][] targetColumns = context.getTargetColumns().orElse(new int[0][]);
+                    checkArgument(
+                            Arrays.stream(targetColumns).allMatch(subArr -> subArr.length <= 1),
+                            "partial-insert composite columns are not supported yet!");
+
                     sinkFunction =
                             new KeyedUpsertingSinkFunction(
-                                    tableName, converter, primaryKeyIndices, expectedNum);
+                                    tableName,
+                                    converter,
+                                    primaryKeyIndices,
+                                    Arrays.stream(targetColumns).mapToInt(a -> a[0]).toArray(),
+                                    expectedNum,
+                                    tableSchema.getFieldCount());
                 } else {
                     checkArgument(
                             expectedNum == -1,
@@ -1940,6 +1957,15 @@ public final class TestValuesTableFactory
                 }
                 return SinkFunctionProvider.of(sinkFunction, this.parallelism);
             }
+        }
+
+        private static int[] getIndexArray(List<String> targetColumns, String[] allColumns) {
+            Map<String, Integer> stringToIndexMap = new HashMap<>();
+            for (int i = 0; i < allColumns.length; i++) {
+                stringToIndexMap.put(allColumns[i], i);
+            }
+
+            return targetColumns.stream().mapToInt(str -> stringToIndexMap.get(str)).toArray();
         }
 
         @Override
@@ -1954,7 +1980,8 @@ public final class TestValuesTableFactory
                     writableMetadata,
                     parallelism,
                     changelogModeEnforced,
-                    rowtimeIndex);
+                    rowtimeIndex,
+                    tableSchema);
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -102,6 +102,7 @@ class DynamicTableSinkSpecSerdeTest {
                                         CatalogManagerMocks.DEFAULT_DATABASE,
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable1, resolvedSchema1)),
+                        null,
                         null);
 
         Map<String, String> options2 = new HashMap<>();
@@ -139,7 +140,8 @@ class DynamicTableSinkSpecSerdeTest {
                                             {
                                                 put("p", "A");
                                             }
-                                        })));
+                                        })),
+                        new int[][] {{0}, {1}});
 
         Map<String, String> options3 = new HashMap<>();
         options3.put("connector", TestValuesTableFactory.IDENTIFIER);
@@ -171,7 +173,8 @@ class DynamicTableSinkSpecSerdeTest {
                         Collections.singletonList(
                                 new WritingMetadataSpec(
                                         Collections.singletonList("m"),
-                                        RowType.of(new BigIntType(), new IntType()))));
+                                        RowType.of(new BigIntType(), new IntType()))),
+                        null);
 
         return Stream.of(spec1, spec2, spec3);
     }
@@ -197,7 +200,8 @@ class DynamicTableSinkSpecSerdeTest {
                                 spec.getContextResolvedTable().getIdentifier(),
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 spec.getContextResolvedTable().getResolvedTable()),
-                        spec.getSinkAbilities());
+                        spec.getSinkAbilities(),
+                        null);
 
         String actualJson = toJson(serdeCtx, spec);
         DynamicTableSinkSpec actual = toObject(serdeCtx, actualJson, DynamicTableSinkSpec.class);
@@ -258,7 +262,8 @@ class DynamicTableSinkSpecSerdeTest {
                                 identifier,
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 planResolvedCatalogTable),
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        new int[0][]);
 
         String actualJson = toJson(serdeCtx, planSpec);
         DynamicTableSinkSpec actual = toObject(serdeCtx, actualJson, DynamicTableSinkSpec.class);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -263,7 +263,7 @@ class DynamicTableSinkSpecSerdeTest {
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 planResolvedCatalogTable),
                         Collections.emptyList(),
-                        new int[0][]);
+                        null);
 
         String actualJson = toJson(serdeCtx, planSpec);
         DynamicTableSinkSpec actual = toObject(serdeCtx, actualJson, DynamicTableSinkSpec.class);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
@@ -127,4 +127,23 @@ public class TableSinkJsonPlanTest extends TableTestBase {
         util.verifyJsonPlan(
                 "insert into sink select user_id, ndFunc(user_name), email, balance from users");
     }
+
+    @Test
+    public void testPartialInsert() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b int,\n"
+                        + "  c varchar,\n"
+                        + "  d int,\n"
+                        + "  e double,\n"
+                        + "  f varchar\n"
+                        + ") partitioned by (c) with (\n"
+                        + "  'connector' = 'filesystem',\n"
+                        + "  'format' = 'testcsv',\n"
+                        + "  'path' = '/tmp')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan(
+                "insert into MySink partition (c='A') (f,a,b) select c, a, b from MyTable");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/connector/file/table/FileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/connector/file/table/FileSystemTableSourceTest.xml
@@ -42,14 +42,14 @@ Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
+LogicalSink(table=[default_catalog.default_database.MySink], targetColumns=[[0],[1],[2]], fields=[a, b, filemeta])
 +- LogicalProject(a=[$0], b=[$1], filemeta=[CAST($3):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTableWithMeta]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.MySink], fields=[a, b, filemeta])
+Sink(table=[default_catalog.default_database.MySink], targetColumns=[[0],[1],[2]], fields=[a, b, filemeta])
 +- Calc(select=[a, b, CAST(filemeta AS VARCHAR(2147483647)) AS filemeta])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTableWithMeta, project=[a, b], metadata=[file.path]]], fields=[a, b, filemeta])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -19,17 +19,17 @@ limitations under the License.
   <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- LogicalProject(a=[IF(>($2, 123), 123, $0)], b=[IF(>($2, 123), _UTF-16LE'v2', $1)], c=[IF(>($2, 123), +($2, 1), $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -70,18 +70,18 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
   <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($2, 1)])
    +- LogicalFilter(condition=[>($2, 123)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -133,17 +133,17 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
   <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- LogicalProject(a=[IF(>($4, 123), 123, $2)], b=[IF(>($4, 123), _UTF-16LE'v2', $3)], c=[IF(>($4, 123), +($4, 1), $4)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
@@ -184,18 +184,18 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
   <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($4, 1)])
    +- LogicalFilter(condition=[>($4, 123)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
 +- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
@@ -247,17 +247,17 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
   <TestCase name="testUpdateWithCustomColumns[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- LogicalProject(b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- Calc(select=[IF(=(b, '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- Calc(select=[IF((b = '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -298,18 +298,18 @@ Sink(table=[default_catalog.default_database.t], fields=[b, c])
   <TestCase name="testUpdateWithCustomColumns[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- LogicalProject(b=[_UTF-16LE'v2'], c=[$2])
    +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- Calc(select=['v2' AS b, c], where=[=(b, '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
 +- Calc(select=['v2' AS b, c], where=[(b = '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
@@ -361,17 +361,17 @@ Sink(table=[default_catalog.default_database.t], fields=[b, c])
   <TestCase name="testUpdateWithFilter[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[IF(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, IF(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -412,17 +412,17 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
   <TestCase name="testUpdateWithoutFilter[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- LogicalProject(a=[*(CHAR_LENGTH($1), $0)], b=[_UTF-16LE'n1'])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- Calc(select=[*(CHAR_LENGTH(b), a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- Calc(select=[(CHAR_LENGTH(b) * a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -474,18 +474,18 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
   <TestCase name="testUpdateWithFilter[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[AND(=($0, 123), =($1, _UTF-16LE'v1'))])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[CAST(123 AS INTEGER) AS a, 'v2' AS b], where=[AND(=(a, 123), =(b, 'v1'))])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[CAST(123 AS INTEGER) AS a, 'v2' AS b], where=[((a = 123) AND (b = 'v1'))])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -537,17 +537,17 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
   <TestCase name="testUpdateWithMetaColumns[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, IF(=(b, '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
@@ -588,18 +588,18 @@ Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b]
   <TestCase name="testUpdateWithMetaColumns[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[=(b, '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
 +- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
@@ -651,7 +651,7 @@ Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b]
   <TestCase name="testUpdateWithSubQuery[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[_UTF-16LE'v2'])
    +- LogicalFilter(condition=[=(CAST($0):BIGINT, $SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
@@ -661,7 +661,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
       +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, 'v2' AS b])
    +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a0, EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
       :- Calc(select=[a, CAST(a AS BIGINT) AS a0])
@@ -674,7 +674,7 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
                      +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, 'v2' AS b])
    +- NestedLoopJoin(joinType=[InnerJoin], where=[(a0 = EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
       :- Calc(select=[a, CAST(a AS BIGINT) AS a0])
@@ -799,17 +799,17 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
   <TestCase name="testUpdateWithoutFilter[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- LogicalProject(a=[*(CHAR_LENGTH($1), $0)], b=[_UTF-16LE'n1'])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- Calc(select=[*(CHAR_LENGTH(b), a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields=[a, b])
 +- Calc(select=[(CHAR_LENGTH(b) * a) AS a, 'n1' AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
@@ -850,7 +850,7 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
   <TestCase name="testUpdateWithSubQuery[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
+LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- LogicalProject(a=[$0], b=[IF(=(CAST($0):BIGINT, $SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
   LogicalProject($f0=[0])
@@ -859,7 +859,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, IF(=(CAST(a AS BIGINT), EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
@@ -871,7 +871,7 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
                      +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
 
 == Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
+Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
 +- Calc(select=[a, IF((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -16,6 +16,399 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- LogicalProject(a=[IF(>($2, 123), 123, $0)], b=[IF(>($2, 123), _UTF-16LE'v2', $1)], c=[IF(>($2, 123), +($2, 1), $2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($2, 1)])
+   +- LogicalFilter(condition=[>($2, 123)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- LogicalProject(a=[IF(>($4, 123), 123, $2)], b=[IF(>($4, 123), _UTF-16LE'v2', $3)], c=[IF(>($4, 123), +($4, 1), $4)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($4, 1)])
+   +- LogicalFilter(condition=[>($4, 123)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
++- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCustomColumns[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
++- LogicalProject(b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[IF(=(b, '123'), 'v2', b) AS b, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[IF((b = '123'), 'v2', b) AS b, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[IF((b = '123'), 'v2', b) AS b, c])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCustomColumns[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
++- LogicalProject(b=[_UTF-16LE'v2'], c=[$2])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=['v2' AS b, c], where=[=(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=['v2' AS b, c], where=[(b = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=['v2' AS b, c], where=[(b = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithFilter[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[IF(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, IF(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpdateWithoutFilter[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
@@ -139,7 +532,121 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
     } ]
   } ]
 }]]>
-	</Resource>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithMetaColumns[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- Calc(select=[meta_f1, meta_f2, a, IF(=(b, '123'), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithMetaColumns[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[_UTF-16LE'v2'])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[=(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
++- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
   </TestCase>
   <TestCase name="testUpdateWithSubQuery[updateMode = UPDATED_ROWS]">
     <Resource name="explain">
@@ -287,259 +794,7 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
     } ]
   } ]
 }]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($2, 1)])
-   +- LogicalFilter(condition=[>($2, 123)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "RowKindSetter[]",
-    "pact" : "Operator",
-    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = UPDATED_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- LogicalProject(a=[123], b=[_UTF-16LE'v2'], c=[+($4, 1)])
-   +- LogicalFilter(condition=[>($4, 123)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[123 AS a, 'v2' AS b, +(c, 1) AS c], where=[>(c, 123)])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[123 AS a, 'v2' AS b, (c + 1) AS c], where=[(c > 123)])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "RowKindSetter[]",
-    "pact" : "Operator",
-    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateWithCustomColumns[updateMode = UPDATED_ROWS]">
-  <Resource name="explain">
-    <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
-+- LogicalProject(b=[_UTF-16LE'v2'], c=[$2])
-   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
-      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
-+- Calc(select=['v2' AS b, c], where=[=(b, '123')])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
-+- Calc(select=['v2' AS b, c], where=[(b = '123')])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=['v2' AS b, c], where=[(b = '123')])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "RowKindSetter[]",
-    "pact" : "Operator",
-    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-  </Resource>
-  </TestCase>
-  <TestCase name="testUpdateWithMetaColumns[updateMode = UPDATED_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[_UTF-16LE'v2'])
-   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
-      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[=(b, '123')])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, 'v2' AS b], where=[(b = '123')])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "RowKindSetter[]",
-    "pact" : "Operator",
-    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
+    </Resource>
   </TestCase>
   <TestCase name="testUpdateWithoutFilter[updateMode = ALL_ROWS]">
     <Resource name="explain">
@@ -590,58 +845,7 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
     } ]
   } ]
 }]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateWithFilter[updateMode = ALL_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
-+- LogicalProject(a=[$0], b=[IF(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
-+- Calc(select=[a, IF(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b])
-+- Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
+    </Resource>
   </TestCase>
   <TestCase name="testUpdateWithSubQuery[updateMode = ALL_ROWS]">
     <Resource name="explain">
@@ -764,210 +968,6 @@ Sink(table=[default_catalog.default_database.t], fields=[a, b])
     } ]
   } ]
 }]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateAllColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- LogicalProject(a=[IF(>($2, 123), 123, $0)], b=[IF(>($2, 123), _UTF-16LE'v2', $1)], c=[IF(>($2, 123), +($2, 1), $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdatePartColsWithOnlyRequireUpdatedCols[updateMode = ALL_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- LogicalProject(a=[IF(>($4, 123), 123, $2)], b=[IF(>($4, 123), _UTF-16LE'v2', $3)], c=[IF(>($4, 123), +($4, 1), $4)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[a, b, c])
-+- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateWithCustomColumns[updateMode = ALL_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
-+- LogicalProject(b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
-+- Calc(select=[IF(=(b, '123'), 'v2', b) AS b, c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[b, c])
-+- Calc(select=[IF((b = '123'), 'v2', b) AS b, c])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((b = '123'), 'v2', b) AS b, c])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
-  </TestCase>
-  <TestCase name="testUpdateWithMetaColumns[updateMode = ALL_ROWS]">
-    <Resource name="explain">
-      <![CDATA[== Abstract Syntax Tree ==
-LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
-
-== Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, IF(=(b, '123'), 'v2', b) AS b])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
-
-== Optimized Execution Plan ==
-Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])
-   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
-
-== Physical Execution Plan ==
-{
-  "nodes" : [ {
-    "id" : ,
-    "type" : "Source: t[]",
-    "pact" : "Data Source",
-    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
-    "parallelism" : 1
-  }, {
-    "id" : ,
-    "type" : "Calc[]",
-    "pact" : "Operator",
-    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  }, {
-    "id" : ,
-    "type" : "Sink: Unnamed",
-    "pact" : "Data Sink",
-    "contents" : "Sink: Unnamed",
-    "parallelism" : 1,
-    "predecessors" : [ {
-      "id" : ,
-      "ship_strategy" : "FORWARD",
-      "side" : "second"
-    } ]
-  } ]
-}]]>
-	</Resource>
+    </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
@@ -16,6 +16,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testManagedTableSinkWithEnableCheckpointing">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDynamicPartWithOrderBy">
     <Resource name="ast">
       <![CDATA[
@@ -32,6 +41,15 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b])
    +- Exchange(distribution=[single])
       +- Calc(select=[a, b])
          +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testManagedTableSinkWithDisableCheckpointing">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
@@ -16,13 +16,100 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testPartialInsert[isBatch: false]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- LogicalProject(a=[$0], EXPR$1=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], d=[$3], e=[$4], EXPR$4=[null:BIGINT], EXPR$5=[null:INTEGER])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- Calc(select=[a, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS EXPR$1, d, e, null:BIGINT AS EXPR$4, null:INTEGER AS EXPR$5])
+   +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      +- Exchange(distribution=[hash[a, b, c, d, e]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- Calc(select=[a, null:VARCHAR(2147483647) AS EXPR$1, d, e, null:BIGINT AS EXPR$4, null:INTEGER AS EXPR$5])
+   +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      +- Exchange(distribution=[hash[a, b, c, d, e]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithUnionAll[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
++- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
+   +- LogicalUnion(all=[true])
+      :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
+      :  +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+      +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[456], EXPR$5=[789])
+         +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
++- Sort(orderBy=[c ASC, d ASC])
+   +- Union(all=[true], union=[a, c, d, e, f, g])
+      :- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
+      :  +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      :     +- Exchange(distribution=[hash[a, b, c, d, e]])
+      :        +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+      +- Calc(select=[a, c, d, e, CAST(456 AS BIGINT) AS f, CAST(789 AS INTEGER) AS g])
+         +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+            +- Exchange(distribution=[hash[a, b, c, d, e]])
+               +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+                  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsert[isBatch: true]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- LogicalProject(a=[$0], EXPR$1=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], d=[$3], e=[$4], EXPR$4=[null:BIGINT], EXPR$5=[null:INTEGER])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- Sort(orderBy=[EXPR$1 ASC, d ASC])
+   +- Calc(select=[a, null:VARCHAR(2147483647) AS EXPR$1, d, e, null:BIGINT AS EXPR$4, null:INTEGER AS EXPR$5])
+      +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+         +- Exchange(distribution=[hash[a, b, c, d, e]])
+            +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
++- Sort(orderBy=[EXPR$1 ASC, d ASC])
+   +- Calc(select=[a, null:VARCHAR(2147483647) AS EXPR$1, d, e, null:BIGINT AS EXPR$4, null:INTEGER AS EXPR$5])
+      +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+         +- Exchange(distribution=[hash[a, b, c, d, e]])
+            +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialInsertWithComplexReorder[isBatch: false]">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink (b,e,a,g,f,c,d) SELECT b,e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.sink], targetColumns=[[1],[4],[0],[6],[5],[2],[3]], fields=[a, b, c, d, e, f, g])
 +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
    +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
@@ -30,7 +117,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.sink], targetColumns=[[1],[4],[0],[6],[5],[2],[3]], fields=[a, b, c, d, e, f, g])
 +- Calc(select=[a, b, c, d, e, 123 AS f, 456 AS g])
    +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
       +- Exchange(distribution=[hash[a, b, c, d, e]])
@@ -44,7 +131,7 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g]
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.sink], targetColumns=[[1],[4],[0],[6],[5],[2],[3]], fields=[a, b, c, d, e, f, g])
 +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
    +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
@@ -52,7 +139,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.sink], targetColumns=[[1],[4],[0],[6],[5],[2],[3]], fields=[a, b, c, d, e, f, g])
 +- Calc(select=[a, b, c, d, e, 123 AS f, 456 AS g])
    +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
       +- Exchange(distribution=[hash[a, b, c, d, e]])
@@ -67,7 +154,7 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g]
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
    +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
@@ -75,7 +162,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a, c, d, e, 123 AS f, 456 AS g])
    +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
       +- Exchange(distribution=[hash[a, b, c, d, e]])
@@ -89,7 +176,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
    +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
@@ -97,7 +184,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Sort(orderBy=[c ASC, d ASC])
    +- Calc(select=[a, c, d, e, 123 AS f, 456 AS g])
       +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
@@ -113,7 +200,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalMinus(all=[true])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -126,7 +213,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a0 AS a, c0 AS c, d0 AS d, e0 AS e, f0 AS f, g0 AS g])
    +- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1, $2, $3, $4, $5, $6)], correlate=[table($REPLICATE_ROWS$1(sum_vcol_marker,a,c,d,e,f,g))], select=[sum_vcol_marker,a,c,d,e,f,g,a0,c0,d0,e0,f0,g0], rowType=[RecordType(BIGINT sum_vcol_marker, INTEGER a, VARCHAR(2147483647) c, VARCHAR(2147483647) d, DOUBLE e, BIGINT f, INTEGER g, INTEGER a0, VARCHAR(2147483647) c0, VARCHAR(2147483647) d0, DOUBLE e0, BIGINT f0, INTEGER g0)], joinType=[INNER])
       +- Calc(select=[sum_vcol_marker, a, c, d, e, f, g], where=[>(sum_vcol_marker, 0)])
@@ -150,7 +237,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalMinus(all=[true])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -163,7 +250,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Sort(orderBy=[c ASC, d ASC])
    +- Calc(select=[a0 AS a, c0 AS c, d0 AS d, e0 AS e, f0 AS f, g0 AS g])
       +- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1, $2, $3, $4, $5, $6)], correlate=[table($REPLICATE_ROWS$1(sum_vcol_marker,a,c,d,e,f,g))], select=[sum_vcol_marker,a,c,d,e,f,g,a0,c0,d0,e0,f0,g0], rowType=[RecordType(BIGINT sum_vcol_marker, INTEGER a, VARCHAR(2147483647) c, VARCHAR(2147483647) d, DOUBLE e, BIGINT f, INTEGER g, INTEGER a0, VARCHAR(2147483647) c0, VARCHAR(2147483647) d0, DOUBLE e0, BIGINT f0, INTEGER g0)], joinType=[INNER])
@@ -191,7 +278,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalIntersect(all=[true])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -204,7 +291,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a0 AS a, c0 AS c, d0 AS d, e0 AS e, f0 AS f, g0 AS g])
    +- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1, $2, $3, $4, $5, $6)], correlate=[table($REPLICATE_ROWS$1($f0,a,c,d,e,f,g))], select=[$f0,a,c,d,e,f,g,a0,c0,d0,e0,f0,g0], rowType=[RecordType(BIGINT $f0, INTEGER a, VARCHAR(2147483647) c, VARCHAR(2147483647) d, DOUBLE e, BIGINT f, INTEGER g, INTEGER a0, VARCHAR(2147483647) c0, VARCHAR(2147483647) d0, DOUBLE e0, BIGINT f0, INTEGER g0)], joinType=[INNER])
       +- Calc(select=[IF(>(vcol_left_cnt, vcol_right_cnt), vcol_right_cnt, vcol_left_cnt) AS $f0, a, c, d, e, f, g], where=[AND(>=(vcol_left_cnt, 1), >=(vcol_right_cnt, 1))])
@@ -228,7 +315,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalIntersect(all=[true])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -241,7 +328,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Sort(orderBy=[c ASC, d ASC])
    +- Calc(select=[a0 AS a, c0 AS c, d0 AS d, e0 AS e, f0 AS f, g0 AS g])
       +- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1, $2, $3, $4, $5, $6)], correlate=[table($REPLICATE_ROWS$1($f0,a,c,d,e,f,g))], select=[$f0,a,c,d,e,f,g,a0,c0,d0,e0,f0,g0], rowType=[RecordType(BIGINT $f0, INTEGER a, VARCHAR(2147483647) c, VARCHAR(2147483647) d, DOUBLE e, BIGINT f, INTEGER g, INTEGER a0, VARCHAR(2147483647) c0, VARCHAR(2147483647) d0, DOUBLE e0, BIGINT f0, INTEGER g0)], joinType=[INNER])
@@ -269,7 +356,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalSort(sort0=[$0], sort1=[$3], sort2=[$1], sort3=[$2], dir0=[ASC-nulls-first], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], dir3=[ASC-nulls-first])
       +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -278,7 +365,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
    +- Sort(orderBy=[a ASC, e ASC, c ASC, d ASC])
       +- Exchange(distribution=[single])
@@ -292,7 +379,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalSort(sort0=[$0], sort1=[$3], sort2=[$1], sort3=[$2], dir0=[ASC-nulls-first], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first], dir3=[ASC-nulls-first])
       +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -301,11 +388,49 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
    +- Sort(orderBy=[a ASC, e ASC, c ASC, d ASC])
       +- Exchange(distribution=[single])
          +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithPersistedMetadata[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO metadata_sink (a,b,c,d,e,f) SELECT a,b,c,d,e,123 FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.metadata_sink], targetColumns=[[0],[1],[2],[3],[4],[5]], fields=[a, b, c, d, e, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[CAST(123:BIGINT):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.metadata_sink], targetColumns=[[0],[1],[2],[3],[4],[5]], fields=[a, b, c, d, e, f])
++- Calc(select=[a, b, c, d, e, CAST(123 AS BIGINT) AS f])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithPersistedMetadata[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO metadata_sink (a,b,c,d,e,f) SELECT a,b,c,d,e,123 FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.metadata_sink], targetColumns=[[0],[1],[2],[3],[4],[5]], fields=[a, b, c, d, e, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[CAST(123:BIGINT):BIGINT])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.metadata_sink], targetColumns=[[0],[1],[2],[3],[4],[5]], fields=[a, b, c, d, e, f])
++- Calc(select=[a, b, c, d, e, CAST(123 AS BIGINT) AS f])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>
     </Resource>
   </TestCase>
@@ -315,7 +440,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalUnion(all=[false])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -328,7 +453,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Calc(select=[a, c, d, e, CAST(EXPR$4 AS BIGINT) AS f, CAST(EXPR$5 AS INTEGER) AS g])
    +- GroupAggregate(groupBy=[a, c, d, e, EXPR$4, EXPR$5], select=[a, c, d, e, EXPR$4, EXPR$5])
       +- Exchange(distribution=[hash[a, c, d, e, EXPR$4, EXPR$5]])
@@ -344,52 +469,13 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testPartialInsertWithUnion[isBatch: true]">
-    <Resource name="sql">
-      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
-+- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
-   +- LogicalUnion(all=[false])
-      :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
-      :  +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
-      :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-      +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[456], EXPR$5=[789])
-         +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
-+- Sort(orderBy=[c ASC, d ASC])
-   +- Calc(select=[a, c, d, e, CAST(EXPR$4 AS BIGINT) AS f, CAST(EXPR$5 AS INTEGER) AS g])
-      +- HashAggregate(isMerge=[true], groupBy=[a, c, d, e, EXPR$4, EXPR$5], select=[a, c, d, e, EXPR$4, EXPR$5])
-         +- Exchange(distribution=[hash[a, c, d, e, EXPR$4, EXPR$5]])
-            +- LocalHashAggregate(groupBy=[a, c, d, e, EXPR$4, EXPR$5], select=[a, c, d, e, EXPR$4, EXPR$5])
-               +- Union(all=[true], union=[a, c, d, e, EXPR$4, EXPR$5])
-                  :- Calc(select=[a, c, d, e, 123 AS EXPR$4, 456 AS EXPR$5])
-                  :  +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-                  :     +- Exchange(distribution=[hash[a, b, c, d, e]])
-                  :        +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-                  :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-                  +- Calc(select=[a, c, d, e, 456 AS EXPR$4, 789 AS EXPR$5])
-                     +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-                        +- Exchange(distribution=[hash[a, b, c, d, e]])
-                           +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-                              +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testPartialInsertWithUnionAll[isBatch: false]">
     <Resource name="sql">
       <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalUnion(all=[true])
       :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
@@ -402,7 +488,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Union(all=[true], union=[a, c, d, e, f, g])
    :- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
    :  +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
@@ -415,48 +501,13 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testPartialInsertWithUnionAll[isBatch: true]">
-    <Resource name="sql">
-      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
-+- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
-   +- LogicalUnion(all=[true])
-      :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
-      :  +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
-      :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-      +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[456], EXPR$5=[789])
-         +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
-+- Sort(orderBy=[c ASC, d ASC])
-   +- Union(all=[true], union=[a, c, d, e, f, g])
-      :- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
-      :  +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-      :     +- Exchange(distribution=[hash[a, b, c, d, e]])
-      :        +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-      :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-      +- Calc(select=[a, c, d, e, CAST(456 AS BIGINT) AS f, CAST(789 AS INTEGER) AS g])
-         +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-            +- Exchange(distribution=[hash[a, b, c, d, e]])
-               +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
-                  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testPartialInsertWithUnionAllNested[isBatch: true]">
     <Resource name="sql">
       <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,123,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalUnion(all=[true])
       :- LogicalUnion(all=[true])
@@ -473,7 +524,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Sort(orderBy=[c ASC, d ASC])
    +- Union(all=[true], union=[a, c, d, e, f, g])
       :- Union(all=[true], union=[a, c, d, e, f, g])
@@ -495,13 +546,52 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPartialInsertWithUnion[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
++- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
+   +- LogicalUnion(all=[false])
+      :- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[123], EXPR$5=[456])
+      :  +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+      +- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], EXPR$4=[456], EXPR$5=[789])
+         +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
++- Sort(orderBy=[c ASC, d ASC])
+   +- Calc(select=[a, c, d, e, CAST(EXPR$4 AS BIGINT) AS f, CAST(EXPR$5 AS INTEGER) AS g])
+      +- HashAggregate(isMerge=[true], groupBy=[a, c, d, e, EXPR$4, EXPR$5], select=[a, c, d, e, EXPR$4, EXPR$5])
+         +- Exchange(distribution=[hash[a, c, d, e, EXPR$4, EXPR$5]])
+            +- LocalHashAggregate(groupBy=[a, c, d, e, EXPR$4, EXPR$5], select=[a, c, d, e, EXPR$4, EXPR$5])
+               +- Union(all=[true], union=[a, c, d, e, EXPR$4, EXPR$5])
+                  :- Calc(select=[a, c, d, e, 123 AS EXPR$4, 456 AS EXPR$5])
+                  :  +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+                  :     +- Exchange(distribution=[hash[a, b, c, d, e]])
+                  :        +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+                  :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+                  +- Calc(select=[a, c, d, e, 456 AS EXPR$4, 789 AS EXPR$5])
+                     +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+                        +- Exchange(distribution=[hash[a, b, c, d, e]])
+                           +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+                              +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialInsertWithUnionAllNested[isBatch: false]">
     <Resource name="sql">
       <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,789,456,c,d FROM MyTable GROUP BY a,b,c,d,e UNION ALL SELECT e,a,123,456,c,d FROM MyTable GROUP BY a,b,c,d,e ]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- LogicalProject(a=[$0], c=[$1], d=[$2], e=[$3], f=[CAST($4):BIGINT], g=[CAST($5):INTEGER])
    +- LogicalUnion(all=[true])
       :- LogicalUnion(all=[true])
@@ -518,7 +608,7 @@ LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
+Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[6],[5],[2],[3]], fields=[a, c, d, e, f, g])
 +- Union(all=[true], union=[a, c, d, e, f, g])
    :- Union(all=[true], union=[a, c, d, e, f, g])
    :  :- Calc(select=[a, c, d, e, CAST(123 AS BIGINT) AS f, CAST(456 AS INTEGER) AS g])
@@ -535,43 +625,5 @@ Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d,
             +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
 ]]>
     </Resource>
-  </TestCase>
-  <TestCase name="testPartialInsertWithPersistedMetadata[isBatch: true]">
-    <Resource name="sql">
-	  <![CDATA[INSERT INTO metadata_sink (a,b,c,d,e,f) SELECT a,b,c,d,e,123 FROM MyTable]]>
-	</Resource>
-    <Resource name="ast">
-	  <![CDATA[
-LogicalSink(table=[default_catalog.default_database.metadata_sink], fields=[a, b, c, d, e, f])
-+- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[CAST(123:BIGINT):BIGINT])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-	  <![CDATA[
-Sink(table=[default_catalog.default_database.metadata_sink], fields=[a, b, c, d, e, f])
-+- Calc(select=[a, b, c, d, e, CAST(123 AS BIGINT) AS f])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPartialInsertWithPersistedMetadata[isBatch: false]">
-	<Resource name="sql">
-	  <![CDATA[INSERT INTO metadata_sink (a,b,c,d,e,f) SELECT a,b,c,d,e,123 FROM MyTable]]>
-	</Resource>
-	<Resource name="ast">
-	  <![CDATA[
-LogicalSink(table=[default_catalog.default_database.metadata_sink], fields=[a, b, c, d, e, f])
-+- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[CAST(123:BIGINT):BIGINT])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
-]]>
-	</Resource>
-	<Resource name="optimized rel plan">
-	  <![CDATA[
-Sink(table=[default_catalog.default_database.metadata_sink], fields=[a, b, c, d, e, f])
-+- Calc(select=[a, b, c, d, e, CAST(123 AS BIGINT) AS f])
-   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
-]]>
-	</Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testPartialInsert[isBatch: false]">
+  <TestCase name="testPartialInsertWithGroupBy[isBatch: false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])
@@ -75,7 +75,7 @@ Sink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testPartialInsert[isBatch: true]">
+  <TestCase name="testPartialInsertWithGroupBy[isBatch: true]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.partitioned_sink], targetColumns=[[4],[0],[3]], fields=[a, EXPR$1, d, e, EXPR$4, EXPR$5])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testPartialInsert.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testPartialInsert.out
@@ -1,0 +1,149 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "id" : 1,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "connector" : "values",
+            "bounded" : "false"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "id" : 2,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "BIGINT"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : "INT"
+    }, {
+      "kind" : "LITERAL",
+      "value" : "A",
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "LITERAL",
+      "value" : null,
+      "type" : "INT"
+    }, {
+      "kind" : "LITERAL",
+      "value" : null,
+      "type" : "DOUBLE"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : "VARCHAR(2147483647)"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `EXPR$2` VARCHAR(2147483647) NOT NULL, `EXPR$3` INT, `EXPR$4` DOUBLE, `c` VARCHAR(2147483647)>",
+    "description" : "Calc(select=[a, b, 'A' AS EXPR$2, null:INTEGER AS EXPR$3, null:DOUBLE AS EXPR$4, c])"
+  }, {
+    "id" : 3,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            }, {
+              "name" : "d",
+              "dataType" : "INT"
+            }, {
+              "name" : "e",
+              "dataType" : "DOUBLE"
+            }, {
+              "name" : "f",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ "c" ],
+          "options" : {
+            "format" : "testcsv",
+            "path" : "/tmp",
+            "connector" : "filesystem"
+          }
+        }
+      },
+      "abilities" : [ {
+        "type" : "Partitioning",
+        "partition" : {
+          "c" : "A"
+        }
+      } ],
+      "targetColumns" : [ [ 5 ], [ 0 ], [ 1 ] ]
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `EXPR$2` VARCHAR(2147483647) NOT NULL, `EXPR$3` INT, `EXPR$4` DOUBLE, `c` VARCHAR(2147483647)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], targetColumns=[[5],[0],[1]], fields=[a, b, EXPR$2, EXPR$3, EXPR$4, c])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
@@ -409,7 +409,7 @@ from cdc t1, lateral table(ndTableFunc(a)) as T(a1)
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, EXPR$2])
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], targetColumns=[[0]], fields=[a, EXPR$1, EXPR$2])
 +- LogicalProject(a=[CAST($4):INTEGER], EXPR$1=[null:BIGINT], EXPR$2=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
       :- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
@@ -418,7 +418,7 @@ LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EX
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, EXPR$2], upsertMaterialize=[true])
+Sink(table=[default_catalog.default_database.sink_with_pk], targetColumns=[[0]], fields=[a, EXPR$1, EXPR$2], upsertMaterialize=[true])
 +- Calc(select=[CAST(EXPR$0 AS INTEGER) AS a, null:BIGINT AS EXPR$1, null:VARCHAR(2147483647) AS EXPR$2])
    +- Correlate(invocation=[ndTableFunc($cor0.a)], correlate=[table(ndTableFunc($cor0.a))], select=[a,b,c,d,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
       +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.xml
@@ -258,14 +258,14 @@ Sink(table=[default_catalog.default_database.sink], fields=[id, city_name])
   <TestCase name="testInsertPartColumn">
     <Resource name="ast">
       <![CDATA[
-LogicalSink(table=[default_catalog.default_database.zm_test], fields=[a, m1, m2, m3, m4])
+LogicalSink(table=[default_catalog.default_database.zm_test], targetColumns=[[0]], fields=[a, m1, m2, m3, m4])
 +- LogicalProject(a=[CAST($0):BIGINT], m1=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", BIGINT) MAP], m2=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", BIGINT) MAP], m3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", BIGINT) MAP], m4=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", BIGINT) MAP])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Sink(table=[default_catalog.default_database.zm_test], fields=[a, m1, m2, m3, m4], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.zm_test], targetColumns=[[0]], fields=[a, m1, m2, m3, m4], changelogMode=[NONE])
 +- Calc(select=[CAST(a AS BIGINT) AS a, null:(VARCHAR(2147483647), BIGINT) MAP AS m1, null:(VARCHAR(2147483647), BIGINT) MAP AS m2, null:(VARCHAR(2147483647), BIGINT) MAP AS m3, null:(VARCHAR(2147483647), BIGINT) MAP AS m4], changelogMode=[I])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
 ]]>
@@ -483,6 +483,22 @@ Sink(table=[default_catalog.default_database.sink], fields=[id, city_name, ts, r
     } ]
   } ]
 }]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInsertWithTargetColumnsAndSqlHint">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.appendSink], targetColumns=[[0],[1]], fields=[EXPR$0, c], hints=[[[OPTIONS options:{sink.parallelism=1}]]])
++- LogicalProject(EXPR$0=[+($0, $1)], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.appendSink], targetColumns=[[0],[1]], fields=[EXPR$0, c], hints=[[[OPTIONS options:{sink.parallelism=1}]]], changelogMode=[NONE])
++- Calc(select=[+(a, b) AS EXPR$0, c], changelogMode=[I])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testManagedTableSinkWithEnableCheckpointing">
@@ -779,20 +795,4 @@ Sink(table=[default_catalog.default_database.SinkJoinChangeLog], fields=[person,
 ]]>
     </Resource>
   </TestCase>
-	<TestCase name="testInsertWithTargetColumnsAndSqlHint">
-		<Resource name="ast">
-			<![CDATA[
-LogicalSink(table=[default_catalog.default_database.appendSink], fields=[EXPR$0, c], hints=[[[OPTIONS options:{sink.parallelism=1}]]])
-+- LogicalProject(EXPR$0=[+($0, $1)], c=[$2])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-		</Resource>
-		<Resource name="optimized rel plan">
-			<![CDATA[
-Sink(table=[default_catalog.default_database.appendSink], fields=[EXPR$0, c], hints=[[[OPTIONS options:{sink.parallelism=1}]]], changelogMode=[NONE])
-+- Calc(select=[+(a, b) AS EXPR$0, c], changelogMode=[I])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], changelogMode=[I])
-]]>
-		</Resource>
-	</TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
@@ -194,7 +194,7 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
   }
 
   @Test
-  def testPartialInsert(): Unit = {
+  def testPartialInsertWithGroupBy(): Unit = {
     util.verifyExplainInsert(
       "INSERT INTO partitioned_sink (e,a,d) " +
         "SELECT e,a,d FROM MyTable GROUP BY a,b,c,d,e")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
@@ -58,6 +58,35 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
                               |  'sink-insert-only' = 'false'
                               |)
                               |""".stripMargin)
+  util.tableEnv.executeSql(s"""
+                              |create table complex_type_src (
+                              |  `a` BIGINT,
+                              |  `b` ROW<b1 STRING, b2 INT>,
+                              |  `c` ROW<c1 BIGINT, c2 STRING>,
+                              |  `d` MAP<STRING, STRING>,
+                              |  `e` DOUBLE,
+                              |  `f` BIGINT,
+                              |  `g` INT
+                              |) with (
+                              |  'connector' = 'values'
+                              |)
+                              |""".stripMargin)
+  util.tableEnv.executeSql(s"""
+                              |create table complex_type_sink (
+                              |  `a` BIGINT,
+                              |  `b` ROW<b1 STRING, b2 INT>,
+                              |  `c` ROW<c1 BIGINT, c2 STRING>,
+                              |  `d` MAP<STRING, STRING>,
+                              |  `e` DOUBLE,
+                              |  `f` BIGINT METADATA,
+                              |  `g` INT,
+                              |  primary key (`a`) not enforced
+                              |) with (
+                              |  'connector' = 'values',
+                              |  'sink-insert-only' = 'false',
+                              |  'writable-metadata' = 'f:bigint'
+                              |)
+                              |""".stripMargin)
 
   util.tableEnv.executeSql(s"""create table metadata_sink (
                               |  `a` INT,
@@ -162,6 +191,21 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
       "INSERT INTO metadata_sink (a,b,c,d,e,h) " +
         "SELECT a,b,c,d,e,123 FROM MyTable"
     )
+  }
+
+  @Test
+  def testPartialInsert(): Unit = {
+    util.verifyExplainInsert(
+      "INSERT INTO partitioned_sink (e,a,d) " +
+        "SELECT e,a,d FROM MyTable GROUP BY a,b,c,d,e")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testPartialInsertCompositeType(): Unit = {
+    // TODO this should be updated after FLINK-31301 fixed
+    util.verifyExplainInsert(
+      "INSERT INTO complex_type_sink (a,b.b1,c.c2,f) " +
+        "SELECT a,b.b1,c.c2,f FROM complex_type_src")
   }
 }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/connector/sink/SinkRuntimeProviderContext.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/connector/sink/SinkRuntimeProviderContext.java
@@ -26,6 +26,10 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
 import static org.apache.flink.table.types.utils.DataTypeUtils.validateOutputDataType;
 
 /** Implementation of {@link DynamicTableSink.Context}. */
@@ -34,8 +38,15 @@ public final class SinkRuntimeProviderContext implements DynamicTableSink.Contex
 
     private final boolean isBounded;
 
+    @Nullable private final int[][] targetColumns;
+
     public SinkRuntimeProviderContext(boolean isBounded) {
+        this(isBounded, null);
+    }
+
+    public SinkRuntimeProviderContext(boolean isBounded, @Nullable int[][] targetColumns) {
         this.isBounded = isBounded;
+        this.targetColumns = targetColumns;
     }
 
     @Override
@@ -60,5 +71,10 @@ public final class SinkRuntimeProviderContext implements DynamicTableSink.Contex
         validateOutputDataType(consumedDataType);
         return new DataStructureConverterWrapper(
                 DataStructureConverters.getConverter(consumedDataType));
+    }
+
+    @Override
+    public Optional<int[][]> getTargetColumns() {
+        return Optional.ofNullable(targetColumns);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
The internal SinkRuntimeProviderContext will support new constructor with targetColumns param, this can be used by connectors to recognize the user-specified column list.

Note: currently nested columns in column list of an insert/update statement is unsupported (as described in [FLINK-31301](https://issues.apache.org/jira/browse/FLINK-31301) & [FLINK-31344](https://issues.apache.org/jira/browse/FLINK-31344)), so we can make this pr support simple columns first and then support nested columns after the two issues been fixed.

## Brief change log
* add new getTargetColumns to DynamicTableSink#Context
* add targetColumns info to related relnodes and execnodes
* add related tests

## Verifying this change
* add partial insert releated case include ut & it

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (java-docs)