### PR TITLE
[FLINK-31530] support oraclecatalog

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
@@ -9,7 +9,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class OracleTablePath {
 
 
-    private static final String DEFAULT_POSTGRES_SCHEMA_NAME = "public";
+    private static final String DEFAULT_ORACLE_SCHEMA_NAME = "public";
 
     private final String oracleSchemaName;
     private final String oracleTableName;
@@ -22,7 +22,7 @@ public class OracleTablePath {
         this.oracleTableName = pgTableName;
     }
 
-    public static org.apache.flink.connector.jdbc.catalog.PostgresTablePath fromFlinkTableName(String flinkTableName) {
+    public static OracleTablePath fromFlinkTableName(String flinkTableName) {
         if (flinkTableName.contains(".")) {
             String[] path = flinkTableName.split("\\.");
 
@@ -32,9 +32,9 @@ public class OracleTablePath {
                             "Table name '%s' is not valid. The parsed length is %d",
                             flinkTableName, path.length));
 
-            return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(path[0], path[1]);
+            return new OracleTablePath(path[0], path[1]);
         } else {
-            return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(DEFAULT_POSTGRES_SCHEMA_NAME, flinkTableName);
+            return new OracleTablePath(DEFAULT_ORACLE_SCHEMA_NAME, flinkTableName);
         }
     }
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
@@ -1,0 +1,82 @@
+package org.apache.flink.connector.jdbc;
+
+import org.apache.flink.util.StringUtils;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+public class OracleTablePath {
+
+
+    private static final String DEFAULT_POSTGRES_SCHEMA_NAME = "public";
+
+    private final String oracleSchemaName;
+    private final String oracleTableName;
+
+    public OracleTablePath(String pgSchemaName, String pgTableName) {
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(pgSchemaName));
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(pgTableName));
+
+        this.oracleSchemaName = pgSchemaName;
+        this.oracleTableName = pgTableName;
+    }
+
+    public static org.apache.flink.connector.jdbc.catalog.PostgresTablePath fromFlinkTableName(String flinkTableName) {
+        if (flinkTableName.contains(".")) {
+            String[] path = flinkTableName.split("\\.");
+
+            checkArgument(
+                    path != null && path.length == 2,
+                    String.format(
+                            "Table name '%s' is not valid. The parsed length is %d",
+                            flinkTableName, path.length));
+
+            return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(path[0], path[1]);
+        } else {
+            return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(DEFAULT_POSTGRES_SCHEMA_NAME, flinkTableName);
+        }
+    }
+
+    public static String toFlinkTableName(String schema, String table) {
+        return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(schema, table).getFullPath();
+    }
+
+    public String getFullPath() {
+        return String.format("%s.%s", oracleSchemaName, oracleTableName);
+    }
+
+    public String getOracleTableName() {
+        return oracleTableName;
+    }
+
+    public String getOracleSchemaName() {
+        return oracleSchemaName;
+    }
+
+    @Override
+    public String toString() {
+        return getFullPath();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        OracleTablePath that = (OracleTablePath) o;
+        return Objects.equals(oracleSchemaName,that.oracleSchemaName )
+                && Objects.equals(oracleTableName, that.oracleTableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oracleSchemaName, oracleTableName);
+    }
+
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/OracleTablePath.java
@@ -39,7 +39,7 @@ public class OracleTablePath {
     }
 
     public static String toFlinkTableName(String schema, String table) {
-        return new org.apache.flink.connector.jdbc.catalog.PostgresTablePath(schema, table).getFullPath();
+        return new OracleTablePath(schema, table).getFullPath();
     }
 
     public String getFullPath() {

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalogUtils.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalogUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.jdbc.catalog;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialectLoader;
 import org.apache.flink.connector.jdbc.dialect.mysql.MySqlDialect;
+import org.apache.flink.connector.jdbc.dialect.oracle.OracleDialect;
 import org.apache.flink.connector.jdbc.dialect.psql.PostgresDialect;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -52,6 +53,9 @@ public class JdbcCatalogUtils {
                     userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
         } else if (dialect instanceof MySqlDialect) {
             return new MySqlCatalog(
+                    userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+        } else if (dialect instanceof OracleDialect) {
+            return new OracleCatalog(
                     userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
         } else {
             throw new UnsupportedOperationException(

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/OracleCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/OracleCatalog.java
@@ -2,6 +2,7 @@ package org.apache.flink.connector.jdbc.catalog;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.apache.flink.connector.jdbc.OracleTablePath;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialectTypeMapper;
 
 import org.apache.flink.connector.jdbc.dialect.oracle.OracleTypeMapper;
@@ -145,17 +146,17 @@ public class OracleCatalog extends AbstractJdbcCatalog {
     @Override
 
     protected String getTableName(ObjectPath tablePath) {
-        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgTableName();
+        return OracleTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgTableName();
     }
 
     @Override
     protected String getSchemaName(ObjectPath tablePath) {
-        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgSchemaName();
+        return OracleTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgSchemaName();
     }
 
     @Override
     protected String getSchemaTableName(ObjectPath tablePath) {
-        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getFullPath();
+        return OracleTablePath.fromFlinkTableName(tablePath.getObjectName()).getFullPath();
     }
 
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/OracleCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/OracleCatalog.java
@@ -1,0 +1,161 @@
+package org.apache.flink.connector.jdbc.catalog;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectTypeMapper;
+
+import org.apache.flink.connector.jdbc.dialect.oracle.OracleTypeMapper;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.util.TemporaryClassLoaderContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class OracleCatalog extends AbstractJdbcCatalog {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OracleCatalog.class);
+
+    private final JdbcDialectTypeMapper dialectTypeMapper;
+    private static final Set<String> builtinDatabases = new HashSet<String>() {
+        {
+            add("SCOTT");
+            add("ANONYMOUS");
+            add("XS$NULL");
+            add("DIP");
+            add("SPATIAL_WFS_ADMIN_USR");
+            add("SPATIAL_CSW_ADMIN_USR");
+            add("APEX_PUBLIC_USER");
+            add("ORACLE_OCM");
+            add("MDDATA");
+        }
+    };
+
+    public OracleCatalog(ClassLoader userClassLoader,
+
+                         String catalogName,
+
+                         String defaultDatabase,
+
+                         String username,
+
+                         String pwd,
+
+                         String baseUrl) {
+
+        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+
+        String driverVersion = Preconditions.checkNotNull(getDriverVersion(), "Driver version must not be null.");
+
+        String databaseVersion = Preconditions.checkNotNull(getDatabaseVersion(), "Database version must not be null.");
+
+        LOG.info("Driver version: {}, database version: {}", driverVersion, databaseVersion);
+
+        this.dialectTypeMapper = new OracleTypeMapper(databaseVersion, driverVersion);
+
+    }
+
+    private String getDatabaseVersion() {
+        try (TemporaryClassLoaderContext ignored =
+                     TemporaryClassLoaderContext.of(userClassLoader)) {
+            try (Connection conn = DriverManager.getConnection(defaultUrl, username, pwd)) {
+                return conn.getMetaData().getDatabaseProductVersion();
+            } catch (Exception e) {
+                throw new CatalogException(
+                        String.format("Failed in getting Oracle version by %s.", defaultUrl), e);
+            }
+        }
+    }
+
+    private String getDriverVersion() {
+
+        try (TemporaryClassLoaderContext ignored =
+                     TemporaryClassLoaderContext.of(userClassLoader)) {
+            try (Connection conn = DriverManager.getConnection(defaultUrl, username, pwd)) {
+                String driverVersion = conn.getMetaData().getDriverVersion();
+                Pattern regexp = Pattern.compile("\\d+?\\.\\d+?\\.\\d+");
+                Matcher matcher = regexp.matcher(driverVersion);
+                return matcher.find() ? matcher.group(0) : null;
+            } catch (Exception e) {
+                throw new CatalogException(
+                        String.format("Failed in getting Oracle driver version by %s.", defaultUrl), e);
+            }
+        }
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+
+        return extractColumnValuesBySQL(this.defaultUrl,
+                "select username from sys.dba_users " +
+                        "where DEFAULT_TABLESPACE <> 'SYSTEM' and DEFAULT_TABLESPACE <> 'SYSAUX' " +
+                        " order by username",
+                1,
+                dbName -> !builtinDatabases.contains(dbName));
+    }
+
+    @Override
+    public List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException {
+        Preconditions.checkState(StringUtils.isNotBlank(databaseName), "Database name must not be blank.");
+        if (!databaseExists(databaseName)){// 注意这个值是 oracle 实例名称
+            throw new DatabaseNotExistException(getName(), databaseName);
+        }
+        List<String> listDatabases = listDatabases().stream().map(username -> "'" + username + "'").collect(Collectors.toList());
+        return extractColumnValuesBySQL(
+                this.defaultUrl,
+                "SELECT OWNER||'.'||TABLE_NAME AS schemaTableName FROM sys.all_tables WHERE OWNER IN (" + String.join(",", listDatabases) + ")"+
+                        "ORDER BY OWNER,TABLE_NAME",1, null, null);
+    }
+
+    @Override
+    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+        String[] schemaTableNames = getSchemaTableName(tablePath).split("\\.");
+        return !extractColumnValuesBySQL( defaultUrl,
+                "SELECT table_name FROM sys.all_tables where OWNER = ? and table_name = ?",
+                1, null,
+                schemaTableNames[0], schemaTableNames[1])
+                .isEmpty();
+    }
+
+    /**
+
+     * Converts Oracle type to Flink {@link DataType}.
+
+     */
+    @Override
+    protected DataType fromJDBCType(ObjectPath tablePath, ResultSetMetaData metadata, int colIndex) throws SQLException {
+        return dialectTypeMapper.mapping(tablePath, metadata, colIndex);
+    }
+
+    @Override
+
+    protected String getTableName(ObjectPath tablePath) {
+        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgTableName();
+    }
+
+    @Override
+    protected String getSchemaName(ObjectPath tablePath) {
+        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getPgSchemaName();
+    }
+
+    @Override
+    protected String getSchemaTableName(ObjectPath tablePath) {
+        return PostgresTablePath.fromFlinkTableName(tablePath.getObjectName()).getFullPath();
+    }
+
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleDialect.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.jdbc.dialect.oracle;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
 import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
 import org.apache.flink.connector.jdbc.internal.converter.OracleRowConverter;
@@ -31,7 +32,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /** JDBC dialect for Oracle. */
-class OracleDialect extends AbstractDialect {
+@Internal
+public class OracleDialect extends AbstractDialect {
 
     private static final long serialVersionUID = 1L;
 
@@ -52,7 +54,7 @@ class OracleDialect extends AbstractDialect {
 
     @Override
     public String getLimitClause(long limit) {
-        return "FETCH FIRST " + limit + " ROWS ONLY";
+        return "WHERE ROWNUM <= " + limit;
     }
 
     @Override

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTypeMapper.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTypeMapper.java
@@ -1,0 +1,85 @@
+package org.apache.flink.connector.jdbc.dialect.oracle;
+
+import oracle.jdbc.internal.OracleTypes;
+
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectTypeMapper;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class OracleTypeMapper implements JdbcDialectTypeMapper {
+
+    private final String databaseVersion;
+
+    private final String driverVersion;
+
+    public OracleTypeMapper(String databaseVersion, String driverVersion) {
+
+        this.databaseVersion = databaseVersion;
+
+        this.driverVersion = driverVersion;
+
+    }
+
+    @Override
+    public DataType mapping(ObjectPath tablePath, ResultSetMetaData metadata, int colIndex) throws SQLException {
+        int jdbcType = metadata.getColumnType(colIndex);
+        String columnName = metadata.getColumnName(colIndex);
+        String oracleType = metadata.getColumnTypeName(colIndex).toUpperCase();
+        int precision = metadata.getPrecision(colIndex);
+        int scale = metadata.getScale(colIndex);
+        switch (jdbcType) {
+
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.STRUCT:
+            case Types.CLOB:
+                return DataTypes.STRING();
+            case Types.BLOB:
+                return DataTypes.BYTES();
+            case Types.INTEGER:
+            case Types.SMALLINT:
+            case Types.TINYINT:
+                return DataTypes.INT();
+            case Types.FLOAT:
+            case Types.REAL:
+            case OracleTypes.BINARY_FLOAT:
+                return DataTypes.FLOAT();
+            case Types.DOUBLE:
+            case OracleTypes.BINARY_DOUBLE:
+                return DataTypes.DOUBLE();
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                if (precision > 0 && precision < DecimalType.MAX_PRECISION) {
+                    return DataTypes.DECIMAL(precision, metadata.getScale(colIndex));
+                }
+                return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
+            case Types.DATE:
+                return DataTypes.DATE();
+            case Types.TIMESTAMP:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+            case OracleTypes.TIMESTAMPTZ:
+            case OracleTypes.TIMESTAMPLTZ:
+                return scale > 0 ? DataTypes.TIMESTAMP(scale) : DataTypes.TIMESTAMP();
+            case OracleTypes.INTERVALYM:
+                return DataTypes.INTERVAL(DataTypes.YEAR(), DataTypes.MONTH());
+            case OracleTypes.INTERVALDS:
+                return DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND());
+            case Types.BOOLEAN:
+                return DataTypes.BOOLEAN();
+            default:
+                final String jdbcColumnName = metadata.getColumnName(colIndex);
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Doesn't support Oracle type '%s' on column '%s' in Oracle version %s, driver version %s yet.",
+                                oracleType, jdbcColumnName, databaseVersion, driverVersion));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

For currently commonly used databases, MySQL and Postgres have implemented catalogs. Currently, catalogs are implemented based on Oracle

Related to [FLINK-31530](https://issues.apache.org/jira/browse/FLINK-31530)
## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
