### PR TITLE
[FLINK-31447][runtime] Aligning unit tests of FineGrainedSlotManager with DeclarativeSlotManager

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
+/** Builder for {@link FineGrainedSlotManager}. */
+public class FineGrainedSlotManagerBuilder {
+    private ResourceTracker resourceTracker = new DefaultResourceTracker();
+    private TaskManagerTracker taskManagerTracker = new FineGrainedTaskManagerTracker();
+    private SlotStatusSyncer slotStatusSyncer =
+            new DefaultSlotStatusSyncer(TestingUtils.infiniteTime());
+    private SlotManagerMetricGroup slotManagerMetricGroup =
+            UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+    private final ScheduledExecutor scheduledExecutor;
+    private ResourceAllocationStrategy resourceAllocationStrategy =
+            TestingResourceAllocationStrategy.newBuilder().build();
+
+    SlotManagerConfiguration slotManagerConfiguration =
+            SlotManagerConfigurationBuilder.newBuilder().build();
+
+    private FineGrainedSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
+        this.scheduledExecutor = scheduledExecutor;
+    }
+
+    public static FineGrainedSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
+        return new FineGrainedSlotManagerBuilder(scheduledExecutor);
+    }
+
+    public FineGrainedSlotManagerBuilder setTaskManagerTracker(
+            TaskManagerTracker taskManagerTracker) {
+        this.taskManagerTracker = taskManagerTracker;
+        return this;
+    }
+
+    public FineGrainedSlotManagerBuilder setSlotManagerMetricGroup(
+            SlotManagerMetricGroup slotManagerMetricGroup) {
+        this.slotManagerMetricGroup = slotManagerMetricGroup;
+        return this;
+    }
+
+    public FineGrainedSlotManagerBuilder setResourceTracker(ResourceTracker resourceTracker) {
+        this.resourceTracker = resourceTracker;
+        return this;
+    }
+
+    public FineGrainedSlotManagerBuilder setSlotStatusSyncer(SlotStatusSyncer slotStatusSyncer) {
+        this.slotStatusSyncer = slotStatusSyncer;
+        return this;
+    }
+
+    public FineGrainedSlotManagerBuilder setResourceAllocationStrategy(
+            ResourceAllocationStrategy resourceAllocationStrategy) {
+        this.resourceAllocationStrategy = resourceAllocationStrategy;
+        return this;
+    }
+
+    public FineGrainedSlotManagerBuilder setSlotManagerConfiguration(
+            SlotManagerConfiguration slotManagerConfiguration) {
+        this.slotManagerConfiguration = slotManagerConfiguration;
+        return this;
+    }
+
+    public FineGrainedSlotManager build() {
+        return new FineGrainedSlotManager(
+                scheduledExecutor,
+                slotManagerConfiguration,
+                slotManagerMetricGroup,
+                resourceTracker,
+                taskManagerTracker,
+                slotStatusSyncer,
+                resourceAllocationStrategy);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -18,11 +18,21 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,6 +78,79 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
                                                                     1,
                                                                     OTHER_SLOT_RESOURCE_PROFILE)));
                             assertThat(declareResourceCount.get()).isEqualTo(0);
