### PR TITLE
[FLINK-31214][python] Add support for new cli option -py.pythonpath

### DIFF
--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -102,7 +102,7 @@
             <td><h5>python.pythonpath</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specify the path on the Worker Node where the Flink Python Dependencies are installed, which gets added into the PYTHONPATH of the Python Worker. </td>
+            <td>Specify the path on the Worker Node where the Flink Python Dependencies are installed, which gets added into the PYTHONPATH of the Python Worker. The option is equivalent to the command line option "-pypath".</td>
         </tr>
         <tr>
             <td><h5>python.requirements</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -278,6 +278,15 @@ public class CliFrontendParser {
                             + "process when submitting the Python jobs via \"flink run\" or compiling "
                             + "the Java/Scala jobs containing Python UDFs.");
 
+    public static final Option PYTHON_PATH =
+            new Option(
+                    "pypath",
+                    "pyPythonPath",
+                    true,
+                    "Specify the path of the python installation in worker nodes."
+                            + "(e.g.: --pyPythonPath /python/lib64/python3.7/)."
+                            + "User can specify multiple paths using the separator \":\".");
+
     static {
         HELP_OPTION.setRequired(false);
 
@@ -344,6 +353,8 @@ public class CliFrontendParser {
         PYEXEC_OPTION.setRequired(false);
 
         PYCLIENTEXEC_OPTION.setRequired(false);
+
+        PYTHON_PATH.setRequired(false);
     }
 
     static final Options RUN_OPTIONS = getRunCommandOptions();
@@ -371,6 +382,7 @@ public class CliFrontendParser {
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
         options.addOption(PYCLIENTEXEC_OPTION);
+        options.addOption(PYTHON_PATH);
         return options;
     }
 
@@ -387,6 +399,7 @@ public class CliFrontendParser {
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
         options.addOption(PYCLIENTEXEC_OPTION);
+        options.addOption(PYTHON_PATH);
         return options;
     }
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -41,6 +41,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYTHON_PATH;
 import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 
 /** Utility class for {@link ProgramOptions}. */
@@ -61,15 +62,16 @@ public enum ProgramOptionsUtils {
     }
 
     /**
-     * @return True if the commandline contains "-pyfs", "-pyarch", "-pyreq", "-pyexec" options,
-     *     false otherwise.
+     * @return True if the commandline contains "-pyfs", "-pyarch", "-pyreq", "-pyexec", "-pypath"
+     *     options, false otherwise.
      */
     public static boolean containsPythonDependencyOptions(CommandLine line) {
         return line.hasOption(PYFILES_OPTION.getOpt())
                 || line.hasOption(PYREQUIREMENTS_OPTION.getOpt())
                 || line.hasOption(PYARCHIVE_OPTION.getOpt())
                 || line.hasOption(PYEXEC_OPTION.getOpt())
-                || line.hasOption(PYCLIENTEXEC_OPTION.getOpt());
+                || line.hasOption(PYCLIENTEXEC_OPTION.getOpt())
+                || line.hasOption(PYTHON_PATH.getOpt());
     }
 
     public static ProgramOptions createPythonProgramOptions(CommandLine line)

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -131,7 +131,8 @@ public class PythonOptions {
                             Description.builder()
                                     .text(
                                             "Specify the path on the Worker Node where the Flink Python Dependencies are installed, which "
-                                                    + "gets added into the PYTHONPATH of the Python Worker. ")
+                                                    + "gets added into the PYTHONPATH of the Python Worker."
+                                                    + " The option is equivalent to the command line option \"-pypath\".")
                                     .build());
 
     public static final ConfigOption<String> PYTHON_ARCHIVES =

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
@@ -44,6 +44,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYTHON_PATH;
 import static org.apache.flink.python.PythonOptions.PYTHON_ARCHIVES_DISTRIBUTED_CACHE_INFO;
 import static org.apache.flink.python.PythonOptions.PYTHON_CLIENT_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
