### PR TITLE
[FLINK-31691][table] Add built-in MAP_FROM_ENTRIES function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -649,6 +649,9 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
+  - sql: MAP_FROM_ENTRIES(array_of_rows)
+    table: mapFromEntries(array_of_rows)
+    description: Returns a map created from an arrays of row with two fields. Note that the number of fields in a row array should be 2 and the key of a row array should not be null.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -47,10 +47,22 @@ Operators that can be disabled include "NestedLoopJoin", "ShuffleHashJoin", "Bro
 By default no operator is disabled.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.interval-join.min-cleanup-interval</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>Specifies a minimum time interval for how long cleanup unmatched records in the interval join operator. Before Flink 1.18, the default value of this param was the half of interval duration. Note: Set this option greater than 0 will cause unmatched records in outer joins to be output later than watermark, leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. The default value is 0, which means it will clean up unmatched records immediately.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.legacy-cast-behaviour</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">DISABLED</td>
             <td><p>Enum</p></td>
             <td>Determines whether CAST will operate following the legacy behaviour or the new one that introduces various fixes and improvements.<br /><br />Possible values:<ul><li>"ENABLED": CAST will operate following the legacy behaviour.</li><li>"DISABLED": CAST will operate following the new correct behaviour.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>table.exec.mapkey-dedup-policy</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">EXCEPTION</td>
+            <td><p>Enum</p></td>
+            <td>The policy to deduplicate map keys in builtin function. When EXCEPTION, the query fails if duplicated map keys are detected. When LAST_WIN, the map key that is inserted at last takes precedence.<br /><br />Possible values:<ul><li>"EXCEPTION": Fails if duplicated map keys are detected</li><li>"LAST_WIN": The map key that is inserted at last takes precedence.</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.exec.mini-batch.allow-latency</h5><br> <span class="label label-primary">Streaming</span></td>
@@ -177,12 +189,6 @@ By default no operator is disabled.</td>
             <td style="word-wrap: break-word;">100000</td>
             <td>Integer</td>
             <td>Sets the window elements buffer size limit used in group window agg operator.</td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.interval-join.min-cleanup-interval</h5><br> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Specifies a minimum time interval for how long cleanup unmatched records in the interval join operator. Before Flink 1.18, the default value of this param was the half of interval duration. Note: Set this option greater than 0 will cause unmatched records in outer joins to be output later than watermark, leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. The default value is 0, which means it will clean up unmatched records immediately.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -55,6 +55,7 @@ Expressions
     row
     map_
     map_from_arrays
+    map_from_entries
     row_interval
     pi
     e

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -503,6 +503,25 @@ def map_from_arrays(key, value) -> Expression:
     return _binary_op("mapFromArrays", key, value)
 
 
