### PR TITLE
[FLINK-31557][Metrics] Add a new executor for view updater to get ride of reporters.

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -59,6 +59,7 @@ metrics.reporter.my_other_reporter.port: 10000
 **注意**：Flink 在启动时必须能访问到发送器所属的 jar 包，发送器会被加载为 [plugins]({{< ref "docs/deployment/filesystems/plugins" >}})，Flink 自带的发送器（文档中已经列出的发送器）无需做其他配置，开箱即用。
 
 你可以实现 `org.apache.flink.metrics.reporter.MetricReporter` 接口来自定义发送器，并实现 `Scheduled` 接口让发送器周期性地将运行时指标发送出去。
+需要注意 `report()` 方法不应该阻塞太长的时间，所有用时很长的操作应该异步执行。
 另外也可以实现 `MetricReporterFactory` 接口，让发送器作为插件被 Flink 导入。
 
 <a name="identifiers-vs-tags"></a>

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -59,7 +59,8 @@ metrics.reporter.my_other_reporter.port: 10000
  All reporters documented on this page are available by default.
 
 You can write your own `Reporter` by implementing the `org.apache.flink.metrics.reporter.MetricReporter` interface.
-If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well.
+If the Reporter should send out reports regularly you have to implement the `Scheduled` interface as well. 
+Be careful that `report()` method must not block for a significant amount of time, and any reporter needing more time should instead run the operation asynchronously.
 By additionally implementing a `MetricReporterFactory` your reporter can also be loaded as a plugin.
 
 ## Identifiers vs. tags

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/Scheduled.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/Scheduled.java
@@ -26,7 +26,8 @@ public interface Scheduled {
 
     /**
      * Report the current measurements. This method is called periodically by the metrics registry
-     * that uses the reporter.
+     * that uses the reporter. This method must not block for a significant amount of time, any
+     * reporter needing more time should instead run the operation asynchronously.
      */
     void report();
 }


### PR DESCRIPTION

## What is the purpose of the change
Custom reporter may block a long time in report(). The view updater may not trigger in-time, resulting rate in MeterView inaccurate.

## Brief change log
  - *Add a new executor for view updater*
  - *Update documents to informer user do not block report() long time*


## Verifying this change
This change is a trivial work without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
