### PR TITLE
[FLINK-31547][jdbc-driver] Introduce FlinkResultSetMetaData for jdbc driver

### DIFF
--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -50,6 +50,11 @@
 			<artifactId>flink-sql-gateway-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -72,6 +77,7 @@
 									<include>org.apache.flink:flink-sql-jdbc-driver</include>
 									<include>org.apache.flink:flink-sql-client</include>
 									<include>org.apache.flink:flink-sql-gateway-api</include>
+									<include>org.apache.flink:flink-table-common</include>
 								</includes>
 							</artifactSet>
 						</configuration>

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
+
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Column info for {@link ResultSetMetaData}, it is converted from {@link LogicalType}. */
+public class ColumnInfo {
+    private static final int VARBINARY_MAX = 1024 * 1024 * 1024;
+    private static final int TIME_ZONE_MAX = 40; // current longest time zone is 32
+    private static final int TIME_MAX = "HH:mm:ss.SSS".length();
+    private static final int TIMESTAMP_MAX = "yyyy-MM-dd HH:mm:ss.SSS".length();
+    private static final int TIMESTAMP_WITH_TIME_ZONE_MAX = TIMESTAMP_MAX + TIME_ZONE_MAX;
+    private static final int DATE_MAX = "yyyy-MM-dd".length();
+    private static final int STRUCT_MAX = 100 * 1024 * 1024;
+
+    private final int columnType;
+    private final String columnTypeName;
+    private final boolean nullable;
+    private final boolean signed;
+    private final int precision;
+    private final int scale;
+    private final int columnDisplaySize;
+    private final String columnName;
+
+    public ColumnInfo(
+            int columnType,
+            String columnTypeName,
+            boolean nullable,
+            boolean signed,
+            int precision,
+            int scale,
+            int columnDisplaySize,
+            String columnName) {
+        this.columnType = columnType;
+        this.columnTypeName = columnTypeName;
+        this.nullable = nullable;
+        this.signed = signed;
+        this.precision = precision;
+        this.scale = scale;
+        this.columnDisplaySize = columnDisplaySize;
+        // TODO use Utils.checkNotNull instead.
+        this.columnName = checkNotNull(columnName, "column name cannot be null");
+    }
+
+    public int getColumnType() {
+        return columnType;
+    }
+
+    public boolean isSigned() {
+        return signed;
+    }
+
+    public int getPrecision() {
+        return precision;
+    }
+
+    public int getScale() {
+        return scale;
+    }
+
+    public int getColumnDisplaySize() {
+        return columnDisplaySize;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    public String columnTypeName() {
+        return columnTypeName;
+    }
+
+    /**
+     * Build column info from given logical type.
+     *
+     * @param columnName the column name
+     * @param type the logical type
+     * @return the result column info
+     */
+    public static ColumnInfo fromLogicalType(String columnName, LogicalType type) {
+        Builder builder =
+                new Builder()
+                        .columnName(columnName)
+                        .nullable(type.isNullable())
+                        .signed(type.is(LogicalTypeFamily.NUMERIC))
+                        .columnTypeName(type.asSummaryString());
+        if (type instanceof BooleanType) {
+            // "true" or "false"
+            builder.columnType(Types.BOOLEAN).columnDisplaySize(5);
+        } else if (type instanceof TinyIntType) {
+            builder.columnType(Types.TINYINT).precision(3).scale(0).columnDisplaySize(4);
+        } else if (type instanceof SmallIntType) {
+            builder.columnType(Types.SMALLINT).precision(5).scale(0).columnDisplaySize(6);
+        } else if (type instanceof IntType) {
+            builder.columnType(Types.INTEGER).precision(10).scale(0).columnDisplaySize(11);
+        } else if (type instanceof BigIntType) {
+            builder.columnType(Types.BIGINT).precision(19).scale(0).columnDisplaySize(20);
+        } else if (type instanceof FloatType) {
+            builder.columnType(Types.FLOAT).precision(9).scale(0).columnDisplaySize(16);
+        } else if (type instanceof DoubleType) {
+            builder.columnType(Types.DOUBLE).precision(17).scale(0).columnDisplaySize(24);
+        } else if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            builder.columnType(Types.DECIMAL)
+                    .columnDisplaySize(decimalType.getPrecision() + 2) // dot and sign
+                    .precision(decimalType.getPrecision())
+                    .scale(decimalType.getScale());
+        } else if (type instanceof CharType) {
+            CharType charType = (CharType) type;
+            builder.columnType(Types.CHAR)
+                    .scale(0)
+                    .precision(charType.getLength())
+                    .columnDisplaySize(charType.getLength());
+        } else if (type instanceof VarCharType) {
+            builder.columnType(Types.VARCHAR)
+                    .scale(0)
+                    .precision(VARBINARY_MAX)
+                    .columnDisplaySize(VARBINARY_MAX);
+        } else if (type instanceof BinaryType) {
+            BinaryType binaryType = (BinaryType) type;
+            builder.columnType(Types.BINARY)
+                    .scale(0)
+                    .precision(binaryType.getLength())
+                    .columnDisplaySize(binaryType.getLength());
+        } else if (type instanceof VarBinaryType) {
+            builder.columnType(Types.VARBINARY)
+                    .scale(0)
+                    .precision(VARBINARY_MAX)
+                    .columnDisplaySize(VARBINARY_MAX);
+        } else if (type instanceof DateType) {
+            builder.columnType(Types.DATE).scale(0).columnDisplaySize(DATE_MAX);
+        } else if (type instanceof TimeType) {
+            TimeType timeType = (TimeType) type;
+            builder.columnType(Types.TIME)
+                    .precision(timeType.getPrecision())
+                    .scale(0)
+                    .columnDisplaySize(TIME_MAX);
+        } else if (type instanceof TimestampType) {
+            TimestampType timestampType = (TimestampType) type;
+            builder.columnType(Types.TIMESTAMP)
+                    .precision(timestampType.getPrecision())
+                    .scale(0)
+                    .columnDisplaySize(TIMESTAMP_MAX);
+        } else if (type instanceof LocalZonedTimestampType) {
+            LocalZonedTimestampType localZonedTimestampType = (LocalZonedTimestampType) type;
+            builder.columnType(Types.TIMESTAMP)
+                    .precision(localZonedTimestampType.getPrecision())
+                    .scale(0)
+                    .columnDisplaySize(TIMESTAMP_MAX);
+        } else if (type instanceof ZonedTimestampType) {
+            ZonedTimestampType zonedTimestampType = (ZonedTimestampType) type;
+            builder.columnType(Types.TIMESTAMP_WITH_TIMEZONE)
+                    .precision(zonedTimestampType.getPrecision())
+                    .scale(0)
+                    .columnDisplaySize(TIMESTAMP_WITH_TIME_ZONE_MAX);
+        } else if (type instanceof ArrayType) {
+            builder.columnType(Types.ARRAY)
+                    .scale(0)
+                    .precision(STRUCT_MAX)
+                    .columnDisplaySize(STRUCT_MAX);
+        } else if (type instanceof MapType) {
+            // Use java object for map while there's no map in Types at the moment
+            builder.columnType(Types.JAVA_OBJECT)
+                    .scale(0)
+                    .precision(STRUCT_MAX)
+                    .columnDisplaySize(STRUCT_MAX);
+        } else if (type instanceof RowType) {
+            builder.columnType(Types.STRUCT)
+                    .precision(STRUCT_MAX)
+                    .scale(0)
+                    .columnDisplaySize(STRUCT_MAX);
+        } else {
+            throw new RuntimeException(String.format("Not supported type[%s]", type));
+        }
+        return builder.build();
+    }
+
+    /** Builder to build {@link ColumnInfo} from {@link LogicalType}. */
+    private static class Builder {
+        private int columnType;
+        private String columnTypeName;
+        private boolean nullable;
+        private boolean signed;
+        private int precision;
+        private int scale;
+        private int columnDisplaySize;
+        private String columnName;
+
+        public Builder columnType(int columnType) {
+            this.columnType = columnType;
+            return this;
+        }
+
+        public Builder columnTypeName(String columnTypeName) {
+            this.columnTypeName = columnTypeName;
+            return this;
+        }
+
+        public Builder nullable(boolean nullable) {
+            this.nullable = nullable;
+            return this;
+        }
+
+        public Builder signed(boolean signed) {
+            this.signed = signed;
+            return this;
+        }
+
+        public Builder precision(int precision) {
+            this.precision = precision;
+            return this;
+        }
+
+        public Builder scale(int scale) {
+            this.scale = scale;
+            return this;
+        }
+
+        public Builder columnDisplaySize(int columnDisplaySize) {
+            this.columnDisplaySize = columnDisplaySize;
+            return this;
+        }
+
+        public Builder columnName(String columnName) {
+            this.columnName = columnName;
+            return this;
+        }
+
+        public ColumnInfo build() {
+            return new ColumnInfo(
+                    columnType,
+                    columnTypeName,
+                    nullable,
+                    signed,
+                    precision,
+                    scale,
+                    columnDisplaySize,
+                    columnName);
+        }
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
@@ -65,7 +65,7 @@ public class ColumnInfo {
     private final int columnDisplaySize;
     private final String columnName;
 
-    public ColumnInfo(
+    private ColumnInfo(
             int columnType,
             String columnTypeName,
             boolean nullable,

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/ColumnInfo.java
@@ -44,7 +44,7 @@ import org.apache.flink.table.types.logical.ZonedTimestampType;
 import java.sql.ResultSetMetaData;
 import java.sql.Types;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.table.jdbc.utils.DriverUtils.checkNotNull;
 
 /** Column info for {@link ResultSetMetaData}, it is converted from {@link LogicalType}. */
 public class ColumnInfo {
@@ -81,7 +81,6 @@ public class ColumnInfo {
         this.precision = precision;
         this.scale = scale;
         this.columnDisplaySize = columnDisplaySize;
-        // TODO use Utils.checkNotNull instead.
         this.columnName = checkNotNull(columnName, "column name cannot be null");
     }
 

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Implementation of {@link ResultSetMetaData} for flink jdbc driver. */
+public class FlinkResultSetMetaData implements ResultSetMetaData {
+    private final List<ColumnInfo> columnList;
+
+    public FlinkResultSetMetaData(ResolvedSchema schema) throws Exception {
+        this.columnList =
+                schema.getColumns().stream()
+                        .map(
+                                c ->
+                                        ColumnInfo.fromLogicalType(
+                                                c.getName(), c.getDataType().getLogicalType()))
+                        .collect(Collectors.toList());
+    }
+
+    @Override
+    public int getColumnCount() throws SQLException {
+        return columnList.size();
+    }
+
+    @Override
+    public boolean isAutoIncrement(int column) throws SQLException {
+        checkIndexBound(column);
+        return false;
+    }
+
+    @Override
+    public boolean isCaseSensitive(int column) throws SQLException {
+        checkIndexBound(column);
+        return false;
+    }
+
+    @Override
+    public boolean isSearchable(int column) throws SQLException {
+        checkIndexBound(column);
+        return true;
+    }
+
+    @Override
+    public boolean isCurrency(int column) throws SQLException {
+        checkIndexBound(column);
+        return false;
+    }
+
+    @Override
+    public int isNullable(int column) throws SQLException {
+        checkIndexBound(column);
+        boolean nullable = column(column).isNullable();
+        return nullable ? columnNullable : columnNoNulls;
+    }
+
+    @Override
+    public boolean isSigned(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).isSigned();
+    }
+
+    @Override
+    public int getColumnDisplaySize(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).getColumnDisplaySize();
+    }
+
+    @Override
+    public String getColumnLabel(int column) throws SQLException {
+        return getColumnName(column);
+    }
+
+    @Override
+    public String getColumnName(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).getColumnName();
+    }
+
+    @Override
+    public String getSchemaName(int column) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkResultSetMetaData#getSchemaName is not supported");
+    }
+
+    @Override
+    public int getPrecision(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).getPrecision();
+    }
+
+    @Override
+    public int getScale(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).getScale();
+    }
+
+    @Override
+    public String getTableName(int column) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkResultSetMetaData#getTableName is not supported");
+    }
+
+    @Override
+    public String getCatalogName(int column) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkResultSetMetaData#getCatalogName is not supported");
+    }
+
+    @Override
+    public int getColumnType(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).getColumnType();
+    }
+
+    @Override
+    public String getColumnTypeName(int column) throws SQLException {
+        checkIndexBound(column);
+        return column(column).columnTypeName();
+    }
+
+    @Override
+    public boolean isReadOnly(int column) throws SQLException {
+        checkIndexBound(column);
+        return true;
+    }
+
+    @Override
+    public boolean isWritable(int column) throws SQLException {
+        checkIndexBound(column);
+        return false;
+    }
+
+    @Override
+    public boolean isDefinitelyWritable(int column) throws SQLException {
+        checkIndexBound(column);
+        return false;
+    }
+
+    @Override
+    public String getColumnClassName(int column) throws SQLException {
+        return getType(getColumnType(column));
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkResultSetMetaData#unwrap is not supported");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkResultSetMetaData#isWrapperFor is not supported");
+    }
+
+    private ColumnInfo column(int columnIndex) {
+        return columnList.get(columnIndex - 1);
+    }
+
+    private void checkIndexBound(int column) throws SQLException {
+        int columnNum = getColumnCount();
+        if (column <= 0) {
+            throw new SQLException(String.format("Column index[%s] must be positive.", column));
+        }
+        if (column > columnNum) {
+            throw new SQLException(
+                    String.format(
+                            "Column index %s out of bound. There are only %s columns.",
+                            column, columnNum));
+        }
+    }
+
+    /**
+     * Get column type name according type in {@link Types}.
+     *
+     * @param type the type in {@link Types}
+     * @return type class name
+     */
+    static String getType(int type) throws SQLException {
+        // see javax.sql.rowset.RowSetMetaDataImpl
+        switch (type) {
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return BigDecimal.class.getName();
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return Boolean.class.getName();
+            case Types.TINYINT:
+                return Byte.class.getName();
+            case Types.SMALLINT:
+                return Short.class.getName();
+            case Types.INTEGER:
+                return Integer.class.getName();
+            case Types.BIGINT:
+                return Long.class.getName();
+            case Types.REAL:
+            case Types.FLOAT:
+                return Float.class.getName();
+            case Types.DOUBLE:
+                return Double.class.getName();
+            case Types.VARCHAR:
+            case Types.CHAR:
+                return String.class.getName();
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return "byte[]";
+            case Types.DATE:
+                return Date.class.getName();
+            case Types.TIME:
+                return Time.class.getName();
+            case Types.TIMESTAMP:
+                return Timestamp.class.getName();
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return OffsetDateTime.class.getName();
+            case Types.JAVA_OBJECT:
+                return Map.class.getName();
+            case Types.ARRAY:
+                return Array.class.getName();
+            case Types.STRUCT:
+                return RowData.class.getName();
+        }
+        throw new SQLFeatureNotSupportedException(
+                String.format("Not support data type [%s]", type));
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 public class FlinkResultSetMetaData implements ResultSetMetaData {
     private final List<ColumnInfo> columnList;
 
-    public FlinkResultSetMetaData(ResolvedSchema schema) throws Exception {
+    public FlinkResultSetMetaData(ResolvedSchema schema) {
         this.columnList =
                 schema.getColumns().stream()
                         .map(

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
@@ -45,30 +45,30 @@ public class FlinkResultSetMetaDataTest {
     public void testResultSetMetaData() throws Exception {
         ResolvedSchema schema =
                 ResolvedSchema.of(
-                        Column.physical("v1", DataTypes.BOOLEAN()),
-                        Column.physical("v2", DataTypes.TINYINT()),
-                        Column.physical("v3", DataTypes.SMALLINT()),
-                        Column.physical("v4", DataTypes.INT()),
-                        Column.physical("v5", DataTypes.BIGINT()),
-                        Column.physical("v6", DataTypes.FLOAT()),
-                        Column.physical("v7", DataTypes.DOUBLE()),
-                        Column.physical("v8", DataTypes.DECIMAL(10, 5)),
-                        Column.physical("v9", DataTypes.STRING()),
-                        Column.physical("v10", DataTypes.BYTES()),
-                        Column.physical("v11", DataTypes.TIME()),
-                        Column.physical("v12", DataTypes.DATE()),
-                        Column.physical("v13", DataTypes.TIMESTAMP(6)),
-                        Column.physical("v14", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(5)),
-                        Column.physical("v15", DataTypes.TIMESTAMP_WITH_TIME_ZONE(4)),
-                        Column.physical("v16", DataTypes.ARRAY(DataTypes.INT())),
-                        Column.physical("v17", DataTypes.ROW()),
+                        Column.physical("c1", DataTypes.BOOLEAN()),
+                        Column.physical("c2", DataTypes.TINYINT()),
+                        Column.physical("c3", DataTypes.SMALLINT()),
+                        Column.physical("c4", DataTypes.INT()),
+                        Column.physical("c5", DataTypes.BIGINT()),
+                        Column.physical("c6", DataTypes.FLOAT()),
+                        Column.physical("c7", DataTypes.DOUBLE()),
+                        Column.physical("c8", DataTypes.DECIMAL(10, 5)),
+                        Column.physical("c9", DataTypes.STRING()),
+                        Column.physical("c10", DataTypes.BYTES()),
+                        Column.physical("c11", DataTypes.TIME()),
+                        Column.physical("c12", DataTypes.DATE()),
+                        Column.physical("c13", DataTypes.TIMESTAMP(6)),
+                        Column.physical("c14", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(5)),
+                        Column.physical("c15", DataTypes.TIMESTAMP_WITH_TIME_ZONE(4)),
+                        Column.physical("c16", DataTypes.ARRAY(DataTypes.INT())),
+                        Column.physical("c17", DataTypes.ROW()),
                         Column.physical(
-                                "v18", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())));
+                                "c18", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())));
         FlinkResultSetMetaData metaData = new FlinkResultSetMetaData(schema);
 
         assertEquals(18, metaData.getColumnCount());
         for (int i = 1; i <= 18; i++) {
-            assertEquals("v" + i, metaData.getColumnName(i));
+            assertEquals("c" + i, metaData.getColumnName(i));
             LogicalType logicalType = schema.getColumnDataTypes().get(i - 1).getLogicalType();
             assertEquals(logicalType.asSummaryString(), metaData.getColumnTypeName(i));
             assertEquals(logicalType.is(LogicalTypeFamily.NUMERIC), metaData.isSigned(i));
@@ -115,7 +115,7 @@ public class FlinkResultSetMetaDataTest {
     @Test
     public void testInvalidType() {
         ResolvedSchema schema =
-                ResolvedSchema.of(Column.physical("v1", DataTypes.MULTISET(DataTypes.STRING())));
+                ResolvedSchema.of(Column.physical("c1", DataTypes.MULTISET(DataTypes.STRING())));
         assertThrowsExactly(
                 RuntimeException.class,
                 () -> new FlinkResultSetMetaData(schema),

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+/** Tests for {@link FlinkResultSetMetaData}. */
+public class FlinkResultSetMetaDataTest {
+    @Test
+    public void testResultSetMetaData() throws Exception {
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical("v1", DataTypes.BOOLEAN()),
+                        Column.physical("v2", DataTypes.TINYINT()),
+                        Column.physical("v3", DataTypes.SMALLINT()),
+                        Column.physical("v4", DataTypes.INT()),
+                        Column.physical("v5", DataTypes.BIGINT()),
+                        Column.physical("v6", DataTypes.FLOAT()),
+                        Column.physical("v7", DataTypes.DOUBLE()),
+                        Column.physical("v8", DataTypes.DECIMAL(10, 5)),
+                        Column.physical("v9", DataTypes.STRING()),
+                        Column.physical("v10", DataTypes.BYTES()),
+                        Column.physical("v11", DataTypes.TIME()),
+                        Column.physical("v12", DataTypes.DATE()),
+                        Column.physical("v13", DataTypes.TIMESTAMP(6)),
+                        Column.physical("v14", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(5)),
+                        Column.physical("v15", DataTypes.TIMESTAMP_WITH_TIME_ZONE(4)),
+                        Column.physical("v16", DataTypes.ARRAY(DataTypes.INT())),
+                        Column.physical("v17", DataTypes.ROW()),
+                        Column.physical(
+                                "v18", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())));
+        FlinkResultSetMetaData metaData = new FlinkResultSetMetaData(schema);
+
+        assertEquals(18, metaData.getColumnCount());
+        for (int i = 1; i <= 18; i++) {
+            assertEquals("v" + i, metaData.getColumnName(i));
+            LogicalType logicalType = schema.getColumnDataTypes().get(i - 1).getLogicalType();
+            assertEquals(logicalType.asSummaryString(), metaData.getColumnTypeName(i));
+            assertEquals(logicalType.is(LogicalTypeFamily.NUMERIC), metaData.isSigned(i));
+        }
+
+        assertEquals(Types.BOOLEAN, metaData.getColumnType(1));
+        assertEquals(Boolean.class.getName(), metaData.getColumnClassName(1));
+        assertEquals(Types.TINYINT, metaData.getColumnType(2));
+        assertEquals(Byte.class.getName(), metaData.getColumnClassName(2));
+        assertEquals(Types.SMALLINT, metaData.getColumnType(3));
+        assertEquals(Short.class.getName(), metaData.getColumnClassName(3));
+        assertEquals(Types.INTEGER, metaData.getColumnType(4));
+        assertEquals(Integer.class.getName(), metaData.getColumnClassName(4));
+        assertEquals(Types.BIGINT, metaData.getColumnType(5));
+        assertEquals(Long.class.getName(), metaData.getColumnClassName(5));
+        assertEquals(Types.FLOAT, metaData.getColumnType(6));
+        assertEquals(Float.class.getName(), metaData.getColumnClassName(6));
+        assertEquals(Types.DOUBLE, metaData.getColumnType(7));
+        assertEquals(Double.class.getName(), metaData.getColumnClassName(7));
+        assertEquals(Types.DECIMAL, metaData.getColumnType(8));
+        assertEquals(BigDecimal.class.getName(), metaData.getColumnClassName(8));
+        assertEquals(Types.VARCHAR, metaData.getColumnType(9));
+        assertEquals(String.class.getName(), metaData.getColumnClassName(9));
+        assertEquals(Types.VARBINARY, metaData.getColumnType(10));
+        assertEquals("byte[]", metaData.getColumnClassName(10));
+        assertEquals(Types.TIME, metaData.getColumnType(11));
+        assertEquals(Time.class.getName(), metaData.getColumnClassName(11));
+        assertEquals(Types.DATE, metaData.getColumnType(12));
+        assertEquals(Date.class.getName(), metaData.getColumnClassName(12));
+        assertEquals(Types.TIMESTAMP, metaData.getColumnType(13));
+        assertEquals(Timestamp.class.getName(), metaData.getColumnClassName(13));
+        assertEquals(Types.TIMESTAMP, metaData.getColumnType(14));
+        assertEquals(Timestamp.class.getName(), metaData.getColumnClassName(14));
+        assertEquals(Types.TIMESTAMP_WITH_TIMEZONE, metaData.getColumnType(15));
+        assertEquals(OffsetDateTime.class.getName(), metaData.getColumnClassName(15));
+        assertEquals(Types.ARRAY, metaData.getColumnType(16));
+        assertEquals(Array.class.getName(), metaData.getColumnClassName(16));
+        assertEquals(Types.STRUCT, metaData.getColumnType(17));
+        assertEquals(RowData.class.getName(), metaData.getColumnClassName(17));
+        assertEquals(Types.JAVA_OBJECT, metaData.getColumnType(18));
+        assertEquals(Map.class.getName(), metaData.getColumnClassName(18));
+    }
+
+    @Test
+    public void testInvalidType() {
+        ResolvedSchema schema =
+                ResolvedSchema.of(Column.physical("v1", DataTypes.MULTISET(DataTypes.STRING())));
+        assertThrowsExactly(
+                RuntimeException.class,
+                () -> new FlinkResultSetMetaData(schema),
+                "Not supported type[MULTISET<STRING>]");
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This PR aims to introduce `FlinkResultSetMetaData` for jdbc driver


## Brief change log
  - Added `ColumnInfo` for `FlinkResultSetMetaData` which is converted from `LogicalType`
  - Added `FlinkResultSetMetaData` implements `ResultSetMetaData`

## Verifying this change

This change added tests and can be verified as follows:

  - Added test case `FlinkResultSetMetaDataTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
