### PR TITLE
[1.17][FLINK-31568][tests] Updates base version for japicmp check.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ under the License.
 		<minikdc.version>3.2.4</minikdc.version>
 		<hive.version>2.3.9</hive.version>
 		<orc.version>1.5.6</orc.version>
-		<japicmp.referenceVersion>1.16.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.17.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.27.1</spotless.version>
 		<spotless.scalafmt.version>3.4.3</spotless.scalafmt.version>
@@ -2175,20 +2175,12 @@ under the License.
 								<include>@org.apache.flink.annotation.Public</include>
 								<!-- The following line is un-commented by tools/releasing/update_japicmp_configuration.sh
 								 	as part of the release process -->
-								<!--<include>@org.apache.flink.annotation.PublicEvolving</include>-->
+								<include>@org.apache.flink.annotation.PublicEvolving</include>
 							</includes>
 							<excludes>
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
-								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
-								<!-- UnionSerializerConfigSnapshot was a PublicEvolving and Deprecated class that has been removed, embedded inside a Public CoGroupedStreams class, triggering this false failure -->
-								<exclude>org.apache.flink.streaming.api.datastream.CoGroupedStreams$UnionSerializerConfigSnapshot</exclude>
-								<exclude>org.apache.flink.api.connector.source.SourceReaderContext#currentParallelism()</exclude>
-								<exclude>org.apache.flink.api.common.io.OutputFormat#open(int,int)</exclude>
-								<exclude>org.apache.flink.api.common.io.OutputFormat#open(org.apache.flink.api.common.io.OutputFormat$InitializationContext)</exclude>
-								<exclude>org.apache.flink.api.common.io.FinalizeOnMaster#finalizeGlobal(int)</exclude>
-								<exclude>org.apache.flink.api.common.io.FinalizeOnMaster#finalizeGlobal(org.apache.flink.api.common.io.FinalizeOnMaster$FinalizationContext)</exclude>
 								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>


### PR DESCRIPTION
Updating the japicmp base version. Verification of API changes happened in FLINK-31167
