### PR TITLE
[FLINK-26945][table] Add built-in DATE_SUB function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -484,6 +484,9 @@ temporal:
   - sql: DATE_FORMAT(timestamp, string)
     table: dateFormat(TIMESTAMP, STRING)
     description: Converts timestamp to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
+  - sql: DATE_SUB(date, integer)
+    table: dateSub(DATE, INTEGER)
+    description: Subtracts a number of days to startdate.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -599,6 +599,9 @@ temporal:
       时间值可以是时间点或时间间隔。例如
       `(TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR)` 返回 TRUE；
       `(TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR)` 返回 FALSE。
+  - sql: DATE_SUB(date, integer)
+    table: dateSub(DATE, INTEGER)
+    description: 减去开始日期的天数。
   - sql: DATE_FORMAT(timestamp, string)
     table: dateFormat(TIMESTAMP, STRING)
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -47,6 +47,7 @@ Expressions
     to_timestamp_ltz
     temporal_overlaps
     date_format
+    date_sub
     timestamp_diff
     convert_tz
     from_unixtime

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -361,6 +361,20 @@ def date_format(timestamp, format) -> Expression:
     return _binary_op("dateFormat", timestamp, format)
 
 
+def date_sub(startDate, days) -> Expression:
+    """
+    Subtracts a number of days to startdate.
+
+    For example,
+    `date_sub(lit("2019-01-01").to_date, lit(1))` leads to 2018-12-31.
+
+    :param startDate: The start date in time.
+    :param days: The number of days.
+    :return: Subtracts a number of days to startdate.
+    """
+    return _binary_op("dateSub", startDate, days)
+
+
 def timestamp_diff(time_point_unit: TimePointUnit, time_point1, time_point2) -> Expression:
     """
     Returns the (signed) number of :class:`~pyflink.table.expression.TimePointUnit` between

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -414,6 +414,19 @@ public final class Expressions {
     }
 
     /**
+     * Subtracts a number of days to startdate.
+     *
+     * <p>For example, {@code dateSub(lit("2019-01-01").toDate(), lit(1))} leads to 2018-12-31.
+     *
+     * @param startDate The start date in time.
+     * @param days The number of days.
+     * @return Subtracts a number of days to startdate.
+     */
+    public static ApiExpression dateSub(Object startDate, Object days) {
+        return apiCall(BuiltInFunctionDefinitions.DATE_SUB, startDate, days);
+    }
+
+    /**
      * Returns the (signed) number of {@link TimePointUnit} between timePoint1 and timePoint2.
      *
      * <p>For example, {@code timestampDiff(TimePointUnit.DAY, lit("2016-06-15").toDate(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1626,6 +1626,25 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition DATE_SUB =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATE_SUB")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    or(
+                                            logical(LogicalTypeRoot.DATE),
+                                            logical(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                                            logical(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    or(
+                                            logical(LogicalTypeRoot.TINYINT),
+                                            logical(LogicalTypeRoot.SMALLINT),
+                                            logical(LogicalTypeRoot.INTEGER))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.DATE())))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.DateSubFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =
             BuiltInFunctionDefinition.newBuilder()
                     .name("timestampDiff")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateSubFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateSubFunction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#DATE_SUB}. */
+@Internal
+public class DateSubFunction extends BuiltInScalarFunction {
+
+    private final SpecializedFunction.ExpressionEvaluator castEvaluator;
+    private transient MethodHandle castHandle;
+
+    public DateSubFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.DATE_SUB, context);
+        final DataType startDate = context.getCallContext().getArgumentDataTypes().get(0);
+        castEvaluator =
+                context.createEvaluator(
+                        $("startDate").cast(DataTypes.DATE().notNull().bridgedTo(int.class)),
+                        DataTypes.DATE().notNull().bridgedTo(int.class),
+                        DataTypes.FIELD("startDate", startDate.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        castHandle = castEvaluator.open(context);
+    }
+
+    public @Nullable Object eval(Object startDate, Object days) {
+        try {
+            if (startDate == null || days == null) {
+                return null;
+            }
+
+            return (int) castHandle.invoke(startDate) - ((Number) days).intValue();
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        castEvaluator.close();
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of DATE_SUB

- Brief change log
DATE_SUB for Table API and SQL
    ```
    Syntax:
     date_sub(startDate, days) 
    
  > SELECT date_sub(DATE '2019-01-01', 1);
   2018-12-31
    ```
    See also
    [Spark](https://spark.apache.org/docs/latest/sql-ref-functions-builtin.html#date-and-timestamp-functions)
    [Hive](https://cwiki.apache.org/confluence/display/hive/languagemanual+udf)


- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)