### PR TITLE
[hotfix] [docs] Fix `ROW()` decleration syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -1197,7 +1197,7 @@ A row type is similar to the `STRUCT` type known from other non-standard-complia
 ROW<n0 t0, n1 t1, ...>
 ROW<n0 t0 'd0', n1 t1 'd1', ...>
 
-ROW(n0 t0, n1 t1, ...>
+ROW(n0 t0, n1 t1, ...)
 ROW(n0 t0 'd0', n1 t1 'd1', ...)
 ```
 {{< /tab >}}

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -1206,7 +1206,7 @@ A row type is similar to the `STRUCT` type known from other non-standard-complia
 ROW<n0 t0, n1 t1, ...>
 ROW<n0 t0 'd0', n1 t1 'd1', ...>
 
-ROW(n0 t0, n1 t1, ...>
+ROW(n0 t0, n1 t1, ...)
 ROW(n0 t0 'd0', n1 t1 'd1', ...)
 ```
 {{< /tab >}}


### PR DESCRIPTION
Fixes typo in the documentation for declaring a `ROW` with the parethesis.