### PR TITLE
[FLINK-28372][rpc] Migrate to Akka Artery

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -175,7 +175,10 @@ public class AkkaOptions {
             ConfigOptions.key("akka.outbound-restart-backoff")
                     .stringType()
                     .defaultValue("50 ms")
-                    .withDescription("Retry outbound connection only after this backoff.");
+                    .withDescription(
+                            "Retry outbound connection only after this backoff."
+                                    + " Replaces the \"akka.retry-gate-closed-for\" key, which is now deprecated."
+                                    + " For now, if only the deprecated key is set, its value will be picked up.");
 
     // ==================================================
     // Configurations for fork-join-executor.
@@ -241,7 +244,9 @@ public class AkkaOptions {
                     .longType()
                     .defaultValue(50L)
                     .withDescription(
-                            "Milliseconds a gate should be closed for after a remote connection was disconnected.");
+                            "Milliseconds a gate should be closed for after a remote connection was disconnected."
+                                    + " Replaced by \"akka.outbound-restart-backoff\"."
+                                    + " For now, this is used as a backup if the new option is not set.");
 
     /** @deprecated Don't use this option anymore. It has no effect on Flink. */
     @Deprecated

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -95,14 +95,6 @@ public class AkkaOptions {
                             "Timeout for all outbound connections. If you should experience problems with connecting to a"
                                     + " TaskManager due to a slow network, you should increase this value.");
 
-    /** Timeout for the startup of the actor system. */
-    public static final ConfigOption<String> STARTUP_TIMEOUT =
-            ConfigOptions.key("akka.startup-timeout")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Timeout after which the startup of a remote component is considered being failed.");
-
     /** Override SSL support for the Akka transport. */
     public static final ConfigOption<Boolean> SSL_ENABLED =
             ConfigOptions.key("akka.ssl.enabled")
@@ -120,7 +112,7 @@ public class AkkaOptions {
                     .withDescription(
                             "Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink"
                                     + " fails because messages exceed this limit, then you should increase it. The message size requires a"
-                                    + " size-unit specifier.");
+                                    + " size-unit specifier. Has to be at least 32 KiB");
 
     /** Maximum number of messages until another actor is executed by the same thread. */
     public static final ConfigOption<Integer> DISPATCHER_THROUGHPUT =
@@ -178,13 +170,12 @@ public class AkkaOptions {
                     .defaultValue(true)
                     .withDescription("Exit JVM on fatal Akka errors.");
 
-    /** Milliseconds a gate should be closed for after a remote connection was disconnected. */
-    public static final ConfigOption<Long> RETRY_GATE_CLOSED_FOR =
-            ConfigOptions.key("akka.retry-gate-closed-for")
-                    .longType()
-                    .defaultValue(50L)
-                    .withDescription(
-                            "Milliseconds a gate should be closed for after a remote connection was disconnected.");
+    /** Retry outbound connection only after this backoff. */
+    public static final ConfigOption<String> OUTBOUND_RESTART_BACKOFF =
+            ConfigOptions.key("akka.outbound-restart-backoff")
+                    .stringType()
+                    .defaultValue("50 ms")
+                    .withDescription("Retry outbound connection only after this backoff.");
 
     // ==================================================
     // Configurations for fork-join-executor.
@@ -223,9 +214,37 @@ public class AkkaOptions {
                                     .build());
 
     // ==================================================
-    // Configurations for client-socket-work-pool.
+    // Deprecated options
     // ==================================================
 
+    /**
+     * Timeout for the startup of the actor system.
+     *
+     * @deprecated Don't use this option anymore. It has no effect on Flink.
+     */
+    @Deprecated
+    public static final ConfigOption<String> STARTUP_TIMEOUT =
+            ConfigOptions.key("akka.startup-timeout")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Timeout after which the startup of a remote component is considered being failed.");
+
+    /**
+     * Milliseconds a gate should be closed for after a remote connection was disconnected.
+     *
+     * @deprecated Don't use this option anymore. It has no effect on Flink.
+     */
+    @Deprecated
+    public static final ConfigOption<Long> RETRY_GATE_CLOSED_FOR =
+            ConfigOptions.key("akka.retry-gate-closed-for")
+                    .longType()
+                    .defaultValue(50L)
+                    .withDescription(
+                            "Milliseconds a gate should be closed for after a remote connection was disconnected.");
+
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Integer> CLIENT_SOCKET_WORKER_POOL_SIZE_MIN =
             ConfigOptions.key("akka.client-socket-worker-pool.pool-size-min")
                     .intType()
@@ -235,6 +254,8 @@ public class AkkaOptions {
                                     .text("Min number of threads to cap factor-based number to.")
                                     .build());
 
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Integer> CLIENT_SOCKET_WORKER_POOL_SIZE_MAX =
             ConfigOptions.key("akka.client-socket-worker-pool.pool-size-max")
                     .intType()
@@ -244,6 +265,8 @@ public class AkkaOptions {
                                     .text("Max number of threads to cap factor-based number to.")
                                     .build());
 
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Double> CLIENT_SOCKET_WORKER_POOL_SIZE_FACTOR =
             ConfigOptions.key("akka.client-socket-worker-pool.pool-size-factor")
                     .doubleType()
@@ -257,10 +280,8 @@ public class AkkaOptions {
                                                     + " pool-size-max values.")
                                     .build());
 
-    // ==================================================
-    // Configurations for server-socket-work-pool.
-    // ==================================================
-
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Integer> SERVER_SOCKET_WORKER_POOL_SIZE_MIN =
             ConfigOptions.key("akka.server-socket-worker-pool.pool-size-min")
                     .intType()
@@ -270,6 +291,8 @@ public class AkkaOptions {
                                     .text("Min number of threads to cap factor-based number to.")
                                     .build());
 
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Integer> SERVER_SOCKET_WORKER_POOL_SIZE_MAX =
             ConfigOptions.key("akka.server-socket-worker-pool.pool-size-max")
                     .intType()
@@ -279,6 +302,8 @@ public class AkkaOptions {
                                     .text("Max number of threads to cap factor-based number to.")
                                     .build());
 
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
     public static final ConfigOption<Double> SERVER_SOCKET_WORKER_POOL_SIZE_FACTOR =
             ConfigOptions.key("akka.server-socket-worker-pool.pool-size-factor")
                     .doubleType()
@@ -291,10 +316,6 @@ public class AkkaOptions {
                                                     + " Resulting size is then bounded by the pool-size-min and"
                                                     + " pool-size-max values.")
                                     .build());
