### PR TITLE
[FLINK-31240][table] Reduce the overhead of conversion between DataStream and Table

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -186,8 +186,11 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * assumes append-only/insert-only semantics during the stream-to-table conversion. Records of
      * type {@link Row} must describe {@link RowKind#INSERT} changes.
      *
-     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
-     * explicitly declared via {@link #fromDataStream(DataStream, Schema)}.
+     * <p>By default, the stream record's timestamp and watermarks are not propagated to downstream
+     * table operations unless explicitly declared via {@link #fromDataStream(DataStream, Schema)}.
+     *
+     * <p>If the returned table is converted back to DataStream via {@link #toDataStream(Table)},
+     * the input DataStream of this method would be returned.
      *
      * @param dataStream The {@link DataStream} to be converted.
      * @param <T> The external type of the {@link DataStream}.
@@ -210,8 +213,8 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * assumes append-only/insert-only semantics during the stream-to-table conversion. Records of
      * class {@link Row} must describe {@link RowKind#INSERT} changes.
      *
-     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
-     * explicitly declared.
+     * <p>By default, the stream record's timestamp and watermarks are not propagated to downstream
+     * table operations unless explicitly declared in the input schema.
      *
      * <p>This method allows to declare a {@link Schema} for the resulting table. The declaration is
      * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
@@ -304,8 +307,9 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
      * will not be accessible.
      *
-     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
-     * explicitly declared via {@link #fromChangelogStream(DataStream, Schema)}.
+     * <p>By default, the stream record's timestamp and watermarks are not propagated to downstream
+     * table operations unless explicitly declared via {@link #fromChangelogStream(DataStream,
+     * Schema)}.
      *
      * @param dataStream The changelog stream of {@link Row}.
      * @return The converted {@link Table}.
@@ -330,8 +334,8 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
      * will not be accessible.
      *
-     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
-     * explicitly declared.
+     * <p>By default, the stream record's timestamp and watermarks are not propagated to downstream
+     * table operations unless explicitly declared in the input schema.
      *
      * <p>This method allows to declare a {@link Schema} for the resulting table. The declaration is
      * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
@@ -372,8 +376,8 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
      * will not be accessible.
      *
-     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
-     * explicitly declared.
+     * <p>By default, the stream record's timestamp and watermarks are not propagated to downstream
+     * table operations unless explicitly declared in the input schema.
      *
      * <p>This method allows to declare a {@link Schema} for the resulting table. The declaration is
      * similar to a {@code CREATE TABLE} DDL in SQL and allows to:

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.api.bridge.java.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -32,8 +33,11 @@ import org.apache.flink.table.api.bridge.internal.AbstractStreamTableEnvironment
 import org.apache.flink.table.api.bridge.java.StreamStatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.SchemaResolver;
 import org.apache.flink.table.catalog.SchemaTranslator;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.delegation.Executor;
@@ -45,6 +49,7 @@ import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.operations.ExternalQueryOperation;
 import org.apache.flink.table.operations.OutputConversionModifyOperation;
 import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.table.sources.TableSource;
@@ -223,6 +228,27 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
         Preconditions.checkNotNull(table, "Table must not be null.");
         // include all columns of the query (incl. metadata and computed columns)
         final DataType sourceType = table.getResolvedSchema().toSourceRowDataType();
+
+        if (!(table.getQueryOperation() instanceof ExternalQueryOperation)) {
+            return toDataStream(table, sourceType);
+        }
+
+        DataTypeFactory dataTypeFactory = getCatalogManager().getDataTypeFactory();
+        SchemaResolver schemaResolver = getCatalogManager().getSchemaResolver();
+        ExternalQueryOperation<?> queryOperation =
+                (ExternalQueryOperation<?>) table.getQueryOperation();
+        DataStream<?> dataStream = queryOperation.getDataStream();
+
+        SchemaTranslator.ConsumingResult consumingResult =
+                SchemaTranslator.createConsumingResult(dataTypeFactory, dataStream.getType(), null);
+        ResolvedSchema defaultSchema = consumingResult.getSchema().resolve(schemaResolver);
+
+        if (queryOperation.getChangelogMode().equals(ChangelogMode.insertOnly())
+                && table.getResolvedSchema().equals(defaultSchema)
+                && dataStream.getType() instanceof RowTypeInfo) {
+            return (DataStream<Row>) dataStream;
+        }
+
         return toDataStream(table, sourceType);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -378,6 +378,19 @@ public class DataStreamJavaITCase extends AbstractTestBase {
     }
 
     @Test
+    public void testFromAndToDataStreamBypassConversion() throws Exception {
+        final StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+
+        DataStream<Row> dataStream = env.fromElements(Row.of(1L, "a"));
+        Table table = tableEnv.fromDataStream(dataStream);
+        DataStream<Row> convertedDataStream = tableEnv.toDataStream(table);
+
+        assertThat(dataStream).isEqualTo(convertedDataStream);
+
+        testResult(convertedDataStream, Row.of(1L, "a"));
+    }
+
+    @Test
     public void testFromAndToChangelogStreamEventTime() throws Exception {
         final StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request reduces the overhead of conversion between DataStream and Table in some cases.

## Brief change log

- Checks if there are paired fromDataStream/toDataStream function call without any transformation, if so use the source datastream directly.

## Impact on performance

The performance of Flink ML's Bucketizer algorithm[1] is used to demonstrate the impact of this optimization. The execution time is obtained by taking the median execution time across 5 runs for each setup.

- Before optimization: 40746ms
- After optimization: 12972ms

Thus this optimization reduces the total execution time of Flink ML's Bucketizer algorithm to about 1/3. 

[1] https://github.com/apache/flink-ml/blob/master/flink-ml-benchmark/src/main/resources/bucketizer-benchmark.json

## Verifying this change

This change is verified by the newly added test cases in `DataStreamJavaITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
