### PR TITLE
[FLINK-31604][table] Reduce usage of CatalogTableImpl in table-planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TableSchemaUtils.java
@@ -118,19 +118,15 @@ public class TableSchemaUtils {
         }
     }
 
-    /** Removes time attributes from the {@link ResolvedSchema} and build a {@link TableSchema}. */
-    public static TableSchema removeTimeAttributeFromResolvedSchema(ResolvedSchema resolvedSchema) {
-        return TableSchema.fromResolvedSchema(
-                new ResolvedSchema(
-                        resolvedSchema.getColumns().stream()
-                                .map(
-                                        col ->
-                                                col.copy(
-                                                        DataTypeUtils.removeTimeAttribute(
-                                                                col.getDataType())))
-                                .collect(Collectors.toList()),
-                        resolvedSchema.getWatermarkSpecs(),
-                        resolvedSchema.getPrimaryKey().orElse(null)));
+    /** Removes time attributes from the {@link ResolvedSchema}. */
+    public static ResolvedSchema removeTimeAttributeFromResolvedSchema(
+            ResolvedSchema resolvedSchema) {
+        return new ResolvedSchema(
+                resolvedSchema.getColumns().stream()
+                        .map(col -> col.copy(DataTypeUtils.removeTimeAttribute(col.getDataType())))
+                        .collect(Collectors.toList()),
+                resolvedSchema.getWatermarkSpecs(),
+                resolvedSchema.getPrimaryKey().orElse(null));
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -20,11 +20,11 @@ package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ContextResolvedTable;
@@ -172,12 +172,19 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
                 TableSourceFactory.Context context =
                         new TableSourceFactoryContextImpl(
                                 contextResolvedTable.getIdentifier(),
-                                new CatalogTableImpl(
-                                        TableSchemaUtils.removeTimeAttributeFromResolvedSchema(
-                                                originTable.getResolvedSchema()),
-                                        originTable.getPartitionKeys(),
-                                        originTable.getOptions(),
-                                        originTable.getComment()),
+                                new ResolvedCatalogTable(
+                                        CatalogTable.of(
+                                                Schema.newBuilder()
+                                                        .fromResolvedSchema(
+                                                                TableSchemaUtils
+                                                                        .removeTimeAttributeFromResolvedSchema(
+                                                                                originTable
+                                                                                        .getResolvedSchema()))
+                                                        .build(),
+                                                originTable.getComment(),
+                                                originTable.getPartitionKeys(),
+                                                originTable.getOptions()),
+                                        originTable.getResolvedSchema()),
                                 config,
                                 contextResolvedTable.isTemporary());
                 TableSource<?> source = TableFactoryUtil.findAndCreateTableSource(context);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogConstraintTest.java
@@ -20,14 +20,16 @@ package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
 import org.apache.flink.table.planner.utils.TableTestUtil;
-import org.apache.flink.table.types.DataType;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 
@@ -36,6 +38,8 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,22 +63,24 @@ public class CatalogConstraintTest {
 
     @Test
     public void testWithPrimaryKey() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"a", "b", "c"},
-                                new DataType[] {
-                                    DataTypes.STRING(),
-                                    DataTypes.BIGINT().notNull(),
-                                    DataTypes.INT()
-                                })
-                        .primaryKey("b")
+        final Schema tableSchema =
+                Schema.newBuilder()
+                        .fromResolvedSchema(
+                                new ResolvedSchema(
+                                        Arrays.asList(
+                                                Column.physical("a", DataTypes.STRING()),
+                                                Column.physical("b", DataTypes.BIGINT().notNull()),
+                                                Column.physical("c", DataTypes.INT())),
+                                        Collections.emptyList(),
+                                        UniqueConstraint.primaryKey(
+                                                "primary_constraint",
+                                                Collections.singletonList("b"))))
                         .build();
         Map<String, String> properties = buildCatalogTableProperties(tableSchema);
 
         catalog.createTable(
                 new ObjectPath(databaseName, "T1"),
-                new CatalogTableImpl(tableSchema, properties, ""),
+                CatalogTable.of(tableSchema, "", Collections.emptyList(), properties),
                 false);
 
         RelNode t1 = TableTestUtil.toRelNode(tEnv.sqlQuery("select * from T1"));
@@ -85,19 +91,20 @@ public class CatalogConstraintTest {
 
     @Test
     public void testWithoutPrimaryKey() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"a", "b", "c"},
-                                new DataType[] {
-                                    DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.INT()
-                                })
+
+        final Schema tableSchema =
+                Schema.newBuilder()
+                        .fromResolvedSchema(
+                                ResolvedSchema.of(
+                                        Column.physical("a", DataTypes.BIGINT()),
+                                        Column.physical("b", DataTypes.STRING()),
+                                        Column.physical("c", DataTypes.INT())))
                         .build();
         Map<String, String> properties = buildCatalogTableProperties(tableSchema);
 
         catalog.createTable(
                 new ObjectPath(databaseName, "T1"),
-                new CatalogTableImpl(tableSchema, properties, ""),
+                CatalogTable.of(tableSchema, "", Collections.emptyList(), properties),
                 false);
 
         RelNode t1 = TableTestUtil.toRelNode(tEnv.sqlQuery("select * from T1"));
