### PR TITLE
[FLINK-31631][FileSystems] Upgrade GCS connector to 2.2.11.

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/gcs.md
+++ b/docs/content.zh/docs/deployment/filesystems/gcs.md
@@ -55,7 +55,7 @@ Note that these examples are *not* exhaustive and you can use GCS in other place
 Flink provides the `flink-gs-fs-hadoop` file system to write to GCS.
 This implementation is self-contained with no dependency footprint, so there is no need to add Hadoop to the classpath to use it.
 
-`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage) library to provide `RecoverableWriter` support.
+`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.11) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.15.0) library to provide `RecoverableWriter` support.
 
 This file system can be used with the [FileSystem connector]({{< ref "docs/connectors/datastream/filesystem.md" >}}).
 
@@ -68,7 +68,7 @@ cp ./opt/flink-gs-fs-hadoop-{{< version >}}.jar ./plugins/gs-fs-hadoop/
 
 ### Configuration
 
-The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your `flink-conf.yaml`.
+The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.11/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your `flink-conf.yaml`.
 
 For example, `gcs-connector` has a `fs.gs.http.connect-timeout` configuration key. If you want to change it, you need to set `gs.http.connect-timeout: xyz` in `flink-conf.yaml`. Flink will internally translate this back to `fs.gs.http.connect-timeout`.
 

--- a/docs/content/docs/deployment/filesystems/gcs.md
+++ b/docs/content/docs/deployment/filesystems/gcs.md
@@ -55,7 +55,7 @@ Note that these examples are *not* exhaustive and you can use GCS in other place
 Flink provides the `flink-gs-fs-hadoop` file system to write to GCS.
 This implementation is self-contained with no dependency footprint, so there is no need to add Hadoop to the classpath to use it.
 
