### PR TITLE
[FLINK-31494][table-planner] Introduce SqlNodeConverter for SqlToOperationConverter

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.RexFactory;
 import org.apache.flink.table.planner.calcite.SqlToRexConverter;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
-import org.apache.flink.table.planner.operations.SqlToOperationConverter;
+import org.apache.flink.table.planner.operations.SqlNodeToOperationConversion;
 import org.apache.flink.table.planner.parse.CalciteParser;
 import org.apache.flink.table.planner.parse.ExtendedParser;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -103,7 +103,7 @@ public class ParserImpl implements Parser {
         List<SqlNode> parsed = sqlNodeList.getList();
         Preconditions.checkArgument(parsed.size() == 1, "only single statement supported");
         return Collections.singletonList(
-                SqlToOperationConverter.convert(planner, catalogManager, parsed.get(0))
+                SqlNodeToOperationConversion.convert(planner, catalogManager, parsed.get(0))
                         .orElseThrow(() -> new TableException("Unsupported query: " + statement)));
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -93,7 +93,7 @@ class SqlCreateTableConverter {
 
         PlannerQueryOperation query =
                 (PlannerQueryOperation)
-                        SqlToOperationConverter.convert(
+                        SqlNodeToOperationConversion.convert(
                                         flinkPlanner, catalogManager, sqlCreateTableAs.getAsQuery())
                                 .orElseThrow(
                                         () ->

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.operations.converters.SqlNodeConverter;
+import org.apache.flink.table.planner.utils.Expander;
+
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/** An implementation of {@link SqlNodeConverter.ConvertContext}. */
+public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
+
+    private final FlinkPlannerImpl flinkPlanner;
+    private final CatalogManager catalogManager;
+
+    public SqlNodeConvertContext(FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
+        this.flinkPlanner = flinkPlanner;
+        this.catalogManager = catalogManager;
+    }
+
+    @Override
+    public SqlValidator getSqlValidator() {
+        return flinkPlanner.getOrCreateSqlValidator();
+    }
+
+    @Override
+    public CatalogManager getCatalogManager() {
+        return catalogManager;
+    }
+
+    @Override
+    public RelRoot toRelRoot(SqlNode sqlNode) {
+        return flinkPlanner.rel(sqlNode);
+    }
+
+    @Override
+    public String toQuotedSqlString(SqlNode sqlNode) {
+        SqlParser.Config parserConfig = flinkPlanner.config().getParserConfig();
+        SqlDialect dialect =
+                new CalciteSqlDialect(
+                        SqlDialect.EMPTY_CONTEXT
+                                .withQuotedCasing(parserConfig.unquotedCasing())
+                                .withConformance(parserConfig.conformance())
+                                .withUnquotedCasing(parserConfig.unquotedCasing())
+                                .withIdentifierQuoteString(parserConfig.quoting().string));
+        return sqlNode.toSqlString(dialect).getSql();
+    }
+
+    @Override
+    public String expandSqlIdentifiers(String originalSql) {
+        return Expander.create(flinkPlanner)
+                .expanded(originalSql)
+                .substitute(this::toQuotedSqlString);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -242,7 +242,7 @@ import java.util.stream.Collectors;
  * <p>Every #convert() should return a {@link Operation} which can be used in {@link
  * org.apache.flink.table.delegation.Planner}.
  */
-public class SqlToOperationConverter {
+public class SqlNodeToOperationConversion {
     private final FlinkPlannerImpl flinkPlanner;
     private final CatalogManager catalogManager;
     private final SqlCreateTableConverter createTableConverter;
@@ -250,7 +250,8 @@ public class SqlToOperationConverter {
 
     // ~ Constructors -----------------------------------------------------------
 
-    private SqlToOperationConverter(FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
+    private SqlNodeToOperationConversion(
+            FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
         this.createTableConverter =
@@ -285,8 +286,8 @@ public class SqlToOperationConverter {
     private static Optional<Operation> convertValidatedSqlNode(
             FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager, SqlNode validated) {
         beforeConversion();
-        SqlToOperationConverter converter =
-                new SqlToOperationConverter(flinkPlanner, catalogManager);
+        SqlNodeToOperationConversion converter =
+                new SqlNodeToOperationConversion(flinkPlanner, catalogManager);
         if (validated instanceof SqlCreateCatalog) {
             return Optional.of(converter.convertCreateCatalog((SqlCreateCatalog) validated));
         } else if (validated instanceof SqlDropCatalog) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateCatalogConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateCatalogConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlCreateCatalog;
+import org.apache.flink.sql.parser.ddl.SqlTableOption;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateCatalogOperation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** A converter for {@link SqlCreateCatalog}. */
+public class SqlCreateCatalogConverter implements SqlNodeConverter<SqlCreateCatalog> {
+
+    @Override
+    public Operation convertSqlNode(SqlCreateCatalog node, ConvertContext context) {
+        // set with properties
+        Map<String, String> properties = new HashMap<>();
+        node.getPropertyList()
+                .getList()
+                .forEach(
+                        p ->
+                                properties.put(
+                                        ((SqlTableOption) p).getKeyString(),
+                                        ((SqlTableOption) p).getValueString()));
+
+        return new CreateCatalogOperation(node.catalogName(), properties);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.planner.utils.Expander;
+
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+/** A converter to convert {@link SqlNode} instance into {@link Operation}. */
+public interface SqlNodeConverter<S extends SqlNode> {
+
+    /**
+     * Convert the given validated {@link SqlNode} into an {@link Operation}.
+     *
+     * @param node a validated {@link SqlNode}.
+     * @param context the utilities and context information to convert
+     */
+    Operation convertSqlNode(S node, ConvertContext context);
+
+    /** Context of {@link SqlNodeConverter}. */
+    interface ConvertContext {
+
+        /** Returns the {@link SqlValidator} in the convert context. */
+        SqlValidator getSqlValidator();
+
+        /** Returns the {@link CatalogManager} in the convert context. */
+        CatalogManager getCatalogManager();
+
+        /** Converts the given validated {@link SqlNode} into a {@link RelRoot}. */
+        RelRoot toRelRoot(SqlNode sqlNode);
+
+        /** Convert the given {@param sqlNode} into a quoted SQL string. */
+        String toQuotedSqlString(SqlNode sqlNode);
+
+        /**
+         * Expands identifiers in a given SQL string.
+         *
+         * @see Expander
+         */
+        String expandSqlIdentifiers(String sql);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.planner.operations.converters.SqlNodeConverter.ConvertContext;
+
+import org.apache.calcite.sql.SqlNode;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Registry of SqlNode converters. */
+public class SqlNodeConverters {
+
+    private static final Map<Class<?>, SqlNodeConverter<?>> CONVERTERS = new HashMap<>();
+
+    static {
+        // register all the converters here
+        register(new SqlCreateCatalogConverter());
+    }
+
+    /**
+     * Convert the given validated SqlNode into Operation if there is a registered converter for the
+     * node.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Optional<Operation> convertSqlNode(
+            SqlNode validatedSqlNode, ConvertContext context) {
+        SqlNodeConverter converter = CONVERTERS.get(validatedSqlNode.getClass());
+        if (converter != null) {
+            return Optional.of(converter.convertSqlNode(validatedSqlNode, context));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static void register(SqlNodeConverter<?> converter) {
+        // extract the parameter type of the converter class
+        TypeInformation<?> typeInfo =
+                TypeExtractor.createTypeInfo(
+                        converter, SqlNodeConverter.class, converter.getClass(), 0);
+        CONVERTERS.put(typeInfo.getTypeClass(), converter);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -89,8 +89,8 @@ import static org.apache.flink.table.planner.utils.OperationMatchers.withSchema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test cases for the DDL statements for {@link SqlToOperationConverter}. */
-public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestBase {
+/** Test cases for the DDL statements for {@link SqlNodeToOperationConversion}. */
+public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBase {
 
     @Test
     public void testCreateDatabase() {
@@ -305,7 +305,8 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
         final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
         SqlNode node = parser.parse(sql);
         assertThat(node).isInstanceOf(SqlCreateTable.class);
-        Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        Operation operation =
+                SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
         assertThat(operation).isInstanceOf(CreateTableOperation.class);
         CreateTableOperation op = (CreateTableOperation) operation;
         CatalogTable catalogTable = op.getCatalogTable();
@@ -341,7 +342,8 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
         SqlNode node = parser.parse(sql);
         assertThat(node).isInstanceOf(SqlCreateTable.class);
 
-        Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        Operation operation =
+                SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
         assertThat(operation).isInstanceOf(CreateTableOperation.class);
         CreateTableOperation op = (CreateTableOperation) operation;
         CatalogTable catalogTable = op.getCatalogTable();
@@ -753,7 +755,8 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
         final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
         SqlNode node = parser.parse(sql);
         assertThat(node).isInstanceOf(SqlCreateTable.class);
-        Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        Operation operation =
+                SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
         TableSchema schema = ((CreateTableOperation) operation).getCatalogTable().getSchema();
         Object[] expectedDataTypes = testItems.stream().map(item -> item.expectedType).toArray();
         assertThat(schema.getFieldDataTypes()).isEqualTo(expectedDataTypes);
@@ -2340,6 +2343,6 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
         final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
 
         SqlNode node = parser.parse(sql);
-        return SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        return SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
@@ -52,8 +52,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
-/** Test cases for the DML statements for {@link SqlToOperationConverter}. */
-public class SqlDmlToOperationConverterTest extends SqlToOperationConverterTestBase {
+/** Test cases for the DML statements for {@link SqlNodeToOperationConversion}. */
+public class SqlDmlToOperationConverterTest extends SqlNodeToOperationConversionTestBase {
 
     @Test
     public void testExplainWithSelect() {
@@ -313,7 +313,8 @@ public class SqlDmlToOperationConverterTest extends SqlToOperationConverterTestB
         CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
         SqlNode node = parser.parse(sql);
         assertThat(node).isInstanceOf(SqlRichExplain.class);
-        Operation operation = SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        Operation operation =
+                SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
         assertThat(operation).isInstanceOf(ExplainOperation.class);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
@@ -58,7 +58,7 @@ import java.util.function.Supplier;
 import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
 
 /** Test base for testing convert sql statement to operation. */
-public class SqlToOperationConverterTestBase {
+public class SqlNodeToOperationConversionTestBase {
     private final boolean isStreamingMode = false;
     private final TableConfig tableConfig = TableConfig.getDefault();
     protected final Catalog catalog = new GenericInMemoryCatalog("MockCatalog", "default");
@@ -126,14 +126,14 @@ public class SqlToOperationConverterTestBase {
 
     protected Operation parse(String sql, FlinkPlannerImpl planner, CalciteParser parser) {
         SqlNode node = parser.parse(sql);
-        return SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        return SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
     }
 
     protected Operation parse(String sql) {
         FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
         final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
         SqlNode node = parser.parse(sql);
-        return SqlToOperationConverter.convert(planner, catalogManager, node).get();
+        return SqlNodeToOperationConversion.convert(planner, catalogManager, node).get();
     }
 
     protected FlinkPlannerImpl getPlannerBySqlDialect(SqlDialect sqlDialect) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -53,9 +53,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test cases for the statements that neither belong to DDL nor DML for {@link
- * SqlToOperationConverter}.
+ * SqlNodeToOperationConversion}.
  */
-public class SqlOtherOperationConverterTest extends SqlToOperationConverterTestBase {
+public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversionTestBase {
 
     @Test
     public void testUseCatalog() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Similar to [FLINK-31368](https://issues.apache.org/jira/browse/FLINK-31368), the  `SqlToOperationConverter` is a bit bloated. This PR is aiming to introduce `SqlNodeConverter` and move conversion logic from `SqlToOperationConverter` in the following PRs. 


## Brief change log

- Rename `SqlToOperationConverter` into `SqlNodeToOperationConversion`, because the Converter name may confuse developers regarding the relationship with `SqlNodeConverter` 
- Introduce `SqlNodeConverter` interface and make `SqlToOperationConverter` supports it.
- Migrate the conversion logic of `SqlCreateCatalog` to verify the happy path. 

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)