### PR TITLE
[FLINK-31651][runtime] Improve logging of granting/revoking leadership in JobMasterServiceLeadershipRunner to INFO level

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcess.java
@@ -181,6 +181,11 @@ public class DefaultJobMasterServiceProcess
     }
 
     @Override
+    public UUID getLeaderSessionId() {
+        return leaderSessionId;
+    }
+
+    @Override
     public boolean isInitializedAndRunning() {
         synchronized (lock) {
             return jobMasterServiceFuture.isDone()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceProcess.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nonnull;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /** JobMasterServiceProcess is responsible for running a {@link JobMasterService}. */
@@ -32,6 +33,9 @@ public interface JobMasterServiceProcess extends AutoCloseableAsync {
     static JobMasterServiceProcess waitingForLeadership() {
         return WaitingForLeadership.INSTANCE;
     }
+
+    /** The leader session id of this process. */
+    UUID getLeaderSessionId();
 
     /** True iff the {@link JobMasterService} has been initialized and is running. */
     boolean isInitializedAndRunning();
@@ -60,6 +64,11 @@ public interface JobMasterServiceProcess extends AutoCloseableAsync {
         @Override
         public CompletableFuture<Void> closeAsync() {
             return FutureUtils.completedVoidFuture();
+        }
+
+        @Override
+        public UUID getLeaderSessionId() {
+            throw new UnsupportedOperationException("Still waiting for the leadership.");
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess.java
@@ -20,12 +20,14 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /** Testing implementation of {@link JobMasterServiceProcess}. */
 public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
 
+    private final UUID leaderSessionId;
     private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
     private final Supplier<Boolean> isInitializedAndRunningSupplier;
     private final Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier;
@@ -33,11 +35,13 @@ public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
     private final Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier;
 
     private TestingJobMasterServiceProcess(
+            UUID leaderSessionId,
             Supplier<CompletableFuture<Void>> closeAsyncSupplier,
             Supplier<Boolean> isInitializedAndRunningSupplier,
             Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier,
             Supplier<CompletableFuture<JobManagerRunnerResult>> getResultFutureSupplier,
             Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier) {
+        this.leaderSessionId = leaderSessionId;
         this.closeAsyncSupplier = closeAsyncSupplier;
         this.isInitializedAndRunningSupplier = isInitializedAndRunningSupplier;
         this.getJobMasterGatewayFutureSupplier = getJobMasterGatewayFutureSupplier;
@@ -48,6 +52,11 @@ public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
     @Override
     public CompletableFuture<Void> closeAsync() {
         return closeAsyncSupplier.get();
+    }
+
+    @Override
+    public UUID getLeaderSessionId() {
+        return leaderSessionId;
     }
 
     @Override
@@ -76,6 +85,8 @@ public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
 
     /** Builder for {@link TestingJobMasterServiceProcess}. */
     public static final class Builder {
+
+        private UUID leaderSessionId = UUID.randomUUID();
         private Supplier<CompletableFuture<Void>> closeAsyncSupplier = unsupportedOperation();
         private Supplier<Boolean> isInitializedAndRunningSupplier = unsupportedOperation();
         private Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier =
@@ -122,8 +133,14 @@ public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
             return this;
         }
 
+        public Builder setLeaderSessionId(UUID leaderSessionId) {
+            this.leaderSessionId = leaderSessionId;
+            return this;
+        }
+
         public TestingJobMasterServiceProcess build() {
             return new TestingJobMasterServiceProcess(
+                    leaderSessionId,
                     closeAsyncSupplier,
                     isInitializedAndRunningSupplier,
                     getJobMasterGatewayFutureSupplier,


### PR DESCRIPTION
## What is the purpose of the change
Currently, the log level of granting/revoking leadership of JobMasterServiceLeadershipRunner is DEBUG. However, we usually configure it to INFO level in production jobs, which make it hard to understand the behaviour from Flink's logs because JobMasterServiceLeadershipRunner may suddenly be stopped. I suggest to improve the logging to INFO level.

## Verifying this change
This change will only change the log level,  without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