-
-    // ==================================================
-    // Deprecated options
-    // ==================================================
 
     /**
      * The Akka death watch heartbeat interval.

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -96,11 +96,6 @@ under the License.
 			<artifactId>akka-slf4j_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty</artifactId>
-			<version>3.10.6.Final</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapTools.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapTools.java
@@ -122,8 +122,7 @@ public class AkkaBootstrapTools {
             } catch (Exception e) {
                 // we can continue to try if this contains a netty channel exception
                 Throwable cause = e.getCause();
-                if (!(cause instanceof org.jboss.netty.channel.ChannelException
-                        || cause instanceof java.net.BindException)) {
+                if (!(cause instanceof java.net.BindException)) {
                     throw e;
                 } // else fall through the loop and try the next port
             }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
@@ -46,7 +46,7 @@ public class AkkaRpcServiceConfiguration {
             boolean captureAskCallStack,
             boolean forceRpcInvocationSerialization) {
 
-        checkArgument(maximumFramesize > 0L, "Maximum framesize must be positive.");
+        checkArgument(maximumFramesize >= 32768L, "Maximum framesize must be at least 32 KiB.");
         this.configuration = configuration;
         this.timeout = timeout;
         this.maximumFramesize = maximumFramesize;

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
@@ -209,8 +209,14 @@ class AkkaUtils {
 
         final String akkaFramesize = configuration.getString(AkkaOptions.FRAMESIZE);
 
-        final String outboundRestartBackoff =
-                configuration.getString(AkkaOptions.OUTBOUND_RESTART_BACKOFF);
+        final String outboundRestartBackoff;
+        if (!configuration.contains(AkkaOptions.OUTBOUND_RESTART_BACKOFF)
+                && configuration.contains(AkkaOptions.RETRY_GATE_CLOSED_FOR)) {
+            outboundRestartBackoff =
+                    configuration.getLong(AkkaOptions.RETRY_GATE_CLOSED_FOR) + " ms";
+        } else {
+            outboundRestartBackoff = configuration.getString(AkkaOptions.OUTBOUND_RESTART_BACKOFF);
+        }
 
         akkaConfigBuilder
                 .add("akka {")

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/CustomSSLEngineProvider.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/CustomSSLEngineProvider.java
@@ -21,7 +21,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrust
 
 import akka.actor.ActorSystem;
 import akka.remote.RemoteTransportException;
-import akka.remote.transport.netty.ConfigSSLEngineProvider;
+import akka.remote.artery.tcp.ConfigSSLEngineProvider;
 import com.typesafe.config.Config;
 
 import javax.net.ssl.TrustManager;
@@ -33,7 +33,6 @@ import java.util.List;
 /**
  * Extension of the {@link ConfigSSLEngineProvider} to use a {@link FingerprintTrustManagerFactory}.
  */
