### PR TITLE
[FLINK-31638][network] Downstream supports reading buffers from tiered store

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -221,7 +221,8 @@ public class NettyShuffleServiceFactory
                         connectionManager,
                         resultPartitionManager,
                         taskEventPublisher,
-                        networkBufferPool);
+                        networkBufferPool,
+                        config.getTieredStorageConfiguration());
 
         return new NettyShuffleEnvironment(
                 taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerClient;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -213,6 +214,9 @@ public class SingleInputGate extends IndexedInputGate {
     private final BufferDebloater bufferDebloater;
     private boolean shouldDrainOnEndOfData = true;
 
+    // The consumer client will be null if the tiered storage is not enabled.
+    @Nullable private final TieredStorageConsumerClient tieredStorageConsumerClient;
+
     public SingleInputGate(
             String owningTaskName,
             int gateIndex,
@@ -226,7 +230,8 @@ public class SingleInputGate extends IndexedInputGate {
             MemorySegmentProvider memorySegmentProvider,
             int segmentSize,
             ThroughputCalculator throughputCalculator,
-            @Nullable BufferDebloater bufferDebloater) {
+            @Nullable BufferDebloater bufferDebloater,
+            @Nullable TieredStorageConsumerClient tieredStorageConsumerClient) {
 
         this.owningTaskName = checkNotNull(owningTaskName);
         Preconditions.checkArgument(0 <= gateIndex, "The gate index must be positive.");
@@ -259,6 +264,8 @@ public class SingleInputGate extends IndexedInputGate {
         this.unpooledSegment = MemorySegmentFactory.allocateUnpooledSegment(segmentSize);
         this.bufferDebloater = bufferDebloater;
         this.throughputCalculator = checkNotNull(throughputCalculator);
+
+        this.tieredStorageConsumerClient = tieredStorageConsumerClient;
     }
 
     protected PrioritizedDeque<InputChannel> getInputChannelsWithData() {
@@ -313,6 +320,12 @@ public class SingleInputGate extends IndexedInputGate {
             }
 
             requestedPartitionsFlag = true;
+            // Start the reader only when all InputChannels have been converted to either
+            // LocalInputChannel or RemoteInputChannel, as this will prevent RecoveredInputChannels
+            // from being queued again.
+            if (enabledTieredStore()) {
+                tieredStorageConsumerClient.start();
+            }
         }
     }
 
@@ -692,6 +705,9 @@ public class SingleInputGate extends IndexedInputGate {
             synchronized (inputChannelsWithData) {
                 inputChannelsWithData.notifyAll();
             }
+            if (enabledTieredStore()) {
+                tieredStorageConsumerClient.close();
+            }
         }
     }
 
@@ -745,9 +761,7 @@ public class SingleInputGate extends IndexedInputGate {
         if (closeFuture.isDone()) {
             throw new CancelTaskException("Input gate is already closed.");
         }
-
-        Optional<InputWithData<InputChannel, BufferAndAvailability>> next =
-                waitAndGetNextData(blocking);
+        Optional<InputWithData<InputChannel, Buffer>> next = waitAndGetNextData(blocking);
         if (!next.isPresent()) {
             throughputCalculator.pauseMeasurement();
             return Optional.empty();
@@ -755,10 +769,10 @@ public class SingleInputGate extends IndexedInputGate {
 
         throughputCalculator.resumeMeasurement();
 
-        InputWithData<InputChannel, BufferAndAvailability> inputWithData = next.get();
+        InputWithData<InputChannel, Buffer> inputWithData = next.get();
         final BufferOrEvent bufferOrEvent =
                 transformToBufferOrEvent(
-                        inputWithData.data.buffer(),
+                        inputWithData.data,
                         inputWithData.moreAvailable,
                         inputWithData.input,
                         inputWithData.morePriorityEvents);
@@ -766,8 +780,8 @@ public class SingleInputGate extends IndexedInputGate {
         return Optional.of(bufferOrEvent);
     }
 
-    private Optional<InputWithData<InputChannel, BufferAndAvailability>> waitAndGetNextData(
-            boolean blocking) throws IOException, InterruptedException {
+    private Optional<InputWithData<InputChannel, Buffer>> waitAndGetNextData(boolean blocking)
+            throws IOException, InterruptedException {
         while (true) {
             synchronized (inputChannelsWithData) {
                 Optional<InputChannel> inputChannelOpt = getChannel(blocking);
@@ -776,40 +790,59 @@ public class SingleInputGate extends IndexedInputGate {
                 }
 
                 final InputChannel inputChannel = inputChannelOpt.get();
-                Optional<BufferAndAvailability> bufferAndAvailabilityOpt =
-                        inputChannel.getNextBuffer();
-
-                if (!bufferAndAvailabilityOpt.isPresent()) {
+                Optional<Buffer> buffer;
+                if (enabledTieredStore()) {
+                    buffer = readBufferFromTieredStore(inputChannel.getChannelIndex());
+                } else {
+                    buffer = readBufferFromInputChannel(inputChannel);
+                }
+                if (!buffer.isPresent()) {
                     checkUnavailability();
                     continue;
                 }
 
-                final BufferAndAvailability bufferAndAvailability = bufferAndAvailabilityOpt.get();
-                if (bufferAndAvailability.moreAvailable()) {
-                    // enqueue the inputChannel at the end to avoid starvation
-                    queueChannelUnsafe(inputChannel, bufferAndAvailability.morePriorityEvents());
-                }
-
                 final boolean morePriorityEvents =
                         inputChannelsWithData.getNumPriorityElements() > 0;
-                if (bufferAndAvailability.hasPriority()) {
-                    lastPrioritySequenceNumber[inputChannel.getChannelIndex()] =
-                            bufferAndAvailability.getSequenceNumber();
+                if (buffer.get().getDataType().hasPriority()) {
                     if (!morePriorityEvents) {
                         priorityAvailabilityHelper.resetUnavailable();
                     }
                 }
-
                 checkUnavailability();
-
                 return Optional.of(
                         new InputWithData<>(
                                 inputChannel,
-                                bufferAndAvailability,
+                                buffer.get(),
                                 !inputChannelsWithData.isEmpty(),
                                 morePriorityEvents));
             }
         }
+    }
+
+    private Optional<Buffer> readBufferFromInputChannel(InputChannel inputChannel)
+            throws IOException, InterruptedException {
+        Optional<BufferAndAvailability> bufferAndAvailabilityOpt = inputChannel.getNextBuffer();
+        if (!bufferAndAvailabilityOpt.isPresent()) {
+            return Optional.empty();
+        }
+        final BufferAndAvailability bufferAndAvailability = bufferAndAvailabilityOpt.get();
+        if (bufferAndAvailability.moreAvailable()) {
+            // enqueue the inputChannel at the end to avoid starvation
+            queueChannelUnsafe(inputChannel, bufferAndAvailability.morePriorityEvents());
+        }
+        if (bufferAndAvailability.hasPriority()) {
+            lastPrioritySequenceNumber[inputChannel.getChannelIndex()] =
+                    bufferAndAvailability.getSequenceNumber();
+        }
+        return Optional.of(bufferAndAvailability.buffer());
+    }
+
+    private Optional<Buffer> readBufferFromTieredStore(int subpartitionId) {
+        return checkNotNull(tieredStorageConsumerClient).getNextBuffer(subpartitionId);
+    }
+
+    private boolean enabledTieredStore() {
+        return tieredStorageConsumerClient != null;
     }
 
     private void checkUnavailability() {
@@ -946,7 +979,9 @@ public class SingleInputGate extends IndexedInputGate {
     @Override
     public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
         checkState(!isFinished(), "InputGate already finished.");
-        channels[channelInfo.getInputChannelIdx()].acknowledgeAllRecordsProcessed();
+        if (!enabledTieredStore()) {
+            channels[channelInfo.getInputChannelIdx()].acknowledgeAllRecordsProcessed();
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -94,7 +94,9 @@ public class SingleInputGateFactory {
 
     private final BufferDebloatConfiguration debloatConfiguration;
 
-    private final TieredStorageConfiguration tieredStorageConfiguration;
+    @Nullable
+    private final TieredStorageConfiguration
+            tieredStorageConfiguration; // is null if tiered storage shuffle is disabled.
 
     public SingleInputGateFactory(
             @Nonnull ResourceID taskExecutorResourceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
@@ -18,5 +18,50 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
-/** Client of the Tiered Storage used by the consumer. */
-public class TieredStorageConsumerClient {}
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** {@link TieredStorageConsumerClient} is used to read buffer from tiered store. */
+public class TieredStorageConsumerClient {
+
+    private final List<TierConsumerAgent> tierConsumerAgents;
+
+    public TieredStorageConsumerClient(List<TierFactory> tierFactories) {
+        this.tierConsumerAgents = createTierConsumerAgents(tierFactories);
+    }
+
+    public void start() {
+        for (TierConsumerAgent tierConsumerAgent : tierConsumerAgents) {
+            tierConsumerAgent.start();
+        }
+    }
+
+    public Optional<Buffer> getNextBuffer(int subpartitionId) {
+        // TODO, the detailed logic will be completed when the memory tier is introduced..
+        return Optional.empty();
+    }
+
+    public void close() throws IOException {
+        for (TierConsumerAgent tierConsumerAgent : tierConsumerAgents) {
+            tierConsumerAgent.close();
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    //  Internal methods
+    // --------------------------------------------------------------------------------------------
+
+    private List<TierConsumerAgent> createTierConsumerAgents(List<TierFactory> tierFactories) {
+        ArrayList<TierConsumerAgent> tierConsumerAgents = new ArrayList<>();
+        for (TierFactory tierFactory : tierFactories) {
+            tierConsumerAgents.add(tierFactory.createConsumerAgent());
+        }
+        return tierConsumerAgents;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierConsumerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierConsumerAgent.java
@@ -18,5 +18,23 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
 
-/** The consumer-side agent of a Tier. */
-public interface TierConsumerAgent {}
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * The {@link TierConsumerAgent} is the consumer agent of each tier in tiered store, which could
+ * read data from responding tier.
+ */
+public interface TierConsumerAgent {
+
+    /** Start the consumer agent. */
+    void start();
+
+    /** Get buffer from the consumer agent. */
+    Optional<Buffer> getNextBuffer(int subpartitionId, int segmentId);
+
+    /** Close the consumer agent. */
+    void close() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.util.Preconditions;
@@ -108,6 +109,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final long hybridShuffleNumRetainedInMemoryRegionsMax;
 
+    private final TieredStorageConfiguration tieredStorageConfiguration;
+
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
@@ -132,7 +135,8 @@ public class NettyShuffleEnvironmentConfiguration {
             boolean connectionReuseEnabled,
             int maxOverdraftBuffersPerGate,
             int hybridShuffleSpilledIndexSegmentSize,
-            long hybridShuffleNumRetainedInMemoryRegionsMax) {
+            long hybridShuffleNumRetainedInMemoryRegionsMax,
+            @Nullable TieredStorageConfiguration tieredStorageConfiguration) {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
@@ -159,6 +163,7 @@ public class NettyShuffleEnvironmentConfiguration {
         this.hybridShuffleSpilledIndexSegmentSize = hybridShuffleSpilledIndexSegmentSize;
         this.hybridShuffleNumRetainedInMemoryRegionsMax =
                 hybridShuffleNumRetainedInMemoryRegionsMax;
+        this.tieredStorageConfiguration = tieredStorageConfiguration;
     }
 
     // ------------------------------------------------------------------------
@@ -261,6 +266,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
     public int getHybridShuffleSpilledIndexSegmentSize() {
         return hybridShuffleSpilledIndexSegmentSize;
+    }
+
+    public TieredStorageConfiguration getTieredStorageConfiguration() {
+        return tieredStorageConfiguration;
     }
 
     // ------------------------------------------------------------------------
@@ -387,6 +396,8 @@ public class NettyShuffleEnvironmentConfiguration {
                         "The configured floating buffer should be at least 1, please increase the value of %s.",
                         NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.key()));
 
+        TieredStorageConfiguration tieredStorageConfiguration = null;
+
         return new NettyShuffleEnvironmentConfiguration(
                 numberOfNetworkBuffers,
                 pageSize,
@@ -411,7 +422,8 @@ public class NettyShuffleEnvironmentConfiguration {
                 connectionReuseEnabled,
                 maxOverdraftBuffersPerGate,
                 hybridShuffleSpilledIndexSegmentSize,
-                hybridShuffleNumRetainedInMemoryRegionsMax);
+                hybridShuffleNumRetainedInMemoryRegionsMax,
+                tieredStorageConfiguration);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -396,6 +396,7 @@ public class NettyShuffleEnvironmentConfiguration {
                         "The configured floating buffer should be at least 1, please increase the value of %s.",
                         NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.key()));
 
+        // TODO: use TieredStorageConfiguration.fromConfiguration() when enabling the feature
         TieredStorageConfiguration tieredStorageConfiguration = null;
 
         return new NettyShuffleEnvironmentConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartitionType;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageConfiguration;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
@@ -94,6 +95,8 @@ public class NettyShuffleEnvironmentBuilder {
     private long hybridShuffleNumRetainedInMemoryRegionsMax = Long.MAX_VALUE;
 
     private int hybridShuffleSpilledIndexSegmentSize = 256;
+
+    private TieredStorageConfiguration tieredStorageConfiguration = null;
 
     public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
         this.taskManagerLocation = taskManagerLocation;
@@ -230,6 +233,12 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setTieredStorageConfiguration(
+            TieredStorageConfiguration tieredStorageConfiguration) {
+        this.tieredStorageConfiguration = tieredStorageConfiguration;
+        return this;
+    }
+
     public NettyShuffleEnvironment build() {
         return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
                 new NettyShuffleEnvironmentConfiguration(
@@ -256,7 +265,8 @@ public class NettyShuffleEnvironmentBuilder {
                         connectionReuseEnabled,
                         maxOverdraftBuffersPerGate,
                         hybridShuffleSpilledIndexSegmentSize,
-                        hybridShuffleNumRetainedInMemoryRegionsMax),
+                        hybridShuffleNumRetainedInMemoryRegionsMax,
+                        tieredStorageConfiguration),
                 taskManagerLocation,
                 new TaskEventDispatcher(),
                 resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -382,6 +382,7 @@ public class InputGateFairnessTest {
                     new UnpooledMemorySegmentProvider(BUFFER_SIZE),
                     BUFFER_SIZE,
                     new ThroughputCalculator(SystemClock.getInstance()),
+                    null,
                     null);
 
             channelsWithData = getInputChannelsWithData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.buffer.NoOpBufferPool;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerClient;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
@@ -79,6 +80,8 @@ public class SingleInputGateBuilder {
             BufferDebloatConfiguration.fromConfiguration(new Configuration());
     private Function<BufferDebloatConfiguration, ThroughputCalculator> createThroughputCalculator =
             config -> new ThroughputCalculator(SystemClock.getInstance());
+
+    private TieredStorageConsumerClient tieredStorageConsumerClient = null;
 
     public SingleInputGateBuilder setPartitionProducerStateProvider(
             PartitionProducerStateProvider partitionProducerStateProvider) {
@@ -157,6 +160,12 @@ public class SingleInputGateBuilder {
         return this;
     }
 
+    public SingleInputGateBuilder setTieredStorageConsumerClient(
+            TieredStorageConsumerClient tieredStorageConsumerClient) {
+        this.tieredStorageConsumerClient = tieredStorageConsumerClient;
+        return this;
+    }
+
     public SingleInputGate build() {
         SingleInputGate gate =
                 new SingleInputGate(
@@ -172,7 +181,8 @@ public class SingleInputGateBuilder {
                         segmentProvider,
                         bufferSize,
                         createThroughputCalculator.apply(bufferDebloatConfiguration),
-                        maybeCreateBufferDebloater(gateIndex));
+                        maybeCreateBufferDebloater(gateIndex),
+                        tieredStorageConsumerClient);
         if (channelFactory != null) {
             gate.setInputChannels(
                     IntStream.range(0, numberOfChannels)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -1337,7 +1337,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                                 ? resultPartitionManager
                                 : netEnv.getResultPartitionManager(),
                         new TaskEventDispatcher(),
-                        netEnv.getNetworkBufferPool())
+                        netEnv.getNetworkBufferPool(),
+                        null)
                 .create(
                         netEnv.createShuffleIOOwnerContext(
                                 "TestTask", taskMetricGroup.executionId(), taskMetricGroup),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -56,7 +56,8 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
                 connectionManager,
                 partitionManager,
                 taskEventPublisher,
-                networkBufferPool);
+                networkBufferPool,
+                null);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

### Enable the SingleInputGate in downstream to be able to read buffers from tiered store.

To achieve this purpose, we could break down the implementation into 2 stages and achieve them sequentially.

#### Stage1: Introduce the TieredStorageConsumerClient

#### Stage2: Introduce the TieredStorageConsumerClient to SingleInputGate

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
