### PR TITLE
[FLINK-31657][rest][docs] Exclude isEmpty property

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -269,9 +269,6 @@ paths:
             application/json:
               schema:
                 type: array
-                properties:
-                  empty:
-                    type: boolean
                 items:
                   $ref: '#/components/schemas/ConfigurationInfoEntry'
   /jobmanager/environment:
@@ -722,9 +719,6 @@ paths:
             application/json:
               schema:
                 type: array
-                properties:
-                  empty:
-                    type: boolean
                 items:
                   $ref: '#/components/schemas/ConfigurationInfoEntry'
   /jobs/{jobid}/jobmanager/environment:
@@ -1883,9 +1877,6 @@ components:
             type: boolean
     ConfigurationInfo:
       type: array
-      properties:
-        empty:
-          type: boolean
       items:
         $ref: '#/components/schemas/ConfigurationInfoEntry'
     ConfigurationInfoEntry:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConfigurationInfo.java
@@ -22,6 +22,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterConfigHandler;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -38,6 +40,12 @@ public class ConfigurationInfo extends ArrayList<ConfigurationInfoEntry> impleme
 
     public ConfigurationInfo(int initialEntries) {
         super(initialEntries);
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isEmpty() {
+        return super.isEmpty();
     }
 
     public static ConfigurationInfo from(Configuration config) {


### PR DESCRIPTION
Ensures the schema generator doesn't pick up List#isEmpty as a property.
This resulted in an invalid schema, as arrays cant have properties.