+                        });
+            }
+        };
+    }
+
+    /**
+     * Tests that un-registration of task managers will cause resource missing again in
+     * ResourceTracker.
+     */
+    @Test
+    void testTaskManagerUnregisterAfterResourceRequirements() throws Exception {
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setRequestSlotFunction(tuple6 -> new CompletableFuture<>())
+                        .createTestingTaskExecutorGateway();
+        final ResourceID resourceId = ResourceID.generate();
+        final TaskExecutorConnection taskManagerConnection =
+                new TaskExecutorConnection(resourceId, taskExecutorGateway);
+        final SlotReport slotReport =
+                new SlotReport(
+                        new SlotStatus(new SlotID(resourceId, 0), DEFAULT_SLOT_RESOURCE_PROFILE));
+        new Context() {
+            {
+                slotManagerConfigurationBuilder.setRequirementCheckDelay(Duration.ZERO);
+                runTest(
+                        () -> {
+                            final CompletableFuture<SlotManager.RegistrationResult>
+                                    registerTaskManagerFuture = new CompletableFuture<>();
+                            final CompletableFuture<Boolean> unRegisterTaskManagerFuture =
+                                    new CompletableFuture<>();
+                            runInMainThread(
+                                    () ->
+                                            registerTaskManagerFuture.complete(
+                                                    getSlotManager()
+                                                            .registerTaskManager(
+                                                                    taskManagerConnection,
+                                                                    slotReport,
+                                                                    DEFAULT_TOTAL_RESOURCE_PROFILE,
+                                                                    DEFAULT_SLOT_RESOURCE_PROFILE)));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
+                                    .isEqualTo(SlotManager.RegistrationResult.SUCCESS);
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .hasSize(1);
+                            assertThat(getTaskManagerTracker().getNumberFreeSlots()).isEqualTo(2);
+
+                            ResourceRequirements resourceRequirements =
+                                    createResourceRequirementsForSingleSlot();
+
+                            runInMainThreadAndWait(
+                                    () ->
+                                            getSlotManager()
+                                                    .processResourceRequirements(
+                                                            resourceRequirements));
+
+                            assertThat(getTaskManagerTracker().getFreeResource())
+                                    .isEqualTo(DEFAULT_SLOT_RESOURCE_PROFILE);
+                            assertThat(getResourceTracker().getMissingResources()).isEmpty();
+
+                            runInMainThread(
+                                    () ->
+                                            unRegisterTaskManagerFuture.complete(
+                                                    getSlotManager()
+                                                            .unregisterTaskManager(
+                                                                    taskManagerConnection
+                                                                            .getInstanceID(),
+                                                                    TEST_EXCEPTION)));
+
+                            assertThat(assertFutureCompleteAndReturn(unRegisterTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .isEmpty();
+                            assertThat(getResourceTracker().getMissingResources())
+                                    .containsKey(resourceRequirements.getJobId());
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -84,6 +84,15 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         };
     }
 
+    @Test
+    void testCloseAfterSuspendDoesNotThrowException() throws Exception {
+        new Context() {
+            {
+                runTest(() -> getSlotManager().suspend());
+            }
+        };
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Register / unregister TaskManager and and slot status reconciliation
     // ---------------------------------------------------------------------------------------------
@@ -672,12 +681,11 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
             {
                 resourceAllocatorBuilder.setDeclareResourceNeededConsumer(
                         (resourceDeclarations) -> {
-                            assertThat(resourceDeclarations.size()).isEqualTo(1);
+                            assertThat(resourceDeclarations).hasSize(1);
                             ResourceDeclaration resourceDeclaration =
                                     resourceDeclarations.iterator().next();
                             assertThat(resourceDeclaration.getNumNeeded()).isEqualTo(0);
-                            assertThat(resourceDeclaration.getUnwantedWorkers().size())
-                                    .isEqualTo(1);
+                            assertThat(resourceDeclaration.getUnwantedWorkers()).hasSize(1);
                             releaseResourceFuture.complete(
                                     resourceDeclaration.getUnwantedWorkers().iterator().next());
                         });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -212,15 +212,17 @@ abstract class FineGrainedSlotManagerTestBase {
         protected final void runTest(RunnableWithException testMethod) throws Exception {
             SlotManagerConfiguration configuration = slotManagerConfigurationBuilder.build();
             slotManager =
-                    new FineGrainedSlotManager(
-                            scheduledExecutor,
-                            configuration,
-                            slotManagerMetricGroup,
-                            resourceTracker,
-                            taskManagerTracker,
-                            slotStatusSyncer,
-                            getResourceAllocationStrategy(configuration)
-                                    .orElse(resourceAllocationStrategyBuilder.build()));
+                    FineGrainedSlotManagerBuilder.newBuilder(scheduledExecutor)
+                            .setSlotManagerConfiguration(configuration)
+                            .setSlotManagerMetricGroup(slotManagerMetricGroup)
+                            .setResourceTracker(resourceTracker)
+                            .setTaskManagerTracker(taskManagerTracker)
+                            .setSlotStatusSyncer(slotStatusSyncer)
+                            .setResourceAllocationStrategy(
+                                    getResourceAllocationStrategy(configuration)
+                                            .orElse(resourceAllocationStrategyBuilder.build()))
+                            .build();
+
             runInMainThreadAndWait(
                     () ->
                             slotManager.start(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
@@ -25,63 +25,62 @@ import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link FineGrainedTaskManagerTracker}. */
-public class FineGrainedTaskManagerTrackerTest extends TestLogger {
+class FineGrainedTaskManagerTrackerTest {
     private static final TaskExecutorConnection TASK_EXECUTOR_CONNECTION =
             new TaskExecutorConnection(
                     ResourceID.generate(),
                     new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
 
     @Test
-    public void testInitState() {
+    void testInitState() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
-        assertThat(taskManagerTracker.getPendingTaskManagers(), is(empty()));
-        assertThat(taskManagerTracker.getRegisteredTaskManagers(), is(empty()));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).isEmpty();
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).isEmpty();
     }
 
     @Test
-    public void testAddAndRemoveTaskManager() {
+    void testAddAndRemoveTaskManager() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
 
         // Add task manager
         taskManagerTracker.addTaskManager(
                 TASK_EXECUTOR_CONNECTION, ResourceProfile.ANY, ResourceProfile.ANY);
-        assertThat(taskManagerTracker.getRegisteredTaskManagers().size(), is(1));
-        assertTrue(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .isPresent());
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).hasSize(1);
+        assertThat(
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .isPresent();
 
         // Remove task manager
         taskManagerTracker.removeTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID());
-        assertThat(taskManagerTracker.getRegisteredTaskManagers().size(), is(0));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testRemoveUnknownTaskManager() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.removeTaskManager(new InstanceID());
+        assertThat(taskManagerTracker.getRegisteredTaskManagers()).isEmpty();
     }
 
     @Test
-    public void testAddAndRemovePendingTaskManager() {
+    void testRemoveUnknownTaskManager() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+                            taskManagerTracker.removeTaskManager(new InstanceID());
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testAddAndRemovePendingTaskManager() {
         final PendingTaskManager pendingTaskManager =
                 new PendingTaskManager(ResourceProfile.ANY, 1);
         final FineGrainedTaskManagerTracker taskManagerTracker =
@@ -96,45 +95,46 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 Collections.singletonMap(
                         pendingTaskManager.getPendingTaskManagerId(),
                         Collections.singletonMap(jobId, resourceCounter)));
-        assertThat(taskManagerTracker.getPendingTaskManagers().size(), is(1));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).hasSize(1);
         assertThat(
-                taskManagerTracker
-                        .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
-                                ResourceProfile.ANY, ResourceProfile.ANY)
-                        .size(),
-                is(1));
+                        taskManagerTracker
+                                .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
+                                        ResourceProfile.ANY, ResourceProfile.ANY))
+                .hasSize(1);
 
         // Remove pending task manager
         final Map<JobID, ResourceCounter> records =
                 taskManagerTracker.removePendingTaskManager(
                         pendingTaskManager.getPendingTaskManagerId());
-        assertThat(taskManagerTracker.getPendingTaskManagers(), is(empty()));
+        assertThat(taskManagerTracker.getPendingTaskManagers()).isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager.getPendingTaskManagerId())
-                        .size(),
-                is(0));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager.getPendingTaskManagerId()))
+                .isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
-                                ResourceProfile.ANY, ResourceProfile.ANY)
-                        .size(),
-                is(0));
-        assertTrue(records.containsKey(jobId));
-        assertThat(records.get(jobId).getResourceCount(ResourceProfile.ANY), is(1));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testRemoveUnknownPendingTaskManager() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.removePendingTaskManager(PendingTaskManagerId.generate());
+                        taskManagerTracker
+                                .getPendingTaskManagersByTotalAndDefaultSlotResourceProfile(
+                                        ResourceProfile.ANY, ResourceProfile.ANY))
+                .isEmpty();
+        assertThat(records).containsKey(jobId);
+        assertThat(records.get(jobId).getResourceCount(ResourceProfile.ANY)).isEqualTo(1);
     }
 
     @Test
