### PR TITLE
[FLINK-31443][runtime] Maintain redundant taskmanagers to speed up failover

### DIFF
--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -78,7 +78,7 @@
             <td><h5>slotmanager.redundant-taskmanager-num</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
-            <td>The number of redundant task managers. Redundant task managers are extra task managers started by Flink, in order to speed up job recovery in case of failures due to task manager lost. Note that this feature is available only to the active deployments (native K8s, Yarn).</td>
+            <td>The number of redundant task managers. Redundant task managers are extra task managers started by Flink, in order to speed up job recovery in case of failures due to task manager lost. Note that this feature is available only to the active deployments (native K8s, Yarn).For fine-grained resource requirement, Redundant resources will be reserved, but it is possible that we have many small pieces of free resources form multiple TMs, which added up larger than the desired redundant resources, but each piece is too small to match the resource requirement of tasks from the failed worker.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -102,6 +102,10 @@ public class ResourceManagerOptions {
      * The number of redundant task managers. Redundant task managers are extra task managers
      * started by Flink, in order to speed up job recovery in case of failures due to task manager
      * lost. Note that this feature is available only to the active deployments (native K8s, Yarn).
+     * For fine-grained resource requirement, Redundant resources will be reserved, but it is
+     * possible that we have many small pieces of free resources form multiple TMs, which added up
+     * larger than the desired redundant resources, but each piece is too small to match the
+     * resource requirement of tasks from the failed worker.
      */
     public static final ConfigOption<Integer> REDUNDANT_TASK_MANAGER_NUM =
             ConfigOptions.key("slotmanager.redundant-taskmanager-num")
@@ -110,7 +114,10 @@ public class ResourceManagerOptions {
                     .withDescription(
                             "The number of redundant task managers. Redundant task managers are extra task managers "
                                     + "started by Flink, in order to speed up job recovery in case of failures due to task manager lost. "
-                                    + "Note that this feature is available only to the active deployments (native K8s, Yarn).");
+                                    + "Note that this feature is available only to the active deployments (native K8s, Yarn)."
+                                    + "For fine-grained resource requirement, Redundant resources will be reserved, but it is possible that "
+                                    + "we have many small pieces of free resources form multiple TMs, which added up larger than the desired "
+                                    + "redundant resources, but each piece is too small to match the resource requirement of tasks from the failed worker.");
 
     /**
      * The maximum number of start worker failures (Native Kubernetes / Yarn) per minute before

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -91,7 +91,8 @@ public class ResourceManagerRuntimeServices {
                                     slotManagerConfiguration.getDefaultWorkerResourceSpec()),
                             slotManagerConfiguration.getNumSlotsPerWorker(),
                             slotManagerConfiguration.isEvenlySpreadOutSlots(),
-                            slotManagerConfiguration.getTaskManagerTimeout()));
+                            slotManagerConfiguration.getTaskManagerTimeout(),
+                            slotManagerConfiguration.getRedundantTaskManagerNum()));
         } else {
             return new DeclarativeSlotManager(
                     scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -90,7 +90,8 @@ public class ResourceManagerRuntimeServices {
                             SlotManagerUtils.generateTaskManagerTotalResourceProfile(
                                     slotManagerConfiguration.getDefaultWorkerResourceSpec()),
                             slotManagerConfiguration.getNumSlotsPerWorker(),
-                            slotManagerConfiguration.isEvenlySpreadOutSlots()));
+                            slotManagerConfiguration.isEvenlySpreadOutSlots(),
+                            slotManagerConfiguration.getTaskManagerTimeout()));
         } else {
             return new DeclarativeSlotManager(
                     scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -127,10 +127,7 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
         taskManagerResourceInfoProvider.getPendingTaskManagers().stream()
                 .filter(
                         pendingTaskManager ->
-                                taskManagerResourceInfoProvider
-                                        .getPendingAllocationsOfPendingTaskManager(
-                                                pendingTaskManager.getPendingTaskManagerId())
-                                        .isEmpty())
+                                pendingTaskManager.getPendingSlotAllocationRecords().isEmpty())
                 .forEach(builder::addPendingTaskManagerToRelease);
 
         // idle task manager timeout.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -35,6 +35,7 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUtils.getEffectiveResourceProfile;
 
@@ -72,11 +73,15 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
 
     private final Time taskManagerTimeout;
 
+    /** Defines the number of redundant task managers. */
+    private final int redundantTaskManagerNum;
+
     public DefaultResourceAllocationStrategy(
             ResourceProfile totalResourceProfile,
             int numSlotsPerWorker,
             boolean evenlySpreadOutSlots,
-            Time taskManagerTimeout) {
+            Time taskManagerTimeout,
+            int redundantTaskManagerNum) {
         this.totalResourceProfile = totalResourceProfile;
         this.numSlotsPerWorker = numSlotsPerWorker;
         this.defaultSlotResourceProfile =
@@ -87,6 +92,7 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                         ? LeastUtilizationResourceMatchingStrategy.INSTANCE
                         : AnyMatchingResourceMatchingStrategy.INSTANCE;
         this.taskManagerTimeout = taskManagerTimeout;
+        this.redundantTaskManagerNum = redundantTaskManagerNum;
     }
 
     @Override
@@ -115,30 +121,89 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                         jobId, unfulfilledJobRequirements, pendingResources, resultBuilder);
             }
         }