+def map_from_entries(rows) -> Expression:
+    """
+    Creates a map from an array of entries (row with two fields).
+
+    Example:
+    ::
+
+        >>> tab.select(
+        >>>     map_from_entries(
+        >>>         array(row(key1, 1), row(key2, 2), row(key3, 3))
+        >>>     ))
+
+    .. note::
+
+        both arrays should have the same length.
+    """
+    return _unary_op("mapFromEntries", rows)
+
+
 def row_interval(rows: int) -> Expression:
     """
     Creates an interval of rows.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -554,6 +554,23 @@ public final class Expressions {
     }
 
     /**
+     * Creates a map from an array of entries (row with two fields).
+     *
+     * <pre>{@code
+     * table.select(
+     *     mapFromEntries(
+     *         array(row(key1, 1), row(key2, 2), row(key3, 3))
+     *     ))
+     * }</pre>
+     *
+     * <p>Note If the number of fields in a row array is not 2 or the key of a row array is null, an
+     * error is returned.
+     */
+    public static ApiExpression mapFromEntries(Object rows) {
+        return apiCall(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, objectToExpression(rows));
+    }
+
+    /**
      * Creates an interval of rows.
      *
      * @see Table#window(GroupWindow)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -435,6 +435,16 @@ public class ExecutionConfigOptions {
                             "Determines whether CAST will operate following the legacy behaviour "
                                     + "or the new one that introduces various fixes and improvements.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<MapKeyDedupPolicy> TABLE_EXEC_MAPKEY_DEDUP_POLICY =
+            key("table.exec.mapkey-dedup-policy")
+                    .enumType(MapKeyDedupPolicy.class)
+                    .defaultValue(MapKeyDedupPolicy.EXCEPTION)
+                    .withDescription(
+                            "The policy to deduplicate map keys in builtin function. "
+                                    + "When EXCEPTION, the query fails if duplicated map keys are detected. "
+                                    + "When LAST_WIN, the map key that is inserted at last takes precedence.");
+
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Long> TABLE_EXEC_RANK_TOPN_CACHE_SIZE =
             ConfigOptions.key("table.exec.rank.topn-cache-size")
@@ -673,6 +683,25 @@ public class ExecutionConfigOptions {
 
         public boolean isEnabled() {
             return enabled;
+        }
+    }
+
+    /** The policy to deduplicate map keys in builtin function. */
+    @PublicEvolving
+    public enum MapKeyDedupPolicy implements DescribedEnum {
+        EXCEPTION(text("Fails if duplicated map keys are detected")),
+        LAST_WIN(text("The map key that is inserted at last takes precedence."));
+
+        private final InlineElement description;
+
+        MapKeyDedupPolicy(InlineElement description) {
+            this.description = description;
+        }
+
+        @Internal
+        @Override
+        public InlineElement getDescription() {
+            return description;
         }
     }
 

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -652,6 +652,11 @@ trait ImplicitExpressionConversions {
     Expressions.mapFromArrays(key, value)
   }
 
+  /** Creates a map from an array of entries (row with two fields). */
+  def mapFromEntries(rows: Expression): Expression = {
+    Expressions.mapFromEntries(rows)
+  }
+
   /** Returns a value that is closer than any other value to pi. */
   def pi(): Expression = {
     Expressions.pi()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -171,6 +171,16 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.MapFromArraysFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition MAP_FROM_ENTRIES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_FROM_ENTRIES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.MAP_FROM_ENTRIES)
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_FROM_ENTRIES))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapFromEntriesFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition SOURCE_WATERMARK =
             BuiltInFunctionDefinition.newBuilder()
                     .name("SOURCE_WATERMARK")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesInputTypeStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.ConstantArgumentCount;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@link InputTypeStrategy} specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}.
+ *
+ * <p>It checks if an argument is an array type of row with two fields.
+ */
+@Internal
+class MapFromEntriesInputTypeStrategy implements InputTypeStrategy {
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return ConstantArgumentCount.of(1);
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+
+        final DataType dataType = argumentDataTypes.get(0);
+        final LogicalType logicalType = dataType.getLogicalType();
+        if (logicalType.is(LogicalTypeRoot.ARRAY)
+                && ((ArrayType) logicalType).getElementType().is(LogicalTypeRoot.ROW)
+                && ((ArrayType) logicalType).getElementType().getChildren().size() == 2) {
+            return Optional.of(Collections.singletonList(dataType));
+        } else {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Unsupported argument type. Expected type 'ARRAY<ROW<`f0` ANY, `f1` ANY>>' but actual type was '%s'.",
+                    logicalType.asSummaryString());
+        }
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        return Collections.singletonList(
+                Signature.of(Signature.Argument.of("ARRAY<ROW<`f0` ANY, `f1` ANY>>")));
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -63,6 +63,9 @@ public final class SpecificInputTypeStrategies {
     public static final InputTypeStrategy CURRENT_WATERMARK =
             new CurrentWatermarkInputTypeStrategy();
 
+    /** See {@link MapFromEntriesInputTypeStrategy}. */
+    public static final InputTypeStrategy MAP_FROM_ENTRIES = new MapFromEntriesInputTypeStrategy();
+
     /** Argument type representing all types supported in a JSON context. */
     public static final ArgumentTypeStrategy JSON_ARGUMENT =
             or(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -19,8 +19,13 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.Optional;
 
 /**
  * Entry point for specific type strategies not covered in {@link TypeStrategies}.
@@ -88,6 +93,20 @@ public final class SpecificTypeStrategies {
 
     /** See {@link ToTimestampLtzTypeStrategy}. */
     public static final TypeStrategy TO_TIMESTAMP_LTZ = new ToTimestampLtzTypeStrategy();
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}. */
+    public static final TypeStrategy MAP_FROM_ENTRIES =
+            callContext ->
+                    Optional.of(
+                            DataTypes.MAP(
+                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getElementDataType()
+                                            .getChildren()
+                                            .get(0),
+                                    ((CollectionDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getElementDataType()
+                                            .getChildren()
+                                            .get(1)));
 
     private SpecificTypeStrategies() {
         // no instantiation

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesInputTypeStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link MapFromEntriesInputTypeStrategy}. */
+class MapFromEntriesInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(SpecificInputTypeStrategies.MAP_FROM_ENTRIES)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT(), DataTypes.STRING())))
+                        .expectSignature("f(ARRAY<ROW<`f0` ANY, `f1` ANY>>)")
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("f0", DataTypes.INT()),
+                                                DataTypes.FIELD("f1", DataTypes.STRING())))),
+                TestSpec.forStrategy(
+                                "ARRAY<ROW<`expected` INT>> doesn't work",
+                                SpecificInputTypeStrategies.MAP_FROM_ENTRIES)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("expected", DataTypes.INT()))))
+                        .expectErrorMessage(
+                                "Unsupported argument type. Expected type 'ARRAY<ROW<`f0` ANY, `f1` ANY>>' but actual type was 'ARRAY<ROW<`expected` INT>>'."));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_MAPKEY_DEDUP_POLICY;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}. */
+@Internal
+public class MapFromEntriesFunction extends BuiltInScalarFunction {
+    private final RowData.FieldGetter[] fieldGetters;
+    private boolean mapKeyDedupThrowException;
+
+    public MapFromEntriesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, context);
+        ExecutionConfigOptions.MapKeyDedupPolicy mapKeyDedupPolicy =
+                context.getConfiguration().get(TABLE_EXEC_MAPKEY_DEDUP_POLICY);
+        switch (mapKeyDedupPolicy) {
+            case EXCEPTION:
+                mapKeyDedupThrowException = true;
+                break;
+            case LAST_WIN:
+                mapKeyDedupThrowException = false;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown mapKey deduplicate policy strategy: " + mapKeyDedupPolicy);
+        }
+        RowType rowType =
+                (RowType)
+                        ((CollectionDataType)
+                                        context.getCallContext().getArgumentDataTypes().get(0))
+                                .getElementDataType()
+                                .getLogicalType();
+        fieldGetters =
+                IntStream.range(0, rowType.getFieldCount())
+                        .mapToObj(i -> RowData.createFieldGetter(rowType.getTypeAt(i), i))
+                        .toArray(RowData.FieldGetter[]::new);
+    }
+
+    public @Nullable MapData eval(@Nullable ArrayData input) {
+        if (input == null) {
+            return null;
+        }
+
+        int size = input.size();
+        Map<Object, Object> map = new HashMap<>();
+        for (int pos = 0; pos < size; pos++) {
+            if (input.isNullAt(pos)) {
+                return null;
+            }
+
+            RowData rowData = input.getRow(pos, 2);
+            final Object key = fieldGetters[0].getFieldOrNull(rowData);
+            if (key == null) {
+                throw new FlinkRuntimeException(
+                        "Invalid function MAP_FROM_ENTRIES call:\n" + "Map key can not be null");
+            }
+            if (mapKeyDedupThrowException && map.containsKey(key)) {
+                throw new FlinkRuntimeException(
+                        String.format(
+                                "Invalid function MAP_FROM_ENTRIES call:\n"
+                                        + "Duplicate keys %s are not allowed",
+                                key));
+            }
+            final Object value = fieldGetters[1].getFieldOrNull(rowData);
+            map.put(key, value);
+        }
+        return new GenericMapData(map);
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of MAP_FROM_ENTRIES

- Brief change log
MAP_FROM_ENTRIES for Table API and SQL
    
```
map_from_entries(map) - Returns a map created from an arrays of row with two fields. Note that the number of fields in a row array should be 2 and the key of a row array should not be null.

Syntax:
  map_from_entries(array_of_rows)

Arguments:
  array_of_rows: an arrays of row with two fields.

Returns:
  Returns a map created from an arrays of row with two fields. Note that the number of fields in a row array should be 2 and the key of a row array should not be null. Returns null if the argument is null

> SELECT map_from_entries(map[1, 'a', 2, 'b']);
 [(1,"a"),(2,"b")]
```


See also
presto https://prestodb.io/docs/current/functions/map.html

spark https://spark.apache.org/docs/latest/api/sql/index.html#map_from_entries

- Verifying this change
This change added tests in MapFunctionITCase.

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)