### PR TITLE
[FLINK-30923][documentation] Provide single script for installing Hugo

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -22,19 +22,18 @@ mvn --version
 java -version
 javadoc -J-version
 
-# setup hugo
-HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
-HUGO_ARTIFACT=hugo_extended_0.110.0_Linux-64bit.tar.gz
-if ! curl --fail -OL $HUGO_REPO ; then
-	echo "Failed to download Hugo binary"
-	exit 1
-fi
-tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin
 git submodule update --init --recursive
-# Setup the external documentation modules
+
 cd docs
+
+# setup hugo
+source setup_hugo.sh
+
+# Setup the external documentation modules
 source setup_docs.sh
+
 cd ..
+
 # Build the docs
 hugo --source docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,12 @@ $ docker run -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest server 
 Make sure you have installed [Hugo](https://gohugo.io/getting-started/installing/) on your system.
 
 ```sh
+$ ./setup_hugo.sh
+```
+
+Then build the docs from source:
+
+```sh
 $ ./build_docs.sh
 ```
 

--- a/docs/setup_hugo.sh
+++ b/docs/setup_hugo.sh
@@ -17,16 +17,11 @@
 # limitations under the License.
 ################################################################################
 
-git submodule update --init --recursive
-# Setup the external documentation modules
-cd docs
-source setup_hugo.sh
-source setup_docs.sh
-cd ..
-# Build the docs
-./hugo --source docs
-
-if [ $? -ne 0 ]; then
-	echo "Error building the docs"
+# setup hugo
+HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
+HUGO_ARTIFACT=hugo_extended_0.110.0_Linux-64bit.tar.gz
+if ! curl --fail -OL $HUGO_REPO ; then
+	echo "Failed to download Hugo binary"
 	exit 1
 fi
+tar -zxvf $HUGO_ARTIFACT -C /usr/local/bin


### PR DESCRIPTION
## What is the purpose of the change

To Add a single source for downloading hugo artifacts for building the documentation.

## Brief change log

- Consolidating Hugo artifact downloads to a single location

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? (N/A
