### PR TITLE
[FLINK-31677][table] Add built-in MAP_ENTRIES function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -652,6 +652,9 @@ collection:
   - sql: MAP_VALUES(map)
     table: MAP.mapValues()
     description: Returns the values of the map as array. No order guaranteed.
+  - sql: MAP_ENTRIES(map)
+    table: MAP.mapEntries()
+    description: Returns an unordered array of all entries in the given map. No order guaranteed.
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -654,7 +654,7 @@ collection:
     description: Returns the values of the map as array. No order guaranteed.
   - sql: MAP_ENTRIES(map)
     table: MAP.mapEntries()
-    description: Returns an unordered array of all entries in the given map. No order guaranteed.
+    description: Returns an array of all entries in the given map. No order guaranteed.
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -233,6 +233,7 @@ advanced type helper functions
     Expression.array_union
     Expression.map_keys
     Expression.map_values
+    Expression.map_entries
 
 
 time definition functions

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -231,9 +231,9 @@ advanced type helper functions
     Expression.array_remove
     Expression.array_reverse
     Expression.array_union
+    Expression.map_entries
     Expression.map_keys
     Expression.map_values
-    Expression.map_entries
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1540,7 +1540,7 @@ class Expression(Generic[T]):
     @property
     def map_entries(self) -> 'Expression':
         """
-        Returns an unordered array of all entries in the given map. No order guaranteed.
+        Returns an array of all entries in the given map. No order guaranteed.
 
         .. seealso:: :py:attr:`~Expression.map_entries`
         """

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1524,7 +1524,7 @@ class Expression(Generic[T]):
         """
         Returns the keys of the map as an array. No order guaranteed.
 
-        .. seealso:: :py:attr:`~Expression.map_values`
+        .. seealso:: :py:attr:`~Expression.map_keys`
         """
         return _unary_op("mapKeys")(self)
 
@@ -1533,9 +1533,18 @@ class Expression(Generic[T]):
         """
         Returns the values of the map as an array. No order guaranteed.
 
-        .. seealso:: :py:attr:`~Expression.map_keys`
+        .. seealso:: :py:attr:`~Expression.map_values`
         """
         return _unary_op("mapValues")(self)
+
+    @property
+    def map_entries(self) -> 'Expression':
+        """
+        Returns an unordered array of all entries in the given map. No order guaranteed.
+
+        .. seealso:: :py:attr:`~Expression.map_entries`
+        """
+        return _unary_op("mapEntries")(self)
 
     # ---------------------------- time definition functions -----------------------------
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -122,6 +122,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOG2;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOWER;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LPAD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LTRIM;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_ENTRIES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_KEYS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_VALUES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAX;
@@ -1415,6 +1416,11 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns the values of the map as an array. */
     public OutType mapValues() {
         return toApiSpecificExpression(unresolvedCall(MAP_VALUES, toExpr()));
+    }
+
+    /** Returns an unordered array of all entries in the given map. */
+    public OutType mapEntries() {
+        return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
     }
 
     // Time definition

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1418,7 +1418,7 @@ public abstract class BaseExpressions<InType, OutType> {
         return toApiSpecificExpression(unresolvedCall(MAP_VALUES, toExpr()));
     }
 
-    /** Returns an unordered array of all entries in the given map. */
+    /** Returns an array of all entries in the given map. */
     public OutType mapEntries() {
         return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -139,7 +139,7 @@ public final class BuiltInFunctionDefinitions {
                             sequence(
                                     new String[] {"input"},
                                     new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
-                    .outputTypeStrategy(nullableIfArgs(SpecificInputTypeStrategies.MAP_KEYS))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_KEYS))
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.MapKeysFunction")
                     .build();
 
@@ -151,9 +151,22 @@ public final class BuiltInFunctionDefinitions {
                             sequence(
                                     new String[] {"input"},
                                     new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
-                    .outputTypeStrategy(nullableIfArgs(SpecificInputTypeStrategies.MAP_VALUES))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_VALUES))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.MapValuesFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition MAP_ENTRIES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_ENTRIES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    new String[] {"input"},
+                                    new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_ENTRIES))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapEntriesFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition MAP_FROM_ARRAYS =
@@ -167,7 +180,7 @@ public final class BuiltInFunctionDefinitions {
                                         logical(LogicalTypeRoot.ARRAY),
                                         logical(LogicalTypeRoot.ARRAY)
                                     }))
