### PR TITLE
[FLINK-29334][runtime] Remove releaseAndTryRemoveAll in StateHandleStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -127,19 +127,6 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
     boolean releaseAndTryRemove(String name) throws Exception;
 
     /**
-     * Releases and removes all the states. Not only the state handles in the distributed
-     * coordination system will be removed, but also the real state data on the distributed storage
-     * will be discarded. This method should be implemented in a idempotent manner, i.e. failing
-     * calls should be able to be repeated.
-     *
-     * @throws Exception if releasing, removing the handles or discarding the state failed. The
-     *     removal of the states should happen independently from each other, i.e. the method call
-     *     fails if at least one removal failed. But the removal of any other state should still be
-     *     performed.
-     */
-    void releaseAndTryRemoveAll() throws Exception;
-
-    /**
      * Only clears all the state handle pointers on Kubernetes or ZooKeeper.
      *
      * @throws Exception if removing the handles failed

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -480,32 +480,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
     }
 
     /**
-     * Releases all lock nodes of this ZooKeeperStateHandleStores and tries to remove all state
-     * nodes which are not locked anymore.
-     *
-     * @throws Exception if the delete operation fails
-     */
-    @Override
-    public void releaseAndTryRemoveAll() throws Exception {
-        Collection<String> children = getAllHandles();
-
-        Exception exception = null;
-
-        for (String child : children) {
-            try {
-                releaseAndTryRemove('/' + child);
-            } catch (Exception e) {
-                exception = ExceptionUtils.firstOrSuppressed(e, exception);
-            }
-        }
-
-        if (exception != null) {
-            throw new Exception(
-                    "Could not properly release and try removing all state nodes.", exception);
-        }
-    }
-
-    /**
      * Releases the lock from the node under the given ZooKeeper path. If no lock exists, then
      * nothing happens.
      *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingStateHandleStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingStateHandleStore.java
@@ -52,7 +52,6 @@ public class TestingStateHandleStore<T extends Serializable>
             getAllSupplier;
     private final SupplierWithException<Collection<String>, Exception> getAllHandlesSupplier;
     private final FunctionWithException<String, Boolean, Exception> removeFunction;
-    private final RunnableWithException removeAllRunnable;
     private final RunnableWithException clearEntriesRunnable;
     private final ThrowingConsumer<String, Exception> releaseConsumer;
     private final RunnableWithException releaseAllHandlesRunnable;
@@ -66,7 +65,6 @@ public class TestingStateHandleStore<T extends Serializable>
                     getAllSupplier,
             SupplierWithException<Collection<String>, Exception> getAllHandlesSupplier,
             FunctionWithException<String, Boolean, Exception> removeFunction,
-            RunnableWithException removeAllRunnable,
             RunnableWithException clearEntriesRunnable,
             ThrowingConsumer<String, Exception> releaseConsumer,
             RunnableWithException releaseAllHandlesRunnable) {
@@ -77,7 +75,6 @@ public class TestingStateHandleStore<T extends Serializable>
         this.getAllSupplier = getAllSupplier;
         this.getAllHandlesSupplier = getAllHandlesSupplier;
         this.removeFunction = removeFunction;
-        this.removeAllRunnable = removeAllRunnable;
         this.clearEntriesRunnable = clearEntriesRunnable;
         this.releaseConsumer = releaseConsumer;
         this.releaseAllHandlesRunnable = releaseAllHandlesRunnable;
@@ -122,11 +119,6 @@ public class TestingStateHandleStore<T extends Serializable>
     }
 
     @Override
-    public void releaseAndTryRemoveAll() throws Exception {
-        removeAllRunnable.run();
-    }
-
-    @Override
     public void clearEntries() throws Exception {
         clearEntriesRunnable.run();
     }
@@ -161,7 +153,6 @@ public class TestingStateHandleStore<T extends Serializable>
         private SupplierWithException<Collection<String>, Exception> getAllHandlesSupplier =
                 Collections::emptyList;
         private FunctionWithException<String, Boolean, Exception> removeFunction = ignore -> false;
-        private RunnableWithException removeAllRunnable = () -> {};
         private RunnableWithException clearEntriesRunnable = () -> {};
 
         private ThrowingConsumer<String, Exception> releaseConsumer = ignore -> {};
@@ -214,11 +205,6 @@ public class TestingStateHandleStore<T extends Serializable>
             return this;
         }
 
-        public Builder<T> setRemoveAllRunnable(RunnableWithException removeAllRunnable) {
-            this.removeAllRunnable = removeAllRunnable;
-            return this;
-        }
-
         public Builder<T> setClearEntriesRunnable(RunnableWithException clearEntriesRunnable) {
             this.clearEntriesRunnable = clearEntriesRunnable;
             return this;
@@ -244,7 +230,6 @@ public class TestingStateHandleStore<T extends Serializable>
                     getAllSupplier,
                     getAllHandlesSupplier,
                     removeFunction,
-                    removeAllRunnable,
                     clearEntriesRunnable,
                     releaseConsumer,
                     releaseAllHandlesRunnable);


### PR DESCRIPTION
## What is the purpose of the change

*Remove releaseAndTryRemoveAll in StateHandleStore.*


## Brief change log

  - *Remove releaseAndTryRemoveAll in StateHandleStore.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
