### PR TITLE
[FLINK-31602][table] Add built-in ARRAY_POSITION function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -636,7 +636,7 @@ collection:
     description: Returns an array with unique elements. If the array itself is null, the function will return null. Keeps ordering of elements.
   - sql: ARRAY_POSITION(haystack, needle)
     table: haystack.arrayPosition(needle)
-    description: Returns the position of the first occurrence of element in the given array as long. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
+    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
   - sql: ARRAY_REMOVE(haystack, needle)
     table: haystack.arrayRemove(needle)
     description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -634,6 +634,9 @@ collection:
   - sql: ARRAY_DISTINCT(haystack)
     table: haystack.arrayDistinct()
     description: Returns an array with unique elements. If the array itself is null, the function will return null. Keeps ordering of elements.
+  - sql: ARRAY_POSITION(haystack, needle)
+    table: haystack.arrayPosition(needle)
+    description: Returns the position of the first occurrence of element in the given array as long. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
   - sql: ARRAY_REMOVE(haystack, needle)
     table: haystack.arrayRemove(needle)
     description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -227,6 +227,7 @@ advanced type helper functions
     Expression.element
     Expression.array_contains
     Expression.array_distinct
+    Expression.array_position
     Expression.array_remove
     Expression.map_keys
     Expression.map_values

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1487,6 +1487,17 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayDistinct")(self)
 
+    def array_position(self, needle) -> 'Expression':
+        """
+        Returns the position of the first occurrence of element in the given array as long.
+
+        Returns 0 if the given value could not be found in the array. Returns null if either of the
+        arguments are null.
+        NOTE: that this is not zero based, but 1-based index. The first element in the array
+        has index 1.
+        """
+        return _binary_op("arrayPosition")(self, needle)
+
     def array_remove(self, needle) -> 'Expression':
         """
         Removes all elements that equal to element from array.

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1489,7 +1489,7 @@ class Expression(Generic[T]):
 
     def array_position(self, needle) -> 'Expression':
         """
-        Returns the position of the first occurrence of element in the given array as long.
+        Returns the position of the first occurrence of element in the given array as int.
 
         Returns 0 if the given value could not be found in the array. Returns null if either of the
         arguments are null.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1364,7 +1364,7 @@ public abstract class BaseExpressions<InType, OutType> {
     }
 
     /**
-     * Returns the position of the first occurrence of element in the given array as long. Returns 0
+     * Returns the position of the first occurrence of element in the given array as int. Returns 0
      * if the given value could not be found in the array. Returns null if either of the arguments
      * are null
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -56,6 +56,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REMOVE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASCII;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
@@ -1360,6 +1361,19 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayDistinct() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_DISTINCT, toExpr()));
+    }
+
+    /**
+     * Returns the position of the first occurrence of element in the given array as long. Returns 0
+     * if the given value could not be found in the array. Returns null if either of the arguments
+     * are null
+     *
+     * <p>NOTE: that this is not zero based, but 1-based index. The first element in the array has
+     * index 1.
+     */
+    public OutType arrayPosition(InType needle) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_POSITION, toExpr(), objectToExpression(needle)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -220,6 +220,20 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayDistinctFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_POSITION =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_POSITION")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("haystack", "needle"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeRoot.ARRAY), ARRAY_ELEMENT_ARG)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BIGINT())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayPositionFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition ARRAY_REMOVE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("ARRAY_REMOVE")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -229,7 +229,7 @@ public final class BuiltInFunctionDefinitions {
                                     Arrays.asList("haystack", "needle"),
                                     Arrays.asList(
                                             logical(LogicalTypeRoot.ARRAY), ARRAY_ELEMENT_ARG)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BIGINT())))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayPositionFunction")
                     .build();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -38,6 +38,15 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