@@ -109,6 +110,9 @@ public class PythonDependencyUtils {
             config.set(
                     PythonOptions.PYTHON_CLIENT_EXECUTABLE,
                     commandLine.getOptionValue(PYCLIENTEXEC_OPTION.getOpt()));
+        }
+        if (commandLine.hasOption(PYTHON_PATH.getOpt())) {
+            config.set(PythonOptions.PYTHON_PATH, commandLine.getOptionValue(PYTHON_PATH.getOpt()));
         }
 
         return config;
@@ -312,6 +316,11 @@ public class PythonDependencyUtils {
 
             config.getOptional(PYTHON_CLIENT_EXECUTABLE)
                     .ifPresent(e -> pythonDependencyConfig.set(PYTHON_CLIENT_EXECUTABLE, e));
+
+            config.getOptional(PythonOptions.PYTHON_PATH)
+                    .ifPresent(
+                            pyPath ->
+                                    pythonDependencyConfig.set(PythonOptions.PYTHON_PATH, pyPath));
         }
 
         private String generateUniqueFileKey(String prefix, String hashString) {

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
@@ -31,6 +31,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYTHON_PATH;
 import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
@@ -49,6 +50,7 @@ class PythonProgramOptionsTest {
         options.addOption(PYREQUIREMENTS_OPTION);
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
+        options.addOption(PYTHON_PATH);
     }
 
     @Test
@@ -60,6 +62,7 @@ class PythonProgramOptionsTest {
             "-pyreq", "a.txt#b_dir",
             "-pyarch", "c.zip#venv,d.zip",
             "-pyexec", "bin/python",
+            "-pypath", "bin/python/lib/:bin/python/lib64",
             "userarg1", "userarg2"
         };
 
@@ -72,6 +75,8 @@ class PythonProgramOptionsTest {
         assertThat(config.get(PYTHON_REQUIREMENTS)).isEqualTo("a.txt#b_dir");
         assertThat(config.get(PythonOptions.PYTHON_ARCHIVES)).isEqualTo("c.zip#venv,d.zip");
         assertThat(config.get(PYTHON_EXECUTABLE)).isEqualTo("bin/python");
+        assertThat(config.get(PythonOptions.PYTHON_PATH))
+                .isEqualTo("bin/python/lib/:bin/python/lib64");
         assertThat(programOptions.getProgramArgs())
                 .containsExactly(
                         "--python", "test.py", "--pyModule", "test", "userarg1", "userarg2");
@@ -80,13 +85,22 @@ class PythonProgramOptionsTest {
     @Test
     void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
         String[] args = {
-            "--python", "xxx.py",
-            "--pyModule", "xxx",
-            "--pyFiles", "/absolute/a.py,relative/b.py,relative/c.py",
-            "--pyRequirements", "d.txt#e_dir",
-            "--pyExecutable", "/usr/bin/python",
-            "--pyArchives", "g.zip,h.zip#data,h.zip#data2",
-            "userarg1", "userarg2"
+            "--python",
+            "xxx.py",
+            "--pyModule",
+            "xxx",
+            "--pyFiles",
+            "/absolute/a.py,relative/b.py,relative/c.py",
+            "--pyRequirements",
+            "d.txt#e_dir",
+            "--pyExecutable",
+            "/usr/bin/python",
+            "--pyArchives",
+            "g.zip,h.zip#data,h.zip#data2",
+            "--pyPythonPath",
+            "bin/python/lib/:bin/python/lib64",
+            "userarg1",
+            "userarg2"
         };
         CommandLine line = CliFrontendParser.parse(options, args, false);
         PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
@@ -98,6 +112,8 @@ class PythonProgramOptionsTest {
         assertThat(config.get(PythonOptions.PYTHON_ARCHIVES))
                 .isEqualTo("g.zip,h.zip#data,h.zip#data2");
         assertThat(config.get(PYTHON_EXECUTABLE)).isEqualTo("/usr/bin/python");
+        assertThat(config.get(PythonOptions.PYTHON_PATH))
+                .isEqualTo("bin/python/lib/:bin/python/lib64");
         assertThat(programOptions.getProgramArgs())
                 .containsExactly("--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2");
     }

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -188,4 +188,18 @@ class PythonOptionsTest {
                 configuration.getBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
         assertThat(actualIsSystemEnvEnabled).isEqualTo(expectedIsSystemEnvEnabled);
     }
+
+    @Test
+    void testPythonPath() {
+        final Configuration configuration = new Configuration();
+        final Optional<String> defaultPythonPath =
+                configuration.getOptional(PythonOptions.PYTHON_PATH);
+        assertThat(defaultPythonPath).isEmpty();
+
+        final String expectedPythonPath = "venv/py37/bin/python";
+        configuration.set(PythonOptions.PYTHON_PATH, expectedPythonPath);
+
+        final String actualPythonPath = configuration.get(PythonOptions.PYTHON_PATH);
+        assertThat(actualPythonPath).isEqualTo(expectedPythonPath);
+    }
 }

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
@@ -234,6 +234,18 @@ class PythonDependencyUtilsTest {
         verifyConfiguration(expectedConfiguration, config);
     }
 
+    @Test
+    void testPythonPath() {
+        String pyPath =
+                "venv/bin/python3/lib64/python3.7/site-packages/:venv/bin/python3/lib/python3.7/site-packages/";
+        Configuration config = new Configuration();
+        config.set(PythonOptions.PYTHON_PATH, pyPath);
+        Configuration actual = configurePythonDependencies(cachedFiles, config);
+        Configuration expectedConfiguration = new Configuration();
+        expectedConfiguration.set(PythonOptions.PYTHON_PATH, pyPath);
+        verifyConfiguration(expectedConfiguration, actual);
+    }
+
     private void verifyCachedFiles(Map<String, String> expected) {
         Map<String, String> actual =
                 cachedFiles.stream().collect(Collectors.toMap(t -> t.f0, t -> t.f1.filePath));

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptionsParser.java
@@ -44,6 +44,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PYCLIENTEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYTHON_PATH;
 
 /** Parser for command line options. */
 public class CliOptionsParser {
@@ -183,6 +184,7 @@ public class CliOptionsParser {
         options.addOption(PYARCHIVE_OPTION);
         options.addOption(PYEXEC_OPTION);
         options.addOption(PYCLIENTEXEC_OPTION);
+        options.addOption(PYTHON_PATH);
         return options;
     }
 

--- a/flink-table/flink-sql-client/src/test/resources/cli/all-mode-help.out
+++ b/flink-table/flink-sql-client/src/test/resources/cli/all-mode-help.out
@@ -106,6 +106,12 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 file:///tmp/myresource.zip,hdfs:
                                                 ///$namenode_address/myresource2
                                                 .zip).
+     -pypath,--pyPythonPath <arg>               Specify the path of the python
+                                                installation in worker
+                                                nodes.(e.g.: --pyPythonPath
+                                                /python/lib64/python3.7/).User
+                                                can specify multiple paths using
+                                                the separator ":".
      -pyreq,--pyRequirements <arg>              Specify a requirements.txt file
                                                 which defines the third-party
                                                 dependencies. These dependencies

--- a/flink-table/flink-sql-client/src/test/resources/cli/embedded-mode-help.out
+++ b/flink-table/flink-sql-client/src/test/resources/cli/embedded-mode-help.out
@@ -103,6 +103,12 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 file:///tmp/myresource.zip,hdfs:
                                                 ///$namenode_address/myresource2
                                                 .zip).
+     -pypath,--pyPythonPath <arg>               Specify the path of the python
+                                                installation in worker
+                                                nodes.(e.g.: --pyPythonPath
+                                                /python/lib64/python3.7/).User
+                                                can specify multiple paths using
+                                                the separator ":".
      -pyreq,--pyRequirements <arg>              Specify a requirements.txt file
                                                 which defines the third-party
                                                 dependencies. These dependencies


### PR DESCRIPTION

## What is the purpose of the change

Add support for new cli option -py.pythonpath. this config will point to path on the instances where python is installed.


## Verifying changes 

covered in UT

## Brief change log

- `-pypythonPath` for command line option.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
