### PR TITLE
[FLINK-31603][table-planner] Line break should be removed in create t…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableOption.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableOption.java
@@ -56,11 +56,11 @@ public class SqlTableOption extends SqlCall {
     }
 
     public String getKeyString() {
-        return ((NlsString) SqlLiteral.value(key)).getValue();
+        return ((NlsString) SqlLiteral.value(key)).getValue().replaceAll("\n", "");
     }
 
     public String getValueString() {
-        return ((NlsString) SqlLiteral.value(value)).getValue();
+        return ((NlsString) SqlLiteral.value(value)).getValue().replaceAll("\n", "");
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
@@ -64,11 +64,21 @@ public abstract class FlinkHints {
      * null.
      */
     public static Map<String, String> getHintedOptions(List<RelHint> tableHints) {
-        return tableHints.stream()
-                .filter(hint -> hint.hintName.equalsIgnoreCase(HINT_NAME_OPTIONS))
-                .findFirst()
-                .map(hint -> hint.kvOptions)
-                .orElse(Collections.emptyMap());
+        Map<String, String> hintedOptions =
+                tableHints.stream()
+                        .filter(hint -> hint.hintName.equalsIgnoreCase(HINT_NAME_OPTIONS))
+                        .findFirst()
+                        .map(hint -> hint.kvOptions)
+                        .orElse(Collections.emptyMap());
+
+        if (!hintedOptions.isEmpty()) {
+            return hintedOptions.entrySet().stream()
+                    .collect(
+                            Collectors.toMap(
+                                    entry -> entry.getKey().replaceAll("\n", ""),
+                                    entry -> entry.getValue().replaceAll("\n", "")));
+        }
+        return hintedOptions;
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -132,6 +132,23 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
     }
 
     @Test
+    public void testCreateDatabaseWithNewLineInTableOptions() {
+        String sql =
+                "create database cat1.db1 comment 'db1_comment' with ('k\n1' = 'v1', 'K2' = 'V\n2')";
+
+        Operation operation = parse(sql);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("k1", "v1");
+        properties.put("K2", "V2");
+
+        assertThat(operation).isInstanceOf(CreateDatabaseOperation.class);
+        final CreateDatabaseOperation createDatabaseOperation = (CreateDatabaseOperation) operation;
+        assertThat(createDatabaseOperation.getCatalogDatabase().getProperties())
+                .isEqualTo(new HashMap<>(properties));
+    }
+
+    @Test
     public void testDropDatabase() {
         final String[] dropDatabaseSqls =
                 new String[] {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
@@ -120,6 +120,20 @@ public class SqlDmlToOperationConverterTest extends SqlToOperationConverterTestB
     }
 
     @Test
+    public void testDynamicTableWithNewLineInOptions() {
+        final String sql =
+                "insert into t1 /*+ OPTIONS('k\n1'='v1', 'k2'='v\n2') */\n"
+                        + "select a, b, c, d from t2";
+        FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+        final CalciteParser parser = getParserBySqlDialect(SqlDialect.DEFAULT);
+        Operation operation = parse(sql, planner, parser);
+        assertThat(operation).isInstanceOf(SinkModifyOperation.class);
+        SinkModifyOperation sinkModifyOperation = (SinkModifyOperation) operation;
+        Map<String, String> dynamicOptions = sinkModifyOperation.getDynamicOptions();
+        assertThat(dynamicOptions.toString()).isEqualTo("{k1=v1, k2=v2}");
+    }
+
+    @Test
     public void testBeginStatementSet() {
         final String sql = "BEGIN STATEMENT SET";
         Operation operation = parse(sql);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -104,6 +104,20 @@ public class SqlOtherOperationConverterTest extends SqlToOperationConverterTestB
     }
 
     @Test
+    public void testLoadModuleWithNewLineInTableOptions() {
+        final String sql = "LOAD MODULE dummy WITH ('k\n1' = 'v1', 'k2' = 'v\n2')";
+        final Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("k1", "v1");
+        expectedOptions.put("k2", "v2");
+
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(LoadModuleOperation.class);
+        final LoadModuleOperation loadModuleOperation = (LoadModuleOperation) operation;
+
+        assertThat(loadModuleOperation.getOptions()).isEqualTo(expectedOptions);
+    }
+
+    @Test
     public void testUnloadModule() {
         final String sql = "UNLOAD MODULE dummy";
         final String expectedModuleName = "dummy";


### PR DESCRIPTION
…able with-clauses, load module with-clauses and table hints for both keys and values

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Line break should be removed in create table with-clauses, load module with-clauses and table hints for both keys and values.

## Brief change log


- changed FlinkTableOptions and FlinkHints key/value retrieving logic by replacing all line breaks before returning the actual values.

Files Updated:
- flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableOption.java
- flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java


## Verifying this change

This change added tests and can be verified as follows:

Added tests for creating table ,loading modules and inserting into clauses with table hint.

UT updated:
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDmlToOperationConverterTest.java
- flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
