### PR TITLE
[FLINK-31489][sql-gateway] Fix instable OperationManagerTest.testCloseOperation

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/operation/OperationManagerTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/operation/OperationManagerTest.java
@@ -186,7 +186,7 @@ class OperationManagerTest {
     }
 
     @Test
-    void testCloseOperation() throws Exception {
+    void testCloseOperation() {
         CountDownLatch endRunningLatch = new CountDownLatch(1);
         OperationHandle operationHandle =
                 operationManager.submitOperation(
@@ -196,9 +196,12 @@ class OperationManagerTest {
                         });
 
         threadFactory.newThread(() -> operationManager.closeOperation(operationHandle)).start();
-        operationManager.awaitOperationTermination(operationHandle);
 
-        assertThatThrownBy(() -> operationManager.getOperation(operationHandle))
+        assertThatThrownBy(
+                        () -> {
+                            operationManager.awaitOperationTermination(operationHandle);
+                            operationManager.getOperation(operationHandle);
+                        })
                 .satisfies(
                         FlinkAssertions.anyCauseMatches(
                                 SqlGatewayException.class,


### PR DESCRIPTION
## What is the purpose of the change
This is hotfix for the instable test `OperationManagerTest.testCloseOperation`, the reason is the concurrent closeOperation may finished before  awaitOperationTermination(operationHandle) which may encounter an expected error when do getOperation inside it.

## Brief change log
move the awaitOperationTermination into the assert thrown block

## Verifying this change
existing testCloseOperation case

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)