### PR TITLE
[FLINK-31528] [table-planner] Move SqlXXXCatalog conversion logic to SqlNodeConverter

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -41,13 +41,11 @@ import org.apache.flink.sql.parser.ddl.SqlAlterViewRename;
 import org.apache.flink.sql.parser.ddl.SqlAnalyzeTable;
 import org.apache.flink.sql.parser.ddl.SqlChangeColumn;
 import org.apache.flink.sql.parser.ddl.SqlCompilePlan;
-import org.apache.flink.sql.parser.ddl.SqlCreateCatalog;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
 import org.apache.flink.sql.parser.ddl.SqlCreateTableAs;
 import org.apache.flink.sql.parser.ddl.SqlCreateView;
-import org.apache.flink.sql.parser.ddl.SqlDropCatalog;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
 import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropPartitions;
@@ -58,7 +56,6 @@ import org.apache.flink.sql.parser.ddl.SqlReset;
 import org.apache.flink.sql.parser.ddl.SqlSet;
 import org.apache.flink.sql.parser.ddl.SqlStopJob;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
-import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.ddl.SqlUseModules;
 import org.apache.flink.sql.parser.ddl.resource.SqlResource;
@@ -73,11 +70,9 @@ import org.apache.flink.sql.parser.dml.SqlStatementSet;
 import org.apache.flink.sql.parser.dql.SqlLoadModule;
 import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
 import org.apache.flink.sql.parser.dql.SqlRichExplain;
-import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowColumns;
 import org.apache.flink.sql.parser.dql.SqlShowCreateTable;
 import org.apache.flink.sql.parser.dql.SqlShowCreateView;
-import org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
 import org.apache.flink.sql.parser.dql.SqlShowFunctions;
@@ -138,11 +133,9 @@ import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.NopOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
-import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowColumnsOperation;
 import org.apache.flink.table.operations.ShowCreateTableOperation;
 import org.apache.flink.table.operations.ShowCreateViewOperation;
-import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
 import org.apache.flink.table.operations.ShowCurrentDatabaseOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
@@ -155,7 +148,6 @@ import org.apache.flink.table.operations.SinkModifyOperation;
 import org.apache.flink.table.operations.SourceQueryOperation;
 import org.apache.flink.table.operations.StatementSetOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
-import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseModulesOperation;
 import org.apache.flink.table.operations.command.AddJarOperation;
@@ -178,12 +170,10 @@ import org.apache.flink.table.operations.ddl.AlterViewRenameOperation;
 import org.apache.flink.table.operations.ddl.AnalyzeTableOperation;
 import org.apache.flink.table.operations.ddl.CompilePlanOperation;
 import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
-import org.apache.flink.table.operations.ddl.CreateCatalogOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateViewOperation;
 import org.apache.flink.table.operations.ddl.DropCatalogFunctionOperation;
-import org.apache.flink.table.operations.ddl.DropCatalogOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
 import org.apache.flink.table.operations.ddl.DropPartitionsOperation;
 import org.apache.flink.table.operations.ddl.DropTableOperation;
