### PR TITLE
[FLINK-31518] [Runtime / REST] Fix StandaloneHaServices#getClusterRestEndpointLeaderRetreiver to return correct rest port

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -176,6 +176,9 @@ public class DefaultDispatcherResourceManagerComponentFactory
             log.debug("Starting Dispatcher REST endpoint.");
             webMonitorEndpoint.start();
 
+            configuration.setInteger(RestOptions.PORT, webMonitorEndpoint.getRestPort());
+            configuration.setString(RestOptions.ADDRESS, webMonitorEndpoint.getServerAddress().getHostString());
+
             final String hostname = RpcUtils.getHostname(rpcService);
 
             resourceManagerService =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServices.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.highavailability;
 
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 
+import java.net.UnknownHostException;
+
 /**
  * {@code ClientHighAvailabilityServices} provides services those are required on client-side. At
  * the moment only the REST endpoint leader retriever is required because all communication between
@@ -32,5 +34,5 @@ public interface ClientHighAvailabilityServices extends AutoCloseable {
      *
      * @return the leader retriever for cluster's rest endpoint.
      */
-    LeaderRetrievalService getClusterRestEndpointLeaderRetriever();
+    LeaderRetrievalService getClusterRestEndpointLeaderRetriever() throws UnknownHostException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -202,7 +203,7 @@ public interface HighAvailabilityServices
     }
 
     @Override
-    default LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+    default LeaderRetrievalService getClusterRestEndpointLeaderRetriever() throws UnknownHostException {
         // for backwards compatibility we delegate to getWebMonitorLeaderRetriever
         // all implementations of this interface should override
         // getClusterRestEndpointLeaderRetriever, though

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -128,11 +128,9 @@ public class HighAvailabilityServicesUtils {
                                 RpcServiceUtils.createWildcardName(Dispatcher.DISPATCHER_NAME),
                                 addressResolution,
                                 configuration);
-                final String webMonitorAddress =
-                        getWebMonitorAddress(configuration, addressResolution);
 
                 return new StandaloneHaServices(
-                        resourceManagerRpcUrl, dispatcherRpcUrl, webMonitorAddress);
+                        resourceManagerRpcUrl, dispatcherRpcUrl, configuration);
             case ZOOKEEPER:
                 return createZooKeeperHaServices(configuration, executor, fatalErrorHandler);
             case KUBERNETES:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
@@ -19,12 +19,17 @@
 package org.apache.flink.runtime.highavailability.nonha.standalone;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.highavailability.nonha.AbstractNonHaServices;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.StandaloneLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
+import org.apache.flink.runtime.rpc.AddressResolution;
+
+import java.net.UnknownHostException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -45,23 +50,22 @@ public class StandaloneHaServices extends AbstractNonHaServices {
     /** The fix address of the Dispatcher. */
     private final String dispatcherAddress;
 
-    private final String clusterRestEndpointAddress;
+    private final Configuration configuration;
 
     /**
      * Creates a new services class for the fix pre-defined leaders.
      *
      * @param resourceManagerAddress The fix address of the ResourceManager
-     * @param clusterRestEndpointAddress
+     * @param configuration
      */
     public StandaloneHaServices(
             String resourceManagerAddress,
             String dispatcherAddress,
-            String clusterRestEndpointAddress) {
+            Configuration configuration) {
         this.resourceManagerAddress =
                 checkNotNull(resourceManagerAddress, "resourceManagerAddress");
         this.dispatcherAddress = checkNotNull(dispatcherAddress, "dispatcherAddress");
-        this.clusterRestEndpointAddress =
-                checkNotNull(clusterRestEndpointAddress, clusterRestEndpointAddress);
+        this.configuration = configuration;
     }
 
     // ------------------------------------------------------------------------
@@ -134,9 +138,12 @@ public class StandaloneHaServices extends AbstractNonHaServices {
     }
 
     @Override
-    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever()
+        throws UnknownHostException {
         synchronized (lock) {
             checkNotShutdown();
+            String clusterRestEndpointAddress = HighAvailabilityServicesUtils.
+                getWebMonitorAddress(configuration, AddressResolution.NO_ADDRESS_RESOLUTION);
 
             return new StandaloneLeaderRetrievalService(
                     clusterRestEndpointAddress, DEFAULT_LEADER_ID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.highavailability.nonha.standalone;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
@@ -39,16 +40,15 @@ public class StandaloneHaServicesTest extends TestLogger {
 
     private final String dispatcherAddress = "dispatcher";
     private final String resourceManagerAddress = "resourceManager";
-    private final String webMonitorAddress = "webMonitor";
 
     private StandaloneHaServices standaloneHaServices;
 
     @Before
     public void setupTest() {
-
+        Configuration config = new Configuration();
         standaloneHaServices =
                 new StandaloneHaServices(
-                        resourceManagerAddress, dispatcherAddress, webMonitorAddress);
+                        resourceManagerAddress, dispatcherAddress, config);
     }
 
     @After


### PR DESCRIPTION
## What is the purpose of the change

Currently, StandaloneHaServices#getClusterRestEndpointLeaderRetreiver returns wrong rest port when a range of ports is configured in rest.port. This patch addresses the same.

## Brief change log

- * DefaultDispatcherResourceManagerComponentFactory sets the configuration with the rest address and rest port, from which the StandaloneHaServices#getClusterRestEndpointLeaderRetriever retrieves the address and port.


## Verifying this change

This change added tests and can be verified as follows:

1. Run a flink job with config rest.port set to a range say 50200-50300.
2. Included below code in a thread launched by the Adaptive Scheduler.


`
LeaderRetrievalService webMonitorRetrievalService = highAvailabilityServices.getClusterRestEndpointLeaderRetriever();
try {
   webMonitorRetrievalService.start(new WebMonitorLeaderListener());
} catch (Exception e) {
  throw new RuntimeException(e);
}


private class WebMonitorLeaderListener implements LeaderRetrievalListener {
@Override
public void notifyLeaderAddress(final String leaderAddress, final UUID leaderSessionID) {
  System.out.println(leaderAddress);
}
`


3. The leader address printed is the correct one which RestServerEndpoint listens. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
