### PR TITLE
[Flink-31615][doc-zh] Translates the query_state_warning in "Table API" page of "Table API & SQL" and fixes some content

### DIFF
--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -225,12 +225,12 @@ result = orders.filter(col("a").is_not_null & col("b").is_not_null & col("c").is
 
 {{< top >}}
 
-Operations
+支持的操作
 ----------
 
 Table API支持如下操作。请注意不是所有的操作都可以既支持流也支持批；这些操作都具有相应的标记。
 
-### Scan, Projection, and Filter
+### Scan, Projection 和 Filter
 
 #### From
 
@@ -294,10 +294,9 @@ table = t_env.from_elements([(1, 'ABC'), (2, 'ABCDE')])
 
 ```
 root
-|-- f0: BIGINT NOT NULL     // original types INT and BIGINT are generalized to BIGINT
-|-- f1: VARCHAR(5) NOT NULL // original types CHAR(3) and CHAR(5) are generalized
-                            // to VARCHAR(5). VARCHAR is used instead of CHAR so that
-                            // no padding is applied
+|-- f0: BIGINT NOT NULL     // 原始类型 INT 和 BIGINT 泛化为 BIGINT 类型。
+|-- f1: VARCHAR(5) NOT NULL // 原始类型 CHAR(3) 和 CHAR(5) 泛化为 VARCHAR(5) 类型。
+                            // 使用 VARCHAR 而不是 CHAR 来保证没有填充
 ```
 
 这个方法会根据输入的表达式自动获取类型。如果在某一个特定位置的类型不一致，该方法会尝试寻找一个所有类型的公共超类型。如果公共超类型不存在，则会抛出异常。
@@ -596,9 +595,9 @@ result = orders.rename_columns(col("b").alias('b2'), col("c").alias('c2'))
 
 {{< top >}}
 
-### Aggregations
+### 聚合操作
 
-#### GroupBy Aggregation
+#### GroupBy 聚合
 
 {{< label "Batch" >}} {{< label "Streaming" >}}
 {{< label "Result Updating" >}}
@@ -627,9 +626,9 @@ result = orders.group_by(col("a")).select(col("a"), col("b").sum.alias('d'))
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
-#### GroupBy Window Aggregation
+#### GroupBy Window 聚合
 
 {{< label "Batch" >}} {{< label "Streaming" >}}
 
@@ -674,9 +673,10 @@ result = orders.window(Tumble.over(lit(5).minutes).on(col('rowtime')).alias("w")
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Over Window Aggregation
+#### Over Window 聚合
 
 和 SQL 的 `OVER` 子句类似。
+基于前一行和后一行的窗口（范围），为每一行计算Over Window聚合。
 更多细节详见 [over windows section](#over-windows)
 
 {{< tabs "overwindowagg" >}}
@@ -732,14 +732,14 @@ result = orders.over_window(Over.partition_by(col("a")).order_by(col("rowtime"))
 
 所有的聚合必须定义在同一个窗口上，比如同一个分区、排序和范围内。目前只支持 PRECEDING 到当前行范围（无界或有界）的窗口。尚不支持 FOLLOWING 范围的窗口。ORDER BY 操作必须指定一个单一的[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}})。
 
-#### Distinct Aggregation
+#### Distinct 聚合
 
 {{< label "Batch" >}} {{< label "Streaming" >}}
 {{< label "Result Updating" >}}
 
 和 SQL DISTINCT 聚合子句类似，例如 `COUNT(DISTINCT a)`。
 Distinct 聚合声明的聚合函数（内置或用户定义的）仅应用于互不相同的输入值。
-Distinct 可以应用于 **GroupBy Aggregation**、**GroupBy Window Aggregation** 和 **Over Window Aggregation**。
+Distinct 可以应用于 **GroupBy 聚合**、**GroupBy Window 聚合** 和 **Over Window 聚合**。
 
 {{< tabs "distinctagg" >}}
 {{< tab "Java" >}}
@@ -824,7 +824,7 @@ result = orders.over_window(Over
 ```java
 Table orders = tEnv.from("Orders");
 
-// 对 user-defined aggregate functions 使用互异（互不相同、去重）聚合
+// 对用户定义的聚合函数使用互异（互不相同、去重）聚合
 tEnv.createTemporarySystemFunction("myUdagg", MyUdagg.class);
 orders.groupBy("users")
     .select(
@@ -837,17 +837,17 @@ orders.groupBy("users")
 ```scala
 val orders: Table = tEnv.from("Orders")
 
-// 对 user-defined aggregate functions 使用互异（互不相同、去重）聚合
+// 对用户定义的聚合函数使用互异（互不相同、去重）聚合
 val myUdagg = new MyUdagg()
 orders.groupBy($"users").select($"users", myUdagg.distinct($"points") as "myDistinctResult")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
-Unsupported
+不支持
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 #### Distinct
 
@@ -878,7 +878,7 @@ result = orders.distinct()
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 {{< top >}}
 
@@ -918,7 +918,7 @@ result = left.join(right).where(col('a') == col('d')).select(col('a'), col('b'),
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 #### Outer Join
 {{< label "Batch" >}} {{< label "Streaming" >}}
@@ -966,7 +966,7 @@ full_outer_result = left.full_outer_join(right, col('a') == col('d')).select(col
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 #### Interval Join
 
@@ -1015,17 +1015,17 @@ result = joined_table.select(col('a'), col('b'), col('e'), col('rowtime1'))
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Inner Join with Table Function (UDTF)
+#### 与表函数 (UDTF) 的 Inner Join 
 
 {{< label "Batch" >}} {{< label "Streaming" >}}
 
 join 表和表函数的结果。左（外部）表的每一行都会 join 表函数相应调用产生的所有行。
-如果表函数调用返回空结果，则删除左侧（外部）表的一行。
+如果表函数调用返回空结果，则对应左侧（外部）表的该行被丢弃。
 
 {{< tabs "udtf" >}}
 {{< tab "Java" >}}
 ```java
-// 注册 User-Defined Table Function
+// 注册用户自定义表函数
 tableEnv.createTemporarySystemFunction("split", MySplitUDTF.class);
 
 // join
@@ -1037,7 +1037,7 @@ Table result = orders
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-// 实例化 User-Defined Table Function
+// 实例化用户自定义表函数
 val split: TableFunction[_] = new MySplitUDTF()
 
 // join
@@ -1048,7 +1048,7 @@ val result: Table = table
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-# 注册 User-Defined Table Function
+# 注册用户自定义表函数
 @udtf(result_types=[DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.BIGINT()])
 def split(x):
     return [Row(1, 2, 3)]
@@ -1062,18 +1062,18 @@ result = joined_table.select(col('a'), col('b'), col('s'), col('t'), col('v'))
 {{< /tabs >}}
 
 
-####  Left Outer Join with Table Function (UDTF)
+####  与表函数 (UDTF) 的 Left Outer Join
 
 {{< label "Batch" >}} {{< label "Streaming" >}}
 
 join 表和表函数的结果。左（外部）表的每一行都会 join 表函数相应调用产生的所有行。如果表函数调用返回空结果，则保留相应的 outer（外部连接）行并用空值填充右侧结果。
 
-目前，表函数左外连接的谓词只能为空或字面（常量）真。
+目前，表函数左外连接的谓词只能为空或字面（常量）值 true。
 
 {{< tabs "outerudtf" >}}
 {{< tab "Java" >}}
 ```java
-// 注册 User-Defined Table Function
+// 注册用户自定义表函数
 tableEnv.createTemporarySystemFunction("split", MySplitUDTF.class);
 
 // join
@@ -1085,7 +1085,7 @@ Table result = orders
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-// 实例化 User-Defined Table Function
+// 实例化用户自定义表函数
 val split: TableFunction[_] = new MySplitUDTF()
 
 // join
@@ -1096,7 +1096,7 @@ val result: Table = table
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-# 注册 User-Defined Table Function
+# 注册用户自定义表函数
 @udtf(result_types=[DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.BIGINT()])
 def split(x):
     return [Row(1, 2, 3)]
@@ -1109,11 +1109,11 @@ result = joined_table.select(col('a'), col('b'), col('s'), col('t'), col('v'))
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Join with Temporal Table
+#### 与 Temporal Table 做 Join
 
 Temporal table 是跟踪随时间变化的表。
 
-Temporal table 函数提供对特定时间点 temporal table 状态的访问。表与 temporal table 函数进行 join 的语法和使用表函数进行 inner join 的语法相同。
+Temporal table 函数提供对特定时间点 temporal table 状态的访问。表与 temporal table 函数进行 join 的语法和与表函数进行 inner join 的语法相同。
 
 目前仅支持与 temporal table 的 inner join。
 
@@ -1153,7 +1153,7 @@ val result = orders
 
 {{< top >}}
 
-### Set Operations
+### Set 操作
 
 #### Union
 
@@ -1387,11 +1387,11 @@ result = left.select(col('a'), col('b'), col('c')).where(col('a').in_(right))
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 {{< top >}}
 
-### OrderBy, Offset & Fetch
+### OrderBy, Offset 和 Fetch
 
 #### Order By 
 
@@ -1417,7 +1417,7 @@ result = tab.order_by(col('a').asc)
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Offset & Fetch 
+#### Offset 和 Fetch 
 
 {{< label Batch >}} {{< label Streaming >}}
 
@@ -1603,7 +1603,7 @@ table = input.window([w: GroupWindow].alias("w")) \
 
 `Window` 参数定义了如何将行映射到窗口。 `Window` 不是用户可以实现的接口。相反，Table API 提供了一组具有特定语义的预定义 `Window` 类。下面列出了支持的窗口定义。
 
-#### Tumble (Tumbling Windows)
+#### Tumble (滚动窗口)
 
 滚动窗口将行分配给固定长度的非重叠连续窗口。例如，一个 5 分钟的滚动窗口以 5 分钟的间隔对行进行分组。滚动窗口可以定义在事件时间、处理时间或行数上。
 
@@ -1614,8 +1614,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1636,13 +1636,13 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```java
-// Tumbling Event-time Window
+// 滚动事件时间窗口
 .window(Tumble.over(lit(10).minutes()).on($("rowtime")).as("w"));
 
-// Tumbling Processing-time Window (assuming a processing-time attribute "proctime")
+// 滚动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble.over(lit(10).minutes()).on($("proctime")).as("w"));
 
-// Tumbling Row-count Window (assuming a processing-time attribute "proctime")
+// 滚动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble.over(rowInterval(10)).on($("proctime")).as("w"));
 ```
 {{< /tab >}}
@@ -1652,8 +1652,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1674,13 +1674,13 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```scala
-// Tumbling Event-time Window
+// 滚动事件时间窗口
 .window(Tumble over 10.minutes on $"rowtime" as $"w")
 
-// Tumbling Processing-time Window (assuming a processing-time attribute "proctime")
+// 滚动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble over 10.minutes on $"proctime" as $"w")
 
-// Tumbling Row-count Window (assuming a processing-time attribute "proctime")
+// 滚动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble over 10.rows on $"proctime" as $"w")
 ```
 {{< /tab >}}
@@ -1690,8 +1690,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1712,19 +1712,19 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```python
-# Tumbling Event-time Window
+# 滚动事件时间窗口
 .window(Tumble.over(lit(10).minutes).on(col('rowtime')).alias("w"))
 
-# Tumbling Processing-time Window (assuming a processing-time attribute "proctime")
+# 滚动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble.over(lit(10).minutes).on(col('proctime')).alias("w"))
 
-# Tumbling Row-count Window (assuming a processing-time attribute "proctime")
+# 滚动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Tumble.over(row_interval(10)).on(col('proctime')).alias("w"))
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Slide (Sliding Windows)
+#### Slide (滑动窗口)
 
 滑动窗口具有固定大小并按指定的滑动间隔滑动。如果滑动间隔小于窗口大小，则滑动窗口重叠。因此，行可能分配给多个窗口。例如，15 分钟大小和 5 分钟滑动间隔的滑动窗口将每一行分配给 3 个不同的 15 分钟大小的窗口，以 5 分钟的间隔进行一次计算。滑动窗口可以定义在事件时间、处理时间或行数上。
 
@@ -1735,8 +1735,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1761,19 +1761,19 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```java
-// Sliding Event-time Window
+// 滑动事件时间窗口
 .window(Slide.over(lit(10).minutes())
             .every(lit(5).minutes())
             .on($("rowtime"))
             .as("w"));
 
-// Sliding Processing-time window (assuming a processing-time attribute "proctime")
+// 滑动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Slide.over(lit(10).minutes())
             .every(lit(5).minutes())
             .on($("proctime"))
             .as("w"));
 
-// Sliding Row-count window (assuming a processing-time attribute "proctime")
+// 滑动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Slide.over(rowInterval(10)).every(rowInterval(5)).on($("proctime")).as("w"));
 ```
 {{< /tab >}}
@@ -1783,8 +1783,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1809,13 +1809,13 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```scala
-// Sliding Event-time Window
+// 滑动事件时间窗口
 .window(Slide over 10.minutes every 5.minutes on $"rowtime" as $"w")
 
-// Sliding Processing-time window (assuming a processing-time attribute "proctime")
+// 滑动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Slide over 10.minutes every 5.minutes on $"proctime" as $"w")
 
-// Sliding Row-count window (assuming a processing-time attribute "proctime")
+// 滑动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Slide over 10.rows every 5.rows on $"proctime" as $"w")
 ```
 {{< /tab >}}
@@ -1825,8 +1825,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1851,21 +1851,21 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```python
-# Sliding Event-time Window
+# 滑动事件时间窗口
 .window(Slide.over(lit(10).minutes).every(lit(5).minutes).on(col('rowtime')).alias("w"))
 
-# Sliding Processing-time window (assuming a processing-time attribute "proctime")
+# 滑动处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Slide.over(lit(10).minutes).every(lit(5).minutes).on(col('proctime')).alias("w"))
 
-# Sliding Row-count window (assuming a processing-time attribute "proctime")
+# 滑动 Row-count 窗口 (假设存在处理时间属性 "proctime")
 .window(Slide.over(row_interval(10)).every(row_interval(5)).on(col('proctime')).alias("w"))
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
-#### Session (Session Windows)
+#### Session (会话窗口)
 
-会话窗口没有固定的大小，其边界是由不活动的间隔定义的，例如，如果在定义的间隔期内没有事件出现，则会话窗口将关闭。例如，定义30 分钟间隔的会话窗口，当观察到一行在 30 分钟内不活动（否则该行将被添加到现有窗口中）且30 分钟内没有添加新行，窗口会关闭。会话窗口支持事件时间和处理时间。
+会话窗口没有固定的大小，其边界是由不活动的间隔定义的，例如，如果在定义的间隔期内没有事件出现，则会话窗口将关闭。例如，定义 30 分钟间隔的会话窗口，当观察到一行在 30 分钟内不活动（否则该行将被添加到现有窗口中）且 30 分钟内没有添加新行，窗口会关闭。会话窗口支持事件时间和处理时间。
 
 {{< tabs "58943253-807b-4e4c-b068-0dc1b783b7b5" >}}
 {{< tab "Java" >}}
@@ -1874,8 +1874,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1896,10 +1896,10 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```java
-// Session Event-time Window
+// 会话事件时间窗口
 .window(Session.withGap(lit(10).minutes()).on($("rowtime")).as("w"));
 
-// Session Processing-time Window (assuming a processing-time attribute "proctime")
+// 会话处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Session.withGap(lit(10).minutes()).on($("proctime")).as("w"));
 ```
 {{< /tab >}}
@@ -1909,8 +1909,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1931,10 +1931,10 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```scala
-// Session Event-time Window
+// 会话事件时间窗口
 .window(Session withGap 10.minutes on $"rowtime" as $"w")
 
-// Session Processing-time Window (assuming a processing-time attribute "proctime")
+// 会话处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Session withGap 10.minutes on $"proctime" as $"w")
 ```
 {{< /tab >}}
@@ -1944,8 +1944,8 @@ table = input.window([w: GroupWindow].alias("w")) \
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 20%">Method</th>
-      <th class="text-left">Description</th>
+      <th class="text-left" style="width: 20%">方法</th>
+      <th class="text-left">描述</th>
     </tr>
   </thead>
 
@@ -1966,10 +1966,10 @@ table = input.window([w: GroupWindow].alias("w")) \
 </table>
 
 ```python
-# Session Event-time Window
+# 会话事件时间窗口
 .window(Session.with_gap(lit(10).minutes).on(col('rowtime')).alias("w"))
 
-# Session Processing-time Window (assuming a processing-time attribute "proctime")
+# 会话处理时间窗口 (假设存在处理时间属性 "proctime")
 .window(Session.with_gap(lit(10).minutes).on(col('proctime')).alias("w"))
 ```
 {{< /tab >}}
@@ -1979,7 +1979,7 @@ table = input.window([w: GroupWindow].alias("w")) \
 
 ### Over Windows
 
-Over window 聚合聚合来自在标准的 SQL（`OVER` 子句），可以在 `SELECT` 查询子句中定义。与在“GROUP BY”子句中指定的 group window 不同， over window 不会折叠行。相反，over window 聚合为每个输入行在其相邻行的范围内计算聚合。
+Over window 聚合来自标准的 SQL（`OVER` 子句），可以在 `SELECT` 查询子句中定义。与在“GROUP BY”子句中指定的 group window 不同， over window 不会折叠行。相反，over window 聚合为每个输入行在其相邻行的范围内计算聚合。
 
 Over windows 使用 `window(w: OverWindow*)` 子句（在 Python API 中使用 `over_window(*OverWindow)`）定义，并通过 `select()` 方法中的别名引用。以下示例显示如何在表上定义 over window 聚合。
 
@@ -1987,20 +1987,20 @@ Over windows 使用 `window(w: OverWindow*)` 子句（在 Python API 中使用 `
 {{< tab "Java" >}}
 ```java
 Table table = input
-  .window([OverWindow w].as("w"))           // define over window with alias w
-  .select($("a"), $("b").sum().over($("w")), $("c").min().over($("w"))); // aggregate over the over window w
+  .window([OverWindow w].as("w"))           // 定义 over window 并指定别名为 w
+  .select($("a"), $("b").sum().over($("w")), $("c").min().over($("w"))); // 在 over window w 上聚合
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
 val table = input
-  .window([w: OverWindow] as $"w")              // define over window with alias w
-  .select($"a", $"b".sum over $"w", $"c".min over $"w") // aggregate over the over window w
+  .window([w: OverWindow] as $"w")              // 定义 over window 并指定别名为 w
+  .select($"a", $"b".sum over $"w", $"c".min over $"w") //  在 over window w 上聚合
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-# define over window with alias w and aggregate over the over window w
+# 定义 over window 并指定别名为 w，在 over window w 上聚合
 table = input.over_window([w: OverWindow].alias("w"))
     .select(col('a'), col('b').sum.over(col('w')), col('c').min.over(col('w')))
 ```
@@ -2159,7 +2159,7 @@ table = input.over_window([w: OverWindow].alias("w"))
 
 {{< top >}}
 
-### Row-based Operations
+### Row-based 操作
 
 基于行生成多列输出的操作。
 
@@ -2547,7 +2547,7 @@ t.select(col('b'), col('rowtime')) \
 
 和 **GroupBy Aggregation** 类似。使用运行中的表之后的聚合算子对分组键上的行进行分组，以按组聚合行。和 AggregateFunction 的不同之处在于，TableAggregateFunction 的每个分组可能返回0或多条记录。你必须使用 select 子句关闭 `flatAggregate`。并且 select 子句不支持聚合函数。
 
-除了使用 emitValue 输出结果，你还可以使用 emitUpdateWithRetract 方法。和 emitValue 不同的是，emitUpdateWithRetract 用于下发已更新的值。此方法在retract 模式下增量输出数据，例如，一旦有更新，我们必须在发送新的更新记录之前收回旧记录。如果在表聚合函数中定义了这两个方法，则将优先使用 emitUpdateWithRetract 方法而不是 emitValue 方法，这是因为该方法可以增量输出值，因此被视为比 emitValue 方法更有效。
+除了使用 `emitValue` 输出结果，你还可以使用 `emitUpdateWithRetract` 方法。和 `emitValue` 不同的是，`emitUpdateWithRetract` 用于下发已更新的值。此方法在 retract 模式下增量输出数据，例如，一旦有更新，我们必须在发送新的更新记录之前收回旧记录。如果在表聚合函数中定义了这两个方法，则将优先使用 `emitUpdateWithRetract` 方法而不是 `emitValue` 方法，这是因为该方法可以增量输出值，因此被视为比 `emitValue` 方法更有效。
 
 ```java
 /**
@@ -2611,7 +2611,7 @@ Table result = orders
 
 和 **GroupBy Aggregation** 类似。使用运行中的表之后的聚合运算符对分组键上的行进行分组，以按组聚合行。和 AggregateFunction 的不同之处在于，TableAggregateFunction 的每个分组可能返回0或多条记录。你必须使用 select 子句关闭 `flatAggregate`。并且 select 子句不支持聚合函数。
 
-除了使用 emitValue 输出结果，你还可以使用 emitUpdateWithRetract 方法。和 emitValue 不同的是，emitUpdateWithRetract 用于发出已更新的值。此方法在retract 模式下增量输出数据，例如，一旦有更新，我们必须在发送新的更新记录之前收回旧记录。如果在表聚合函数中定义了这两个方法，则将优先使用 emitUpdateWithRetract 方法而不是 emitValue 方法，这是因为该方法可以增量输出值，因此被视为比 emitValue 方法更有效。
+除了使用 `emitValue` 输出结果，你还可以使用 `emitUpdateWithRetract` 方法。和 `emitValue` 不同的是，`emitUpdateWithRetract` 用于发出已更新的值。此方法在 retract 模式下增量输出数据，例如，一旦有更新，我们必须在发送新的更新记录之前收回旧记录。如果在表聚合函数中定义了这两个方法，则将优先使用 `emitUpdateWithRetract` 方法而不是 `emitValue` 方法，这是因为该方法可以增量输出值，因此被视为比 `emitValue` 方法更有效。
 
 ```scala
 import java.lang.{Integer => JInteger}
@@ -2732,7 +2732,7 @@ result = t.select(col('a'), col('c')) \
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< query_state_warning >}}
+{{< query_state_warning_zh >}}
 
 <a name="data-types"></a>
 数据类型

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -376,7 +376,7 @@ result = orders.select(col("a"), col("c").alias('d'))
 {{< /tab >}}
 {{< /tabs >}}
 
-You can use star `(*)` to act as a wild card, selecting all of the columns in the table.
+You can use star `(*)` to act as a wild card, selecting all columns in the table.
 
 {{< tabs "selectstar" >}}
 {{< tab "Java" >}}
@@ -854,7 +854,7 @@ Unsupported
 {{< label "Result Updating" >}}
 
 Similar to a SQL `DISTINCT` clause.
-Returns records with distinct value combinations.
+Return records with distinct value combinations.
 
 {{< tabs "distinct" >}}
 {{< tab "Java" >}}
@@ -1114,7 +1114,7 @@ Temporal tables are tables that track changes over time.
 
 A temporal table function provides access to the state of a temporal table at a specific point in time. The syntax to join a table with a temporal table function is the same as in Inner Join with Table Function.
 
-Currently only inner joins with temporal tables are supported.
+Currently, only inner joins with temporal tables are supported.
 
 {{< tabs "temporaltablefunc" >}}
 {{< tab "Java" >}}
@@ -1396,7 +1396,7 @@ result = left.select(col('a'), col('b'), col('c')).where(col('a').in_(right))
 
 {{< label Batch >}} {{< label Streaming >}}
 
-Similar to a SQL `ORDER BY` clause. Returns records globally sorted across all parallel partitions. For unbounded tables, this operation requires a sorting on a time attribute or a subsequent fetch operation.
+Similar to a SQL `ORDER BY` clause. Return records globally sorted across all parallel partitions. For unbounded tables, this operation requires a sorting on a time attribute or a subsequent fetch operation.
 
 {{< tabs "orderby" >}}
 {{< tab "Java" >}}
@@ -1864,7 +1864,7 @@ Sliding windows are defined by using the `Slide` class as follows:
 
 #### Session (Session Windows)
 
-Session windows do not have a fixed size but their bounds are defined by an interval of inactivity, i.e., a session window is closes if no event appears for a defined gap period. For example a session window with a 30 minute gap starts when a row is observed after 30 minutes inactivity (otherwise the row would be added to an existing window) and is closed if no row is added within 30 minutes. Session windows can work on event-time or processing-time.
+Session windows do not have a fixed size but their bounds are defined by an interval of inactivity, i.e., a session window is closes if no event appears for a defined gap period. For example a session window with a 30-minute gap starts when a row is observed after 30 minutes inactivity (otherwise the row would be added to an existing window) and is closed if no row is added within 30 minutes. Session windows can work on event-time or processing-time.
 
 {{< tabs "58943253-807b-4e4c-b068-0dc1b783b7b5" >}}
 {{< tab "Java" >}}
@@ -1978,7 +1978,7 @@ A session window is defined by using the `Session` class as follows:
 
 ### Over Windows
 
-Over window aggregates are known from standard SQL (`OVER` clause) and defined in the `SELECT` clause of a query. Unlike group windows, which are specified in the `GROUP BY` clause, over windows do not collapse rows. Instead over window aggregates compute an aggregate for each input row over a range of its neighboring rows.
+Over window aggregates are known from standard SQL (`OVER` clause) and defined in the `SELECT` clause of a query. Unlike group windows, which are specified in the `GROUP BY` clause, over windows do not collapse rows. Instead, over window aggregates compute an aggregate for each input row over a range of its neighboring rows.
 
 Over windows are defined using the `window(w: OverWindow*)` clause (using `over_window(*OverWindow)` in Python API) and referenced via an alias in the `select()` method. The following example shows how to define an over window aggregation on a table.
 
@@ -2547,7 +2547,7 @@ t.select(col('b'), col('rowtime')) \
 
 Similar to a **GroupBy Aggregation**. Groups the rows on the grouping keys with the following running table aggregation operator to aggregate rows group-wise. The difference from an AggregateFunction is that TableAggregateFunction may return 0 or more records for a group. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.
 
-Instead of using emitValue to output results, you can also use the emitUpdateWithRetract method. Different from emitValue, emitUpdateWithRetract is used to emit values that have been updated. This method outputs data incrementally in retract mode, i.e., once there is an update, we have to retract old records before sending new updated ones. The emitUpdateWithRetract method will be used in preference to the emitValue method if both methods are defined in the table aggregate function, because the method is treated to be more efficient than emitValue as it can output values incrementally. 
+Instead of using `emitValue` to output results, you can also use the `emitUpdateWithRetract` method. Different from `emitValue`, `emitUpdateWithRetract` is used to emit values that have been updated. This method outputs data incrementally in retract mode, i.e., once there is an update, we have to retract old records before sending new updated ones. The emitUpdateWithRetract method will be used in preference to the emitValue method if both methods are defined in the table aggregate function, because the method is treated to be more efficient than emitValue as it can output values incrementally. 
 
 ```java
 /**
@@ -2611,7 +2611,7 @@ Table result = orders
 
 Similar to a **GroupBy Aggregation**. Groups the rows on the grouping keys with the following running table aggregation operator to aggregate rows group-wise. The difference from an AggregateFunction is that TableAggregateFunction may return 0 or more records for a group. You have to close the "flatAggregate" with a select statement. And the select statement does not support aggregate functions.
 
-Instead of using emitValue to output results, you can also use the emitUpdateWithRetract method. Different from emitValue, emitUpdateWithRetract is used to emit values that have been updated. This method outputs data incrementally in retract mode, i.e., once there is an update, we have to retract old records before sending new updated ones. The emitUpdateWithRetract method will be used in preference to the emitValue method if both methods are defined in the table aggregate function, because the method is treated to be more efficient than emitValue as it can output values incrementally. 
+Instead of using `emitValue` to output results, you can also use the `emitUpdateWithRetract` method. Different from `emitValue`, `emitUpdateWithRetract` is used to emit values that have been updated. This method outputs data incrementally in retract mode, i.e., once there is an update, we have to retract old records before sending new updated ones. The `emitUpdateWithRetract` method will be used in preference to the `emitValue` method if both methods are defined in the table aggregate function, because the method is treated to be more efficient than `emitValue` as it can output values incrementally. 
 
 ```scala
 import java.lang.{Integer => JInteger}

--- a/docs/layouts/shortcodes/query_state_warning_zh.html
+++ b/docs/layouts/shortcodes/query_state_warning_zh.html
@@ -1,0 +1,21 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+对于流式查询，计算查询结果所需的状态可能会无限增长，具体取决于关于聚合类型和不同分组键的数量。请配置空闲状态
+维持时间以防止状态过大。详情可查看
+<a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/table/concepts/overview/#idle-state-retention-time">空闲状态维持时间</a>。


### PR DESCRIPTION
## What is the purpose of the change

This pull request translates the query_state_warning in "Table API" page of "Table API & SQL" and fixes some content.

## Brief change log

  - Add query_state_warning_zh.html
  - Modify the "Table API" page of "Table API & SQL"

## Verifying this change

This change is a document change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