-@SuppressWarnings("deprecation")
 public class CustomSSLEngineProvider extends ConfigSSLEngineProvider {
     private final String sslTrustStore;
     private final String sslTrustStorePassword;
@@ -42,7 +41,7 @@ public class CustomSSLEngineProvider extends ConfigSSLEngineProvider {
     public CustomSSLEngineProvider(ActorSystem system) {
         super(system);
         final Config securityConfig =
-                system.settings().config().getConfig("akka.remote.classic.netty.ssl.security");
+                system.settings().config().getConfig("akka.remote.artery.ssl.config-ssl-engine");
         sslTrustStore = securityConfig.getString("trust-store");
         sslTrustStorePassword = securityConfig.getString("trust-store-password");
         sslCertFingerprints = securityConfig.getStringList("cert-fingerprints");

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for the over sized response message handling of the {@link AkkaRpcActor}. */
 class AkkaRpcActorOversizedResponseMessageTest {
 
-    private static final int FRAMESIZE = 32000;
+    private static final int FRAMESIZE = 32768;
 
     private static final String OVERSIZED_PAYLOAD = new String(new byte[FRAMESIZE]);
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -46,7 +46,7 @@ class MessageSerializationTest {
     private static RpcService akkaRpcService1;
     private static RpcService akkaRpcService2;
 
-    private static final int maxFrameSize = 32000;
+    private static final int maxFrameSize = 32768;
 
     @BeforeAll
     static void setup() throws Exception {

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -145,6 +146,7 @@ class RemoteAkkaRpcActorTest {
     }
 
     @Test
+    @Disabled("Not meaningful for Artery")
     void failsRpcResultImmediatelyIfRemoteRpcServiceIsNotAvailable() throws Exception {
         final AkkaRpcService toBeClosedRpcService =
                 AkkaRpcServiceUtils.createRemoteRpcService(

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.common.io.GenericInputFormat;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -40,14 +38,11 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /** Integration tests for {@link org.apache.flink.api.java.RemoteEnvironment}. */
-@SuppressWarnings("serial")
 public class RemoteEnvironmentITCase extends TestLogger {
 
     private static final int TM_SLOTS = 4;
 
     private static final int USER_DOP = 2;
-
-    private static final String VALID_STARTUP_TIMEOUT = "100 s";
 
     @ClassRule
     public static final MiniClusterResource MINI_CLUSTER_RESOURCE =
@@ -59,15 +54,12 @@ public class RemoteEnvironmentITCase extends TestLogger {
     /** Ensure that the program parallelism can be set even if the configuration is supplied. */
     @Test
     public void testUserSpecificParallelism() throws Exception {
-        Configuration config = new Configuration();
-        config.setString(AkkaOptions.STARTUP_TIMEOUT, VALID_STARTUP_TIMEOUT);
-
         final URI restAddress = MINI_CLUSTER_RESOURCE.getRestAddress();
         final String hostname = restAddress.getHost();
         final int port = restAddress.getPort();
 
         final ExecutionEnvironment env =
-                ExecutionEnvironment.createRemoteEnvironment(hostname, port, config);
+                ExecutionEnvironment.createRemoteEnvironment(hostname, port);
         env.setParallelism(USER_DOP);
 
         DataSet<Integer> result =


### PR DESCRIPTION
## What is the purpose of the change

Changes Akka remoting mechanism from the classic Netty based one to  Artery.


## Brief change log

- Akka RPC does not depend on Netty anymore.
- Changes in Akka configurations, as artery has some different config options, but mostly configs that are not needed anymore.


## Verifying this change

After deploying a job, check the job and task managers on the Flink dashboard.

This change is already covered by existing tests under the `flink-rpc` module.

There are some parts that may require some discussion. I disabled the `RemoteAkkaRpcActorTest#failsRpcResultImmediatelyIfRemoteRpcServiceIsNotAvailable` test case, because with Artery, lifecycle monitoring is only triggered if the 2 RPC service are on different nodes. Also, in the current iteration I did not exposed `watch-failure-detector` related fields in the `AkkaOptions`, which probably should be done, but first I just wanted to get some opinion about the way it is in general currently.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no (it removes Netty from `flink-rpc`)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
