### PR TITLE
[FLINK-31259][sql-gateway] SqlGateway supports initializing catalog with init file

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -26,14 +26,12 @@ import org.apache.flink.table.client.cli.CliOptionsParser;
 import org.apache.flink.table.client.gateway.DefaultContextUtils;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SingleSessionManager;
-import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.gateway.SqlGateway;
 import org.apache.flink.table.gateway.rest.SqlGatewayRestEndpointFactory;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestOptions;
 import org.apache.flink.table.gateway.service.context.DefaultContext;
 import org.apache.flink.util.NetUtils;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jline.terminal.Terminal;
 import org.slf4j.Logger;
@@ -42,10 +40,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -53,6 +48,7 @@ import java.util.function.Supplier;
 
 import static org.apache.flink.table.client.cli.CliClient.DEFAULT_TERMINAL_FACTORY;
 import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.getSqlGatewayOptionPrefix;
+import static org.apache.flink.table.gateway.service.utils.FileUtils.readFromURL;
 
 /**
  * SQL Client for submitting SQL statements. The client can be executed in two modes: a gateway and
@@ -336,15 +332,6 @@ public class SqlClient {
             return readFromURL(options.getSqlFile());
         } else {
             return options.getUpdateStatement().trim();
-        }
-    }
-
-    private String readFromURL(URL file) {
-        try {
-            return IOUtils.toString(file, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new SqlExecutionException(
-                    String.format("Fail to read content from the %s.", file.getPath()), e);
         }
     }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.util.NetUtils;
 
@@ -30,7 +29,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import java.io.File;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -44,6 +42,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.table.gateway.service.utils.FileUtils.localFileToURL;
 
 /** Parser for command line options. */
 public class CliOptionsParser {
@@ -313,11 +312,8 @@ public class CliOptionsParser {
                     .distinct()
                     .map(
                             (url) -> {
-                                checkFilePath(url);
                                 try {
-                                    return Path.fromLocalFile(new File(url).getAbsoluteFile())
-                                            .toUri()
-                                            .toURL();
+                                    return localFileToURL(url);
                                 } catch (Exception e) {
                                     throw new SqlClientException(
                                             "Invalid path for option '"
@@ -330,14 +326,6 @@ public class CliOptionsParser {
                     .collect(Collectors.toList());
         }
         return null;
-    }
-
-    public static void checkFilePath(String filePath) {
-        Path path = new Path(filePath);
-        String scheme = path.toUri().getScheme();
-        if (scheme != null && !scheme.equals("file")) {
-            throw new SqlClientException("SQL Client only supports to load files in local.");
-        }
     }
 
     private static String checkSessionId(CommandLine line) {

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/SqlGateway.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/SqlGateway.java
@@ -114,7 +114,8 @@ public class SqlGateway {
                         ConfigurationUtils.createConfiguration(cliOptions.getDynamicConfigs()),
                         Collections.emptyList(),
                         true,
-                        true);
+                        true,
+                        cliOptions.getInitFilePath());
         SqlGateway gateway =
                 new SqlGateway(
                         defaultContext.getFlinkConfig(), SessionManager.create(defaultContext));

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/cli/SqlGatewayOptions.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/cli/SqlGatewayOptions.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.gateway.cli;
 
+import javax.annotation.Nullable;
+
 import java.util.Properties;
 
 /** Options to configure the {@code SqlGateway}. */
@@ -25,10 +27,12 @@ public class SqlGatewayOptions {
 
     private final boolean isPrintHelp;
     private final Properties dynamicConfigs;
+    @Nullable private final String initFilePath;
 
-    public SqlGatewayOptions(boolean isPrintHelp, Properties dynamicConfigs) {
+    public SqlGatewayOptions(boolean isPrintHelp, Properties dynamicConfigs, String initFilePath) {
         this.isPrintHelp = isPrintHelp;
         this.dynamicConfigs = dynamicConfigs;
+        this.initFilePath = initFilePath;
     }
 
     public boolean isPrintHelp() {
@@ -37,5 +41,10 @@ public class SqlGatewayOptions {
 
     public Properties getDynamicConfigs() {
         return dynamicConfigs;
+    }
+
+    @Nullable
+    public String getInitFilePath() {
+        return initFilePath;
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/cli/SqlGatewayOptionsParser.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/cli/SqlGatewayOptionsParser.java
@@ -48,6 +48,17 @@ public class SqlGatewayOptionsParser {
                     .desc("Use value for given property")
                     .build();
 
+    public static final Option OPTION_INIT_FILE =
+            Option.builder("i")
+                    .required(false)
+                    .longOpt("init")
+                    .numberOfArgs(1)
+                    .argName("catalog initialization file")
+                    .desc(
+                            "Script file that used to init the session in gateway. "
+                                    + "If get error in execution, the gateway will exit. Notice it's only allowed to add create catalog into the init file.")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     //  Line Parsing
     // --------------------------------------------------------------------------------------------
@@ -58,7 +69,8 @@ public class SqlGatewayOptionsParser {
             CommandLine line = parser.parse(getSqlGatewayOptions(), args, true);
             return new SqlGatewayOptions(
                     line.hasOption(SqlGatewayOptionsParser.OPTION_HELP.getOpt()),
-                    line.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt()));
+                    line.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt()),
+                    line.getOptionValue(OPTION_INIT_FILE.getOpt()));
         } catch (ParseException e) {
             throw new SqlGatewayException(e.getMessage());
         }
@@ -101,6 +113,7 @@ public class SqlGatewayOptionsParser {
         Options options = new Options();
         options.addOption(OPTION_HELP);
         options.addOption(DYNAMIC_PROPERTY_OPTION);
+        options.addOption(OPTION_INIT_FILE);
         return options;
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/Session.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/Session.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.gateway.service.session;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.service.context.SessionContext;
@@ -72,6 +74,11 @@ public class Session implements Closeable {
 
     public OperationExecutor createExecutor(Configuration executionConfig) {
         return sessionContext.createOperationExecutor(executionConfig);
+    }
+
+    @VisibleForTesting
+    public CatalogManager catalogManager() {
+        return sessionContext.getSessionState().catalogManager;
     }
 
     @Override

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/FileUtils.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/FileUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service.utils;
+
+import org.apache.flink.core.fs.Path;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** File utils for gateway and client. */
+public class FileUtils {
+    private static final String CATALOG_SPLIT_DELIMITER = ";\n";
+    private static final String CATALOG_END_DELIMITER = ";";
+
+    /**
+     * Convert local file path to url.
+     *
+     * @param filePath the given local file path
+     * @return the file path url
+     * @throws Exception the thrown exception
+     */
+    public static URL localFileToURL(String filePath) throws Exception {
+        Path path = new Path(filePath);
+        String scheme = path.toUri().getScheme();
+        if (scheme != null && !scheme.equals("file")) {
+            throw new Exception("Only supports to load files in local.");
+        }
+        return Path.fromLocalFile(new File(filePath).getAbsoluteFile()).toUri().toURL();
+    }
+
+    /**
+     * Read content from local file url.
+     *
+     * @param file the given file url
+     * @return the content
+     */
+    public static String readFromURL(URL file) {
+        try {
+            return IOUtils.toString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new SqlExecutionException(
+                    String.format("Fail to read content from the %s.", file.getPath()), e);
+        }
+    }
+
+    /**
+     * Parse catalog sql list from content.
+     *
+     * @param content the given sql content
+     * @return the catalog sql list
+     */
+    public static List<String> parseCatalogSqls(String content) {
+        return Arrays.stream(StringUtils.splitByWholeSeparator(content, CATALOG_SPLIT_DELIMITER))
+                .map(String::trim)
+                .filter(v -> v.length() > 0)
+                .map(
+                        v -> {
+                            if (v.endsWith(CATALOG_END_DELIMITER)) {
+                                return v;
+                            } else {
+                                return v + CATALOG_END_DELIMITER;
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/SqlGatewayTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/SqlGatewayTest.java
@@ -81,9 +81,15 @@ class SqlGatewayTest {
                         "Start the Flink SQL Gateway as a daemon to submit Flink SQL.\n"
                                 + "\n"
                                 + "  Syntax: start [OPTIONS]\n"
-                                + "     -D <property=value>   Use value for given property\n"
-                                + "     -h,--help             Show the help message with descriptions of all\n"
-                                + "                           options.\n\n");
+                                + "     -D <property=value>                       Use value for given property\n"
+                                + "     -h,--help                                 Show the help message with\n"
+                                + "                                               descriptions of all options.\n"
+                                + "     -i,--init <catalog initialization file>   Script file that used to init the\n"
+                                + "                                               session in gateway. If get error\n"
+                                + "                                               in execution, the gateway will\n"
+                                + "                                               exit. Notice it's only allowed to\n"
+                                + "                                               add create catalog into the init\n"
+                                + "                                               file.");
     }
 
     @Test

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/utils/FileUtilsTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/utils/FileUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.utils;
+
+import org.apache.flink.table.gateway.service.utils.FileUtils;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FileUtils}. */
+public class FileUtilsTest {
+    @Test
+    public void testParseCatalogSqlList(@TempDir Path tempFolder) throws Exception {
+        File file = new File(tempFolder.toFile(), "catalog.sql");
+        List<String> catalogSqlList =
+                Arrays.asList(
+                        "create catalog catalog1 with ('type'='generic_in_memory');",
+                        "",
+                        "\n",
+                        "create catalog catalog2 with\n ('type'='generic_in_memory');",
+                        "",
+                        "create catalog catalog3 with ('type'='generic_in_memory');");
+        IOUtils.writeLines(catalogSqlList, "\n", Files.newOutputStream(file.toPath()), "utf-8");
+        String content = FileUtils.readFromURL(FileUtils.localFileToURL(file.getPath()));
+        assertThat(FileUtils.parseCatalogSqls(content))
+                .containsExactlyInAnyOrder(
+                        "create catalog catalog1 with ('type'='generic_in_memory');",
+                        "create catalog catalog2 with\n ('type'='generic_in_memory');",
+                        "create catalog catalog3 with ('type'='generic_in_memory');");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to start `SqlGateway` with an init file, the gateway can create catalogs and register them to the `CatalogManager` when it open a session.

## Brief change log
  - Added `-i initFile` in `SqlGateway` options
  - Parse catalog sql list from the init file
  - Create and register catalogs when `SqlGateway` open a session

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added `FileUtilsTest` to read and parse catalog sql list.
  - Added `SessionManagerImplTest.testInitCatalogFile` to parse and register catalogs when session manager create a session.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
