### PR TITLE
[FLINK-31612][Filesystems] Remove no longer necessary Hadoop relocation rules

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -129,56 +129,12 @@ under the License.
 								</includes>
 							</artifactSet>
 							<relocations>
-								<!-- relocate the references to Hadoop to match the shaded Hadoop config -->
-								<relocation>
-									<pattern>org.apache.hadoop</pattern>
-									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop</shadedPattern>
-								</relocation>
-
-								<!-- shade dependencies internally used by Hadoop and never exposed downstream -->
-								<relocation>
-									<pattern>org.apache.commons</pattern>
-									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.commons</shadedPattern>
-								</relocation>
-
-								<!-- relocate the Azure dependencies -->
-								<relocation>
-									<pattern>com.microsoft.azure</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.com.microsoft.azure</shadedPattern>
-								</relocation>
-
-								<!-- shade dependencies internally used by Azure and never exposed downstream -->
-								<relocation>
-									<pattern>org.apache.http</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.org.apache.http</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>commons-logging</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.commons-logging</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>commons-codec</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.commons-codec</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.fasterxml</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.com.fasterxml</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.com.google</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>org.eclipse</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.org.eclipse</shadedPattern>
-								</relocation>
-
-								<!-- shade Flink's Hadoop FS adapter classes  -->
+								<!-- shade Flink's Hadoop FS adapter classes, forces plugin classloader for them -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>
 									<shadedPattern>org.apache.flink.fs.azure.common.hadoop</shadedPattern>
 								</relocation>
-								<!-- shade Flink's Hadoop FS utility classes -->
+								<!-- shade Flink's Hadoop FS utility classes, forces plugin classloader for them -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.azure.common</shadedPattern>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -188,31 +188,16 @@ under the License.
 								</includes>
 							</artifactSet>
 							<relocations>
-
-								<!-- relocate the references to Hadoop to match the shaded Hadoop config -->
-								<relocation>
-									<pattern>org.apache.hadoop</pattern>
-									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop</shadedPattern>
-								</relocation>
-
-								<!-- shade dependencies internally used by Hadoop and never exposed downstream -->
-								<relocation>
-									<pattern>org.apache.commons</pattern>
-									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.commons</shadedPattern>
-								</relocation>
-
-								<!-- shade Flink's Hadoop FS adapter classes  -->
+								<!-- shade Flink's Hadoop FS adapter classes, forces plugin classloader for them -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>
 									<shadedPattern>org.apache.flink.fs.gs.org.apache.flink.runtime.fs.hdfs</shadedPattern>
 								</relocation>
-
-								<!-- shade Flink's Hadoop FS utility classes -->
+								<!-- shade Flink's Hadoop FS utility classes, forces plugin classloader for them -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.util</pattern>
 									<shadedPattern>org.apache.flink.fs.gs.org.apache.flink.runtime.util</shadedPattern>
 								</relocation>
-
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -145,19 +145,6 @@ under the License.
 								</includes>
 							</artifactSet>
 							<relocations>
-								<relocation>
-									<pattern>org.apache.hadoop</pattern>
-									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop</shadedPattern>
-								</relocation>
-								<!-- relocate the OSS dependencies -->
-								<relocation>
-									<pattern>com.aliyun</pattern>
-									<shadedPattern>org.apache.flink.fs.osshadoop.shaded.com.aliyun</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.aliyuncs</pattern>
-									<shadedPattern>org.apache.flink.fs.osshadoop.shaded.com.aliyuncs</shadedPattern>
-								</relocation>
 								<!-- shade Flink's Hadoop FS adapter classes, forces plugin classloader for them -->
 								<relocation>
 									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>


### PR DESCRIPTION
## What is the purpose of the change

* Removes no longer needed Hadoop relocation rules for Azure/GS/OSS Filesystem implementations

## Brief change log

* Updated shade relocation rules

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: **yes** 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