-    public void testSlotAllocation() {
+    void testRemoveUnknownPendingTaskManager() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+
+                            taskManagerTracker.removePendingTaskManager(
+                                    PendingTaskManagerId.generate());
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testSlotAllocation() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -149,13 +149,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.PENDING);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(7, 800)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(7, 800)));
 
         // Notify pending slot is now allocated
         taskManagerTracker.notifySlotStatus(
@@ -164,13 +165,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.ALLOCATED);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(7, 800)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(7, 800)));
 
         // Notify free slot is now allocated
         taskManagerTracker.notifySlotStatus(
@@ -179,17 +181,18 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(2, 300),
                 SlotState.ALLOCATED);
-        assertTrue(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(5, 500)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(5, 500)));
     }
 
     @Test
-    public void testFreeSlot() {
+    void testFreeSlot() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -217,13 +220,14 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(3, 200),
                 SlotState.FREE);
-        assertFalse(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId1)).isNotPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(ResourceProfile.fromResources(8, 700)));
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(ResourceProfile.fromResources(8, 700)));
         // Free allocated slot
         taskManagerTracker.notifySlotStatus(
                 allocationId2,
@@ -231,30 +235,35 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 TASK_EXECUTOR_CONNECTION.getInstanceID(),
                 ResourceProfile.fromResources(2, 300),
                 SlotState.FREE);
