### PR TITLE
[hotfix][docs] Fix the example configuration of pipeline.cached-files.

### DIFF
--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>pipeline.cached-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>Files to be registered at the distributed cache under the given name. The files will be accessible from any user-defined function in the (distributed) runtime under a local path. Files may be local files (which will be distributed via BlobServer), or files in a distributed file system. The runtime will copy the files temporarily to a local cache, if needed.<br /><br />Example:<br /><code class="highlighter-rouge">name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2`</code></td>
+            <td>Files to be registered at the distributed cache under the given name. The files will be accessible from any user-defined function in the (distributed) runtime under a local path. Files may be local files (which will be distributed via BlobServer), or files in a distributed file system. The runtime will copy the files temporarily to a local cache, if needed.<br /><br />Example:<br /><code class="highlighter-rouge">name:file1,path:'file:///tmp/file1';name:file2,path:'hdfs:///tmp/file2'</code></td>
         </tr>
         <tr>
             <td><h5>pipeline.classpaths</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -267,7 +267,7 @@ public class PipelineOptions {
                                     .linebreak()
                                     .add(
                                             TextElement.code(
-                                                    "name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2`"))
+                                                    "name:file1,path:'file:///tmp/file1';name:file2,path:'hdfs:///tmp/file2'"))
                                     .build());
 
     public static final ConfigOption<VertexDescriptionMode> VERTEX_DESCRIPTION_MODE =


### PR DESCRIPTION
## What is the purpose of the change

The path of cached files should quote by either single (') or double quotes ("), not the back quote (`)

The path will parsed as '`file' when using back quote.
![image](https://user-images.githubusercontent.com/5869080/227765717-4e8f8b49-1b11-4cd3-af8b-33930e42e1a5.png)

## Brief change log
  - *Fix examples of pipeline.cached-files in documents*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

