### PR TITLE
[FLINK-31632] Fix maxAllowedWatermark arithmetic overflow when the source is idle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -178,9 +178,16 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                                     aggregator.getAggregatedWatermark().getTimestamp());
                         });
 
-        long maxAllowedWatermark =
-                globalCombinedWatermark.getTimestamp()
-                        + watermarkAlignmentParams.getMaxAllowedWatermarkDrift();
+        long maxAllowedWatermark;
+        try {
+            maxAllowedWatermark =
+                    Math.addExact(
+                            globalCombinedWatermark.getTimestamp(),
+                            watermarkAlignmentParams.getMaxAllowedWatermarkDrift());
+        } catch (ArithmeticException e) {
+            maxAllowedWatermark = Watermark.MAX_WATERMARK.getTimestamp();
+        }
+
         Set<Integer> subTaskIds = combinedWatermark.keySet();
         LOG.info(
                 "Distributing maxAllowedWatermark={} to subTaskIds={}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -185,6 +185,8 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             globalCombinedWatermark.getTimestamp(),
                             watermarkAlignmentParams.getMaxAllowedWatermarkDrift());
         } catch (ArithmeticException e) {
+            // when the source is idle, globalCombinedWatermark.getTimestamp() is Long.MAX_VALUE,
+            // and maxAllowedWatermark arithmetic overflow
             maxAllowedWatermark = Watermark.MAX_WATERMARK.getTimestamp();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -83,6 +83,22 @@ class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
             reportWatermarkEvent(sourceCoordinator1, subtask0, 42);
             assertLatestWatermarkAlignmentEvent(subtask0, 1042);
             assertLatestWatermarkAlignmentEvent(subtask1, 1042);
+
+            // all subtask becomes idle
+            reportWatermarkEvent(sourceCoordinator1, subtask0, Long.MAX_VALUE);
+            reportWatermarkEvent(sourceCoordinator1, subtask1, Long.MAX_VALUE);
+            assertLatestWatermarkAlignmentEvent(subtask0, Long.MAX_VALUE);
+            assertLatestWatermarkAlignmentEvent(subtask1, Long.MAX_VALUE);
+
+            // subtask0 becomes active again
+            reportWatermarkEvent(sourceCoordinator1, subtask0, 42);
+            assertLatestWatermarkAlignmentEvent(subtask0, 1042);
+            assertLatestWatermarkAlignmentEvent(subtask1, 1042);
+
+            // subtask1 becomes active again
+            reportWatermarkEvent(sourceCoordinator1, subtask1, 46);
+            assertLatestWatermarkAlignmentEvent(subtask0, 1042);
+            assertLatestWatermarkAlignmentEvent(subtask1, 1042);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -160,6 +160,8 @@ public class SourceOperatorAlignmentTest {
             expectedOutput.add(record1);
             context.getTimeService().advance(1);
             assertLatestReportedWatermarkEvent(context, record1);
+            // mock WatermarkAlignmentEvent from SourceCoordinator
+            operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 100));
             assertOutput(actualOutput, expectedOutput);
             assertTrue(operator.isAvailable());
 
@@ -167,6 +169,9 @@ public class SourceOperatorAlignmentTest {
             assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
             context.getTimeService().advance(1);
             assertLatestReportedWatermarkEvent(context, Long.MAX_VALUE);
+            // receive Long.MAX_VALUE as WatermarkAlignmentEvent
+            // because reported Long.MAX_VALUE watermark + maxAllowedWatermarkDrift will overflow
+            operator.handleOperatorEvent(new WatermarkAlignmentEvent(Long.MAX_VALUE));
 
             // it is easier to create a new split than add records the old one. The old one is
             // serialized, when sending the AddSplitEvent, so it is not as easy as
@@ -185,6 +190,7 @@ public class SourceOperatorAlignmentTest {
             // becomes active again, should go back to the previously emitted
             // watermark, as the record2 does not emit watermarks
             assertLatestReportedWatermarkEvent(context, record1);
+            operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 100));
             assertOutput(actualOutput, expectedOutput);
             assertTrue(operator.isAvailable());
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -169,8 +169,8 @@ public class SourceOperatorAlignmentTest {
             assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
             context.getTimeService().advance(1);
             assertLatestReportedWatermarkEvent(context, Long.MAX_VALUE);
-            // receive Long.MAX_VALUE as WatermarkAlignmentEvent
-            // because reported Long.MAX_VALUE watermark + maxAllowedWatermarkDrift will overflow
+            // If all source subtasks of the watermark group are idle,
+            // then the coordinator will report Long.MAX_VALUE
             operator.handleOperatorEvent(new WatermarkAlignmentEvent(Long.MAX_VALUE));
 
             // it is easier to create a new split than add records the old one. The old one is


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix maxAllowedWatermark overflow when source is idle, which leads to source can't resume to active.


## Brief change log

check maxAllowedWatermark is overflow. if so, set Long.MAX_VALUE

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