@@ -106,7 +113,7 @@ public class CatalogConstraintTest {
         assertThat(mq.getUniqueKeys(t1)).isEqualTo(ImmutableSet.of());
     }
 
-    private Map<String, String> buildCatalogTableProperties(TableSchema tableSchema) {
+    private Map<String, String> buildCatalogTableProperties(Schema tableSchema) {
         Map<String, String> properties = new HashMap<>();
         properties.put("connector.type", "filesystem");
         properties.put("connector.property-version", "1");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
@@ -22,16 +22,17 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
@@ -102,16 +103,19 @@ public class SqlNodeToOperationConversionTestBase {
 
         final ObjectPath path1 = new ObjectPath(catalogManager.getCurrentDatabase(), "t1");
         final ObjectPath path2 = new ObjectPath(catalogManager.getCurrentDatabase(), "t2");
-        final TableSchema tableSchema =
-                TableSchema.builder()
-                        .field("a", DataTypes.BIGINT())
-                        .field("b", DataTypes.VARCHAR(Integer.MAX_VALUE))
-                        .field("c", DataTypes.INT())
-                        .field("d", DataTypes.VARCHAR(Integer.MAX_VALUE))
+        final Schema tableSchema =
+                Schema.newBuilder()
+                        .fromResolvedSchema(
+                                ResolvedSchema.of(
+                                        Column.physical("a", DataTypes.BIGINT()),
+                                        Column.physical("b", DataTypes.VARCHAR(Integer.MAX_VALUE)),
+                                        Column.physical("c", DataTypes.INT()),
+                                        Column.physical("d", DataTypes.VARCHAR(Integer.MAX_VALUE))))
                         .build();
         Map<String, String> options = new HashMap<>();
         options.put("connector", "COLLECTION");
-        final CatalogTable catalogTable = new CatalogTableImpl(tableSchema, options, "");
+        final CatalogTable catalogTable =
+                CatalogTable.of(tableSchema, "", Collections.emptyList(), options);
         catalog.createTable(path1, catalogTable, true);
         catalog.createTable(path2, catalogTable, true);
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2802,7 +2802,11 @@ class TableEnvironmentTest {
         table: CatalogBaseTable): CatalogBaseTable = {
       numTempTable += 1
       if (table.isInstanceOf[CatalogTable]) {
-        new CatalogTableImpl(table.getSchema, table.getOptions, tableComment)
+        CatalogTable.of(
+          table.getUnresolvedSchema,
+          tableComment,
+          Collections.emptyList(),
+          table.getOptions)
       } else {
         val view = table.asInstanceOf[CatalogView]
         CatalogView.of(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRuleTest.scala
@@ -17,7 +17,9 @@
  */
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.api.{DataTypes, TableSchema}
+import org.apache.flink.table.api.{DataTypes, Schema}
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
 import org.apache.flink.table.planner.utils.{BatchTableTestUtil, TableConfigUtils, TableTestBase, TestPartitionableSourceFactory}
@@ -58,21 +60,25 @@ class PushPartitionIntoLegacyTableSourceScanRuleTest(
         .build()
     )
 
-    val tableSchema = TableSchema
-      .builder()
-      .field("id", DataTypes.INT())
-      .field("name", DataTypes.STRING())
-      .field("part1", DataTypes.STRING())
-      .field("part2", DataTypes.INT())
+    val tableSchema = Schema
+      .newBuilder()
+      .fromResolvedSchema(ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("name", DataTypes.STRING()),
+        Column.physical("part1", DataTypes.STRING()),
+        Column.physical("part2", DataTypes.INT())
+      ))
       .build()
 
-    val tableSchema2 = TableSchema
-      .builder()
-      .field("id", DataTypes.INT())
-      .field("name", DataTypes.STRING())
-      .field("part1", DataTypes.STRING())
-      .field("part2", DataTypes.INT())
-      .field("virtualField", DataTypes.INT(), "`part2` + 1")
+    val tableSchema2 = Schema
+      .newBuilder()
+      .fromResolvedSchema(ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("name", DataTypes.STRING()),
+        Column.physical("part1", DataTypes.STRING()),
+        Column.physical("part2", DataTypes.INT()),
+        Column.computed("virtualField", ResolvedExpressionMock.of(DataTypes.INT(), "`part2` + 1"))
+      ))
       .build()
 
     TestPartitionableSourceFactory.createTemporaryTable(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/testTableSourceSinks.scala
@@ -26,10 +26,9 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.core.io.InputSplit
 import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
-import org.apache.flink.table.api
 import org.apache.flink.table.api.{DataTypes, TableEnvironment, TableSchema}
 import org.apache.flink.table.api.internal.TableEnvironmentInternal
-import org.apache.flink.table.catalog.{CatalogPartitionImpl, CatalogPartitionSpec, CatalogTableImpl, ObjectPath}
+import org.apache.flink.table.catalog._
 import org.apache.flink.table.descriptors._
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR, CONNECTOR_TYPE}
 import org.apache.flink.table.expressions.{CallExpression, Expression, FieldReferenceExpression, ValueLiteralExpression}
@@ -42,7 +41,7 @@ import org.apache.flink.table.planner.plan.hint.OptionsHintTest.IS_BOUNDED
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.EventTimeSourceFunction
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
-import org.apache.flink.table.sinks.{CsvAppendTableSinkFactory, CsvBatchTableSinkFactory, StreamTableSink, TableSink}
+import org.apache.flink.table.sinks.{CsvBatchTableSinkFactory, StreamTableSink, TableSink}
 import org.apache.flink.table.sources._
 import org.apache.flink.table.sources.tsextractors.ExistingField
 import org.apache.flink.table.sources.wmstrategies.{AscendingTimestamps, PreserveWatermarks}
@@ -1143,12 +1142,14 @@ class TestPartitionableSourceFactory extends TableSourceFactory[Row] {
 }
 
 object TestPartitionableSourceFactory {
-  private val tableSchema: TableSchema = TableSchema
-    .builder()
-    .field("id", DataTypes.INT())
-    .field("name", DataTypes.STRING())
-    .field("part1", DataTypes.STRING())
-    .field("part2", DataTypes.INT())
+  private val tableSchema: org.apache.flink.table.api.Schema = org.apache.flink.table.api.Schema
+    .newBuilder()
+    .fromResolvedSchema(ResolvedSchema.of(
+      Column.physical("id", DataTypes.INT()),
+      Column.physical("name", DataTypes.STRING()),
+      Column.physical("part1", DataTypes.STRING()),
+      Column.physical("part2", DataTypes.INT())
+    ))
     .build()
 
   /** For java invoking. */
@@ -1160,7 +1161,7 @@ object TestPartitionableSourceFactory {
       tEnv: TableEnvironment,
       tableName: String,
       isBounded: Boolean,
-      tableSchema: TableSchema = tableSchema,
+      tableSchema: org.apache.flink.table.api.Schema = tableSchema,
       remainingPartitions: JList[JMap[String, String]] = null,
       sourceFetchPartitions: Boolean = false): Unit = {
     val properties = new DescriptorProperties()
@@ -1177,11 +1178,11 @@ object TestPartitionableSourceFactory {
       }
     }
 
-    val table = new CatalogTableImpl(
+    val table = CatalogTable.of(
       tableSchema,
+      "",
       util.Arrays.asList[String]("part1", "part2"),
-      properties.asMap(),
-      ""
+      properties.asMap()
     )
     val catalog = tEnv.getCatalog(tEnv.getCurrentCatalog).get()
     val path = new ObjectPath(tEnv.getCurrentDatabase, tableName)


### PR DESCRIPTION
## What is the purpose of the change

`CatalogTableImpl` is deprecated and it is suggested to use `CatalogTable` in comments.
The PR replaces `CatalogTableImpl` usages in table-planner with `CatalogTable`.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
