### PR TITLE
[FLINK-31692][Connectors/MongoDB] Integrate MongoDB connector docs in…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Both methods require you to execute commands in the directory of this module (`d
 ```sh
 $ git submodule update --init --recursive
 $ ./setup_docs.sh
+$ docker pull jakejarvis/hugo-extended:latest
 $ docker run -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest server --buildDrafts --buildFuture --bind 0.0.0.0
 ```
 

--- a/docs/content.zh/docs/connectors/datastream/overview.md
+++ b/docs/content.zh/docs/connectors/datastream/overview.md
@@ -50,6 +50,7 @@ under the License.
  * [Hybrid Source]({{< ref "docs/connectors/datastream/hybridsource" >}}) (source)
  * [Apache Pulsar]({{< ref "docs/connectors/datastream/pulsar" >}}) (source)
  * [JDBC]({{< ref "docs/connectors/datastream/jdbc" >}}) (sink)
+ * [MongoDB]({{< ref "docs/connectors/datastream/mongodb" >}}) (source/sink)
 
 请记住，在使用一种连接器时，通常需要额外的第三方组件，比如：数据存储服务器或者消息队列。
 要注意这些列举的连接器是 Flink 工程的一部分，包含在发布的源码中，但是不包含在二进制发行版中。

--- a/docs/content.zh/docs/connectors/table/overview.md
+++ b/docs/content.zh/docs/connectors/table/overview.md
@@ -102,6 +102,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Unbounded Scan, Bounded Scan, Lookup</td>
       <td>Streaming Sink, Batch Sink</td>
     </tr>
+    <tr>
+      <td><a href="{{< ref "docs/connectors/table/mongodb" >}}">MongoDB</a></td>
+      <td></td>
+      <td>Bounded Scan, Lookup</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -51,6 +51,7 @@ Connectors provide code for interfacing with various third-party systems. Curren
  * [Hybrid Source]({{< ref "docs/connectors/datastream/hybridsource" >}}) (source)
  * [Apache Pulsar]({{< ref "docs/connectors/datastream/pulsar" >}}) (source)
  * [JDBC]({{< ref "docs/connectors/datastream/jdbc" >}}) (sink)
+ * [MongoDB]({{< ref "docs/connectors/datastream/mongodb" >}}) (source/sink)
 
 Keep in mind that to use one of these connectors in an application, additional third party
 components are usually required, e.g. servers for the data stores or message queues.

--- a/docs/content/docs/connectors/table/overview.md
+++ b/docs/content/docs/connectors/table/overview.md
@@ -102,6 +102,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Unbounded Scan, Bounded Scan, Lookup</td>
       <td>Streaming Sink, Batch Sink</td>
     </tr>
+    <tr>
+      <td><a href="{{< ref "docs/connectors/table/mongodb" >}}">MongoDB</a></td>
+      <td></td>
+      <td>Bounded Scan, Lookup</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -201,3 +201,9 @@ rabbitmq:
     category: connector
     maven: flink-connector-rabbitmq
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-rabbitmq/3.0.0-1.16/flink-sql-connector-rabbitmq-3.0.0-1.16.jar
+
+mongodb:
+    name: MongoDB
+    category: connector
+    maven: flink-connector-mongodb
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-mongodb/1.0.0-1.16/flink-sql-connector-mongodb-1.0.0-1.16.jar

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -50,6 +50,7 @@ integrate_connector_docs pulsar main
 integrate_connector_docs jdbc v3.0.0
 integrate_connector_docs rabbitmq v3.0.0
 integrate_connector_docs gcp-pubsub v3.0.0
+integrate_connector_docs mongodb v1.0.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
…to Flink website

## What is the purpose of the change

Update Flink docs to include MongoDB connector for table/datastream/SQL.

## Brief change log

- MongoDB Datastream and Table connector docs added
- Updated SQL download table
- Updated README to pull latest docker image

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Run locally and viewed the web build in the browser.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
