### PR TITLE
[FLINK-31652][k8s] Handle the deleted event in case pod is deleted during the pending phase

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -185,6 +185,18 @@ class KubernetesResourceManagerDriverTest
     }
 
     @Test
+    void testOnPodDeletedWithDeletedEvent() throws Exception {
+        new Context() {
+            {
+                // If the pod is deleted during the pending phase, we cannot detect the pod is
+                // terminated because its status won't be updated, but should handle the deleted
+                // event
+                testOnPodTerminated((pod) -> getPodCallbackHandler().onDeleted(pod), false, false);
+            }
+        };
+    }
+
+    @Test
     void testOnError() throws Exception {
         new Context() {
             {
@@ -499,6 +511,14 @@ class KubernetesResourceManagerDriverTest
 
         void testOnPodTerminated(Consumer<List<KubernetesPod>> sendPodTerminatedEvent)
                 throws Exception {
+            testOnPodTerminated(sendPodTerminatedEvent, true, true);
+        }
+
+        void testOnPodTerminated(
+                Consumer<List<KubernetesPod>> sendPodTerminatedEvent,
+                boolean isPodScheduled,
+                boolean isPodTerminated)
+                throws Exception {
             final CompletableFuture<KubernetesWorkerNode> requestResourceFuture =
                     new CompletableFuture<>();
             final CompletableFuture<ResourceID> onWorkerTerminatedConsumer =
@@ -537,7 +557,8 @@ class KubernetesResourceManagerDriverTest
 
                         sendPodTerminatedEvent.accept(
                                 Collections.singletonList(
-                                        new TestingKubernetesPod(pod.getName(), true, true)));
+                                        new TestingKubernetesPod(
+                                                pod.getName(), isPodScheduled, isPodTerminated)));
 
                         // make sure finishing validation
                         validationFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently,  in kubernetes deployment, if the taskmanager pod is deleted in 'Pending' phase, the flink job will get stuck and keep waiting for the pod scheduled. The cause reason is that the pod status will not be updated in time, so the KubernetesResourceManagerDriver won't detect the pod is terminated, but should handle the deleted event.


## Brief change log
  -  The method KubernetesResourceManagerDriver#handlePodEventsInMainThread handle the deleted event


## Verifying this change
  -  Add UT in `KubernetesResourceManagerDriverTest#testOnPodDeletedWithDeletedEvent`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
