### PR TITLE
[FLINK-31656][runtime][security] Obtain delegation tokens early to support external file system usage in HA services

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -213,6 +213,20 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         LOG.info("Delegation tokens obtained successfully");
     }
 
+    @Override
+    public void obtainDelegationTokens() throws Exception {
+        LOG.info("Obtaining delegation tokens");
+        DelegationTokenContainer container = new DelegationTokenContainer();
+        obtainDelegationTokensAndGetNextRenewal(container);
+        LOG.info("Delegation tokens obtained successfully");
+
+        if (container.hasTokens()) {
+            delegationTokenReceiverRepository.onNewTokensObtained(container);
+        } else {
+            LOG.warn("No tokens obtained so skipping notifications");
+        }
+    }
+
     protected Optional<Long> obtainDelegationTokensAndGetNextRenewal(
             DelegationTokenContainer container) {
         return delegationTokenProviders.values().stream()
@@ -281,7 +295,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 listener.onNewTokensObtained(InstantiationUtil.serializeObject(container));
                 LOG.info("Listener notified successfully");
             } else {
-                LOG.warn("No tokens obtained so skipping listener notification");
+                LOG.warn("No tokens obtained so skipping notifications");
             }
 
             if (nextRenewal.isPresent()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -46,8 +46,16 @@ public interface DelegationTokenManager {
     void obtainDelegationTokens(DelegationTokenContainer container) throws Exception;
 
     /**
+     * Obtains new tokens in a one-time fashion and automatically distributes them to all local JVM
+     * receivers.
+     */
+    void obtainDelegationTokens() throws Exception;
+
+    /**
      * Creates a re-occurring task which obtains new tokens and automatically distributes them to
-     * task managers.
+     * all receivers (in local JVM as well as in registered task managers too). Task manager
+     * distribution must be implemented in the listener logic in order to keep the manager logic
+     * clean.
      */
     void start(Listener listener) throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
@@ -39,6 +39,11 @@ public class NoOpDelegationTokenManager implements DelegationTokenManager {
     }
 
     @Override
+    public void obtainDelegationTokens() {
+        LOG.debug("obtainDelegationTokens");
+    }
+
+    @Override
     public void start(Listener listener) {
         LOG.debug("start");
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
@@ -74,7 +74,8 @@ class FileSystemBlobStoreTest {
 
         final JobID jobId = new JobID();
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
-        assertThat(getBlobDirectoryPath()).isEmptyDirectory();
+        // Blob store operations are creating the base directory on-the-fly
+        assertThat(getBlobDirectoryPath()).doesNotExist();
 
         final boolean successfullyWritten =
                 testInstance.put(temporaryFile.toFile(), jobId, blobKey);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreFileOperationsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStoreFileOperationsTest.java
@@ -117,6 +117,9 @@ public class FileSystemJobResultStoreFileOperationsTest {
 
         fileSystemJobResultStore =
                 new FileSystemJobResultStore(basePath.getFileSystem(), basePath, false);
+        // Result store operations are creating the base directory on-the-fly
+        assertThat(emptyBaseDirectory).doesNotExist();
+        fileSystemJobResultStore.createDirtyResult(DUMMY_JOB_RESULT_ENTRY);
         assertThat(emptyBaseDirectory).exists().isDirectory();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenReceiver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenReceiver.java
@@ -32,11 +32,14 @@ public class ExceptionThrowingDelegationTokenReceiver implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> constructed =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Integer> onNewTokensObtainedCallCount =
+            ThreadLocal.withInitial(() -> 0);
 
     public static void reset() {
         throwInInit.set(false);
         throwInUsage.set(false);
         constructed.set(false);
+        onNewTokensObtainedCallCount.set(0);
     }
 
     public ExceptionThrowingDelegationTokenReceiver() {
@@ -60,5 +63,6 @@ public class ExceptionThrowingDelegationTokenReceiver implements DelegationToken
         if (throwInUsage.get()) {
             throw new IllegalArgumentException();
         }
+        onNewTokensObtainedCallCount.set(onNewTokensObtainedCallCount.get() + 1);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

At the moment there are no delegation tokens available when HA services is starting. If the HA services uses an external file system where the authentication type is delegation token based (typically S3) then it throws and exception since there are no credentials.

In this PR I've moved the delegation token manager initialization before HA services and trigger a manual token obtain + local JVM receiver propagation. Additionally deferred base directory creation in `FileSystemBlobStore` and `FileSystemJobResultStore`.

## Brief change log

* The delegation token manager initialization moved before HA services and trigger a manual token obtain + local JVM receiver propagation. This is the solution for the job manager side.
* Deferred base directory creation in `FileSystemBlobStore` and `FileSystemJobResultStore`. This is the solution for the task manager side.
* Changed the `DelegationTokenManager` API documentation for better clarity
* Changed a log message for better clarity

## Verifying this change

Manually on cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
