### PR TITLE
[FLINK-31518][Runtime / REST] Fix StandaloneHaServices#getClusterRestEndpointLeaderRetreiver to return correct rest port

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -176,6 +176,10 @@ public class DefaultDispatcherResourceManagerComponentFactory
             log.debug("Starting Dispatcher REST endpoint.");
             webMonitorEndpoint.start();
 
+            configuration.setInteger(RestOptions.PORT, webMonitorEndpoint.getRestPort());
+            configuration.setString(
+                    RestOptions.ADDRESS, webMonitorEndpoint.getServerAddress().getHostString());
+
             final String hostname = RpcUtils.getHostname(rpcService);
 
             resourceManagerService =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ClientHighAvailabilityServices.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.highavailability;
 
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 
+import java.net.UnknownHostException;
+
 /**
  * {@code ClientHighAvailabilityServices} provides services those are required on client-side. At
  * the moment only the REST endpoint leader retriever is required because all communication between
@@ -32,5 +34,5 @@ public interface ClientHighAvailabilityServices extends AutoCloseable {
      *
      * @return the leader retriever for cluster's rest endpoint.
      */
-    LeaderRetrievalService getClusterRestEndpointLeaderRetriever();
+    LeaderRetrievalService getClusterRestEndpointLeaderRetriever() throws UnknownHostException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -202,7 +203,8 @@ public interface HighAvailabilityServices
     }
 
     @Override
-    default LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+    default LeaderRetrievalService getClusterRestEndpointLeaderRetriever()
+            throws UnknownHostException {
         // for backwards compatibility we delegate to getWebMonitorLeaderRetriever
         // all implementations of this interface should override
         // getClusterRestEndpointLeaderRetriever, though

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -128,11 +128,9 @@ public class HighAvailabilityServicesUtils {
                                 RpcServiceUtils.createWildcardName(Dispatcher.DISPATCHER_NAME),
                                 addressResolution,
                                 configuration);
-                final String webMonitorAddress =
-                        getWebMonitorAddress(configuration, addressResolution);
 
                 return new StandaloneHaServices(
-                        resourceManagerRpcUrl, dispatcherRpcUrl, webMonitorAddress);
+                        resourceManagerRpcUrl, dispatcherRpcUrl, configuration);
             case ZOOKEEPER:
                 return createZooKeeperHaServices(configuration, executor, fatalErrorHandler);
             case KUBERNETES:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.util.Preconditions;
@@ -41,7 +40,7 @@ public class MiniClusterConfiguration {
 
     static final int DEFAULT_IO_POOL_SIZE = 4;
 
-    private final UnmodifiableConfiguration configuration;
+    private final Configuration configuration;
 
     private final int numTaskManagers;
 
@@ -72,7 +71,7 @@ public class MiniClusterConfiguration {
         this.pluginManager = pluginManager;
     }
 
-    private UnmodifiableConfiguration generateConfiguration(final Configuration configuration) {
+    private Configuration generateConfiguration(final Configuration configuration) {
         final Configuration modifiedConfig = new Configuration(configuration);
 
         TaskExecutorResourceUtils.adjustForLocalExecution(modifiedConfig);
@@ -94,7 +93,7 @@ public class MiniClusterConfiguration {
             modifiedConfig.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofMinutes(5L));
         }
 
-        return new UnmodifiableConfiguration(modifiedConfig);
+        return new Configuration(modifiedConfig);
     }
 
     // ------------------------------------------------------------------------
@@ -146,7 +145,7 @@ public class MiniClusterConfiguration {
                 : configuration.getString(TaskManagerOptions.BIND_HOST, "localhost");
     }
 
-    public UnmodifiableConfiguration getConfiguration() {
+    public Configuration getConfiguration() {
         return configuration;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.highavailability.nonha.standalone;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
@@ -39,16 +40,14 @@ public class StandaloneHaServicesTest extends TestLogger {
 
     private final String dispatcherAddress = "dispatcher";
     private final String resourceManagerAddress = "resourceManager";
-    private final String webMonitorAddress = "webMonitor";
 
     private StandaloneHaServices standaloneHaServices;
 
     @Before
     public void setupTest() {
-
+        Configuration config = new Configuration();
         standaloneHaServices =
-                new StandaloneHaServices(
-                        resourceManagerAddress, dispatcherAddress, webMonitorAddress);
+                new StandaloneHaServices(resourceManagerAddress, dispatcherAddress, config);
     }
 
     @After


### PR DESCRIPTION


## What is the purpose of the change

Currently, `StandaloneHaServices#getClusterRestEndpointLeaderRetreiver` returns wrong rest port when a range of ports is configured in rest.port. This patch addresses the same.

## Brief change log

`DefaultDispatcherResourceManagerComponentFactory` sets the configuration with the rest address and rest port, from which the `StandaloneHaServices#getClusterRestEndpointLeaderRetriever` retrieves the address and port.


## Verifying this change

This change added tests and can be verified as follows:

1. Run a flink job with config rest.port set to a range say 50200-50300.
2. Included below code in a thread launched by the Adaptive Scheduler.
```
LeaderRetrievalService webMonitorRetrievalService = highAvailabilityServices.getClusterRestEndpointLeaderRetriever();
try {
webMonitorRetrievalService.start(new WebMonitorLeaderListener());
} catch (Exception e) {
throw new RuntimeException(e);
}

private class WebMonitorLeaderListener implements LeaderRetrievalListener {
@OverRide
public void notifyLeaderAddress(final String leaderAddress, final UUID leaderSessionID) {
System.out.println(leaderAddress);
}
```

3. The leader address printed is the correct one which RestServerEndpoint listens.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) 
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
