### PR TITLE
[FLINK-31621][table] Add built-in ARRAY_REVERSE function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -640,6 +640,9 @@ collection:
   - sql: ARRAY_REMOVE(haystack, needle)
     table: haystack.arrayRemove(needle)
     description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.
+  - sql: ARRAY_REVERSE(haystack)
+    table: haystack.arrayReverse()
+    description: Returns an array in reverse order. If the array itself is null, the function will return null.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -229,6 +229,7 @@ advanced type helper functions
     Expression.array_distinct
     Expression.array_position
     Expression.array_remove
+    Expression.array_reverse
     Expression.map_keys
     Expression.map_values
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1505,6 +1505,13 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayRemove")(self, needle)
 
+    def array_reverse(self) -> 'Expression':
+        """
+        Returns an array in reverse order.
+        If the array itself is null, the function will return null.
+        """
+        return _binary_op("arrayReverse")(self)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -58,6 +58,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REMOVE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REVERSE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASCII;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AT;
@@ -1384,6 +1385,15 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayRemove(InType needle) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_REMOVE, toExpr(), objectToExpression(needle)));
+    }
+
+    /**
+     * Returns an array in reverse order.
+     *
+     * <p>If the array itself is null, the function will return null.
+     */
+    public OutType arrayReverse() {
+        return toApiSpecificExpression(unresolvedCall(ARRAY_REVERSE, toExpr()));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -248,6 +248,19 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayRemoveFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_REVERSE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_REVERSE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Collections.singletonList("haystack"),
+                                    Collections.singletonList(logical(LogicalTypeRoot.ARRAY))))
+                    .outputTypeStrategy(nullableIfArgs(argument(0)))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayReverseFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -387,8 +387,6 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 new Row[] {
                                     Row.of(true, LocalDate.of(2022, 4, 20)),
                                     Row.of(true, LocalDate.of(1990, 10, 14)),
-                                    Row.of(true, LocalDate.of(1990, 10, 14)),
-                                    Row.of(true, LocalDate.of(1990, 10, 14)),
                                     null
                                 })
                         .andDataTypes(
@@ -411,8 +409,6 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ARRAY_REVERSE(f2)",
                                 new Row[] {
                                     null,
-                                    Row.of(true, LocalDate.of(1990, 10, 14)),
-                                    Row.of(true, LocalDate.of(1990, 10, 14)),
                                     Row.of(true, LocalDate.of(1990, 10, 14)),
                                     Row.of(true, LocalDate.of(2022, 4, 20)),
                                 },

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -41,7 +41,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayContainsTestCases(),
                         arrayDistinctTestCases(),
                         arrayPositionTestCases(),
-                        arrayRemoveTestCases())
+                        arrayRemoveTestCases(),
+                        arrayReverseTestCases())
                 .flatMap(s -> s);
     }
 
@@ -375,5 +376,47 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayRemove(true),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_REMOVE(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arrayReverseTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_REVERSE)
+                        .onFieldsWithData(
+                                new Integer[] {1, 2, 2, null},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                })
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())))
+                        .testResult(
+                                $("f0").arrayReverse(),
+                                "ARRAY_REVERSE(f0)",
+                                new Integer[] {null, 2, 2, 1},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        .testResult(
+                                $("f1").arrayReverse(),
+                                "ARRAY_REVERSE(f1)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        .testResult(
+                                $("f2").arrayReverse(),
+                                "ARRAY_REVERSE(f2)",
+                                new Row[] {
+                                    null,
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                },
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE()))));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayDistinctFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayDistinctFunction.java
@@ -69,7 +69,7 @@ public class ArrayDistinctFunction extends BuiltInScalarFunction {
                 return null;
             }
 
-            List list = new ArrayList();
+            List<Object> list = new ArrayList();
             boolean alreadyStoredNull = false;
 
             for (int i = 0; i < haystack.size(); i++) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayRemoveFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayRemoveFunction.java
@@ -70,7 +70,7 @@ public class ArrayRemoveFunction extends BuiltInScalarFunction {
                 return null;
             }
 