+                        arrayContainsTestCases(),
+                        arrayDistinctTestCases(),
+                        arrayPositionTestCases(),
+                        arrayRemoveTestCases())
+                .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> arrayContainsTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS)
                         .onFieldsWithData(
                                 new Integer[] {1, 2, 3},
@@ -131,7 +140,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testTableApiValidationError(
                                 $("f0").arrayContains(true),
                                 "Invalid input arguments. Expected signatures are:\n"
-                                        + "ARRAY_CONTAINS(haystack <ARRAY>, needle <ARRAY ELEMENT>)"),
+                                        + "ARRAY_CONTAINS(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arrayDistinctTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_DISTINCT)
                         .onFieldsWithData(
                                 new Integer[] {1, 2, 3},
@@ -181,7 +194,83 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     null
                                 },
                                 DataTypes.ARRAY(
-                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE()))),
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE()))));
+    }
+
+    private Stream<TestSetSpec> arrayPositionTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_POSITION)
+                        .onFieldsWithData(
+                                new Integer[] {null, 1, 2, 2, null},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Integer[][] {
+                                    new Integer[] {1, null, 3}, new Integer[] {0}, new Integer[] {1}
+                                },
+                                new Map[] {
+                                    null,
+                                    CollectionUtil.map(entry(1, "a"), entry(2, "b")),
+                                    CollectionUtil.map(entry(3, "c"), entry(4, "d")),
+                                })
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT().notNull()).notNull(),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())),
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())))
+                        .testResult(
+                                $("f0").arrayPosition(lit(2, DataTypes.INT().notNull())),
+                                "ARRAY_POSITION(f0, 2)",
+                                3L,
+                                DataTypes.BIGINT().notNull())
+                        .testResult(
+                                $("f0").arrayPosition(null),
+                                "ARRAY_POSITION(f0, NULL)",
+                                null,
+                                DataTypes.BIGINT())
+                        .testResult(
+                                $("f1").arrayPosition(2),
+                                "ARRAY_POSITION(f1, 2)",
+                                null,
+                                DataTypes.BIGINT())
+                        // ARRAY<ROW<BOOLEAN, DATE>>
+                        .testResult(
+                                $("f2").arrayPosition(row(true, LocalDate.of(1990, 10, 14))),
+                                "ARRAY_POSITION(f2, (TRUE, DATE '1990-10-14'))",
+                                2L,
+                                DataTypes.BIGINT())
+                        // ARRAY<ARRAY<INT>>
+                        .testResult(
+                                $("f3").arrayPosition(new Integer[] {0, 1}),
+                                "ARRAY_POSITION(f3, ARRAY[0, 1])",
+                                0L,
+                                DataTypes.BIGINT())
+                        // ARRAY<MAP<INT, STRING>>
+                        .testResult(
+                                $("f4").arrayPosition(
+                                                CollectionUtil.map(entry(3, "c"), entry(4, "d"))),
+                                "ARRAY_POSITION(f4, MAP[3, 'c', 4, 'd'])",
+                                3L,
+                                DataTypes.BIGINT())
+                        // invalid signatures
+                        .testSqlValidationError(
+                                "ARRAY_POSITION(f0, TRUE)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_POSITION(haystack <ARRAY>, needle <ARRAY ELEMENT>)")
+                        .testTableApiValidationError(
+                                $("f0").arrayPosition(true),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_POSITION(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arrayRemoveTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_REMOVE)
                         .onFieldsWithData(
                                 new Integer[] {1, 2, 2},

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -227,37 +227,37 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").arrayPosition(lit(2, DataTypes.INT().notNull())),
                                 "ARRAY_POSITION(f0, 2)",
-                                3L,
-                                DataTypes.BIGINT().notNull())
+                                3,
+                                DataTypes.INT().notNull())
                         .testResult(
                                 $("f0").arrayPosition(null),
                                 "ARRAY_POSITION(f0, NULL)",
                                 null,
-                                DataTypes.BIGINT())
+                                DataTypes.INT())
                         .testResult(
                                 $("f1").arrayPosition(2),
                                 "ARRAY_POSITION(f1, 2)",
                                 null,
-                                DataTypes.BIGINT())
+                                DataTypes.INT())
                         // ARRAY<ROW<BOOLEAN, DATE>>
                         .testResult(
                                 $("f2").arrayPosition(row(true, LocalDate.of(1990, 10, 14))),
                                 "ARRAY_POSITION(f2, (TRUE, DATE '1990-10-14'))",
-                                2L,
-                                DataTypes.BIGINT())
+                                2,
+                                DataTypes.INT())
                         // ARRAY<ARRAY<INT>>
                         .testResult(
                                 $("f3").arrayPosition(new Integer[] {0, 1}),
                                 "ARRAY_POSITION(f3, ARRAY[0, 1])",
-                                0L,
-                                DataTypes.BIGINT())
+                                0,
+                                DataTypes.INT())
                         // ARRAY<MAP<INT, STRING>>
                         .testResult(
                                 $("f4").arrayPosition(
                                                 CollectionUtil.map(entry(3, "c"), entry(4, "d"))),
                                 "ARRAY_POSITION(f4, MAP[3, 'c', 4, 'd'])",
-                                3L,
-                                DataTypes.BIGINT())
+                                3,
+                                DataTypes.INT())
                         // invalid signatures
                         .testSqlValidationError(
                                 "ARRAY_POSITION(f0, TRUE)",

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayPositionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayPositionFunction.java
@@ -63,7 +63,7 @@ public class ArrayPositionFunction extends BuiltInScalarFunction {
         equalityHandle = equalityEvaluator.open(context);
     }
 
-    public @Nullable Long eval(ArrayData haystack, Object needle) {
+    public @Nullable Integer eval(ArrayData haystack, Object needle) {
         try {
             if (haystack == null || needle == null) {
                 return null;
@@ -74,11 +74,11 @@ public class ArrayPositionFunction extends BuiltInScalarFunction {
                 if (element != null) {
                     final boolean isEqual = (boolean) equalityHandle.invoke(element, needle);
                     if (isEqual) {
-                        return Long.valueOf(pos + 1);
+                        return Integer.valueOf(pos + 1);
                     }
                 }
             }
-            return 0L;
+            return 0;
         } catch (Throwable t) {
             throw new FlinkRuntimeException(t);
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayPositionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayPositionFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction.ExpressionEvaluator;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_POSITION}. */
+@Internal
+public class ArrayPositionFunction extends BuiltInScalarFunction {
+
+    private final ArrayData.ElementGetter elementGetter;
+    private final ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle equalityHandle;
+
+    public ArrayPositionFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_POSITION, context);
+        final DataType elementDataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        final DataType needleDataType = context.getCallContext().getArgumentDataTypes().get(1);
+        elementGetter = ArrayData.createElementGetter(elementDataType.getLogicalType());
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element").isEqual($("needle")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element", elementDataType.notNull().toInternal()),
+                        DataTypes.FIELD("needle", needleDataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable Long eval(ArrayData haystack, Object needle) {
+        try {
+            if (haystack == null || needle == null) {
+                return null;
+            }
+            final int size = haystack.size();
+            for (int pos = 0; pos < size; pos++) {
+                final Object element = elementGetter.getElementOrNull(haystack, pos);
+                if (element != null) {
+                    final boolean isEqual = (boolean) equalityHandle.invoke(element, needle);
+                    if (isEqual) {
+                        return Long.valueOf(pos + 1);
+                    }
+                }
+            }
+            return 0L;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityEvaluator.close();
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of ARRAY_POSITION

- Brief change log
ARRAY_POSITION for Table API and SQL
    
  ```
  array_position(array, element) - Returns the (1-based) index of the first element of the array as long.
  Syntax:
      array_position(array, element)
      
      Arguments:
      array: An ARRAY to be handled.
      
      Returns:
      Returns the position of the first occurrence of element in the given array as long.
      Returns 0 if the given value could not be found in the array.
      Returns null if either of the arguments are null
   
      > SELECT array_position(array(3, 2, 1), 1);
       3 
  ```

   See also
    spark https://spark.apache.org/docs/latest/api/sql/index.html#array_position
    
    postgresql https://www.postgresql.org/docs/12/functions-array.html#ARRAY-FUNCTIONS-TABLE

- Verifying this change
This change added tests in CollectionFunctionsITCase

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)