### PR TITLE
[FLINK-31626] HsSubpartitionFileReaderImpl should recycle skipped read buffers.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -35,18 +37,22 @@ public interface HsDataView {
      * <p>Only invoked by consumer thread.
      *
      * @param nextBufferToConsume next buffer index to consume.
+     * @param buffersToRecycle buffers to recycle if needed.
      * @return If the target buffer does exist, return buffer and next buffer's backlog, otherwise
      *     return {@link Optional#empty()}.
      */
-    Optional<BufferAndBacklog> consumeBuffer(int nextBufferToConsume) throws Throwable;
+    Optional<BufferAndBacklog> consumeBuffer(
+            int nextBufferToConsume, Collection<Buffer> buffersToRecycle) throws Throwable;
 
     /**
      * Get dataType of next buffer to consume.
      *
      * @param nextBufferToConsume next buffer index to consume
+     * @param buffersToRecycle buffers to recycle if needed.
      * @return next buffer's dataType. If not found in memory, return {@link DataType#NONE}.
      */
-    DataType peekNextToConsumeDataType(int nextBufferToConsume);
+    DataType peekNextToConsumeDataType(
+            int nextBufferToConsume, Collection<Buffer> buffersToRecycle);
 
     /**
      * Get the number of buffers backlog.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Optional;
@@ -84,6 +85,7 @@ public class HsSubpartitionConsumerMemoryDataManager implements HsDataView {
      * return the buffer and backlog.
      *
      * @param toConsumeIndex index of buffer to be consumed.
+     * @param buffersToRecycle buffers to recycle if needed.
      * @return If the head of {@link #unConsumedBuffers} is target, return optional of the buffer
      *     and backlog. Otherwise, return {@link Optional#empty()}.
      */
@@ -91,7 +93,8 @@ public class HsSubpartitionConsumerMemoryDataManager implements HsDataView {
     // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
     // subpartitionLock.
     @Override
-    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(int toConsumeIndex) {
+    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(
+            int toConsumeIndex, Collection<Buffer> buffersToRecycle) {
         Optional<Tuple2<HsBufferContext, Buffer.DataType>> bufferAndNextDataType =
                 callWithLock(
                         () -> {
@@ -125,6 +128,7 @@ public class HsSubpartitionConsumerMemoryDataManager implements HsDataView {
      * If so, return the next buffer's data type.
      *
      * @param nextToConsumeIndex index of the buffer to be consumed next time.
+     * @param buffersToRecycle buffers to recycle if needed.
      * @return If the head of {@link #unConsumedBuffers} is target, return the buffer's data type.
      *     Otherwise, return {@link Buffer.DataType#NONE}.
      */
@@ -132,7 +136,8 @@ public class HsSubpartitionConsumerMemoryDataManager implements HsDataView {
     // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
     // consumerLock.
     @Override
-    public Buffer.DataType peekNextToConsumeDataType(int nextToConsumeIndex) {
+    public Buffer.DataType peekNextToConsumeDataType(
+            int nextToConsumeIndex, Collection<Buffer> buffersToRecycle) {
         return callWithLock(() -> peekNextToConsumeDataTypeInternal(nextToConsumeIndex));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -69,7 +70,13 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     private final Consumer<HsSubpartitionFileReader> fileReaderReleaser;
 
-    private volatile boolean isFailed;
+    private final Object lock = new Object();
+
+    @GuardedBy("lock")
+    private boolean isFailed;
+
+    @GuardedBy("lock")
+    private boolean isReleased;
 
     public HsSubpartitionFileReaderImpl(
             int subpartitionId,
@@ -119,72 +126,83 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
      * read ahead the downstream consuming offset.
      */
     @Override
-    public synchronized void readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler)
+    public void readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler)
             throws IOException {
-        if (isFailed) {
-            throw new IOException("subpartition reader has already failed.");
-        }
-        int firstBufferToLoad = bufferIndexManager.getNextToLoad();
-        if (firstBufferToLoad < 0) {
-            return;
-        }
-
-        // If lookup result is empty, it means that one the following things have happened:
-        // 1) The target buffer has not been spilled into disk.
-        // 2) The target buffer has not been released from memory.
-        // So, just skip this round reading.
-        int numRemainingBuffer = cachedRegionManager.getRemainingBuffersInRegion(firstBufferToLoad);
-        if (numRemainingBuffer == 0) {
-            return;
-        }
-        moveFileOffsetToBuffer(firstBufferToLoad);
-
-        int indexToLoad;
-        int numLoaded = 0;
-        while (!buffers.isEmpty()
-                && (indexToLoad = bufferIndexManager.getNextToLoad()) >= 0
-                && numRemainingBuffer-- > 0) {
-            MemorySegment segment = buffers.poll();
-            Buffer buffer;
-            try {
-                if ((buffer = readFromByteChannel(dataFileChannel, headerBuf, segment, recycler))
-                        == null) {
-                    buffers.add(segment);
-                    break;
-                }
-            } catch (Throwable throwable) {
-                buffers.add(segment);
-                throw throwable;
+        synchronized (lock) {
+            if (isReleased) {
+                return;
+            }
+            if (isFailed) {
+                throw new IOException("subpartition reader has already failed.");
+            }
+            int firstBufferToLoad = bufferIndexManager.getNextToLoad();
+            if (firstBufferToLoad < 0) {
+                return;
             }
 
-            loadedBuffers.add(BufferIndexOrError.newBuffer(buffer, indexToLoad));
-            bufferIndexManager.updateLastLoaded(indexToLoad);
-            cachedRegionManager.advance(
-                    buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH);
-            ++numLoaded;
-        }
+            // If lookup result is empty, it means that one the following things have happened:
+            // 1) The target buffer has not been spilled into disk.
+            // 2) The target buffer has not been released from memory.
+            // So, just skip this round reading.
+            int numRemainingBuffer =
+                    cachedRegionManager.getRemainingBuffersInRegion(firstBufferToLoad);
+            if (numRemainingBuffer == 0) {
+                return;
+            }
+            moveFileOffsetToBuffer(firstBufferToLoad);
 
-        if (loadedBuffers.size() <= numLoaded) {
-            operations.notifyDataAvailable();
+            int indexToLoad;
+            int numLoaded = 0;
+            while (!buffers.isEmpty()
+                    && (indexToLoad = bufferIndexManager.getNextToLoad()) >= 0
+                    && numRemainingBuffer-- > 0) {
+                MemorySegment segment = buffers.poll();
+                Buffer buffer;
+                try {
+                    if ((buffer =
+                                    readFromByteChannel(
+                                            dataFileChannel, headerBuf, segment, recycler))
+                            == null) {
+                        buffers.add(segment);
+                        break;
+                    }
+                } catch (Throwable throwable) {
+                    buffers.add(segment);
+                    throw throwable;
+                }
+
+                loadedBuffers.add(BufferIndexOrError.newBuffer(buffer, indexToLoad));
+                bufferIndexManager.updateLastLoaded(indexToLoad);
+                cachedRegionManager.advance(
+                        buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH);
+                ++numLoaded;
+            }
+
+            if (loadedBuffers.size() <= numLoaded) {
+                operations.notifyDataAvailable();
+            }
         }
     }
 
     @Override
-    public synchronized void fail(Throwable failureCause) {
-        if (isFailed) {
-            return;
-        }
-        isFailed = true;
-        BufferIndexOrError bufferIndexOrError;
-        // empty from tail, in-case subpartition view consumes concurrently and gets the wrong order
-        while ((bufferIndexOrError = loadedBuffers.pollLast()) != null) {
-            if (bufferIndexOrError.getBuffer().isPresent()) {
-                checkNotNull(bufferIndexOrError.buffer).recycleBuffer();
+    public void fail(Throwable failureCause) {
+        synchronized (lock) {
+            if (isFailed) {
+                return;
             }
-        }
+            isFailed = true;
+            BufferIndexOrError bufferIndexOrError;
+            // empty from tail, in-case subpartition view consumes concurrently and gets the wrong
+            // order
+            while ((bufferIndexOrError = loadedBuffers.pollLast()) != null) {
+                if (bufferIndexOrError.getBuffer().isPresent()) {
+                    checkNotNull(bufferIndexOrError.buffer).recycleBuffer();
+                }
+            }
 
-        loadedBuffers.add(BufferIndexOrError.newError(failureCause));
-        operations.notifyDataAvailable();
+            loadedBuffers.add(BufferIndexOrError.newError(failureCause));
+            operations.notifyDataAvailable();
+        }
     }
 
     /** Refresh downstream consumption progress for another round scheduling of reading. */
@@ -251,6 +269,9 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     @Override
     public void releaseDataView() {
+        synchronized (lock) {
+            isReleased = true;
+        }
         fileReaderReleaser.accept(this);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
@@ -484,12 +485,13 @@ class HsFileDataManagerTest {
 
         @Override
         public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(
-                int nextBufferToConsume) {
+                int nextBufferToConsume, Collection<Buffer> buffersToRecycle) {
             return Optional.empty();
         }
 
         @Override
-        public Buffer.DataType peekNextToConsumeDataType(int nextBufferToConsume) {
+        public Buffer.DataType peekNextToConsumeDataType(
+                int nextBufferToConsume, Collection<Buffer> buffersToRecycle) {
             return Buffer.DataType.NONE;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantLock;
@@ -48,7 +49,9 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
                 createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
 
         subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
-        assertThat(subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(1))
+        assertThat(
+                        subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(
+                                1, new ArrayDeque<>()))
                 .isEqualTo(Buffer.DataType.NONE);
     }
 
@@ -68,7 +71,9 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
         buffer1.release();
         buffer2.release();
 
-        assertThat(subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(2))
+        assertThat(
+                        subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(
+                                2, Collections.emptyList()))
                 .isEqualTo(Buffer.DataType.EVENT_BUFFER);
     }
 
@@ -80,7 +85,8 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
                 createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
 
         subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
-        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1)).isNotPresent();
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1, Collections.emptyList()))
+                .isNotPresent();
     }
 
     @Test
@@ -99,7 +105,8 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
         buffer1.release();
         buffer2.release();
 
-        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2)).isPresent();
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2, Collections.emptyList()))
+                .isPresent();
     }
 
     @Test
@@ -112,7 +119,7 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
         subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
 
         Optional<ResultSubpartition.BufferAndBacklog> bufferOpt =
-                subpartitionConsumerMemoryDataManager.consumeBuffer(0);
+                subpartitionConsumerMemoryDataManager.consumeBuffer(0, Collections.emptyList());
         assertThat(bufferOpt)
                 .hasValueSatisfying(
                         (bufferAndBacklog ->
@@ -132,21 +139,21 @@ class HsSubpartitionConsumerMemoryDataManagerTest {
         subpartitionConsumerMemoryDataManager.addInitialBuffers(initialBuffers);
         subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(2, true));
 
-        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(0))
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(0, Collections.emptyList()))
                 .hasValueSatisfying(
                         bufferAndBacklog -> {
                             assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(0);
                             assertThat(bufferAndBacklog.buffer().getDataType())
                                     .isEqualTo(Buffer.DataType.DATA_BUFFER);
                         });
-        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1))
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1, Collections.emptyList()))
                 .hasValueSatisfying(
                         bufferAndBacklog -> {
                             assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(1);
                             assertThat(bufferAndBacklog.buffer().getDataType())
                                     .isEqualTo(Buffer.DataType.DATA_BUFFER);
                         });
-        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2))
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2, Collections.emptyList()))
                 .hasValueSatisfying(
                         bufferAndBacklog -> {
                             assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
@@ -165,7 +165,7 @@ class HsSubpartitionMemoryDataManagerTest {
                 subpartitionMemoryDataManager.registerNewConsumer(DEFAULT);
         ArrayList<Optional<BufferAndBacklog>> bufferAndBacklogOpts = new ArrayList<>();
         for (int i = 0; i < numDataBuffers + 1; i++) {
-            bufferAndBacklogOpts.add(consumer.consumeBuffer(i));
+            bufferAndBacklogOpts.add(consumer.consumeBuffer(i, Collections.emptyList()));
         }
         checkConsumedBufferAndNextDataType(
                 numRecordsPerBuffer, bufferDecompressor, expectedRecords, bufferAndBacklogOpts);
@@ -205,8 +205,8 @@ class HsSubpartitionMemoryDataManagerTest {
         subpartitionMemoryDataManager.spillSubpartitionBuffers(toStartSpilling, spilledDoneFuture);
 
         // consume buffer 0, 1
-        consumer.consumeBuffer(0);
-        consumer.consumeBuffer(1);
+        consumer.consumeBuffer(0, Collections.emptyList());
+        consumer.consumeBuffer(1, Collections.emptyList());
 
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(SpillStatus.ALL, ALL_ANY),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingHsDataView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingHsDataView.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.util.function.FunctionWithException;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,13 +58,14 @@ public class TestingHsDataView implements HsDataView {
     }
 
     @Override
-    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(int nextBufferToConsume)
-            throws Throwable {
+    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(
+            int nextBufferToConsume, Collection<Buffer> buffersToRecycle) throws Throwable {
         return consumeBufferFunction.apply(nextBufferToConsume);
     }
 
     @Override
-    public Buffer.DataType peekNextToConsumeDataType(int nextBufferToConsume) {
+    public Buffer.DataType peekNextToConsumeDataType(
+            int nextBufferToConsume, Collection<Buffer> buffersToRecycle) {
         return peekNextToConsumeDataTypeFunction.apply(nextBufferToConsume);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*In [FLINK-30189](https://issues.apache.org/jira/browse/FLINK-30189), `HsSubpartitionFileReaderImpl` will skip the buffer has been consumed from memory to avoid double-consumption. But these buffers were not returned to the `BatchShuffleReadBufferPool`, resulting in read buffer leaks. In addition, all loaded buffers should also be recycled after data view released.*


## Brief change log

  - *`HsSubpartitionFileReader` should not read buffers from disk after it has been released.*
  - *`HsSubpartitionFileReaderImpl` should recycle skipped read buffers.*


## Verifying this change

This change added unit tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