+
+        // Unlike tryFulfillRequirementsForJobWithPendingResources, which updates pendingResources
+        // to the latest state after a new PendingTaskManager is created,
+        // tryFulFillRedundantResources will not update pendingResources even after new
+        // PendingTaskManagers are created.
+        // This is because the pendingResources are no longer needed afterwards.
+        tryFulFillRedundantResources(
+                totalResourceProfile.multiply(redundantTaskManagerNum),
+                registeredResources,
+                pendingResources,
+                resultBuilder);
+
         return resultBuilder.build();
     }
 
     @Override
     public ResourceReleaseResult tryReleaseUnusedResources(
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
+        ResourceProfile requiredRedundantResources =
+                totalResourceProfile.multiply(redundantTaskManagerNum);
         ResourceReleaseResult.Builder builder = ResourceReleaseResult.builder();
 
-        // useless pending task manager.
-        taskManagerResourceInfoProvider.getPendingTaskManagers().stream()
-                .filter(
-                        pendingTaskManager ->
-                                pendingTaskManager.getPendingSlotAllocationRecords().isEmpty())
-                .forEach(builder::addPendingTaskManagerToRelease);
-
-        // idle task manager timeout.
+        List<TaskManagerInfo> taskManagersIdleTimeout = new ArrayList<>();
+        List<TaskManagerInfo> taskManagersNonTimeout = new ArrayList<>();
         long currentTime = System.currentTimeMillis();
-        taskManagerResourceInfoProvider.getRegisteredTaskManagers().stream()
-                .filter(
-                        taskManager ->
-                                taskManager.isIdle()
-                                        && currentTime - taskManager.getIdleSince()
-                                                >= taskManagerTimeout.toMilliseconds())
-                .forEach(builder::addTaskManagerToRelease);
+        taskManagerResourceInfoProvider
+                .getRegisteredTaskManagers()
+                .forEach(
+                        taskManagerInfo -> {
+                            if (taskManagerInfo.isIdle()
+                                    && currentTime - taskManagerInfo.getIdleSince()
+                                            >= taskManagerTimeout.toMilliseconds()) {
+                                taskManagersIdleTimeout.add(taskManagerInfo);
+                            } else {
+                                taskManagersNonTimeout.add(taskManagerInfo);
+                            }
+                        });
+
+        List<PendingTaskManager> pendingTaskManagersNonUse = new ArrayList<>();
+        List<PendingTaskManager> pendingTaskManagersInuse = new ArrayList<>();
+        taskManagerResourceInfoProvider
+                .getPendingTaskManagers()
+                .forEach(
+                        pendingTaskManager -> {
+                            if (pendingTaskManager.getPendingSlotAllocationRecords().isEmpty()) {
+                                pendingTaskManagersNonUse.add(pendingTaskManager);
+                            } else {
+                                pendingTaskManagersInuse.add(pendingTaskManager);
+                            }
+                        });
+
+        if (taskManagersIdleTimeout.isEmpty() && pendingTaskManagersNonUse.isEmpty()) {
+            // short-cut for nothing to release
+            return builder.build();
+        }
+
+        ResourceProfile resourcesToKeep = ResourceProfile.ZERO;
+
+        // check whether available resources of used (pending) task manager is enough.
+        ResourceProfile availableResourcesOfNonIdle =
+                getAvailableResourceOfTaskManagers(taskManagersNonTimeout);
+        resourcesToKeep = resourcesToKeep.merge(availableResourcesOfNonIdle);
+        if (!canFulfillRequirement(requiredRedundantResources, resourcesToKeep)) {
+            ResourceProfile availableResourcesOfNonIdlePendingTaskManager =
+                    getAvailableResourceOfPendingTaskManagers(pendingTaskManagersInuse);
+            resourcesToKeep = resourcesToKeep.merge(availableResourcesOfNonIdlePendingTaskManager);
+        }
+
+        // try reserve or release unused (pending) task managers
+        for (TaskManagerInfo taskManagerInfo : taskManagersIdleTimeout) {
+            if (canFulfillRequirement(requiredRedundantResources, resourcesToKeep)) {
+                builder.addTaskManagerToRelease(taskManagerInfo);
+            } else {
+                resourcesToKeep = resourcesToKeep.merge(taskManagerInfo.getAvailableResource());
+            }
+        }
+        for (PendingTaskManager pendingTaskManager : pendingTaskManagersNonUse) {
+            if (canFulfillRequirement(requiredRedundantResources, resourcesToKeep)) {
+                builder.addPendingTaskManagerToRelease(pendingTaskManager);
+            } else {
+                resourcesToKeep = resourcesToKeep.merge(pendingTaskManager.getUnusedResource());
+            }
+        }
 
         return builder.build();
     }
@@ -264,6 +329,39 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                 }
             }
         }
+    }
+
+    private void tryFulFillRedundantResources(
+            ResourceProfile requiredRedundantResource,
+            List<InternalResourceInfo> availableRegisteredResources,
+            List<InternalResourceInfo> availablePendingResources,
+            ResourceAllocationResult.Builder resultBuilder) {
+        ResourceProfile totalAvailableResources =
+                Stream.concat(
+                                availableRegisteredResources.stream(),
+                                availablePendingResources.stream())
+                        .map(internalResourceInfo -> internalResourceInfo.availableProfile)
+                        .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
+
+        while (!canFulfillRequirement(requiredRedundantResource, totalAvailableResources)) {
+            PendingTaskManager pendingTaskManager =
+                    new PendingTaskManager(totalResourceProfile, numSlotsPerWorker);
+            resultBuilder.addPendingTaskManagerAllocate(pendingTaskManager);
+            totalAvailableResources = totalAvailableResources.merge(totalResourceProfile);
+        }
+    }
+
+    private ResourceProfile getAvailableResourceOfTaskManagers(List<TaskManagerInfo> taskManagers) {
+        return taskManagers.stream()
+                .map(TaskManagerInfo::getAvailableResource)
+                .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
+    }
+
+    private ResourceProfile getAvailableResourceOfPendingTaskManagers(
+            List<PendingTaskManager> pendingTaskManagers) {
+        return pendingTaskManagers.stream()
+                .map(PendingTaskManager::getUnusedResource)
+                .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
     }
 
     private static class InternalResourceInfo {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
@@ -83,14 +83,12 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
         LOG.trace("Record the pending allocations {}.", pendingSlotAllocations);
         pendingSlotAllocationRecords.clear();
         pendingSlotAllocationRecords.putAll(pendingSlotAllocations);
-        removeUnusedPendingTaskManagers();
     }
 
     @Override
     public void clearPendingAllocationsOfJob(JobID jobId) {
         LOG.info("Clear all pending allocations for job {}.", jobId);
         pendingSlotAllocationRecords.values().forEach(allocation -> allocation.remove(jobId));
-        removeUnusedPendingTaskManagers();
     }
 
     @Override
