### PR TITLE
[FLINK-31538][jdbc-driver] Supports parse catalog/database and properties for uri

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver/pom.xml
@@ -47,4 +47,23 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>org/apache/flink/table/jdbc/driver.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>org/apache/flink/table/jdbc/driver.properties</exclude>
+				</excludes>
+			</resource>
+		</resources>
+	</build>
 </project>

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseConnection.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseConnection.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/** Base connection in flink driver. */
+abstract class BaseConnection implements Connection {
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareCall is not supported yet.");
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#nativeSQL is not supported yet.");
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setAutoCommit is not supported yet.");
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getAutoCommit is not supported yet.");
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#commit is not supported yet.");
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#rollback is not supported yet.");
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setReadOnly is not supported yet.");
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#isReadOnly is not supported yet.");
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setTransactionIsolation is not supported yet.");
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getTransactionIsolation is not supported yet.");
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getWarnings is not supported yet.");
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#clearWarnings is not supported yet.");
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createStatement is not supported yet.");
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(
+            String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareCall is not supported yet.");
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getTypeMap is not supported yet.");
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setTypeMap is not supported yet.");
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setHoldability is not supported yet.");
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getHoldability is not supported yet.");
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setSavepoint is not supported yet.");
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setSavepoint is not supported yet.");
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#rollback is not supported yet.");
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#releaseSavepoint is not supported yet.");
+    }
+
+    @Override
+    public Statement createStatement(
+            int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createStatement is not supported yet.");
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(
+            String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public CallableStatement prepareCall(
+            String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareCall is not supported yet.");
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames)
+            throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#prepareStatement is not supported yet.");
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createClob is not supported yet.");
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createBlob is not supported yet.");
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createNClob is not supported yet.");
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createSQLXML is not supported yet.");
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#isValid is not supported yet.");
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createArrayOf is not supported yet.");
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#createStruct is not supported yet.");
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#abort is not supported yet.");
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#setNetworkTimeout is not supported yet.");
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#getNetworkTimeout is not supported yet.");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkConnection#unwrap is not supported yet.");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkConnection#isWrapperFor is not supported yet.");
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverInfo.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.Integer.parseInt;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Driver info for flink driver, it reads driver name and version from driver.properties which will
+ * be updated by flink version.
+ */
+final class DriverInfo {
+    private static final Logger LOG = LoggerFactory.getLogger(DriverInfo.class);
+
+    private static final String DRIVER_NAME_OPTION = "flink.driver.name";
+    private static final String DRIVER_VERSION_OPTION = "flink.driver.version";
+    static final String DRIVER_NAME;
+    static final String DRIVER_VERSION;
+    static final int DRIVER_VERSION_MAJOR;
+    static final int DRIVER_VERSION_MINOR;
+
+    static {
+        try {
+            Properties properties = new Properties();
+            URL url = DriverInfo.class.getResource("driver.properties");
+            try (InputStream in = checkNotNull(url.openStream())) {
+                properties.load(in);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            DRIVER_NAME =
+                    checkNotNull(
+                            properties.getProperty(DRIVER_NAME_OPTION),
+                            String.format("%s is null or empty", DRIVER_NAME_OPTION));
+            DRIVER_VERSION =
+                    checkNotNull(
+                            properties.getProperty(DRIVER_VERSION_OPTION),
+                            String.format("%s is null or empty", DRIVER_VERSION_OPTION));
+
+            Matcher matcher =
+                    Pattern.compile("^(\\d+)(\\.(\\d+))($|[.-])?").matcher(DRIVER_VERSION);
+            checkState(
+                    matcher.find(),
+                    String.format("%s is invalid: %s", DRIVER_VERSION_OPTION, DRIVER_VERSION));
+
+            DRIVER_VERSION_MAJOR = parseInt(matcher.group(1));
+            final String minor = matcher.group(3);
+            DRIVER_VERSION_MINOR =
+                    parseInt(StringUtils.isNullOrWhitespaceOnly(minor) ? "0" : minor);
+        } catch (RuntimeException e) {
+            LOG.error("Failed to load flink driver info", e);
+            throw e;
+        }
+    }
+
+    private DriverInfo() {}
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverUri.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/DriverUri.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.util.StringUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Splitter;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static java.lang.String.format;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Parse catalog, table and connection properties from uri for {@link FlinkDriver}. */
+public class DriverUri {
+    private static final String URL_PREFIX = "jdbc:";
+    private static final String URL_START = URL_PREFIX + "flink:";
+
+    private static final Splitter URL_ARG_SPLITTER = Splitter.on('&').omitEmptyStrings();
+    private static final Splitter ARG_VALUE_SPLITTER = Splitter.on('=').limit(2);
+    private final String host;
+    private final int port;
+    private final URI uri;
+
+    private final Properties properties;
+
+    private Optional<String> catalog = Optional.empty();
+    private Optional<String> database = Optional.empty();
+
+    private DriverUri(String url, Properties driverProperties) throws SQLException {
+        this(parseDriverUrl(url), driverProperties);
+    }
+
+    private DriverUri(URI uri, Properties driverProperties) throws SQLException {
+        this.uri = checkNotNull(uri, "uri is null");
+        this.host = uri.getHost();
+        this.port = uri.getPort();
+        this.properties = mergeDynamicProperties(uri, driverProperties);
+
+        initCatalogAndSchema();
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public Optional<String> getCatalog() {
+        return catalog;
+    }
+
+    public Optional<String> getDatabase() {
+        return database;
+    }
+
+    private void initCatalogAndSchema() throws SQLException {
+        String path = uri.getPath();
+        if (StringUtils.isNullOrWhitespaceOnly(uri.getPath()) || path.equals("/")) {
+            return;
+        }
+
+        // remove first slash
+        if (!path.startsWith("/")) {
+            throw new SQLException("Path in uri does not start with a slash: " + uri);
+        }
+        path = path.substring(1);
+
+        List<String> parts = Splitter.on("/").splitToList(path);
+        // remove last item due to a trailing slash
+        if (parts.get(parts.size() - 1).isEmpty()) {
+            parts = parts.subList(0, parts.size() - 1);
+        }
+
+        if (parts.size() > 2) {
+            throw new SQLException("Invalid path segments in URL: " + uri);
+        }
+
+        if (parts.get(0).isEmpty()) {
+            throw new SQLException("Catalog name in URL is empty: " + uri);
+        }
+
+        catalog = Optional.ofNullable(parts.get(0));
+
+        if (parts.size() > 1) {
+            if (parts.get(1).isEmpty()) {
+                throw new SQLException("Database name in URL is empty: " + uri);
+            }
+
+            database = Optional.ofNullable(parts.get(1));
+        }
+    }
+
+    private static Properties mergeDynamicProperties(URI uri, Properties driverProperties)
+            throws SQLException {
+        Map<String, String> urlProperties = parseUriParameters(uri.getQuery());
+        Map<String, String> suppliedProperties = Maps.fromProperties(driverProperties);
+
+        for (String key : urlProperties.keySet()) {
+            if (suppliedProperties.containsKey(key)) {
+                throw new SQLException(
+                        format("Connection property '%s' is both in the URL and an argument", key));
+            }
+        }
+
+        Properties result = new Properties();
+        setMapToProperties(result, urlProperties);
+        setMapToProperties(result, suppliedProperties);
+        return result;
+    }
+
+    private static void setMapToProperties(Properties properties, Map<String, String> values) {
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private static Map<String, String> parseUriParameters(String query) throws SQLException {
+        Map<String, String> result = new HashMap<>();
+
+        if (query != null) {
+            Iterable<String> queryArgs = URL_ARG_SPLITTER.split(query);
+            for (String queryArg : queryArgs) {
+                List<String> parts = ARG_VALUE_SPLITTER.splitToList(queryArg);
+                if (parts.size() != 2) {
+                    throw new SQLException(
+                            format(
+                                    "Connection property in uri must be key=val format: '%s'",
+                                    queryArg));
+                }
+                if (result.put(parts.get(0), parts.get(1)) != null) {
+                    throw new SQLException(
+                            format(
+                                    "Connection property '%s' is in URL multiple times",
+                                    parts.get(0)));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static URI parseDriverUrl(String url) throws SQLException {
+        if (!url.startsWith(URL_START)) {
+            throw new SQLException("Invalid Flink JDBC URL: " + url);
+        }
+
+        if (url.equals(URL_START)) {
+            throw new SQLException("Empty Flink JDBC URL: " + url);
+        }
+
+        URI uri;
+        try {
+            uri = new URI(url.substring(URL_PREFIX.length()));
+        } catch (URISyntaxException e) {
+            throw new SQLException("Invalid Flink JDBC URL: " + url, e);
+        }
+
+        if (StringUtils.isNullOrWhitespaceOnly(uri.getHost())) {
+            throw new SQLException("No host specified in uri: " + url);
+        }
+        if (uri.getPort() == -1) {
+            throw new SQLException("No port specified in uri: " + url);
+        }
+        if ((uri.getPort() < 1) || (uri.getPort() > 65535)) {
+            throw new SQLException("Port must be [1, 65535] in uri: " + url);
+        }
+        return uri;
+    }
+
+    public static boolean acceptsURL(String url) {
+        return url.startsWith(URL_START);
+    }
+
+    public static DriverUri create(String url, Properties properties) throws SQLException {
+        return new DriverUri(url, properties == null ? new Properties() : properties);
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/** Connection to flink sql gateway for jdbc driver. */
+public class FlinkConnection extends BaseConnection {
+    private final DriverUri driverUri;
+
+    public FlinkConnection(DriverUri driverUri) {
+        this.driverUri = driverUri;
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public void close() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        throw new SQLClientInfoException();
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        throw new SQLClientInfoException();
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DriverUtils.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DriverUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.utils;
+
+import javax.annotation.Nullable;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/** Utils methods are copied from flink-core for flink jdbc driver to avoid excessive dependency. */
+public class DriverUtils {
+
+    /**
+     * Ensures that the given object reference is not null. Upon violation, a {@code
+     * NullPointerException} with the given message is thrown.
+     *
+     * @param reference The object reference
+     * @param errorMessage The message for the {@code NullPointerException} that is thrown if the
+     *     check fails.
+     * @return The object reference itself (generically typed).
+     * @throws NullPointerException Thrown, if the passed reference was null.
+     */
+    public static <T> T checkNotNull(@Nullable T reference, @Nullable String errorMessage) {
+        if (reference == null) {
+            throw new NullPointerException(String.valueOf(errorMessage));
+        }
+        return reference;
+    }
+
+    /**
+     * Checks the given boolean condition, and throws an {@code IllegalArgumentException} if the
+     * condition is not met (evaluates to {@code false}). The exception will have the given error
+     * message.
+     *
+     * @param condition The condition to check
+     * @param errorMessage The message for the {@code IllegalArgumentException} that is thrown if
+     *     the check fails.
+     * @throws IllegalArgumentException Thrown, if the condition is violated.
+     */
+    public static void checkArgument(boolean condition, @Nullable Object errorMessage) {
+        if (!condition) {
+            throw new IllegalArgumentException(String.valueOf(errorMessage));
+        }
+    }
+
+    /**
+     * Checks if the string is null, empty, or contains only whitespace characters. A whitespace
+     * character is defined via {@link Character#isWhitespace(char)}.
+     *
+     * @param str The string to check
+     * @return True, if the string is null or blank, false otherwise.
+     */
+    public static boolean isNullOrWhitespaceOnly(String str) {
+        if (str == null || str.length() == 0) {
+            return true;
+        }
+
+        final int len = str.length();
+        for (int i = 0; i < len; i++) {
+            if (!Character.isWhitespace(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Generate map from given properties.
+     *
+     * @param properties the given properties
+     * @return the result map
+     */
+    public static Map<String, String> fromProperties(Properties properties) {
+        Map<String, String> map = new HashMap<>();
+        Enumeration<?> e = properties.propertyNames();
+
+        while (e.hasMoreElements()) {
+            String key = (String) e.nextElement();
+            map.put(key, properties.getProperty(key));
+        }
+
+        return map;
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/resources/org/apache/flink/table/jdbc/driver.properties
+++ b/flink-table/flink-sql-jdbc-driver/src/main/resources/org/apache/flink/table/jdbc/driver.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+flink.driver.name=Flink JDBC Driver
+flink.driver.version=${project.version}

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDriverTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDriverTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_NAME;
+import static org.apache.flink.table.jdbc.DriverInfo.DRIVER_VERSION_MAJOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link FlinkDriver}. */
+public class FlinkDriverTest {
+    @Test
+    public void testDriverInfo() {
+        assertEquals(DRIVER_VERSION_MAJOR, 1);
+        assertEquals(DRIVER_NAME, "Flink JDBC Driver");
+    }
+
+    @Test
+    public void testDriverUri() throws Exception {
+        String uri =
+                "jdbc:flink://localhost:8888/catalog_name/database_name?sessionId=123&key1=val1&key2=val2";
+        assertTrue(DriverUri.acceptsURL(uri));
+
+        Properties properties = new Properties();
+        properties.put("key3", "val3");
+        properties.put("key4", "val4");
+        DriverUri driverUri = DriverUri.create(uri, properties);
+        assertEquals("catalog_name", driverUri.getCatalog().get());
+        assertEquals("database_name", driverUri.getDatabase().get());
+        assertEquals("localhost", driverUri.getHost());
+        assertEquals(8888, driverUri.getPort());
+        assertEquals(5, driverUri.getProperties().size());
+
+        properties.put("key1", "val11");
+        assertThrows(
+                SQLException.class,
+                () -> DriverUri.create(uri, properties),
+                "Connection property 'key1' is both in the URL and an argument");
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR aims to parse catalog/database/properties for uri and read `project.version` as jdbc version. 

## Brief change log
  - Added `DriverInfo` to read project version
  - Added `DriverUri` to parse catalog/database and properties for uri
  - Added `FlinkConnection` to implement `java.sql.Connection`

## Verifying this change
This change added tests and can be verified as follows:

  - Added `FlinkDriverTest.testDriverInfo` to test version
  - Added `FlinkDriverTest.testDriverUri` to parse catalog/properties for uri

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