-        assertFalse(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2).isPresent());
+        assertThat(taskManagerTracker.getAllocatedOrPendingSlot(allocationId2)).isNotPresent();
         assertThat(
-                taskManagerTracker
-                        .getRegisteredTaskManager(TASK_EXECUTOR_CONNECTION.getInstanceID())
-                        .get()
-                        .getAvailableResource(),
-                is(totalResource));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testFreeUnknownSlot() {
-        final FineGrainedTaskManagerTracker taskManagerTracker =
-                new FineGrainedTaskManagerTracker();
-
-        taskManagerTracker.notifySlotStatus(
-                new AllocationID(),
-                new JobID(),
-                new InstanceID(),
-                ResourceProfile.ANY,
-                SlotState.FREE);
+                        taskManagerTracker.getRegisteredTaskManager(
+                                TASK_EXECUTOR_CONNECTION.getInstanceID()))
+                .hasValueSatisfying(
+                        taskManagerInfo ->
+                                assertThat(taskManagerInfo.getAvailableResource())
+                                        .isEqualTo(totalResource));
     }
 
     @Test
-    public void testRecordPendingAllocations() {
+    void testFreeUnknownSlot() {
+        assertThatThrownBy(
+                        () -> {
+                            final FineGrainedTaskManagerTracker taskManagerTracker =
+                                    new FineGrainedTaskManagerTracker();
+
+                            taskManagerTracker.notifySlotStatus(
+                                    new AllocationID(),
+                                    new JobID(),
+                                    new InstanceID(),
+                                    ResourceProfile.ANY,
+                                    SlotState.FREE);
+                        })
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testRecordPendingAllocations() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final PendingTaskManager pendingTaskManager1 =
@@ -277,27 +286,24 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                         pendingTaskManager2.getPendingTaskManagerId(),
                         Collections.singletonMap(jobId, resourceCounter)));
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager1.getPendingTaskManagerId())
-                        .size(),
-                is(0));
-        assertTrue(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager2.getPendingTaskManagerId())
-                        .containsKey(jobId));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager1.getPendingTaskManagerId()))
+                .isEmpty();
         assertThat(
-                taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(
-                                pendingTaskManager2.getPendingTaskManagerId())
-                        .get(jobId)
-                        .getResourceCount(ResourceProfile.ANY),
-                is(1));
+                        taskManagerTracker.getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager2.getPendingTaskManagerId()))
+                .containsKey(jobId);
+        assertThat(
+                        taskManagerTracker
+                                .getPendingAllocationsOfPendingTaskManager(
+                                        pendingTaskManager2.getPendingTaskManagerId())
+                                .get(jobId)
+                                .getResourceCount(ResourceProfile.ANY))
+                .isEqualTo(1);
     }
 
     @Test