-`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage) library to provide `RecoverableWriter` support. 
+`flink-gs-fs-hadoop` registers a `FileSystem` wrapper for URIs with the *gs://* scheme. It uses Google's [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/hadoop3-2.2.11) Hadoop library to access GCS. It also uses Google's [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.15.0) library to provide `RecoverableWriter` support.
 
 This file system can be used with the [FileSystem connector]({{< ref "docs/connectors/datastream/filesystem.md" >}}).
 
@@ -68,7 +68,7 @@ cp ./opt/flink-gs-fs-hadoop-{{< version >}}.jar ./plugins/gs-fs-hadoop/
 
 ### Configuration
 
-The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your `flink-conf.yaml`.
+The underlying Hadoop file system can be configured using the [Hadoop configuration keys](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.11/gcs/CONFIGURATION.md) for `gcs-connector` by adding the configurations to your `flink-conf.yaml`.
 
 For example, `gcs-connector` has a `fs.gs.http.connect-timeout` configuration key. If you want to change it, you need to set `gs.http.connect-timeout: xyz` in `flink-conf.yaml`. Flink will internally translate this back to `fs.gs.http.connect-timeout`. 
 

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -32,10 +32,12 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<fs.gs.sdk.version>2.2.3</fs.gs.sdk.version>
-		<fs.gs.connector.version>hadoop3-2.2.4</fs.gs.connector.version>
+		<!-- If updating these dependency versions, please also update the corresponding links -->
+		<!-- in the GCS file system documentation. -->
+		<fs.gs.sdk.version>2.15.0</fs.gs.sdk.version>
+		<fs.gs.connector.version>hadoop3-2.2.11</fs.gs.connector.version>
 		<!-- Set this to the highest version of grpc artifacts from gcs-connector and google-cloud-storage -->
-		<fs.gs.grpc.version>1.43.2</fs.gs.grpc.version>
+		<fs.gs.grpc.version>1.50.2</fs.gs.grpc.version>
 	</properties>
 
 	<dependencies>

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -8,64 +8,88 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.google.android:annotations:4.1.1.4
-- com.google.api-client:google-api-client-jackson2:1.32.2
-- com.google.api-client:google-api-client:1.33.0
-- com.google.api.grpc:grpc-google-cloud-storage-v2:2.0.1-alpha
-- com.google.api.grpc:proto-google-cloud-storage-v2:2.0.1-alpha
-- com.google.api.grpc:proto-google-common-protos:2.7.1
-- com.google.api.grpc:proto-google-iam-v1:1.2.0
-- com.google.apis:google-api-services-iamcredentials:v1-rev20210326-1.32.1
-- com.google.apis:google-api-services-storage:v1-rev20211201-1.32.1
-- com.google.auto.value:auto-value-annotations:1.9
-- com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.4
-- com.google.cloud.bigdataoss:gcsio:2.2.4
-- com.google.cloud.bigdataoss:util-hadoop:hadoop3-2.2.4
-- com.google.cloud.bigdataoss:util:2.2.4
-- com.google.cloud:google-cloud-core-http:2.3.5
-- com.google.cloud:google-cloud-core:2.3.5
-- com.google.cloud:google-cloud-storage:2.2.3
-- com.google.code.gson:gson:2.8.9
+- com.google.api-client:google-api-client-jackson2:2.0.1
+- com.google.api-client:google-api-client:2.0.1
+- com.google.api.grpc:gapic-google-cloud-storage-v2:2.15.0-alpha
+- com.google.api.grpc:grpc-google-cloud-storage-v2:2.15.0-alpha
+- com.google.api.grpc:grpc-google-iam-v1:1.6.7
+- com.google.api.grpc:proto-google-cloud-monitoring-v3:1.64.0
+- com.google.api.grpc:proto-google-cloud-storage-v2:2.15.0-alpha
+- com.google.api.grpc:proto-google-common-protos:2.10.0
+- com.google.api.grpc:proto-google-iam-v1:1.6.7
+- com.google.apis:google-api-services-iamcredentials:v1-rev20211203-2.0.0
+- com.google.apis:google-api-services-storage:v1-rev20220705-2.0.0
+- com.google.auto.value:auto-value-annotations:1.10
+- com.google.cloud.bigdataoss:gcs-connector:hadoop3-2.2.11
+- com.google.cloud.bigdataoss:gcsio:2.2.11
+- com.google.cloud.bigdataoss:util-hadoop:hadoop3-2.2.11
+- com.google.cloud.bigdataoss:util:2.2.11
+- com.google.cloud:google-cloud-core-grpc:2.8.27
+- com.google.cloud:google-cloud-core-http:2.8.27
+- com.google.cloud:google-cloud-core:2.8.27
+- com.google.cloud:google-cloud-monitoring:1.82.0
+- com.google.cloud:google-cloud-storage:2.15.0
+- com.google.code.gson:gson:2.10
 - com.google.flogger:flogger-system-backend:0.7.1
 - com.google.flogger:flogger:0.7.1
 - com.google.flogger:google-extensions:0.7.1
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.http-client:google-http-client-apache-v2:1.41.0
-- com.google.http-client:google-http-client-appengine:1.41.0
-- com.google.http-client:google-http-client-gson:1.41.0
-- com.google.http-client:google-http-client-jackson2:1.41.0
-- com.google.http-client:google-http-client:1.41.0
-- com.google.oauth-client:google-oauth-client:1.32.1
+- com.google.http-client:google-http-client-apache-v2:1.42.3
+- com.google.http-client:google-http-client-appengine:1.42.3
+- com.google.http-client:google-http-client-gson:1.42.3
+- com.google.http-client:google-http-client-jackson2:1.42.3
+- com.google.http-client:google-http-client:1.42.3
+- com.google.oauth-client:google-oauth-client:1.34.1
+- com.lmax:disruptor:3.4.2
 - commons-codec:commons-codec:1.15
-- io.grpc:grpc-alts:1.43.2
-- io.grpc:grpc-api:1.43.2
-- io.grpc:grpc-auth:1.43.2
-- io.grpc:grpc-context:1.43.2
-- io.grpc:grpc-core:1.43.2
-- io.grpc:grpc-grpclb:1.43.2
-- io.grpc:grpc-netty-shaded:1.43.2
-- io.grpc:grpc-protobuf-lite:1.43.2
-- io.grpc:grpc-protobuf:1.43.2
-- io.grpc:grpc-stub:1.43.2
-- io.opencensus:opencensus-api:0.28.0
-- io.opencensus:opencensus-contrib-http-util:0.28.0
-- io.perfmark:perfmark-api:0.23.0
+- io.grpc:grpc-alts:1.50.2
+- io.grpc:grpc-api:1.50.2
+- io.grpc:grpc-auth:1.50.2
+- io.grpc:grpc-census:1.50.2
+- io.grpc:grpc-context:1.50.2
+- io.grpc:grpc-core:1.50.2
+- io.grpc:grpc-googleapis:1.50.2
+- io.grpc:grpc-grpclb:1.50.2
+- io.grpc:grpc-netty-shaded:1.50.2
+- io.grpc:grpc-protobuf-lite:1.50.2
+- io.grpc:grpc-protobuf:1.50.2
+- io.grpc:grpc-services:1.50.2
+- io.grpc:grpc-stub:1.50.2
+- io.grpc:grpc-xds:1.50.2
+- io.opencensus:opencensus-api:0.31.1
+- io.opencensus:opencensus-contrib-exemplar-util:0.31.0
+- io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
+- io.opencensus:opencensus-contrib-http-util:0.31.1
+- io.opencensus:opencensus-contrib-resource-util:0.31.0
+- io.opencensus:opencensus-exporter-metrics-util:0.31.0
+- io.opencensus:opencensus-exporter-stats-stackdriver:0.31.0
+- io.opencensus:opencensus-impl:0.31.0
+- io.opencensus:opencensus-impl-core:0.31.0
+- io.opencensus:opencensus-proto:0.2.0
+- io.perfmark:perfmark-api:0.25.0
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.conscrypt:conscrypt-openjdk-uber:2.5.1
+- org.conscrypt:conscrypt-openjdk-uber:2.5.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.
 
-- com.google.api:api-common:2.1.2
-- com.google.api:gax-httpjson:0.93.1
-- com.google.api:gax:2.8.1
+- com.google.api:api-common:2.2.2
+- com.google.api:gax-grpc:2.19.5
+- com.google.api:gax-httpjson:0.104.5
+- com.google.api:gax:2.19.5
 
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.
 
-- com.google.auth:google-auth-library-credentials:1.3.0
-- com.google.auth:google-auth-library-oauth2-http:1.3.0
-- com.google.protobuf:protobuf-java-util:3.19.2
-- com.google.protobuf:protobuf-java:3.19.2
-- org.threeten:threetenbp:1.5.2
+- com.google.auth:google-auth-library-credentials:1.12.1
+- com.google.auth:google-auth-library-oauth2-http:1.12.1
+- com.google.protobuf:protobuf-java-util:3.21.9
+- com.google.protobuf:protobuf-java:3.21.9
+- com.google.re2j:re2j:1.6
+- org.threeten:threetenbp:1.6.4
 
+This project bundles the following dependencies under the MIT License.
+See bundled license files for details.
+
+- org.codehaus.mojo:animal-sniffer-annotations:1.22


### PR DESCRIPTION
## What is the purpose of the change

Upgrade GCS connector to 2.2.11.

## Brief change log

Upgrade the [GCS Connector](https://github.com/GoogleCloudDataproc/hadoop-connectors/tree/v2.2.11/gcs) bundled in the Flink distro from version 2.2.3 to 2.2.11. The new release contains multiple bug fixes and enhancements discussed in the [Release Notes](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v2.2.11/gcs/CHANGES.md). Notable changes include:

* Improved socket timeout handling.
* Trace logging capabilities.
* Fix bug that prevented usage of GCS as a [Hadoop Credential Provider](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
* Dependency upgrades.
* Support OAuth2 based client authentication.

## Verifying this change

This change is already covered by existing tests. These tests pass with the new version.

```
mvn -Pfast -pl flink-filesystems/flink-gs-fs-hadoop clean test
```

Additionally, I built a full distro and successfully ran a job that reads and writes to a GCS bucket.

```
mvn -Pfast clean package -DskipTests
```

```
mkdir ./plugins/gs-fs-hadoop
cp ./opt/flink-gs-fs-hadoop-1.18-SNAPSHOT.jar ./plugins/gs-fs-hadoop

bin/start-cluster.sh

bin/flink run examples/batch/WordCount.jar \
    --input gs://dataproc-datasets-us-central1/shakespeare \
    --output gs://cnauroth-hive-metastore-proxy-dist/output/shakespeare-word-count.txt
```

The documentation changes were tested by starting up the local server and clicking through the updated links.

```
cd docs
./build_docs.sh -p
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
