### PR TITLE
[FLINK-31555][docs-zh] Translate "hiveserver2" page of "sql-gateway" into Chinese

### DIFF
--- a/docs/content.zh/docs/dev/table/sql-gateway/hiveserver2.md
+++ b/docs/content.zh/docs/dev/table/sql-gateway/hiveserver2.md
@@ -26,9 +26,8 @@ under the License.
 
 # HiveServer2 Endpoint
 
-HiveServer2 Endpoint is compatible with [HiveServer2](https://cwiki.apache.org/confluence/display/hive/hiveserver2+overview)
-wire protocol and allows users to interact (e.g. submit Hive SQL) with Flink SQL Gateway with existing Hive clients, such as Hive JDBC, Beeline, DBeaver, Apache Superset and so on.
+HiveServer2 Endpoint 兼容 [HiveServer2](https://cwiki.apache.org/confluence/display/hive/hiveserver2+overview)
+协议，允许用户使用 Hive JDBC、Beeline、DBeaver、Apache Superset 等 Hive 客户端和 Flink SQL Gateway 交互（例如提交 Hive SQL）。
 
-It suggests to use HiveServer2 Endpoint with Hive Catalog and Hive dialect to get the same experience
-as HiveServer2. Please refer to the [Hive Compatibility]({{< ref "docs/dev/table/hive-compatibility/hiveserver2" >}})
-for more details. 
+建议将 HiveServer2 Endpoint 和 Hive Catalog、Hive 方言一起使用，以获得与 HiveServer2 一样的使用体验。
+请参阅 [Hive Compatibility]({{< ref "docs/dev/table/hive-compatibility/hiveserver2" >}}) 了解更多详情。 


### PR DESCRIPTION

## What is the purpose of the change

This PR aims to translate "hiveserver2.md" page of "sql-gateway" into Chinese


## Brief change log
  - Translate hiveserver2.md of sql-gateway into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
