### PR TITLE
[FLINK-27637][flink-streaming-java] Optimize the log information when the asynchronous part of checkpoint is canceled

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -248,6 +248,7 @@ public class StreamOperatorStateHandler {
                 }
             }
         } catch (Exception snapshotException) {
+            LOG.warn("Failed to snapshot state.", snapshotException);
             try {
                 snapshotInProgress.cancel();
             } catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -392,6 +392,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                     stateSize += tuple2.f0;
                     checkpointedSize += tuple2.f1;
                 } catch (Exception cancelException) {
+                    LOG.warn("Failed to cleanup checkpoint.", cancelException);
                     exception = ExceptionUtils.firstOrSuppressed(cancelException, exception);
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

*Optimize the log information when the asynchronous part of checkpoint is canceled.*


## Brief change log

  - *Optimize the log information when the asynchronous part of checkpoint is canceled.*