-            List list = new ArrayList();
+            List<Object> list = new ArrayList();
             final int size = haystack.size();
             for (int pos = 0; pos < size; pos++) {
                 final Object element = elementGetter.getElementOrNull(haystack, pos);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
@@ -25,12 +25,10 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_REVERSE}. */
@@ -47,20 +45,15 @@ public class ArrayReverseFunction extends BuiltInScalarFunction {
     }
 
     public @Nullable ArrayData eval(ArrayData haystack) {
-        try {
-            if (haystack == null) {
-                return null;
-            }
-
-            List list = new ArrayList();
-            for (int i = 0; i < haystack.size(); i++) {
-                final Object element = elementGetter.getElementOrNull(haystack, i);
-                list.add(element);
-            }
-            Collections.reverse(list);
-            return new GenericArrayData(list.toArray());
-        } catch (Throwable t) {
-            throw new FlinkRuntimeException(t);
+        if (haystack == null) {
+            return null;
         }
+
+        List list = new ArrayList();
+        for (int j = haystack.size() - 1; j >= 0; j--) {
+            final Object element = elementGetter.getElementOrNull(haystack, j);
+            list.add(element);
+        }
+        return new GenericArrayData(list.toArray());
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
@@ -28,9 +28,6 @@ import org.apache.flink.table.types.DataType;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_REVERSE}. */
 @Internal
 public class ArrayReverseFunction extends BuiltInScalarFunction {
@@ -51,11 +48,11 @@ public class ArrayReverseFunction extends BuiltInScalarFunction {
         if (haystack.size() <= 1) {
             return haystack;
         }
-        List<Object> list = new ArrayList(haystack.size());
-        for (int j = haystack.size() - 1; j >= 0; j--) {
-            final Object element = elementGetter.getElementOrNull(haystack, j);
-            list.add(element);
+        Object[] array = new Object[haystack.size()];
+        for (int i = 0; i < haystack.size(); i++) {
+            final Object element = elementGetter.getElementOrNull(haystack, i);
+            array[haystack.size() - 1 - i] = element;
         }
-        return new GenericArrayData(list.toArray());
+        return new GenericArrayData(array);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_REVERSE}. */
+@Internal
+public class ArrayReverseFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    public ArrayReverseFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_REVERSE, context);
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+    }
+
+    public @Nullable ArrayData eval(ArrayData haystack) {
+        try {
+            if (haystack == null) {
+                return null;
+            }
+
+            List list = new ArrayList();
+            for (int i = 0; i < haystack.size(); i++) {
+                final Object element = elementGetter.getElementOrNull(haystack, i);
+                list.add(element);
+            }
+            Collections.reverse(list);
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
@@ -51,7 +51,7 @@ public class ArrayReverseFunction extends BuiltInScalarFunction {
         if (haystack.size() <= 1) {
             return haystack;
         }
-        List list = new ArrayList(haystack.size());
+        List<Object> list = new ArrayList(haystack.size());
         for (int j = haystack.size() - 1; j >= 0; j--) {
             final Object element = elementGetter.getElementOrNull(haystack, j);
             list.add(element);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayReverseFunction.java
@@ -48,8 +48,10 @@ public class ArrayReverseFunction extends BuiltInScalarFunction {
         if (haystack == null) {
             return null;
         }
-
-        List list = new ArrayList();
+        if (haystack.size() <= 1) {
+            return haystack;
+        }
+        List list = new ArrayList(haystack.size());
         for (int j = haystack.size() - 1; j >= 0; j--) {
             final Object element = elementGetter.getElementOrNull(haystack, j);
             list.add(element);


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of ARRAY_REVERSE

- Brief change log
ARRAY_REVERSE for Table API and SQL
    
  ```
  array_reverse(array) - Returns an array in reverse order.
  Syntax:
      array_reverse(array)
      
      Arguments:
      array: An ARRAY to be handled.
      
      Returns:
      Returns an array in reverse order.
      If the array itself is null, the function will return null.
   
      > SELECT array_reverse(array(1, 2, 2, NULL));
       NULL, 2, 2, 1
  ```

   See also
    bigquery https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#array_reverse

- Verifying this change
This change added tests in CollectionFunctionsITCase

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)