-                    .outputTypeStrategy(nullableIfArgs(SpecificInputTypeStrategies.ARRAYS_FOR_MAP))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_FROM_ARRAYS))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.MapFromArraysFunction")
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -19,21 +19,15 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.JsonOnNull;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
-import org.apache.flink.table.types.CollectionDataType;
-import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
-import org.apache.flink.table.types.inference.TypeStrategy;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.StructuredType;
-
-import java.util.Optional;
 
 import static org.apache.flink.table.types.inference.InputTypeStrategies.LITERAL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
@@ -59,7 +53,7 @@ public final class SpecificInputTypeStrategies {
     /** See {@link MapInputTypeStrategy}. */
     public static final InputTypeStrategy MAP = new MapInputTypeStrategy();
 
-    /** See {@link CurrentWatermarkTypeStrategy}. */
+    /** See {@link CurrentWatermarkInputTypeStrategy}. */
     public static final InputTypeStrategy CURRENT_WATERMARK =
             new CurrentWatermarkInputTypeStrategy();
 
@@ -125,32 +119,6 @@ public final class SpecificInputTypeStrategies {
      */
     public static final InputTypeStrategy TWO_EQUALS_COMPARABLE =
             comparable(ConstantArgumentCount.of(2), StructuredType.StructuredComparison.EQUALS);
-
-    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_KEYS}. */
-    public static final TypeStrategy MAP_KEYS =
-            callContext ->
-                    Optional.of(
-                            DataTypes.ARRAY(
-                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
-                                            .getKeyDataType()));
-
-    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_VALUES}. */
-    public static final TypeStrategy MAP_VALUES =
-            callContext ->
-                    Optional.of(
-                            DataTypes.ARRAY(
-                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
-                                            .getValueDataType()));
-
-    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ARRAYS}. */
-    public static final TypeStrategy ARRAYS_FOR_MAP =
-            callContext ->
-                    Optional.of(
-                            DataTypes.MAP(
-                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(0))
-                                            .getElementDataType(),
-                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(1))
-                                            .getElementDataType()));
 
     private SpecificInputTypeStrategies() {
         // no instantiation

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -117,16 +117,20 @@ public final class SpecificTypeStrategies {
                     Optional.of(
                             DataTypes.ARRAY(
                                     DataTypes.ROW(
-                                            ((KeyValueDataType)
-                                                            callContext
-                                                                    .getArgumentDataTypes()
-                                                                    .get(0))
-                                                    .getKeyDataType(),
-                                            ((KeyValueDataType)
-                                                            callContext
-                                                                    .getArgumentDataTypes()
-                                                                    .get(0))
-                                                    .getValueDataType())));
+                                            DataTypes.FIELD(
+                                                    "key",
+                                                    ((KeyValueDataType)
+                                                                    callContext
+                                                                            .getArgumentDataTypes()
+                                                                            .get(0))
+                                                            .getKeyDataType()),
+                                            DataTypes.FIELD(
+                                                    "value",
+                                                    ((KeyValueDataType)
+                                                                    callContext
+                                                                            .getArgumentDataTypes()
+                                                                            .get(0))
+                                                            .getValueDataType()))));
 
     /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ARRAYS}. */
     public static final TypeStrategy MAP_FROM_ARRAYS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -19,8 +19,14 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.Optional;
 
 /**
  * Entry point for specific type strategies not covered in {@link TypeStrategies}.
@@ -88,6 +94,49 @@ public final class SpecificTypeStrategies {
 
     /** See {@link ToTimestampLtzTypeStrategy}. */
     public static final TypeStrategy TO_TIMESTAMP_LTZ = new ToTimestampLtzTypeStrategy();
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_KEYS}. */
+    public static final TypeStrategy MAP_KEYS =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getKeyDataType()));
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_VALUES}. */
+    public static final TypeStrategy MAP_VALUES =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getValueDataType()));
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_ENTRIES}. */
+    public static final TypeStrategy MAP_ENTRIES =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    DataTypes.ROW(
+                                            ((KeyValueDataType)
+                                                            callContext
+                                                                    .getArgumentDataTypes()
+                                                                    .get(0))
+                                                    .getKeyDataType(),
+                                            ((KeyValueDataType)
+                                                            callContext
+                                                                    .getArgumentDataTypes()
+                                                                    .get(0))
+                                                    .getValueDataType())));
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ARRAYS}. */
+    public static final TypeStrategy MAP_FROM_ARRAYS =
+            callContext ->
+                    Optional.of(
+                            DataTypes.MAP(
+                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getElementDataType(),
+                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(1))
+                                            .getElementDataType()));
 
     private SpecificTypeStrategies() {
         // no instantiation

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -326,23 +326,30 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                 new Row[] {Row.of(null, "item")},
                                 DataTypes.ARRAY(
                                                 DataTypes.ROW(
-                                                        DataTypes.BOOLEAN(), DataTypes.STRING()))
+                                                        DataTypes.FIELD("key", DataTypes.BOOLEAN()),
+                                                        DataTypes.FIELD(
+                                                                "value", DataTypes.STRING())))
                                         .notNull())
                         .testResult(
                                 $("f2").mapEntries(),
                                 "MAP_ENTRIES(f2)",
                                 new Row[] {Row.of(1, "value1")},
-                                DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT(), DataTypes.STRING())))
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD("value", DataTypes.STRING()))))
                         .testResult(
                                 $("f3").mapEntries(),
                                 "MAP_ENTRIES(f3)",
                                 new Row[] {Row.of(3, Collections.singletonMap(true, "value2"))},
                                 DataTypes.ARRAY(
                                         DataTypes.ROW(
-                                                DataTypes.INT(),
-                                                DataTypes.MAP(
-                                                        DataTypes.BOOLEAN(),
-                                                        DataTypes.STRING())))));
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD(
+                                                        "value",
+                                                        DataTypes.MAP(
+                                                                DataTypes.BOOLEAN(),
+                                                                DataTypes.STRING()))))));
     }
 
     private Stream<TestSetSpec> mapFromArraysTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapEntriesFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.KeyValueDataType;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_ENTRIES}. */