@@ -277,16 +275,6 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
                         SlotState.PENDING);
         taskManager.notifyAllocation(allocationId, slot);
         slots.put(allocationId, slot);
-    }
-
-    private void removeUnusedPendingTaskManagers() {
-        Set<PendingTaskManagerId> unusedPendingTaskManager =
-                pendingTaskManagers.keySet().stream()
-                        .filter(id -> !pendingSlotAllocationRecords.containsKey(id))
-                        .collect(Collectors.toSet());
-        for (PendingTaskManagerId pendingTaskManagerId : unusedPendingTaskManager) {
-            removePendingTaskManager(pendingTaskManagerId);
-        }
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Represents a pending task manager in the {@link SlotManager}. */
 public class PendingTaskManager {
@@ -28,12 +33,17 @@ public class PendingTaskManager {
     private final ResourceProfile defaultSlotResourceProfile;
     private final int numSlots;
 
+    private ResourceProfile unusedResource;
+    Map<JobID, ResourceCounter> pendingSlotAllocationRecords;
+
     public PendingTaskManager(ResourceProfile totalResourceProfile, int numSlots) {
         this.numSlots = numSlots;
         this.totalResourceProfile = Preconditions.checkNotNull(totalResourceProfile);
         this.defaultSlotResourceProfile =
                 SlotManagerUtils.generateDefaultSlotResourceProfile(totalResourceProfile, numSlots);
         this.pendingTaskManagerId = PendingTaskManagerId.generate();
+        this.unusedResource = totalResourceProfile;
+        this.pendingSlotAllocationRecords = new HashMap<>();
     }
 
     public ResourceProfile getTotalResourceProfile() {
@@ -50,6 +60,37 @@ public class PendingTaskManager {
 
     public int getNumSlots() {
         return numSlots;
+    }
+
+    public ResourceProfile getUnusedResource() {
+        return unusedResource;
+    }
+
+    public Map<JobID, ResourceCounter> getPendingSlotAllocationRecords() {
+        return pendingSlotAllocationRecords;
+    }
+
+    public void clearAllPendingAllocations() {
+        pendingSlotAllocationRecords.clear();
+        unusedResource = totalResourceProfile;
+    }
+
+    public void replaceAllPendingAllocations(Map<JobID, ResourceCounter> pendingSlotAllocations) {
+        pendingSlotAllocationRecords.clear();
+        pendingSlotAllocationRecords.putAll(pendingSlotAllocations);
+        unusedResource = calculateUnusedResourceProfile();
+    }
+
+    public void clearPendingAllocationsOfJob(JobID jobId) {
+        ResourceCounter resourceCounter = pendingSlotAllocationRecords.remove(jobId);
+        unusedResource = unusedResource.merge(resourceCounter.getTotalResource());
+    }
+
+    private ResourceProfile calculateUnusedResourceProfile() {
+        return totalResourceProfile.subtract(
+                pendingSlotAllocationRecords.values().stream()
+                        .map(ResourceCounter::getTotalResource)
+                        .reduce(ResourceProfile.ZERO, ResourceProfile::merge));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
@@ -46,4 +46,17 @@ public interface ResourceAllocationStrategy {
             Map<JobID, Collection<ResourceRequirement>> missingResources,
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider,
             BlockedTaskManagerChecker blockedTaskManagerChecker);
+
+    /**
+     * Try to make a release decision to release useless PendingTaskManagers and TaskManagers. This
+     * is more light weighted than {@link #tryFulfillRequirements}, only consider empty registered /
+     * pending workers and assume all requirements are fulfilled by registered / pending workers.
+     *
+     * @param taskManagerResourceInfoProvider provide the registered/pending resources of the
+     *     current cluster
+     * @return a {@link ResourceReleaseResult} based on the current status, which contains the
+     *     actions to take
+     */
+    ResourceReleaseResult tryReleaseUnusedResources(
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
@@ -48,7 +48,7 @@ public interface ResourceAllocationStrategy {
             BlockedTaskManagerChecker blockedTaskManagerChecker);
 
     /**
-     * Try to make a release decision to release useless PendingTaskManagers and TaskManagers. This
+     * Try to make a release decision to release unused PendingTaskManagers and TaskManagers. This
      * is more light weighted than {@link #tryFulfillRequirements}, only consider empty registered /
      * pending workers and assume all requirements are fulfilled by registered / pending workers.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceReleaseResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceReleaseResult.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Contains the results of the {@link ResourceAllocationStrategy}. */
+public class ResourceReleaseResult {
+    private final List<PendingTaskManager> pendingTaskManagersToRelease;
+    private final List<TaskManagerInfo> taskManagersToRelease;
+
+    public ResourceReleaseResult(
+            List<PendingTaskManager> pendingTaskManagersToRelease,
+            List<TaskManagerInfo> taskManagersToRelease) {
+        this.pendingTaskManagersToRelease = pendingTaskManagersToRelease;
+        this.taskManagersToRelease = taskManagersToRelease;
+    }
+
+    public List<PendingTaskManager> getPendingTaskManagersToRelease() {
+        return pendingTaskManagersToRelease;
+    }
+
+    public List<TaskManagerInfo> getTaskManagersToRelease() {
+        return taskManagersToRelease;
+    }
+
+    public boolean needRelease() {
+        return !pendingTaskManagersToRelease.isEmpty() || !taskManagersToRelease.isEmpty();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final List<PendingTaskManager> pendingTaskManagersToRelease = new ArrayList<>();
+        private final List<TaskManagerInfo> taskManagersToRelease = new ArrayList<>();
+
+        public Builder addPendingTaskManagerToRelease(PendingTaskManager pendingTaskManager) {
+            this.pendingTaskManagersToRelease.add(pendingTaskManager);
+            return this;
+        }
+
+        public Builder addTaskManagerToRelease(TaskManagerInfo taskManagerInfo) {
+            this.taskManagersToRelease.add(taskManagerInfo);
+            return this;
+        }
+
+        public ResourceReleaseResult build() {
+            return new ResourceReleaseResult(pendingTaskManagersToRelease, taskManagersToRelease);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -63,6 +63,7 @@ public class SlotManagerConfiguration {
             Duration requirementCheckDelay,
             Duration declareNeededResourceDelay,
             boolean waitResultConsumedBeforeRelease,
+            SlotMatchingStrategy slotMatchingStrategy,
             boolean evenlySpreadOutSlots,
             WorkerResourceSpec defaultWorkerResourceSpec,
             int numSlotsPerWorker,
@@ -77,10 +78,7 @@ public class SlotManagerConfiguration {
         this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
         this.declareNeededResourceDelay = Preconditions.checkNotNull(declareNeededResourceDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
-        this.slotMatchingStrategy =
-                evenlySpreadOutSlots
-                        ? LeastUtilizationSlotMatchingStrategy.INSTANCE
-                        : AnyMatchingSlotMatchingStrategy.INSTANCE;
+        this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
         this.evenlySpreadOutSlots = evenlySpreadOutSlots;
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
         Preconditions.checkState(numSlotsPerWorker > 0);
@@ -173,6 +171,10 @@ public class SlotManagerConfiguration {
 
         boolean evenlySpreadOutSlots =
                 configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
+        final SlotMatchingStrategy slotMatchingStrategy =
+                evenlySpreadOutSlots
+                        ? LeastUtilizationSlotMatchingStrategy.INSTANCE
+                        : AnyMatchingSlotMatchingStrategy.INSTANCE;
 
         int numSlotsPerWorker = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 
@@ -188,6 +190,7 @@ public class SlotManagerConfiguration {
                 requirementCheckDelay,
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
+                slotMatchingStrategy,
                 evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -35,6 +35,8 @@ import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -102,7 +104,7 @@ class TaskExecutorManager implements AutoCloseable {
 
     private final Executor mainThreadExecutor;
 
-    private final ScheduledFuture<?> taskManagerTimeoutsAndRedundancyCheck;
+    @Nullable private final ScheduledFuture<?> taskManagerTimeoutsAndRedundancyCheck;
 
     private final Set<InstanceID> unWantedWorkers;
     private final ScheduledExecutor scheduledExecutor;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerResourceInfoProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerResourceInfoProvider.java
@@ -17,26 +17,15 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.util.ResourceCounter;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 
 /** Provide the information of TaskManager's resource and slot status. */
 interface TaskManagerResourceInfoProvider {
-    /**
-     * Get the pending allocations of the given pending task manager.
-     *
-     * @param pendingTaskManagerId of the pending task manager
-     * @return pending allocations, mapped by jobId
-     */
-    Map<JobID, ResourceCounter> getPendingAllocationsOfPendingTaskManager(
-            PendingTaskManagerId pendingTaskManagerId);
 
     /**
      * Get the {@link TaskManagerInfo}s of all registered task managers.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ResourceCounter.java
@@ -63,6 +63,17 @@ public final class ResourceCounter {
     }
 
     /**
+     * Computes the total resources in this counter.
+     *
+     * @return the total resources in this counter
+     */
+    public ResourceProfile getTotalResource() {
+        return resources.entrySet().stream()
+                .map(entry -> entry.getKey().multiply(entry.getValue()))
+                .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
+    }
+
+    /**
      * Adds increment to this resource counter value and returns the resulting value.
      *
      * @param increment increment to add to this resource counter value

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -160,6 +160,9 @@ public class DeclarativeSlotManagerBuilder {
                         requirementCheckDelay,
                         declareNeededResourceDelay,
                         waitResultConsumedBeforeRelease,
+                        evenlySpreadOutSlots
+                                ? LeastUtilizationSlotMatchingStrategy.INSTANCE
+                                : AnyMatchingSlotMatchingStrategy.INSTANCE,
                         evenlySpreadOutSlots,
                         defaultWorkerResourceSpec,
                         numSlotsPerWorker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -369,16 +369,13 @@ class DefaultResourceAllocationStrategyTest {
     void testUsedPendingTaskManagerShouldNotBeReleased() {
         final PendingTaskManager pendingTaskManager =
                 new PendingTaskManager(DEFAULT_SLOT_RESOURCE, 1);
+        pendingTaskManager.replaceAllPendingAllocations(
+                Collections.singletonMap(
+                        new JobID(), ResourceCounter.withResource(DEFAULT_SLOT_RESOURCE, 1)));
         final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
                 TestingTaskManagerResourceInfoProvider.newBuilder()
                         .setPendingTaskManagersSupplier(
                                 () -> Collections.singleton(pendingTaskManager))
-                        .setGetPendingAllocationsOfPendingTaskManagerFunction(
-                                pendingTaskManagerId ->
-                                        Collections.singletonMap(
-                                                new JobID(),
-                                                ResourceCounter.withResource(
-                                                        DEFAULT_SLOT_RESOURCE, 1)))
                         .build();
 
         ResourceReleaseResult result =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -406,7 +406,7 @@ class DefaultResourceAllocationStrategyTest {
     }
 
     @Test
-    void testUselessResourcesShouldBeReleasedIfNonIdleResourceIsEnough() {
+    void testUnusedResourcesShouldBeReleasedIfNonIdleResourceIsEnough() {
         final TaskManagerInfo taskManagerInUse =
                 new TestingTaskManagerInfo(
                         DEFAULT_SLOT_RESOURCE.multiply(5),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -41,18 +41,9 @@ class DefaultResourceAllocationStrategyTest {
             ResourceProfile.fromResources(1, 100);
     private static final int NUM_OF_SLOTS = 5;
     private static final DefaultResourceAllocationStrategy ANY_MATCHING_STRATEGY =
-            new DefaultResourceAllocationStrategy(
-                    DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
-                    NUM_OF_SLOTS,
-                    false,
-                    Time.milliseconds(0));
+            createStrategy(false);
 
-    private static final DefaultResourceAllocationStrategy EVENLY_STRATEGY =
-            new DefaultResourceAllocationStrategy(
-                    DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
-                    NUM_OF_SLOTS,
-                    true,
-                    Time.milliseconds(0));
+    private static final DefaultResourceAllocationStrategy EVENLY_STRATEGY = createStrategy(true);
 
     @Test
     void testFulfillRequirementWithRegisteredResources() {
@@ -382,5 +373,131 @@ class DefaultResourceAllocationStrategyTest {
                 ANY_MATCHING_STRATEGY.tryReleaseUnusedResources(taskManagerResourceInfoProvider);
 
         assertThat(result.getPendingTaskManagersToRelease()).isEmpty();
+    }
+
+    @Test
+    void testFulFillRequirementShouldTakeRedundantInAccount() {
+        DefaultResourceAllocationStrategy strategy = createStrategy(1);
+
+        final TaskManagerInfo taskManager =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE);
+
+        final JobID jobId = new JobID();
+        final ResourceProfile largeResource = DEFAULT_SLOT_RESOURCE.multiply(4);
+        final List<ResourceRequirement> requirements =
+                Collections.singletonList(ResourceRequirement.create(largeResource, 1));
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(() -> Collections.singleton(taskManager))
+                        .build();
+
+        final ResourceAllocationResult result =
+                strategy.tryFulfillRequirements(
+                        Collections.singletonMap(jobId, requirements),
+                        taskManagerResourceInfoProvider,
+                        resourceID -> false);
+        assertThat(result.getUnfulfillableJobs()).isEmpty();
+        assertThat(result.getPendingTaskManagersToAllocate()).hasSize(1);
+        assertThat(result.getAllocationsOnPendingResources()).isEmpty();
+    }
+
+    @Test
+    void testUselessResourcesShouldBeReleasedIfNonIdleResourceIsEnough() {
+        final TaskManagerInfo taskManagerInUse =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE.multiply(2),
+                        DEFAULT_SLOT_RESOURCE);
+
+        final TestingTaskManagerInfo taskManagerIdle =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE);
+        taskManagerIdle.setIdleSince(System.currentTimeMillis() - 10);
+
+        final PendingTaskManager pendingTaskManagerInUse =
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(5), NUM_OF_SLOTS);
+        pendingTaskManagerInUse.replaceAllPendingAllocations(
+                Collections.singletonMap(
+                        new JobID(), ResourceCounter.withResource(DEFAULT_SLOT_RESOURCE, 2)));
+
+        final PendingTaskManager pendingTaskManagerIdle =
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(5), NUM_OF_SLOTS);
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(
+                                () -> Arrays.asList(taskManagerInUse, taskManagerIdle))
+                        .setPendingTaskManagersSupplier(
+                                () ->
+                                        Arrays.asList(
+                                                pendingTaskManagerInUse, pendingTaskManagerIdle))
+                        .build();
+
+        DefaultResourceAllocationStrategy strategy = createStrategy(1);
+        ResourceReleaseResult result =
+                strategy.tryReleaseUnusedResources(taskManagerResourceInfoProvider);
+        assertThat(result.getPendingTaskManagersToRelease())
+                .containsExactly(pendingTaskManagerIdle);
+        assertThat(result.getTaskManagersToRelease()).containsExactly(taskManagerIdle);
+    }
+
+    @Test
+    void testRedundantResourceShouldBeReserved() {
+        final TaskManagerInfo taskManagerInUse =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE.multiply(2),
+                        DEFAULT_SLOT_RESOURCE);
+
+        final TestingTaskManagerInfo taskManagerIdle =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE.multiply(5),
+                        DEFAULT_SLOT_RESOURCE);
+        taskManagerIdle.setIdleSince(System.currentTimeMillis() - 10);
+
+        final PendingTaskManager pendingTaskManagerIdle =
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(5), NUM_OF_SLOTS);
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(
+                                () -> Arrays.asList(taskManagerInUse, taskManagerIdle))
+                        .setPendingTaskManagersSupplier(
+                                () -> Collections.singletonList(pendingTaskManagerIdle))
+                        .build();
+
+        DefaultResourceAllocationStrategy strategy = createStrategy(1);
+        ResourceReleaseResult result =
+                strategy.tryReleaseUnusedResources(taskManagerResourceInfoProvider);
+        // pending task manager should release at first
+        assertThat(result.getPendingTaskManagersToRelease())
+                .containsExactly(pendingTaskManagerIdle);
+        // idle task manager should reserved for redundant
+        assertThat(result.getTaskManagersToRelease()).isEmpty();
+    }
+
+    private static DefaultResourceAllocationStrategy createStrategy(boolean evenlySpreadOutSlots) {
+        return createStrategy(evenlySpreadOutSlots, 0);
+    }
+
+    private static DefaultResourceAllocationStrategy createStrategy(int redundantTaskManagerNum) {
+        return createStrategy(false, redundantTaskManagerNum);
+    }
+
+    private static DefaultResourceAllocationStrategy createStrategy(
+            boolean evenlySpreadOutSlots, int redundantTaskManagerNum) {
+        return new DefaultResourceAllocationStrategy(
+                DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                NUM_OF_SLOTS,
+                evenlySpreadOutSlots,
+                Time.milliseconds(0),
+                redundantTaskManagerNum);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -56,7 +56,8 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
                         DEFAULT_TOTAL_RESOURCE_PROFILE,
                         DEFAULT_NUM_SLOTS_PER_WORKER,
                         slotManagerConfiguration.isEvenlySpreadOutSlots(),
-                        slotManagerConfiguration.getTaskManagerTimeout()));
+                        slotManagerConfiguration.getTaskManagerTimeout(),
+                        slotManagerConfiguration.getRedundantTaskManagerNum()));
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -18,7 +18,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -226,10 +225,19 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             JobID jobID = jobRequirements.keySet().stream().findFirst().get();
                             ResourceAllocationResult.Builder builder =
                                     ResourceAllocationResult.builder();
-                            PendingTaskManager pendingTaskManager =
-                                    new PendingTaskManager(
-                                            DEFAULT_TOTAL_RESOURCE_PROFILE,
-                                            DEFAULT_NUM_SLOTS_PER_WORKER);
+                            final PendingTaskManager pendingTaskManager;
+                            if (getTaskManagerTracker().getPendingTaskManagers().isEmpty()) {
+                                pendingTaskManager =
+                                        new PendingTaskManager(
+                                                DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                DEFAULT_NUM_SLOTS_PER_WORKER);
+                            } else {
+                                pendingTaskManager =
+                                        getTaskManagerTracker()
+                                                .getPendingTaskManagers()
+                                                .iterator()
+                                                .next();
+                            }
                             builder.addPendingTaskManagerAllocate(pendingTaskManager);
                             builder.addAllocationOnPendingResource(
                                     jobID,
@@ -657,100 +665,6 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                     .processResourceRequirements(
                                                             resourceRequirements3));
                             assertFutureCompleteAndReturn(checkRequirementFutures.get(1));
-                        });
-            }
-        };
-    }
-
-    // ---------------------------------------------------------------------------------------------
-    // Task manager timeout
-    // ---------------------------------------------------------------------------------------------
-
-    /**
-     * Tests that formerly used task managers can timeout after all of their slots have been freed.
-     */
-    @Test
-    void testTimeoutForUnusedTaskManager() throws Exception {
-        final Time taskManagerTimeout = Time.milliseconds(50L);
-
-        final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
-        final AllocationID allocationId = new AllocationID();
-        final TaskExecutorConnection taskExecutionConnection = createTaskExecutorConnection();
-        final InstanceID instanceId = taskExecutionConnection.getInstanceID();
-        new Context() {
-            {
-                resourceAllocatorBuilder.setDeclareResourceNeededConsumer(
-                        (resourceDeclarations) -> {
-                            assertThat(resourceDeclarations).hasSize(1);
-                            ResourceDeclaration resourceDeclaration =
-                                    resourceDeclarations.iterator().next();
-                            assertThat(resourceDeclaration.getNumNeeded()).isEqualTo(0);
-                            assertThat(resourceDeclaration.getUnwantedWorkers()).hasSize(1);
-                            releaseResourceFuture.complete(
-                                    resourceDeclaration.getUnwantedWorkers().iterator().next());
-                        });
-                slotManagerConfigurationBuilder.setTaskManagerTimeout(taskManagerTimeout);
-                runTest(
-                        () -> {
-                            final CompletableFuture<SlotManager.RegistrationResult>
-                                    registerTaskManagerFuture = new CompletableFuture<>();
-                            runInMainThread(
-                                    () ->
-                                            registerTaskManagerFuture.complete(
-                                                    getSlotManager()
-                                                            .registerTaskManager(
-                                                                    taskExecutionConnection,
-                                                                    new SlotReport(
-                                                                            createAllocatedSlotStatus(
-                                                                                    new JobID(),
-                                                                                    allocationId,
-                                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)),
-                                                                    DEFAULT_TOTAL_RESOURCE_PROFILE,
-                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
-                                    .isEqualTo(SlotManager.RegistrationResult.SUCCESS);
-                            assertThat(getSlotManager().getTaskManagerIdleSince(instanceId))
-                                    .isEqualTo(Long.MAX_VALUE);
-
-                            final CompletableFuture<Long> idleSinceFuture =
-                                    new CompletableFuture<>();
-                            runInMainThread(
-                                    () -> {
-                                        getSlotManager()
-                                                .freeSlot(
-                                                        new SlotID(
-                                                                taskExecutionConnection
-                                                                        .getResourceID(),
-                                                                0),
-                                                        allocationId);
-                                        idleSinceFuture.complete(
-                                                getSlotManager()
-                                                        .getTaskManagerIdleSince(instanceId));
-                                    });
-
-                            assertThat(assertFutureCompleteAndReturn(idleSinceFuture))
-                                    .isNotEqualTo(Long.MAX_VALUE);
-                            assertThat(assertFutureCompleteAndReturn(releaseResourceFuture))
-                                    .isEqualTo(instanceId);
-                            // A task manager timeout does not remove the slots from the
-                            // SlotManager. The receiver of the callback can then decide what to do
-                            // with the TaskManager.
-                            assertThat(getSlotManager().getNumberRegisteredSlots())
-                                    .isEqualTo(DEFAULT_NUM_SLOTS_PER_WORKER);
-
-                            final CompletableFuture<Boolean> unregisterTaskManagerFuture =
-                                    new CompletableFuture<>();
-                            runInMainThread(
-                                    () ->
-                                            unregisterTaskManagerFuture.complete(
-                                                    getSlotManager()
-                                                            .unregisterTaskManager(
-                                                                    taskExecutionConnection
-                                                                            .getInstanceID(),
-                                                                    TEST_EXCEPTION)));
-                            assertThat(assertFutureCompleteAndReturn(unregisterTaskManagerFuture))
-                                    .isTrue();
-                            assertThat(getSlotManager().getNumberRegisteredSlots()).isEqualTo(0);
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -143,6 +143,9 @@ public class SlotManagerConfigurationBuilder {
                 requirementCheckDelay,
                 declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
+                evenlySpreadOutSlots
+                        ? LeastUtilizationSlotMatchingStrategy.INSTANCE
+                        : AnyMatchingSlotMatchingStrategy.INSTANCE,
                 evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
@@ -36,7 +36,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
             tryFulfillRequirementsFunction;
 
     private final Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
-            tryReleaseUselessResourcesFunction;
+            tryReleaseUnusedResourcesFunction;
 
     private TestingResourceAllocationStrategy(
             BiFunction<
@@ -45,11 +45,11 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                             ResourceAllocationResult>
                     tryFulfillRequirementsFunction,
             Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
-                    tryReleaseUselessResourcesFunction) {
+                    tryReleaseUnusedResourcesFunction) {
         this.tryFulfillRequirementsFunction =
                 Preconditions.checkNotNull(tryFulfillRequirementsFunction);
-        this.tryReleaseUselessResourcesFunction =
-                Preconditions.checkNotNull(tryReleaseUselessResourcesFunction);
+        this.tryReleaseUnusedResourcesFunction =
+                Preconditions.checkNotNull(tryReleaseUnusedResourcesFunction);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
     @Override
     public ResourceReleaseResult tryReleaseUnusedResources(
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
-        return tryReleaseUselessResourcesFunction.apply(taskManagerResourceInfoProvider);
+        return tryReleaseUnusedResourcesFunction.apply(taskManagerResourceInfoProvider);
     }
 
     public static Builder newBuilder() {
@@ -80,7 +80,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                         (ignored0, ignored1) -> ResourceAllocationResult.builder().build();
 
         private Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
-                tryReleaseUselessResourcesFunction =
+                tryReleaseUnusedResourcesFunction =
                         ignored -> ResourceReleaseResult.builder().build();
 
         public Builder setTryFulfillRequirementsFunction(
@@ -93,16 +93,16 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
             return this;
         }
 
-        public Builder setTryReleaseUselessResourcesFunction(
+        public Builder setTryReleaseUnusedResourcesFunction(
                 Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
-                        tryReleaseUselessResourcesFunction) {
-            this.tryReleaseUselessResourcesFunction = tryReleaseUselessResourcesFunction;
+                        tryReleaseUnusedResourcesFunction) {
+            this.tryReleaseUnusedResourcesFunction = tryReleaseUnusedResourcesFunction;
             return this;
         }
 
         public TestingResourceAllocationStrategy build() {
             return new TestingResourceAllocationStrategy(
-                    tryFulfillRequirementsFunction, tryReleaseUselessResourcesFunction);
+                    tryFulfillRequirementsFunction, tryReleaseUnusedResourcesFunction);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /** Implementation of {@link ResourceAllocationStrategy} for testing purpose. */
 public class TestingResourceAllocationStrategy implements ResourceAllocationStrategy {
@@ -34,14 +35,21 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                     ResourceAllocationResult>
             tryFulfillRequirementsFunction;
 
+    private final Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+            tryReleaseUselessResourcesFunction;
+
     private TestingResourceAllocationStrategy(
             BiFunction<
                             Map<JobID, Collection<ResourceRequirement>>,
                             TaskManagerResourceInfoProvider,
                             ResourceAllocationResult>
-                    tryFulfillRequirementsFunction) {
+                    tryFulfillRequirementsFunction,
+            Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+                    tryReleaseUselessResourcesFunction) {
         this.tryFulfillRequirementsFunction =
                 Preconditions.checkNotNull(tryFulfillRequirementsFunction);
+        this.tryReleaseUselessResourcesFunction =
+                Preconditions.checkNotNull(tryReleaseUselessResourcesFunction);
     }
 
     @Override
@@ -51,6 +59,12 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
             BlockedTaskManagerChecker blockedTaskManagerChecker) {
         return tryFulfillRequirementsFunction.apply(
                 missingResources, taskManagerResourceInfoProvider);
+    }
+
+    @Override
+    public ResourceReleaseResult tryReleaseUnusedResources(
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
+        return tryReleaseUselessResourcesFunction.apply(taskManagerResourceInfoProvider);
     }
 
     public static Builder newBuilder() {
@@ -65,6 +79,10 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                 tryFulfillRequirementsFunction =
                         (ignored0, ignored1) -> ResourceAllocationResult.builder().build();
 
+        private Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+                tryReleaseUselessResourcesFunction =
+                        ignored -> ResourceReleaseResult.builder().build();
+
         public Builder setTryFulfillRequirementsFunction(
                 BiFunction<
                                 Map<JobID, Collection<ResourceRequirement>>,
@@ -75,8 +93,16 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
             return this;
         }
 
+        public Builder setTryReleaseUselessResourcesFunction(
+                Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+                        tryReleaseUselessResourcesFunction) {
+            this.tryReleaseUselessResourcesFunction = tryReleaseUselessResourcesFunction;
+            return this;
+        }
+
         public TestingResourceAllocationStrategy build() {
-            return new TestingResourceAllocationStrategy(tryFulfillRequirementsFunction);
+            return new TestingResourceAllocationStrategy(
+                    tryFulfillRequirementsFunction, tryReleaseUselessResourcesFunction);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerInfo.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerInfo.java
@@ -37,6 +37,8 @@ public class TestingTaskManagerInfo implements TaskManagerInfo {
     private final ResourceProfile defaultSlotResourceProfile;
     private final int defaultNumSlots;
 
+    private long idleSince = Long.MAX_VALUE;
+
     public TestingTaskManagerInfo(
             ResourceProfile totalResource,
             ResourceProfile availableResource,
@@ -52,6 +54,10 @@ public class TestingTaskManagerInfo implements TaskManagerInfo {
                 new TaskExecutorConnection(
                         ResourceID.generate(),
                         new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
+    }
+
+    public void setIdleSince(long idleSince) {
+        this.idleSince = idleSince;
     }
 
     @Override
@@ -91,11 +97,11 @@ public class TestingTaskManagerInfo implements TaskManagerInfo {
 
     @Override
     public long getIdleSince() {
-        return Long.MAX_VALUE;
+        return idleSince;
     }
 
     @Override
     public boolean isIdle() {
-        return false;
+        return idleSince != Long.MAX_VALUE;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerResourceInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerResourceInfoProvider.java
@@ -18,16 +18,13 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -35,8 +32,6 @@ import java.util.function.Supplier;
 
 /** Implementation of {@link TaskManagerResourceInfoProvider} for testing purpose. */
 public class TestingTaskManagerResourceInfoProvider implements TaskManagerResourceInfoProvider {
-    private final Function<PendingTaskManagerId, Map<JobID, ResourceCounter>>
-            getPendingAllocationsOfPendingTaskManagerFunction;
     private final Supplier<Collection<? extends TaskManagerInfo>> registeredTaskManagersSupplier;
     private final Function<InstanceID, Optional<TaskManagerInfo>> getRegisteredTaskManagerFunction;
     private final Supplier<Collection<PendingTaskManager>> pendingTaskManagersSupplier;
@@ -46,8 +41,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
             getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction;
 
     private TestingTaskManagerResourceInfoProvider(
-            Function<PendingTaskManagerId, Map<JobID, ResourceCounter>>
-                    getPendingAllocationsOfPendingTaskManagerFunction,
             Supplier<Collection<? extends TaskManagerInfo>> registeredTaskManagersSupplier,
             Function<InstanceID, Optional<TaskManagerInfo>> getRegisteredTaskManagerFunction,
             Supplier<Collection<PendingTaskManager>> pendingTaskManagersSupplier,
@@ -55,8 +48,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
                     getAllocatedOrPendingSlotFunction,
             BiFunction<ResourceProfile, ResourceProfile, Collection<PendingTaskManager>>
                     getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction) {
-        this.getPendingAllocationsOfPendingTaskManagerFunction =
-                Preconditions.checkNotNull(getPendingAllocationsOfPendingTaskManagerFunction);
         this.registeredTaskManagersSupplier =
                 Preconditions.checkNotNull(registeredTaskManagersSupplier);
         this.getRegisteredTaskManagerFunction =
@@ -67,12 +58,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
         this.getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction =
                 Preconditions.checkNotNull(
                         getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction);
-    }
-
-    @Override
-    public Map<JobID, ResourceCounter> getPendingAllocationsOfPendingTaskManager(
-            PendingTaskManagerId pendingTaskManagerId) {
-        return getPendingAllocationsOfPendingTaskManagerFunction.apply(pendingTaskManagerId);
     }
 
     @Override
@@ -110,9 +95,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
     }
 
     public static class Builder {
-        private Function<PendingTaskManagerId, Map<JobID, ResourceCounter>>
-                getPendingAllocationsOfPendingTaskManagerFunction =
-                        ignore -> Collections.emptyMap();
         private Supplier<Collection<? extends TaskManagerInfo>> registeredTaskManagersSupplier =
                 Collections::emptyList;
         private Function<InstanceID, Optional<TaskManagerInfo>> getRegisteredTaskManagerFunction =
@@ -129,14 +111,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
                 Function<AllocationID, Optional<TaskManagerSlotInformation>>
                         getAllocatedOrPendingSlotFunction) {
             this.getAllocatedOrPendingSlotFunction = getAllocatedOrPendingSlotFunction;
-            return this;
-        }
-
-        public Builder setGetPendingAllocationsOfPendingTaskManagerFunction(
-                Function<PendingTaskManagerId, Map<JobID, ResourceCounter>>
-                        getPendingAllocationsOfPendingTaskManagerFunction) {
-            this.getPendingAllocationsOfPendingTaskManagerFunction =
-                    getPendingAllocationsOfPendingTaskManagerFunction;
             return this;
         }
 
@@ -168,7 +142,6 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
 
         public TestingTaskManagerResourceInfoProvider build() {
             return new TestingTaskManagerResourceInfoProvider(
-                    getPendingAllocationsOfPendingTaskManagerFunction,
                     registeredTaskManagersSupplier,
                     getRegisteredTaskManagerFunction,
                     pendingTaskManagersSupplier,


### PR DESCRIPTION
## What is the purpose of the change
implementation of [FLINK-18625](https://issues.apache.org/jira/browse/FLINK-18625) in FineGrainedSlotManager.


## Brief change log
  - *check that redundancy requirements are fulfilled periodically*


## Verifying this change
  - *Added unit test: FineGrainedSlotManagerTest#testRedundantTaskManagers*
  - *Manually verified the change by running a session cluster on Kubernetes. No redundant task manager will request at first, after submit a job, one redundant task manager will be requested.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
