### PR TITLE
[BP-1.15][FLINK-27640][Connector/Hive][SQL Client] Exclude Pentaho dependency from Hive to avoid build problems with newer Maven versions. Newer Maven versions block http repositories such as conjars. Conjars is where Pentaho artifacts are stored (#22299)

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -508,6 +508,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.pentaho</groupId>
+					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -425,6 +425,10 @@ under the License.
 					<groupId>commons-lang</groupId>
 					<artifactId>commons-lang</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.pentaho</groupId>
+					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
This is a backport of https://github.com/apache/flink/pull/22299 to 1.15