### PR TITLE
[FLINK-31521][jdbc-driver] Initialize jdbc driver module in flink-table

### DIFF
--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -29,22 +29,49 @@
 		<version>1.18-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>flink-sql-jdbc-driver</artifactId>
-	<name>Flink : Table : SQL Jdbc Driver</name>
+	<artifactId>flink-sql-jdbc-driver-bundle</artifactId>
+	<name>Flink : Table : SQL Jdbc Driver Bundle</name>
 
 	<packaging>jar</packaging>
 
 	<dependencies>
-		<!-- Table ecosystem -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-jdbc-driver</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-gateway-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-api-java-bridge</artifactId>
-			<version>${project.version}</version>
-		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- Build flink-sql-gateway jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<!-- Exclude all flink-dist files and only contain sql-gateway files -->
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>org.apache.flink:flink-sql-jdbc-driver</include>
+									<include>org.apache.flink:flink-sql-gateway-api</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-table/flink-sql-jdbc-driver/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-table</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.18-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-sql-jdbc-driver</artifactId>
+	<name>Flink : Table : SQL Jdbc Driver</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<!-- Table ecosystem -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-gateway-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- Build flink-sql-gateway jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<!-- Exclude all flink-dist files and only contain sql-gateway files -->
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>org.apache.flink:flink-sql-gateway-api</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDriver.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDriver.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Jdbc Driver for flink sql gateway. Only Batch Mode queries are supported. If you force to submit
+ * streaming queries, you may get unrecognized updates, deletions and other results in result set.
+ */
+public class FlinkDriver implements Driver {
+    public static final String URL_PREFIX = "jdbc:flink://";
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        throw new SQLFeatureNotSupportedException("Not implemented yet.");
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return url.startsWith(URL_PREFIX);
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkDriver#getParentLogger is not supported yet.");
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDriver.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDriver.java
@@ -48,14 +48,24 @@ public class FlinkDriver implements Driver {
         return new DriverPropertyInfo[0];
     }
 
+    /**
+     * Major version of flink.
+     *
+     * @return the major version
+     */
     @Override
     public int getMajorVersion() {
-        return 0;
+        throw new RuntimeException("Not implemented yet, will use major version of flink.");
     }
 
+    /**
+     * Minor version of flink.
+     *
+     * @return the minor version
+     */
     @Override
     public int getMinorVersion() {
-        return 0;
+        throw new RuntimeException("Not implemented yet, will use minor version of flink.");
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/resources/META-INF/services/java.sql.Driver
+++ b/flink-table/flink-sql-jdbc-driver/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.jdbc.FlinkDriver

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -46,6 +46,7 @@ under the License.
 		<module>flink-sql-gateway-api</module>
 		<module>flink-sql-gateway</module>
 		<module>flink-sql-client</module>
+		<module>flink-sql-jdbc-driver</module>
 		<module>flink-sql-parser</module>
 		<module>flink-table-code-splitter</module>
 		<module>flink-table-test-utils</module>

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -47,6 +47,7 @@ under the License.
 		<module>flink-sql-gateway</module>
 		<module>flink-sql-client</module>
 		<module>flink-sql-jdbc-driver</module>
+		<module>flink-sql-jdbc-driver-bundle</module>
 		<module>flink-sql-parser</module>
 		<module>flink-table-code-splitter</module>
 		<module>flink-table-test-utils</module>


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to initialize jdbc driver module in flink-table

## Brief change log

Add flink-sql-jdbc-driver module in flink-table

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
