### PR TITLE
[FLINK-31541][UI] encode request params to support special characters metrics name.

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
@@ -97,15 +97,17 @@ export class JobManagerService {
 
   loadMetrics(listOfMetricName: string[]): Observable<MetricMap> {
     const metricName = listOfMetricName.join(',');
-    return this.httpClient.get<JobMetric[]>(`${this.configService.BASE_URL}/jobmanager/metrics?get=${metricName}`).pipe(
-      map(arr => {
-        const result: MetricMap = {};
-        arr.forEach(item => {
-          result[item.id] = parseInt(item.value, 10);
-        });
-        return result;
-      })
-    );
+    return this.httpClient
+      .get<JobMetric[]>(`${this.configService.BASE_URL}/jobmanager/metrics`, { params: { get: metricName } })
+      .pipe(
+        map(arr => {
+          const result: MetricMap = {};
+          arr.forEach(item => {
+            result[item.id] = parseInt(item.value, 10);
+          });
+          return result;
+        })
+      );
   }
 
   loadHistoryServerConfig(jobId: string): Observable<ClusterConfiguration[]> {

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -54,7 +54,9 @@ export class MetricsService {
   public loadMetrics(jobId: string, vertexId: string, listOfMetricName: string[]): Observable<MetricMapWithTimestamp> {
     const metricName = listOfMetricName.join(',');
     return this.httpClient
-      .get<JobMetric[]>(`${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/metrics?get=${metricName}`)
+      .get<JobMetric[]>(`${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/metrics`, {
+        params: { get: metricName }
+      })
       .pipe(
         map(arr => {
           const result: MetricMap = {};
@@ -79,7 +81,8 @@ export class MetricsService {
     const metricName = listOfMetricName.join(',');
     return this.httpClient
       .get<Array<{ id: string; min: number; max: number; avg: number; sum: number }>>(
-        `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/subtasks/metrics?get=${metricName}`
+        `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/subtasks/metrics`,
+        { params: { get: metricName } }
       )
       .pipe(
         map(arr => {

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -100,7 +100,9 @@ export class TaskManagerService {
   loadMetrics(taskManagerId: string, listOfMetricName: string[]): Observable<MetricMap> {
     const metricName = listOfMetricName.join(',');
     return this.httpClient
-      .get<JobMetric[]>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/metrics?get=${metricName}`)
+      .get<JobMetric[]>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/metrics`, {
+        params: { get: metricName }
+      })
       .pipe(
         map(arr => {
           const result: MetricMap = {};


### PR DESCRIPTION
## What is the purpose of the change
User could set operator name with some special characters, such as '%' and '['. This cause request failed when try to get metrics of this operator in WEB UI. 

## Brief change log
  - *move the request parameters from url to option:params to let http client encode the special characters *

## Verifying this change
  - *Run web ui with special operator name, metrics could be retrieved successfully.*
  - ![image](https://user-images.githubusercontent.com/5869080/227109062-0f9fd59d-e4c0-4a5e-9cde-b352cd43a16a.png)
  - ![image](https://user-images.githubusercontent.com/5869080/227109066-b3cde565-cc62-4452-9712-80d3a2a6ef90.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
 
## Documentation

  - Does this pull request introduce a new feature? (no)
