### PR TITLE
[FLINK-31591] JobGraphWriter persists JobResourceRequirements

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/SingleJobJobGraphStore.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
@@ -62,6 +63,15 @@ public class SingleJobJobGraphStore implements JobGraphStore {
             throw new FlinkException(
                     "Cannot put additional jobs into this submitted job graph store.");
         }
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) throws Exception {
+        Preconditions.checkArgument(
+                jobId.equals(jobGraph.getJobID()),
+                String.format("The %s can only store a single job.", getClass().getSimpleName()));
+        JobResourceRequirements.writeToJobGraph(jobGraph, jobResourceRequirements);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.dispatcher.cleanup.GloballyCleanableResource;
 import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +36,16 @@ public interface JobGraphWriter extends LocallyCleanableResource, GloballyCleana
      * <p>If a job graph with the same {@link JobID} exists, it is replaced.
      */
     void putJobGraph(JobGraph jobGraph) throws Exception;
+
+    /**
+     * Persist {@link JobResourceRequirements job resource requirements} for the given job.
+     *
+     * @param jobId job the given requirements belong to
+     * @param jobResourceRequirements requirements to persist
+     * @throws Exception in case we're not able to persist the requirements for some reason
+     */
+    void putJobResourceRequirements(JobID jobId, JobResourceRequirements jobResourceRequirements)
+            throws Exception;
 
     @Override
     default CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -44,6 +45,12 @@ public class StandaloneJobGraphStore implements JobGraphStore {
 
     @Override
     public void putJobGraph(JobGraph jobGraph) {
+        // Nothing to do
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) {
         // Nothing to do
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.jobmanager;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 
 /** {@link JobGraphWriter} implementation which does not allow to store {@link JobGraph}. */
 public enum ThrowingJobGraphWriter implements JobGraphWriter {
@@ -27,5 +29,11 @@ public enum ThrowingJobGraphWriter implements JobGraphWriter {
     @Override
     public void putJobGraph(JobGraph jobGraph) {
         throw new UnsupportedOperationException("Cannot store job graphs.");
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) {
+        throw new UnsupportedOperationException("Cannot persist job resource requirements.");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
@@ -18,13 +18,23 @@
 
 package org.apache.flink.runtime.dispatcher;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 
 /** Testing implementation of {@link JobGraphWriter} which does nothing. */
 public enum NoOpJobGraphWriter implements JobGraphWriter {
     INSTANCE;
 
     @Override
-    public void putJobGraph(JobGraph jobGraph) throws Exception {}
+    public void putJobGraph(JobGraph jobGraph) {
+        // No-op.
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) {
+        // No-op.
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStoreTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.checkpoint.TestingRetrievableStateStorageHelper;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 import org.apache.flink.runtime.persistence.IntegerResourceVersion;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.persistence.TestingStateHandleStore;
@@ -33,13 +35,19 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -366,6 +374,61 @@ public class DefaultJobGraphStoreTest extends TestLogger {
 
         final String actual = releaseFuture.get();
         assertThat(actual, is(testingJobGraph.getJobID().toString()));
+    }
+
+    @Test
+    public void testRecoverPersistedJobResourceRequirements() throws Exception {
+        final Map<String, RetrievableStateHandle<JobGraph>> handles = new HashMap<>();
+        final TestingStateHandleStore<JobGraph> stateHandleStore =
+                builder.setAddFunction(
+                                (key, state) -> {
+                                    final RetrievableStateHandle<JobGraph> handle =
+                                            jobGraphStorageHelper.store(state);
+                                    handles.put(key, handle);
+                                    return handle;
+                                })
+                        .setGetFunction(
+                                key -> {
+                                    final RetrievableStateHandle<JobGraph> handle =
+                                            handles.get(key);
+                                    if (handle != null) {
+                                        return handle;
+                                    }
+                                    throw new StateHandleStore.NotExistException("Does not exist.");
+                                })
+                        .build();
+
+        final JobResourceRequirements jobResourceRequirements =
+                JobResourceRequirements.newBuilder()
+                        .setParallelismForJobVertex(new JobVertexID(), 1, 1)
+                        .build();
+
+        final JobGraphStore jobGraphStore = createAndStartJobGraphStore(stateHandleStore);
+        jobGraphStore.putJobGraph(testingJobGraph);
+        jobGraphStore.putJobResourceRequirements(
+                testingJobGraph.getJobID(), jobResourceRequirements);
+
+        final Optional<JobResourceRequirements> maybeRecovered =
+                JobResourceRequirements.readFromJobGraph(
+                        Objects.requireNonNull(
+                                jobGraphStore.recoverJobGraph(testingJobGraph.getJobID())));
+        Assertions.assertThat(maybeRecovered).get().isEqualTo(jobResourceRequirements);
+    }
+
+    @Test
+    public void testPutJobResourceRequirementsOfNonExistentJob() throws Exception {
+        final TestingStateHandleStore<JobGraph> stateHandleStore =
+                builder.setGetFunction(
+                                ignore -> {
+                                    throw new StateHandleStore.NotExistException("Does not exist.");
+                                })
+                        .build();
+        final JobGraphStore jobGraphStore = createAndStartJobGraphStore(stateHandleStore);
+        assertThrows(
+                FileNotFoundException.class,
+                () ->
+                        jobGraphStore.putJobResourceRequirements(
+                                new JobID(), JobResourceRequirements.empty()));
     }
 
     private JobGraphStore createAndStartJobGraphStore(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
@@ -21,9 +21,11 @@ package org.apache.flink.runtime.testutils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.jobmaster.JobResourceRequirements;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -58,6 +60,9 @@ public class TestingJobGraphStore implements JobGraphStore {
 
     private final ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer;
 
+    private final BiConsumerWithException<JobGraph, JobResourceRequirements, ? extends Exception>
+            putJobResourceRequirementsConsumer;
+
     private final BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction;
 
     private final BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction;
@@ -72,6 +77,8 @@ public class TestingJobGraphStore implements JobGraphStore {
             BiFunctionWithException<JobID, Map<JobID, JobGraph>, JobGraph, ? extends Exception>
                     recoverJobGraphFunction,
             ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer,
+            BiConsumerWithException<JobGraph, JobResourceRequirements, ? extends Exception>
+                    putJobResourceRequirementsConsumer,
             BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction,
             BiFunction<JobID, Executor, CompletableFuture<Void>> localCleanupFunction,
             Collection<JobGraph> initialJobGraphs) {
@@ -80,6 +87,7 @@ public class TestingJobGraphStore implements JobGraphStore {
         this.jobIdsFunction = jobIdsFunction;
         this.recoverJobGraphFunction = recoverJobGraphFunction;
         this.putJobGraphConsumer = putJobGraphConsumer;
+        this.putJobResourceRequirementsConsumer = putJobResourceRequirementsConsumer;
         this.globalCleanupFunction = globalCleanupFunction;
         this.localCleanupFunction = localCleanupFunction;
 
@@ -111,6 +119,15 @@ public class TestingJobGraphStore implements JobGraphStore {
         verifyIsStarted();
         putJobGraphConsumer.accept(jobGraph);
         storedJobs.put(jobGraph.getJobID(), jobGraph);
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) throws Exception {
+        verifyIsStarted();
+        final JobGraph jobGraph =
+                Preconditions.checkNotNull(storedJobs.get(jobId), "Job [%s] not found.", jobId);
+        putJobResourceRequirementsConsumer.accept(jobGraph, jobResourceRequirements);
     }
 
     @Override
@@ -159,6 +176,9 @@ public class TestingJobGraphStore implements JobGraphStore {
 
         private ThrowingConsumer<JobGraph, ? extends Exception> putJobGraphConsumer = ignored -> {};
 
+        private BiConsumerWithException<JobGraph, JobResourceRequirements, ? extends Exception>
+                putJobResourceRequirementsConsumer = (graph, requirements) -> {};
+
         private BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction =
                 (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
 
@@ -202,6 +222,13 @@ public class TestingJobGraphStore implements JobGraphStore {
             return this;
         }
 
+        public Builder setPutJobResourceRequirementsConsumer(
+                BiConsumerWithException<JobGraph, JobResourceRequirements, ? extends Exception>
+                        putJobResourceRequirementsConsumer) {
+            this.putJobResourceRequirementsConsumer = putJobResourceRequirementsConsumer;
+            return this;
+        }
+
         public Builder setGlobalCleanupFunction(
                 BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupFunction) {
             this.globalCleanupFunction = globalCleanupFunction;
@@ -232,6 +259,7 @@ public class TestingJobGraphStore implements JobGraphStore {
                             jobIdsFunction,
                             recoverJobGraphFunction,
                             putJobGraphConsumer,
+                            putJobResourceRequirementsConsumer,
                             globalCleanupFunction,
                             localCleanupFunction,
                             initialJobGraphs);


### PR DESCRIPTION
Extend the JGWriter to persist the JRRequirements in the JobGraph.