-    public void testGetStatistics() {
+    void testGetStatistics() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final ResourceProfile totalResource = ResourceProfile.fromResources(10, 1000);
@@ -322,11 +328,12 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
         taskManagerTracker.addPendingTaskManager(
                 new PendingTaskManager(ResourceProfile.fromResources(4, 200), 1));
 
-        assertThat(taskManagerTracker.getFreeResource(), is(ResourceProfile.fromResources(6, 700)));
-        assertThat(taskManagerTracker.getRegisteredResource(), is(totalResource));
-        assertThat(taskManagerTracker.getNumberRegisteredSlots(), is(10));
-        assertThat(taskManagerTracker.getNumberFreeSlots(), is(8));
-        assertThat(
-                taskManagerTracker.getPendingResource(), is(ResourceProfile.fromResources(4, 200)));
+        assertThat(taskManagerTracker.getFreeResource())
+                .isEqualTo(ResourceProfile.fromResources(6, 700));
+        assertThat(taskManagerTracker.getRegisteredResource()).isEqualTo(totalResource);
+        assertThat(taskManagerTracker.getNumberRegisteredSlots()).isEqualTo(10);
+        assertThat(taskManagerTracker.getNumberFreeSlots()).isEqualTo(8);
+        assertThat(taskManagerTracker.getPendingResource())
+                .isEqualTo(ResourceProfile.fromResources(4, 200));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -24,20 +24,24 @@ import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /** Testing implementation of the {@link ResourceAllocator}. */
 public class TestingResourceAllocator implements ResourceAllocator {
 
     @Nonnull private final Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer;
+    @Nonnull private final Supplier<Boolean> isSupportedSupplier;
 
     public TestingResourceAllocator(
-            @Nonnull Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
+            @Nonnull Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer,
+            @Nonnull Supplier<Boolean> isSupportedSupplier) {
         this.declareResourceNeededConsumer = declareResourceNeededConsumer;
+        this.isSupportedSupplier = isSupportedSupplier;
     }
 
     @Override
     public boolean isSupported() {
-        return true;
+        return isSupportedSupplier.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
@@ -20,11 +20,13 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import java.util.Collection;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /** Builder for the {@link TestingResourceAllocator}. */
 public class TestingResourceAllocatorBuilder {
     private Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer =
             (ignored) -> {};
+    private Supplier<Boolean> isSupportedSupplier = () -> true;
 
     public TestingResourceAllocatorBuilder setDeclareResourceNeededConsumer(
             Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
@@ -32,7 +34,11 @@ public class TestingResourceAllocatorBuilder {
         return this;
     }
 
+    public void setIsSupportedSupplier(Supplier<Boolean> isSupportedSupplier) {
+        this.isSupportedSupplier = isSupportedSupplier;
+    }
+
     public TestingResourceAllocator build() {
-        return new TestingResourceAllocator(declareResourceNeededConsumer);
+        return new TestingResourceAllocator(declareResourceNeededConsumer, isSupportedSupplier);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/MockResourceManagerRuntimeServices.java
@@ -25,13 +25,10 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.DefaultJobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
-import org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManagerBuilder;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
-import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
-import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -45,18 +42,6 @@ public class MockResourceManagerRuntimeServices {
     public final TestingLeaderElectionService rmLeaderElectionService;
     public final JobLeaderIdService jobLeaderIdService;
     public final SlotManager slotManager;
-
-    public MockResourceManagerRuntimeServices(RpcService rpcService) {
-        this(
-                rpcService,
-                DeclarativeSlotManagerBuilder.newBuilder(
-                                new ScheduledExecutorServiceAdapter(
-                                        new DirectScheduledExecutorService()))
-                        .setTaskManagerRequestTimeout(Time.seconds(10))
-                        .setSlotRequestTimeout(Time.seconds(10))
-                        .setTaskManagerTimeout(Time.minutes(1))
-                        .build());
-    }
 
     public MockResourceManagerRuntimeServices(RpcService rpcService, SlotManager slotManager) {
         this.rpcService = checkNotNull(rpcService);


### PR DESCRIPTION
## What is the purpose of the change
Aligning unit tests of FineGrainedSlotManager with DeclarativeSlotManager
The unit test diff between FGSM and DSM are list in : https://docs.google.com/spreadsheets/d/1km5gwECvdC0pu6HwvjBfBdHB4RIXYn5ls7AggHkH3Hk/edit#gid=0

## Brief change log
  - *Let ResourceManagerTest run with DeclarativeSlotManager and FineGrainedSlotManager*
  - *Add some unit tests for FineGrainedSlotManager*


## Verifying this change
  - *This change is only about unit tests*

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
