### PR TITLE
[FLINK-17398][connector/filesystem] Filesystem sources support flexible path reading

### DIFF
--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -47,6 +47,8 @@ CREATE TABLE MyUserTable (
   'format' = '...',                     -- 必选：文件系统连接器指定 format
                                         -- 有关更多详情，请参考 Table Formats
   'partition.default-name' = '...',     -- 可选：默认的分区名，动态分区模式下分区字段值是 null 或空字符串
+  'source.path.regex-pattern' = '...',  -- 可选: 指定用于匹配需要读取文件的绝对路径的正则表达式，配置后连接器
+                                        -- 会遍历 path 配置项的目录下的全部文件进行匹配
 
   -- 可选：该属性开启了在 sink 阶段通过动态分区字段来 shuffle 数据，该功能可以大大减少文件系统 sink 的文件数，但是可能会导致数据倾斜，默认值是 false
   'sink.shuffle-by-partition.enable' = '...',

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -50,6 +50,11 @@ CREATE TABLE MyUserTable (
                                         -- section for more details
   'partition.default-name' = '...',     -- optional: default partition name in case the dynamic partition
                                         -- column value is null/empty string
+  'source.path.regex-pattern' = '...',  -- optional: regex pattern to filter files to read under the 
+                                        -- directory of `path` option. This regex pattern should be
+                                        -- matched with the absolute file path. If this option is set,
+                                        -- the connector  will recursive all files under the directory
+                                        -- of `path` option
 
   -- optional: the option to enable shuffle data by dynamic partition fields in sink phase, this can greatly
   -- reduce the number of file for filesystem sink but may lead data skew, the default value is false.

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveAllDirEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveAllDirEnumerator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.enumerate;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.compression.StandardDeCompressors;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+/**
+ * This {@code FileEnumerator} enumerates all files under the given paths recursively except the
+ * hidden directories, and creates a separate split for each file block.
+ *
+ * <p>Please note that file blocks are only exposed by some file systems, such as HDFS. File systems
+ * that do not expose block information will not create multiple file splits per file, but keep the
+ * files as one source split.
+ *
+ * <p>Files with suffixes corresponding to known compression formats (for example '.gzip', '.bz2',
+ * ...) will not be split. See {@link StandardDeCompressors} for a list of known formats and
+ * suffixes.
+ *
+ * <p>Compared to {@link BlockSplittingRecursiveEnumerator}, this enumerator will enumerate all
+ * files even through its parent directory is filtered out by the file filter.
+ */
+@Internal
+public class BlockSplittingRecursiveAllDirEnumerator extends BlockSplittingRecursiveEnumerator {
+
+    /** The filter used to skip hidden directories. */
+    private final DefaultFileFilter hiddenDirFilter = new DefaultFileFilter();
+
+    /**
+     * Creates a new enumerator that enumerates all files whose file path matches the regex except
+     * hidden files. Hidden files are considered files where the filename starts with '.' or with
+     * '_'.
+     *
+     * <p>The enumerator does not split files that have a suffix corresponding to a known
+     * compression format (for example '.gzip', '.bz2', '.xy', '.zip', ...). See {@link
+     * StandardDeCompressors} for details.
+     */
+    public BlockSplittingRecursiveAllDirEnumerator(String pathPattern) {
+        this(
+                new RegexFileFilter(pathPattern),
+                StandardDeCompressors.getCommonSuffixes().toArray(new String[0]));
+    }
+
+    /**
+     * Creates a new enumerator that uses the given predicate as a filter for file paths, and avoids
+     * splitting files with the given extension (typically to avoid splitting compressed files).
+     */
+    public BlockSplittingRecursiveAllDirEnumerator(
+            final Predicate<Path> fileFilter, final String[] nonSplittableFileSuffixes) {
+        super(fileFilter, nonSplittableFileSuffixes);
+    }
+
+    @Override
+    protected void addSplitsForPath(
+            FileStatus fileStatus, FileSystem fs, ArrayList<FileSourceSplit> target)
+            throws IOException {
+        if (fileStatus.isDir()) {
+            if (!hiddenDirFilter.test(fileStatus.getPath())) {
+                return;
+            }
+            final FileStatus[] containedFiles = fs.listStatus(fileStatus.getPath());
+            for (FileStatus containedStatus : containedFiles) {
+                addSplitsForPath(containedStatus, fs, target);
+            }
+        } else if (fileFilter.test(fileStatus.getPath())) {
+            convertToSourceSplits(fileStatus, fs, target);
+            return;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveAllDirEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveAllDirEnumerator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.enumerate;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+/**
+ * This {@code FileEnumerator} enumerates all files under the given paths recursively except the
+ * hidden directories. Each file matched the given regex pattern becomes one split; this enumerator
+ * does not split files into smaller "block" units.
+ *
+ * <p>The default instantiation of this enumerator filters files with the common hidden file
+ * prefixes '.' and '_'. A custom file filter can be specified.
+ *
+ * <p>Compared to {@link NonSplittingRecursiveEnumerator}, this enumerator will enumerate all files
+ * even through its parent directory is filtered out by the file filter.
+ */
+@Internal
+public class NonSplittingRecursiveAllDirEnumerator extends NonSplittingRecursiveEnumerator {
+    /** The filter used to skip hidden directories. */
+    private final DefaultFileFilter hiddenDirFilter = new DefaultFileFilter();
+
+    /**
+     * Creates a NonSplittingRegexEnumerator that enumerates all files whose file path matches the
+     * regex except hidden files. Hidden files are considered files where the filename starts with
+     * '.' or with '_'.
+     */
+    public NonSplittingRecursiveAllDirEnumerator(String pathRegexPattern) {
+        this(new RegexFileFilter(pathRegexPattern));
+    }
+
+    /**
+     * Creates a NonSplittingRegexEnumerator that enumerates all files whose file path matches the
+     * regex. Support to use given custom predicate as a filter for file paths.
+     */
+    public NonSplittingRecursiveAllDirEnumerator(Predicate<Path> fileFilter) {
+        super(fileFilter);
+    }
+
+    @Override
+    protected void addSplitsForPath(
+            FileStatus fileStatus, FileSystem fs, ArrayList<FileSourceSplit> target)
+            throws IOException {
+        if (fileStatus.isDir()) {
+            if (!hiddenDirFilter.test(fileStatus.getPath())) {
+                return;
+            }
+            final FileStatus[] containedFiles = fs.listStatus(fileStatus.getPath());
+            for (FileStatus containedStatus : containedFiles) {
+                addSplitsForPath(containedStatus, fs, target);
+            }
+        } else if (fileFilter.test(fileStatus.getPath())) {
+            convertToSourceSplits(fileStatus, fs, target);
+            return;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveEnumerator.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class NonSplittingRecursiveEnumerator implements FileEnumerator {
 
     /** The filter predicate to filter out unwanted files. */
-    private final Predicate<Path> fileFilter;
+    protected final Predicate<Path> fileFilter;
 
     /**
      * The current Id as a mutable string representation. This covers more values than the integer
@@ -87,7 +87,7 @@ public class NonSplittingRecursiveEnumerator implements FileEnumerator {
         return splits;
     }
 
-    private void addSplitsForPath(
+    protected void addSplitsForPath(
             FileStatus fileStatus, FileSystem fs, ArrayList<FileSourceSplit> target)
             throws IOException {
         if (!fileFilter.test(fileStatus.getPath())) {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/RegexFileFilter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/enumerate/RegexFileFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.enumerate;
+
+import org.apache.flink.core.fs.Path;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/**
+ * A file filter that filters out hidden files, see {@link DefaultFileFilter} and the files whose
+ * path doesn't match the given regex pattern.
+ */
+public class RegexFileFilter implements Predicate<Path> {
+    private final Pattern pattern;
+    private final DefaultFileFilter defaultFileFilter;
+
+    public RegexFileFilter(String pathPattern) {
+        this.defaultFileFilter = new DefaultFileFilter();
+        this.pattern = Pattern.compile(pathPattern);
+    }
+
+    @Override
+    public boolean test(Path path) {
+        return defaultFileFilter.test(path) && pattern.matcher(path.getPath()).matches();
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -68,6 +68,17 @@ public class FileSystemConnectorOptions {
                                     + "The statistics reporting is a heavy operation in some cases,"
                                     + "this config allows users to choose the statistics type according to different situations.");
 
+    public static final ConfigOption<String> SOURCE_PATH_REGEX_PATTERN =
+            key("source.path.regex-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The regex pattern to filter files or directories in the directory of the `path` option. "
+                                    + "This regex pattern should be matched with the absolute file path."
+                                    + "For example, if we want to get all files under some path like '/dir', "
+                                    + "the table should set 'path'='/dir' and 'source.regex-pattern'='/dir/.*'."
+                                    + "The hidden files and directories will not be matched.");
+
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")
                     .memoryType()

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -107,6 +107,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
         options.add(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
         options.add(FileSystemConnectorOptions.SOURCE_REPORT_STATISTICS);
+        options.add(FileSystemConnectorOptions.SOURCE_PATH_REGEX_PATTERN);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_FILE_SIZE);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_ROLLOVER_INTERVAL);
         options.add(FileSystemConnectorOptions.SINK_ROLLING_POLICY_INACTIVITY_INTERVAL);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveAllDirEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/BlockSplittingRecursiveAllDirEnumeratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.enumerate;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.testutils.TestingFileSystem;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumeratorTest.assertSplitsEqual;
+
+/** Unit tests for the {@link BlockSplittingRecursiveAllDirEnumerator}. */
+public class BlockSplittingRecursiveAllDirEnumeratorTest
+        extends NonSplittingRecursiveAllDirEnumeratorTest {
+    @Test
+    @Override
+    void testFileWithMultipleBlocks() throws Exception {
+        final Path testPath = new Path("testfs:///dir/file");
+        testFs =
+                TestingFileSystem.createForFileStatus(
+                        "testfs",
+                        TestingFileSystem.TestFileStatus.forFileWithBlocks(
+                                testPath,
+                                1000L,
+                                new TestingFileSystem.TestBlockLocation(0L, 100L, "host1", "host2"),
+                                new TestingFileSystem.TestBlockLocation(
+                                        100L, 520L, "host2", "host3"),
+                                new TestingFileSystem.TestBlockLocation(
+                                        620L, 380L, "host3", "host4")));
+        testFs.register();
+
+        final FileEnumerator enumerator = createEnumerator(testPath.getPath());
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {new Path("testfs:///dir")}, 0);
+
+        final Collection<FileSourceSplit> expected =
+                Arrays.asList(
+                        new FileSourceSplit(
+                                "ignoredId", testPath, 0L, 100L, 0, 1000L, "host1", "host2"),
+                        new FileSourceSplit(
+                                "ignoredId", testPath, 100L, 520L, 0, 1000L, "host1", "host2"),
+                        new FileSourceSplit(
+                                "ignoredId", testPath, 620L, 380L, 0, 1000L, "host1", "host2"));
+
+        assertSplitsEqual(expected, splits);
+    }
+
+    protected FileEnumerator createEnumerator(String pattern) {
+        return new BlockSplittingRecursiveAllDirEnumerator(pattern);
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveAllDirEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/enumerate/NonSplittingRecursiveAllDirEnumeratorTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.enumerate;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.testutils.TestingFileSystem;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumeratorTest.assertSplitsEqual;
+import static org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumeratorTest.toPaths;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link NonSplittingRecursiveAllDirEnumerator}. */
+public class NonSplittingRecursiveAllDirEnumeratorTest {
+    /**
+     * Testing file system reference, to be cleaned up in an @After method. That way it also gets
+     * cleaned up on a test failure, without needing finally clauses in every test.
+     */
+    protected TestingFileSystem testFs;
+
+    @AfterEach
+    void unregisterTestFs() throws Exception {
+        if (testFs != null) {
+            testFs.unregister();
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Test
+    void testIncludeSingleFile() throws Exception {
+        final Path[] testPaths =
+                new Path[] {
+                    new Path("testfs:///dir/file1"),
+                    new Path("testfs:///dir/nested/file.out"),
+                    new Path("testfs:///dir/nested/anotherfile.txt")
+                };
+        testFs = TestingFileSystem.createWithFiles("testfs", testPaths);
+        testFs.register();
+
+        Path baseDir = new Path("testfs:///dir");
+        final FileEnumerator enumerator = createEnumerator(baseDir.getPath() + "/nested/file.out");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {baseDir}, 1);
+
+        assertThat(toPaths(splits)).containsExactlyInAnyOrder(testPaths[1]);
+    }
+
+    @Test
+    void testIncludeFilesFromRegexDirectory() throws Exception {
+        final Path[] testPaths =
+                new Path[] {
+                    new Path("testfs:///dir/file1"),
+                    new Path("testfs:///dir/nested/file.out"),
+                    new Path("testfs:///dir/nested/anotherFile.txt"),
+                    new Path("testfs:///dir/nested/nested/doubleNestedFile.txt")
+                };
+        testFs = TestingFileSystem.createWithFiles("testfs", testPaths);
+        testFs.register();
+
+        Path baseDir = new Path("testfs:///dir");
+        final FileEnumerator enumerator = createEnumerator(baseDir.getPath() + "/nest.[a-z]/.*");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {baseDir}, 1);
+
+        assertThat(toPaths(splits))
+                .containsExactlyInAnyOrder(Arrays.copyOfRange(testPaths, 1, testPaths.length));
+    }
+
+    @Test
+    void testIncludeSingleFileFromMultiDirectory() throws Exception {
+        final Path[] testPaths =
+                new Path[] {
+                    new Path("testfs:///dir/file1"),
+                    new Path("testfs:///dir/nested/file.out"),
+                    new Path("testfs:///dir/nested/anotherFile.txt"),
+                    new Path("testfs:///dir/nested/nested/doubleNestedFile.txt"),
+                    new Path("testfs:///dir/anotherNested/file.out"),
+                    new Path("testfs:///dir/anotherNested/nested/file.out"),
+                };
+        testFs = TestingFileSystem.createWithFiles("testfs", testPaths);
+        testFs.register();
+
+        Path baseDir = new Path("testfs:///dir");
+        final FileEnumerator enumerator = createEnumerator(baseDir.getPath() + "/.*/file.out");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {baseDir}, 1);
+
+        assertThat(toPaths(splits))
+                .containsExactlyInAnyOrder(
+                        Arrays.stream(testPaths)
+                                .filter(p -> p.getPath().endsWith("file.out"))
+                                .toArray(Path[]::new));
+    }
+
+    @Test
+    void testDefaultHiddenFilesFilter() throws Exception {
+        final Path[] testPaths =
+                new Path[] {
+                    new Path("testfs:///visiblefile"),
+                    new Path("testfs:///.hiddenfile1"),
+                    new Path("testfs:///_hiddenfile2")
+                };
+        testFs = TestingFileSystem.createWithFiles("testfs", testPaths);
+        testFs.register();
+
+        Path baseDir = new Path("testfs:///");
+        final FileEnumerator enumerator = createEnumerator("/.*");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {baseDir}, 1);
+
+        assertThat(toPaths(splits)).isEqualTo(Collections.singletonList(testPaths[0]));
+    }
+
+    @Test
+    void testHiddenDirectories() throws Exception {
+        final Path[] testPaths =
+                new Path[] {
+                    new Path("testfs:///dir/visiblefile"),
+                    new Path("testfs:///dir/.hiddendir/file"),
+                    new Path("testfs:///_notvisible/afile")
+                };
+        testFs = TestingFileSystem.createWithFiles("testfs", testPaths);
+        testFs.register();
+
+        Path baseDir = new Path("testfs:///");
+        final FileEnumerator enumerator = createEnumerator("/.*");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {baseDir}, 1);
+
+        assertThat(toPaths(splits)).isEqualTo(Collections.singletonList(testPaths[0]));
+    }
+
+    @Test
+    void testFilesWithNoBlockInfo() throws Exception {
+        final Path testPath = new Path("testfs:///dir/file1");
+        testFs =
+                TestingFileSystem.createForFileStatus(
+                        "testfs",
+                        TestingFileSystem.TestFileStatus.forFileWithBlocks(testPath, 12345L));
+        testFs.register();
+
+        final FileEnumerator enumerator = createEnumerator("/.*/file.");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {new Path("testfs:///dir")}, 0);
+
+        assertThat(splits).hasSize(1);
+        assertSplitsEqual(
+                new FileSourceSplit("ignoredId", testPath, 0L, 12345L, 0, 12345L),
+                splits.iterator().next());
+    }
+
+    @Test
+    void testFileWithIncorrectBlocks() throws Exception {
+        final Path testPath = new Path("testfs:///testdir/testfile");
+
+        testFs =
+                TestingFileSystem.createForFileStatus(
+                        "testfs",
+                        TestingFileSystem.TestFileStatus.forFileWithBlocks(
+                                testPath,
+                                10000L,
+                                new TestingFileSystem.TestBlockLocation(0L, 1000L),
+                                new TestingFileSystem.TestBlockLocation(2000L, 1000L)));
+        testFs.register();
+
+        final FileEnumerator enumerator = createEnumerator("/.*");
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {new Path("testfs:///testdir")}, 0);
+
+        assertThat(splits).hasSize(1);
+        assertSplitsEqual(
+                new FileSourceSplit("ignoredId", testPath, 0L, 10000L, 0, 12345L),
+                splits.iterator().next());
+    }
+
+    @Test
+    void testFileWithMultipleBlocks() throws Exception {
+        final Path testPath = new Path("testfs:///dir/file");
+        testFs =
+                TestingFileSystem.createForFileStatus(
+                        "testfs",
+                        TestingFileSystem.TestFileStatus.forFileWithBlocks(
+                                testPath,
+                                1000L,
+                                new TestingFileSystem.TestBlockLocation(0L, 100L, "host1", "host2"),
+                                new TestingFileSystem.TestBlockLocation(
+                                        100L, 520L, "host2", "host3"),
+                                new TestingFileSystem.TestBlockLocation(
+                                        620L, 380L, "host3", "host4")));
+        testFs.register();
+
+        final FileEnumerator enumerator = createEnumerator(testPath.getPath());
+        final Collection<FileSourceSplit> splits =
+                enumerator.enumerateSplits(new Path[] {new Path("testfs:///dir")}, 0);
+
+        assertSplitsEqual(
+                new FileSourceSplit(
+                        "ignoredId",
+                        testPath,
+                        0L,
+                        1000L,
+                        0,
+                        1000L,
+                        "host1",
+                        "host2",
+                        "host3",
+                        "host4"),
+                splits.iterator().next());
+    }
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * The instantiation of the enumerator is overridable so that we can reuse these tests for
+     * sub-classes.
+     */
+    protected FileEnumerator createEnumerator(String pattern) {
+        return new NonSplittingRecursiveAllDirEnumerator(pattern);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes filesystem sources support flexible path reading.

## Brief change log

  - Add two new FileEnumerator and a new file filter.
  - Add new table option 'source.regex-pattern'
  - use the new FileEnumerator if 'source.regex-pattern' is set

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
