### PR TITLE
[FLINK-31506][table] Move execution logic of AlterOperation out from TableEnvironmentImpl

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
@@ -18,8 +18,14 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -30,9 +36,9 @@ import java.util.Map;
 /** Operation to describe a ALTER FUNCTION statement for catalog functions. */
 public class AlterCatalogFunctionOperation implements AlterOperation {
     private final ObjectIdentifier functionIdentifier;
-    private CatalogFunction catalogFunction;
-    private boolean ifExists;
-    private boolean isTemporary;
+    private final CatalogFunction catalogFunction;
+    private final boolean ifExists;
+    private final boolean isTemporary;
 
     public AlterCatalogFunctionOperation(
             ObjectIdentifier functionIdentifier,
@@ -78,5 +84,29 @@ public class AlterCatalogFunctionOperation implements AlterOperation {
 
     public String getFunctionName() {
         return this.functionIdentifier.getObjectName();
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            CatalogFunction function = getCatalogFunction();
+            if (isTemporary()) {
+                throw new ValidationException("Alter temporary catalog function is not supported");
+            } else {
+                Catalog catalog =
+                        ctx.getCatalogManager()
+                                .getCatalogOrThrowException(
+                                        getFunctionIdentifier().getCatalogName());
+                catalog.alterFunction(
+                        getFunctionIdentifier().toObjectPath(), function, isIfExists());
+            }
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
+        } catch (FunctionNotExistException e) {
+            throw new ValidationException(e.getMessage(), e);
+        } catch (Exception e) {
+            throw new TableException(String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
@@ -60,5 +66,19 @@ public class AlterDatabaseOperation implements AlterOperation {
 
         return OperationUtils.formatWithChildren(
                 "ALTER DATABASE", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        Catalog catalog = ctx.getCatalogManager().getCatalogOrThrowException(getCatalogName());
+        try {
+            catalog.alterDatabase(getDatabaseName(), getCatalogDatabase(), false);
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (DatabaseNotExistException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s", asSummaryString()), e);
+        } catch (Exception e) {
+            throw new TableException(String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterOperation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.operations.ddl;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.operations.ExecutableOperation;
 import org.apache.flink.table.operations.Operation;
 
 /**
@@ -28,4 +29,4 @@ import org.apache.flink.table.operations.Operation;
  * operation may have a target table name and a flag to describe if is exists.
  */
 @Internal
-public interface AlterOperation extends Operation {}
+public interface AlterOperation extends Operation, ExecutableOperation {}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableChangeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableChangeOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.TableChange;
@@ -137,5 +139,16 @@ public class AlterTableChangeOperation extends AlterTableOperation {
             throw new UnsupportedOperationException(
                     String.format("Unknown table change: %s.", tableChange));
         }
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager()
+                .alterTable(
+                        getNewTable(),
+                        getTableChanges(),
+                        getTableIdentifier(),
+                        ignoreIfTableNotExists());
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOptionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOptionsOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.OperationUtils;
@@ -59,5 +61,12 @@ public class AlterTableOptionsOperation extends AlterTableOperation {
                 ignoreIfTableNotExists ? "IF EXISTS " : "",
                 tableIdentifier.asSummaryString(),
                 description);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager()
+                .alterTable(getCatalogTable(), getTableIdentifier(), ignoreIfTableNotExists());
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableRenameOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableRenameOperation.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 
 /** Operation to describe a ALTER TABLE .. RENAME to .. statement. */
 public class AlterTableRenameOperation extends AlterTableOperation {
@@ -43,5 +49,22 @@ public class AlterTableRenameOperation extends AlterTableOperation {
                 ignoreIfTableNotExists ? "IF EXISTS " : "",
                 tableIdentifier.asSummaryString(),
                 newTableIdentifier.asSummaryString());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        final Catalog catalog =
+                ctx.getCatalogManager()
+                        .getCatalogOrThrowException(getTableIdentifier().getCatalogName());
+        try {
+            catalog.renameTable(
+                    getTableIdentifier().toObjectPath(),
+                    getNewTableIdentifier().getObjectName(),
+                    ignoreIfTableNotExists());
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (TableAlreadyExistException | TableNotExistException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableSchemaOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableSchemaOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
@@ -46,5 +48,12 @@ public class AlterTableSchemaOperation extends AlterTableOperation {
                 ignoreIfTableNotExists ? "IF EXISTS " : "",
                 tableIdentifier.asSummaryString(),
                 catalogTable.getUnresolvedSchema().toString());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager()
+                .alterTable(getCatalogTable(), getTableIdentifier(), ignoreIfTableNotExists());
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewAsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewAsOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
@@ -40,5 +42,11 @@ public class AlterViewAsOperation extends AlterViewOperation {
         return String.format(
                 "ALTER VIEW %s AS %s",
                 viewIdentifier.asSummaryString(), newView.getOriginalQuery());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager().alterTable(getNewView(), getViewIdentifier(), false);
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewPropertiesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewPropertiesOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.operations.OperationUtils;
@@ -49,5 +51,11 @@ public class AlterViewPropertiesOperation extends AlterViewOperation {
                         .collect(Collectors.joining(", "));
         return String.format(
                 "ALTER VIEW %s SET (%s)", viewIdentifier.asSummaryString(), description);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager().alterTable(getCatalogView(), getViewIdentifier(), false);
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewRenameOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterViewRenameOperation.java
@@ -18,7 +18,14 @@
 
 package org.apache.flink.table.operations.ddl;
 
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 
 /** Operation to describe a ALTER VIEW .. RENAME to .. statement. */
 public class AlterViewRenameOperation extends AlterViewOperation {
@@ -40,5 +47,24 @@ public class AlterViewRenameOperation extends AlterViewOperation {
         return String.format(
                 "ALTER VIEW %s RENAME TO %s",
                 viewIdentifier.asSummaryString(), newViewIdentifier.asSummaryString());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        Catalog catalog =
+                ctx.getCatalogManager()
+                        .getCatalogOrThrowException(getViewIdentifier().getCatalogName());
+        try {
+            catalog.renameTable(
+                    getViewIdentifier().toObjectPath(),
+                    getNewViewIdentifier().getObjectName(),
+                    false);
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (TableAlreadyExistException | TableNotExistException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s", asSummaryString()), e);
+        } catch (Exception e) {
+            throw new TableException(String.format("Could not execute %s", asSummaryString()), e);
+        }
     }
 }


### PR DESCRIPTION
The PR continues the work started at https://github.com/apache/flink/pull/22175

This PR does this for `AlterOperation`.

## What is the purpose of the change

Migrate `AlterOperation`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Brief change log

Migrate `AlterOperation`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