+@Internal
+public class MapEntriesFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter keyElementGetter;
+    private final ArrayData.ElementGetter valueElementGetter;
+
+    public MapEntriesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_ENTRIES, context);
+        KeyValueDataType inputType =
+                ((KeyValueDataType) context.getCallContext().getArgumentDataTypes().get(0));
+        keyElementGetter =
+                ArrayData.createElementGetter(inputType.getKeyDataType().getLogicalType());
+        valueElementGetter =
+                ArrayData.createElementGetter(inputType.getValueDataType().getLogicalType());
+    }
+
+    public @Nullable ArrayData eval(@Nullable MapData input) {
+        if (input == null) {
+            return null;
+        }
+
+        ArrayData keys = input.keyArray();
+        ArrayData values = input.valueArray();
+        int size = input.size();
+
+        Object[] resultData = new Object[size];
+        for (int pos = 0; pos < size; pos++) {
+            final Object key = keyElementGetter.getElementOrNull(keys, pos);
+            final Object value = valueElementGetter.getElementOrNull(values, pos);
+            resultData[pos] = GenericRowData.of(key, value);
+        }
+        return new GenericArrayData(resultData);
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of MAP_ENTRIES

- Brief change log
MAP_ENTRIES for Table API and SQL
    
```
map_entries(map) - Returns an unordered array of all entries in the given map.
Syntax:
    map_entries(map)
Arguments:
    map: An MAP to be handled.
Returns:Returns an unordered array of all entries in the given map. Returns null if the argument is null

> SELECT map_entries(map[1, 'a', 2, 'b']);
 [(1,"a"),(2,"b")] 
```


See also
presto https://prestodb.io/docs/current/functions/map.html
spark https://spark.apache.org/docs/latest/api/sql/index.html#map_entries

- Verifying this change
This change added tests in MapFunctionITCase.

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)