@@ -298,21 +288,12 @@ public class SqlNodeToOperationConversion {
         // TODO: all the below conversion logic should be migrated to SqlNodeConverters
         SqlNodeToOperationConversion converter =
                 new SqlNodeToOperationConversion(flinkPlanner, catalogManager);
-        if (validated instanceof SqlDropCatalog) {
-            return Optional.of(converter.convertDropCatalog((SqlDropCatalog) validated));
-        } else if (validated instanceof SqlLoadModule) {
+        if (validated instanceof SqlLoadModule) {
             return Optional.of(converter.convertLoadModule((SqlLoadModule) validated));
-        } else if (validated instanceof SqlShowCatalogs) {
-            return Optional.of(converter.convertShowCatalogs((SqlShowCatalogs) validated));
-        } else if (validated instanceof SqlShowCurrentCatalog) {
-            return Optional.of(
-                    converter.convertShowCurrentCatalog((SqlShowCurrentCatalog) validated));
         } else if (validated instanceof SqlShowModules) {
             return Optional.of(converter.convertShowModules((SqlShowModules) validated));
         } else if (validated instanceof SqlUnloadModule) {
             return Optional.of(converter.convertUnloadModule((SqlUnloadModule) validated));
-        } else if (validated instanceof SqlUseCatalog) {
-            return Optional.of(converter.convertUseCatalog((SqlUseCatalog) validated));
         } else if (validated instanceof SqlUseModules) {
             return Optional.of(converter.convertUseModules((SqlUseModules) validated));
         } else if (validated instanceof SqlCreateDatabase) {
@@ -883,35 +864,6 @@ public class SqlNodeToOperationConversion {
         return new EndStatementSetOperation();
     }
 
-    /** Convert use catalog statement. */
-    private Operation convertUseCatalog(SqlUseCatalog useCatalog) {
-        return new UseCatalogOperation(useCatalog.catalogName());
-    }
-
-    /** Convert CREATE CATALOG statement. */
-    private Operation convertCreateCatalog(SqlCreateCatalog sqlCreateCatalog) {
-        String catalogName = sqlCreateCatalog.catalogName();
-
-        // set with properties
-        Map<String, String> properties = new HashMap<>();
-        sqlCreateCatalog
-                .getPropertyList()
-                .getList()
-                .forEach(
-                        p ->
-                                properties.put(
-                                        ((SqlTableOption) p).getKeyString(),
-                                        ((SqlTableOption) p).getValueString()));
-
-        return new CreateCatalogOperation(catalogName, properties);
-    }
-
-    /** Convert DROP CATALOG statement. */
-    private Operation convertDropCatalog(SqlDropCatalog sqlDropCatalog) {
-        String catalogName = sqlDropCatalog.catalogName();
-        return new DropCatalogOperation(catalogName, sqlDropCatalog.getIfExists());
-    }
-
     /** Convert use database statement. */
     private Operation convertUseDatabase(SqlUseDatabase useDatabase) {
         String[] fullDatabaseName = useDatabase.fullDatabaseName();
@@ -1017,16 +969,6 @@ public class SqlNodeToOperationConversion {
         CatalogDatabase catalogDatabase =
                 new CatalogDatabaseImpl(properties, originCatalogDatabase.getComment());
         return new AlterDatabaseOperation(catalogName, databaseName, catalogDatabase);
-    }
-
-    /** Convert SHOW CATALOGS statement. */
-    private Operation convertShowCatalogs(SqlShowCatalogs sqlShowCatalogs) {
-        return new ShowCatalogsOperation();
-    }
-
-    /** Convert SHOW CURRENT CATALOG statement. */
-    private Operation convertShowCurrentCatalog(SqlShowCurrentCatalog sqlShowCurrentCatalog) {
-        return new ShowCurrentCatalogOperation();
     }
 
     /** Convert SHOW DATABASES statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlDropCatalogConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlDropCatalogConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlDropCatalog;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.DropCatalogOperation;
+
+/** A converter for {@link SqlDropCatalog}. */
+public class SqlDropCatalogConverter implements SqlNodeConverter<SqlDropCatalog> {
+
+    @Override
+    public Operation convertSqlNode(SqlDropCatalog node, ConvertContext context) {
+        String catalogName = node.catalogName();
+        return new DropCatalogOperation(catalogName, node.getIfExists());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -37,6 +37,10 @@ public class SqlNodeConverters {
     static {
         // register all the converters here
         register(new SqlCreateCatalogConverter());
+        register(new SqlUseCatalogConverter());
+        register(new SqlShowCatalogsConverter());
+        register(new SqlShowCatalogsConverter());
+        register(new SqlDropCatalogConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCatalogsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCatalogsConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCatalogsOperation;
+
+/** A converter for {@link SqlShowCatalogs}. */
+public class SqlShowCatalogsConverter implements SqlNodeConverter<SqlShowCatalogs> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowCatalogs node, ConvertContext context) {
+        return new ShowCatalogsOperation();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCurrentCatalogConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCurrentCatalogConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
+
+/** A converter for {@link SqlShowCurrentCatalog}. */
+public class SqlShowCurrentCatalogConverter implements SqlNodeConverter<SqlShowCurrentCatalog> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowCurrentCatalog node, ConvertContext context) {
+        return new ShowCurrentCatalogOperation();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlUseCatalogConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlUseCatalogConverter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.UseCatalogOperation;
+
+/** A converter for {@link SqlUseCatalog}. */
+public class SqlUseCatalogConverter implements SqlNodeConverter<SqlUseCatalog> {
+
+    @Override
+    public Operation convertSqlNode(SqlUseCatalog node, ConvertContext context) {
+        return new UseCatalogOperation(node.catalogName());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Similar to [FLINK-31368](https://issues.apache.org/jira/browse/FLINK-31368), the SqlToOperationConverter is a bit bloated. 
Introduce SqlNodeConverter for SqlCatalog*-related conversion logic

## Brief change log
- Add SqlNodeConverter implementation of SqlUseCatalogConverter, SqlShowCatalogsConverter,SqlShowCurrentCatalogConverter and SqlDropCatalogConverter

## Verifying this change
This change is already covered by existing tests, such as (please describe tests).

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving):  no
The serializers: no
The runtime per-record code paths (performance sensitive):  no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: 
 no
The S3 file system connector:  no 

## Documentation
Does this pull request introduce a new feature?  no
If yes, how is the feature documented? not applicable 