### PR TITLE
[hotfix][doc][table] Fix the incorrect syntax description for explain statement set

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/explain.md
+++ b/docs/content.zh/docs/dev/table/sql/explain.md
@@ -526,7 +526,7 @@ No available advice...
 EXPLAIN [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR] <query_statement_or_insert_statement_or_statement_set>
 
 statement_set:
-EXECUTE STATEMENT SET
+STATEMENT SET
 BEGIN
 insert_statement;
 ...

--- a/docs/content/docs/dev/table/sql/explain.md
+++ b/docs/content/docs/dev/table/sql/explain.md
@@ -519,7 +519,7 @@ Specify `JSON_EXECUTION_PLAN` will inform the optimizer to attach the json-forma
 EXPLAIN [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR] <query_statement_or_insert_statement_or_statement_set>
 
 statement_set:
-EXECUTE STATEMENT SET
+STATEMENT SET
 BEGIN
 insert_statement;
 ...


### PR DESCRIPTION
## What is the purpose of the change

This is hotfix the Explain doc, the current syntax for explain statement set should be
```
EXPLAIN [([ExplainDetail[, ExplainDetail]*]) | PLAN FOR] <query_statement_or_insert_statement_or_statement_set>

statement_set:
STATEMENT SET
BEGIN
insert_statement;
...
insert_statement;
END;
```


## Brief change log

Fix incorrect description.


## Verifying this change

This change is a trivial fix and can be verified by the current test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
