### PR TITLE
[FLINK-31505][table] Move execution logic of DropOperation out from TableEnvironmentImpl

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ExecutableOperationContextImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ExecutableOperationContextImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.internal;
 
 import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.ExecutableOperation;
 
@@ -26,17 +27,26 @@ import org.apache.flink.table.operations.ExecutableOperation;
 public class ExecutableOperationContextImpl implements ExecutableOperation.Context {
 
     private final CatalogManager catalogManager;
+    private final FunctionCatalog functionCatalog;
     private final ModuleManager moduleManager;
 
     public ExecutableOperationContextImpl(
-            CatalogManager catalogManager, ModuleManager moduleManager) {
+            CatalogManager catalogManager,
+            FunctionCatalog functionCatalog,
+            ModuleManager moduleManager) {
         this.catalogManager = catalogManager;
+        this.functionCatalog = functionCatalog;
         this.moduleManager = moduleManager;
     }
 
     @Override
     public CatalogManager getCatalogManager() {
         return catalogManager;
+    }
+
+    @Override
+    public FunctionCatalog getFunctionCatalog() {
+        return functionCatalog;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -246,6 +246,14 @@ public final class CatalogManager {
         return Optional.ofNullable(catalogs.get(catalogName));
     }
 
+    public Catalog getCatalogOrThrowException(String catalogName) {
+        return getCatalog(catalogName)
+                .orElseThrow(
+                        () ->
+                                new ValidationException(
+                                        String.format("Catalog %s does not exist", catalogName)));
+    }
+
     /**
      * Gets the current catalog that will be used when resolving table path.
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExecutableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExecutableOperation.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.module.ModuleManager;
 
 /**
@@ -52,6 +53,8 @@ public interface ExecutableOperation extends Operation {
     interface Context {
 
         CatalogManager getCatalogManager();
+
+        FunctionCatalog getFunctionCatalog();
 
         ModuleManager getModuleManager();
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -67,5 +73,29 @@ public class DropCatalogFunctionOperation implements DropOperation {
 
     public String getFunctionName() {
         return this.functionIdentifier.getObjectName();
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            if (isTemporary()) {
+                ctx.getFunctionCatalog()
+                        .dropTempCatalogFunction(getFunctionIdentifier(), isIfExists());
+            } else {
+                Catalog catalog =
+                        ctx.getCatalogManager()
+                                .getCatalogOrThrowException(
+                                        getFunctionIdentifier().getCatalogName());
+
+                catalog.dropFunction(getFunctionIdentifier().toObjectPath(), isIfExists());
+            }
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
+        } catch (FunctionNotExistException e) {
+            throw new ValidationException(e.getMessage(), e);
+        } catch (Exception e) {
+            throw new TableException(String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogOperation.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -50,5 +54,16 @@ public class DropCatalogOperation implements DropOperation {
 
         return OperationUtils.formatWithChildren(
                 "DROP CATALOG", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            ctx.getCatalogManager().unregisterCatalog(getCatalogName(), isIfExists());
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (CatalogException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.operations.ExecutableOperation;
 import org.apache.flink.table.operations.Operation;
 
 /**
@@ -26,4 +27,4 @@ import org.apache.flink.table.operations.Operation;
  * <p>Different sub operations can have their special target name. For example, a drop table
  * operation may have a target table name and a flag to describe if is exists.
  */
-public interface DropOperation extends Operation {}
+public interface DropOperation extends Operation, ExecutableOperation {}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
@@ -60,5 +62,15 @@ public class DropTableOperation implements DropOperation {
 
         return OperationUtils.formatWithChildren(
                 "DROP TABLE", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        if (isTemporary()) {
+            ctx.getCatalogManager().dropTemporaryTable(getTableIdentifier(), isIfExists());
+        } else {
+            ctx.getCatalogManager().dropTable(getTableIdentifier(), isIfExists());
+        }
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTempSystemFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTempSystemFunctionOperation.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -54,5 +58,17 @@ public class DropTempSystemFunctionOperation implements DropOperation {
                 params,
                 Collections.emptyList(),
                 Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            ctx.getFunctionCatalog().dropTemporarySystemFunction(getFunctionName(), isIfExists());
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TableException(String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropViewOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropViewOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
@@ -61,5 +63,15 @@ public class DropViewOperation implements DropOperation {
 
         return OperationUtils.formatWithChildren(
                 "DROP VIEW", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        if (isTemporary()) {
+            ctx.getCatalogManager().dropTemporaryView(getViewIdentifier(), isIfExists());
+        } else {
+            ctx.getCatalogManager().dropView(getViewIdentifier(), isIfExists());
+        }
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }


### PR DESCRIPTION
The PR continues the work started at https://github.com/apache/flink/pull/22175

This PR does this for `DropOperation`.
It also removes  methods became unused after merging of https://github.com/apache/flink/pull/22175


## What is the purpose of the change

Migrate `DropOperation`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Brief change log

Migrate `DropOperation`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
