### PR TITLE
[FLINK-31516][table] Move execution logic of LoadModule and UnloadModule operations out from TableEnvironmentImpl

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LoadModuleOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LoadModuleOperation.java
@@ -78,7 +78,7 @@ public class LoadModuleOperation implements Operation, ExecutableOperation {
         return sb.toString();
     }
 
-    // @Override
+    @Override
     public TableResultInternal execute(Context ctx) {
         try {
             final Module module =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LoadModuleOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LoadModuleOperation.java
@@ -19,6 +19,12 @@
 package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.module.Module;
 
 import java.util.Collections;
 import java.util.Map;
@@ -30,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Operation to describe a LOAD MODULE statement. */
 @Internal
-public class LoadModuleOperation implements Operation {
+public class LoadModuleOperation implements Operation, ExecutableOperation {
 
     private final String moduleName;
     private final Map<String, String> options;
@@ -70,5 +76,27 @@ public class LoadModuleOperation implements Operation {
         }
 
         return sb.toString();
+    }
+
+    // @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            final Module module =
+                    FactoryUtil.createModule(
+                            getModuleName(),
+                            getOptions(),
+                            ctx.getTableConfig(),
+                            ctx.getResourceManager().getUserClassLoader());
+            ctx.getModuleManager().loadModule(getModuleName(), module);
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s. %s", asSummaryString(), e.getMessage()),
+                    e);
+        } catch (Exception e) {
+            throw new TableException(
+                    String.format("Could not execute %s. %s", asSummaryString(), e.getMessage()),
+                    e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UnloadModuleOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UnloadModuleOperation.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.table.operations;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Operation to describe an UNLOAD MODULE statement. */
-public class UnloadModuleOperation implements Operation {
+public class UnloadModuleOperation implements Operation, ExecutableOperation {
     private final String moduleName;
 
     public UnloadModuleOperation(String moduleName) {
@@ -35,5 +39,17 @@ public class UnloadModuleOperation implements Operation {
     @Override
     public String asSummaryString() {
         return String.format("UNLOAD MODULE %s", moduleName);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            ctx.getModuleManager().unloadModule(getModuleName());
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s. %s", asSummaryString(), e.getMessage()),
+                    e);
+        }
     }
 }


### PR DESCRIPTION
The PR continues the work started at https://github.com/apache/flink/pull/22175

This PR does this for `LoadModule` and `UnloadModule`.

## What is the purpose of the change

Migrate `LoadModule` and `UnloadModule`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Brief change log

Migrate `LoadModule` and `UnloadModule`s to extend ExecutableOperation and move it's execution logic  out from TableEnvironmentImpl.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
