### PR TITLE
[FLINK-31635][network] Support writing records to the new tiered store architecture

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageBytesBasedDataIdentifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageBytesBasedDataIdentifier.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.util.StringUtils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** The bytes based unique identification for the Tiered Storage. */
+public abstract class TieredStorageBytesBasedDataIdentifier
+        implements TieredStorageDataIdentifier, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The bytes data of this identifier. */
+    protected final byte[] bytes;
+
+    protected final int hashCode;
+
+    public TieredStorageBytesBasedDataIdentifier(byte[] bytes) {
+        checkArgument(bytes != null, "Must be not null.");
+
+        this.bytes = bytes;
+        this.hashCode = Arrays.hashCode(bytes);
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (that == null || getClass() != that.getClass()) {
+            return false;
+        }
+
+        TieredStorageBytesBasedDataIdentifier thatID = (TieredStorageBytesBasedDataIdentifier) that;
+        return hashCode == thatID.hashCode && Arrays.equals(bytes, thatID.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return "TieredStorageBytesBasedDataIdentifier{"
+                + "ID="
+                + StringUtils.byteToHexString(bytes)
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
@@ -19,9 +19,20 @@
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 /** Configurations for the Tiered Storage. */
 public class TieredStorageConfiguration {
+
+    // TODO, after implementing the tier factory, add appreciate implementations to the array.
+    private static final TierFactory[] DEFAULT_MEMORY_DISK_TIER_FACTORIES = new TierFactory[0];
+
+    public List<TierFactory> getTierFactories() {
+        return Arrays.asList(DEFAULT_MEMORY_DISK_TIER_FACTORIES);
+    }
 
     public static TieredStorageConfiguration.Builder builder() {
         return new TieredStorageConfiguration.Builder();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.configuration.Configuration;
+
+/** Configurations for the Tiered Storage. */
+public class TieredStorageConfiguration {
+
+    public static TieredStorageConfiguration.Builder builder() {
+        return new TieredStorageConfiguration.Builder();
+    }
+
+    /** Builder for {@link TieredStorageConfiguration}. */
+    public static class Builder {
+        public TieredStorageConfiguration build() {
+            return new TieredStorageConfiguration();
+        }
+    }
+
+    public static TieredStorageConfiguration fromConfiguration(Configuration conf) {
+        // TODO, from the configuration, get the configured options(i.e., remote storage path, the
+        // reserved storage size, etc.), then set them to the builder.
+        return new TieredStorageConfiguration.Builder().build();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageDataIdentifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageDataIdentifier.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+/** Identifier interface in the Tiered Storage. */
+public interface TieredStorageDataIdentifier {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.util.AbstractID;
+
+/** Utils to convert the Ids to Tiered Storage Ids, or vice versa. */
+public class TieredStorageIdMappingUtils {
+
+    public static TieredStorageTopicId convertId(IntermediateDataSetID intermediateDataSetID) {
+        return new TieredStorageTopicId(intermediateDataSetID.getBytes());
+    }
+
+    public static IntermediateDataSetID convertId(TieredStorageTopicId topicId) {
+        return new IntermediateDataSetID(new AbstractID(topicId.getBytes()));
+    }
+
+    public static TieredStoragePartitionId convertId(ResultPartitionID resultPartitionId) {
+        return new TieredStoragePartitionId(resultPartitionId.getBytes());
+    }
+
+    public static ResultPartitionID convertId(TieredStoragePartitionId partitionId) {
+        return new ResultPartitionID(partitionId.getBytes());
+    }
+
+    public static TieredStorageSubpartitionId convertId(int subpartitionId) {
+        return new TieredStorageSubpartitionId(subpartitionId);
+    }
+
+    public static int convertId(TieredStorageSubpartitionId subpartitionId) {
+        return subpartitionId.getSubpartitionId();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStoragePartitionId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStoragePartitionId.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.util.StringUtils;
+
+/**
+ * Identifier of a partition.
+ *
+ * <p>A partition is equivalent to a result partition in Flink.
+ */
+public class TieredStoragePartitionId extends TieredStorageBytesBasedDataIdentifier {
+
+    private static final long serialVersionUID = 1L;
+
+    public TieredStoragePartitionId(byte[] bytes) {
+        super(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return "TieredStoragePartitionId{" + "ID=" + StringUtils.byteToHexString(bytes) + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageSubpartitionId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageSubpartitionId.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import java.io.Serializable;
+
+/**
+ * Identifier of a subpartition.
+ *
+ * <p>A subpartition is equivalent to a subpartition in Flink.
+ */
+public class TieredStorageSubpartitionId implements TieredStorageDataIdentifier, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int subpartitionId;
+
+    public TieredStorageSubpartitionId(int subpartitionId) {
+        this.subpartitionId = subpartitionId;
+    }
+
+    public int getSubpartitionId() {
+        return subpartitionId;
+    }
+
+    @Override
+    public int hashCode() {
+        return subpartitionId;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (that == null || getClass() != that.getClass()) {
+            return false;
+        }
+
+        TieredStorageSubpartitionId thatID = (TieredStorageSubpartitionId) that;
+        return subpartitionId == thatID.subpartitionId;
+    }
+
+    @Override
+    public String toString() {
+        return "TieredStorageSubpartitionId{" + "ID=" + subpartitionId + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageTopicId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageTopicId.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.util.StringUtils;
+
+/**
+ * Identifier of a topic.
+ *
+ * <p>A topic is equivalent to an intermediate data set in Flink.
+ */
+public class TieredStorageTopicId extends TieredStorageBytesBasedDataIdentifier {
+
+    private static final long serialVersionUID = 1L;
+
+    public TieredStorageTopicId(byte[] bytes) {
+        super(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return "TieredStorageTopicId{" + "ID=" + StringUtils.byteToHexString(bytes) + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageConfiguration;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMasterClient;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils.convertId;
+
+/**
+ * A wrapper internal shuffle master class for tiered storage. All the tiered storage operations
+ * with the shuffle master should be wrapped in this class.
+ */
+public class TieredInternalShuffleMaster {
+
+    private final TieredStorageMasterClient tieredStorageMasterClient;
+
+    private final Map<JobID, List<ResultPartitionID>> jobPartitionIds;
+
+    private final Map<ResultPartitionID, JobID> partitionJobIds;
+
+    public TieredInternalShuffleMaster(Configuration conf) {
+        TieredStorageConfiguration tieredStorageConfiguration =
+                TieredStorageConfiguration.fromConfiguration(conf);
+        TieredStorageResourceRegistry resourceRegistry = new TieredStorageResourceRegistry();
+        List<TierMasterAgent> tierFactories =
+                tieredStorageConfiguration.getTierFactories().stream()
+                        .map(tierFactory -> tierFactory.createMasterAgent(resourceRegistry))
+                        .collect(Collectors.toList());
+        this.tieredStorageMasterClient = new TieredStorageMasterClient(tierFactories);
+        this.jobPartitionIds = new HashMap<>();
+        this.partitionJobIds = new HashMap<>();
+    }
+
+    public void addPartition(JobID jobID, ResultPartitionID resultPartitionID) {
+        jobPartitionIds.computeIfAbsent(jobID, ignore -> new ArrayList<>()).add(resultPartitionID);
+        partitionJobIds.put(resultPartitionID, jobID);
+        tieredStorageMasterClient.addPartition(convertId(resultPartitionID));
+    }
+
+    public void releasePartition(ResultPartitionID resultPartitionID) {
+        tieredStorageMasterClient.releasePartition(convertId(resultPartitionID));
+        JobID jobID = partitionJobIds.remove(resultPartitionID);
+        if (jobID == null) {
+            return;
+        }
+
+        List<ResultPartitionID> resultPartitionIDs = jobPartitionIds.get(jobID);
+        if (resultPartitionIDs == null) {
+            return;
+        }
+
+        resultPartitionIDs.remove(resultPartitionID);
+        // If the result partition id list has been empty, remove the jobID from the map eagerly
+        if (resultPartitionIDs.isEmpty()) {
+            jobPartitionIds.remove(jobID);
+        }
+    }
+
+    public void unregisterJob(JobID jobID) {
+        List<ResultPartitionID> resultPartitionIDs = jobPartitionIds.remove(jobID);
+        if (resultPartitionIDs != null) {
+            resultPartitionIDs.forEach(
+                    resultPartitionID -> {
+                        tieredStorageMasterClient.releasePartition(convertId(resultPartitionID));
+                        partitionJobIds.remove(resultPartitionID);
+                    });
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartition.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.EndOfData;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageProducerClient;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * {@link TieredResultPartition} appends records and events to the tiered storage, which supports
+ * the upstream dynamically switches storage tier for writing shuffle data, and the downstream will
+ * read data from the relevant tier.
+ */
+public class TieredResultPartition extends ResultPartition {
+
+    private final TieredStoragePartitionId partitionId;
+
+    private final TieredStorageProducerClient tieredStorageProducerClient;
+
+    private final TieredStorageResourceRegistry tieredStorageResourceRegistry;
+
+    private boolean hasNotifiedEndOfUserRecords;
+
+    public TieredResultPartition(
+            String owningTaskName,
+            int partitionIndex,
+            ResultPartitionID partitionId,
+            ResultPartitionType partitionType,
+            int numSubpartitions,
+            int numTargetKeyGroups,
+            ResultPartitionManager partitionManager,
+            @Nullable BufferCompressor bufferCompressor,
+            SupplierWithException<BufferPool, IOException> bufferPoolFactory,
+            TieredStorageProducerClient tieredStorageProducerClient,
+            TieredStorageResourceRegistry tieredStorageResourceRegistry) {
+        super(
+                owningTaskName,
+                partitionIndex,
+                partitionId,
+                partitionType,
+                numSubpartitions,
+                numTargetKeyGroups,
+                partitionManager,
+                bufferCompressor,
+                bufferPoolFactory);
+
+        this.partitionId = TieredStorageIdMappingUtils.convertId(partitionId);
+        this.tieredStorageProducerClient = tieredStorageProducerClient;
+        this.tieredStorageResourceRegistry = tieredStorageResourceRegistry;
+    }
+
+    @Override
+    protected void setupInternal() throws IOException {
+        if (isReleased()) {
+            throw new IOException("Result partition has been released.");
+        }
+    }
+
+    @Override
+    public void setMetricGroup(TaskIOMetricGroup metrics) {
+        super.setMetricGroup(metrics);
+    }
+
+    @Override
+    public void emitRecord(ByteBuffer record, int consumerId) throws IOException {
+        resultPartitionBytes.inc(consumerId, record.remaining());
+        emit(record, consumerId, Buffer.DataType.DATA_BUFFER, false);
+    }
+
+    @Override
+    public void broadcastRecord(ByteBuffer record) throws IOException {
+        resultPartitionBytes.incAll(record.remaining());
+        broadcast(record, Buffer.DataType.DATA_BUFFER);
+    }
+
+    @Override
+    public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
+        Buffer buffer = EventSerializer.toBuffer(event, isPriorityEvent);
+        try {
+            ByteBuffer serializedEvent = buffer.getNioBufferReadable();
+            broadcast(serializedEvent, buffer.getDataType());
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    private void broadcast(ByteBuffer record, Buffer.DataType dataType) throws IOException {
+        checkInProduceState();
+        emit(record, 0, dataType, true);
+    }
+
+    private void emit(
+            ByteBuffer record, int consumerId, Buffer.DataType dataType, boolean isBroadcast)
+            throws IOException {
+        tieredStorageProducerClient.write(
+                record, TieredStorageIdMappingUtils.convertId(consumerId), dataType, isBroadcast);
+    }
+
+    @Override
+    public ResultSubpartitionView createSubpartitionView(
+            int subpartitionId, BufferAvailabilityListener availabilityListener)
+            throws IOException {
+        checkState(!isReleased(), "ResultPartition already released.");
+        // TODO, create subpartition views
+        return null;
+    }
+
+    @Override
+    public void finish() throws IOException {
+        broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+        checkState(!isReleased(), "Result partition is already released.");
+        super.finish();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        tieredStorageProducerClient.close();
+    }
+
+    @Override
+    protected void releaseInternal() {
+        tieredStorageResourceRegistry.clearResourceFor(partitionId);
+    }
+
+    @Override
+    public void notifyEndOfData(StopMode mode) throws IOException {
+        if (!hasNotifiedEndOfUserRecords) {
+            broadcastEvent(new EndOfData(mode), false);
+            hasNotifiedEndOfUserRecords = true;
+        }
+    }
+
+    @Override
+    public void alignedBarrierTimeout(long checkpointId) throws IOException {
+        // Nothing to do.
+    }
+
+    @Override
+    public void abortCheckpoint(long checkpointId, CheckpointException cause) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void flushAll() {
+        // Nothing to do.
+    }
+
+    @Override
+    public void flush(int subpartitionIndex) {
+        // Nothing to do.
+    }
+
+    @Override
+    public CompletableFuture<Void> getAllDataProcessedFuture() {
+        // Nothing to do.
+        return FutureUtils.completedVoidFuture();
+    }
+
+    @Override
+    public void onSubpartitionAllDataProcessed(int subpartition) {
+        // Nothing to do.
+    }
+
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        // Nothing to do.
+        return 0;
+    }
+
+    @Override
+    public long getSizeOfQueuedBuffersUnsafe() {
+        // Nothing to do.
+        return 0;
+    }
+
+    @Override
+    public int getNumberOfQueuedBuffers(int targetSubpartition) {
+        // Nothing to do.
+        return 0;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/BufferAccumulator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/BufferAccumulator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * Accumulates received records into buffers. The {@link BufferAccumulator} receives the records
+ * from tiered store producer and the records will accumulate and transform into buffers.
+ */
+public interface BufferAccumulator {
+
+    /**
+     * Setup the accumulator.
+     *
+     * @param numSubpartitions number of subpartitions
+     * @param bufferFlusher accepts the accumulated buffers. The first field is the subpartition id,
+     *     while the list in the second field contains accumulated buffers in order for that
+     *     subpartition.
+     */
+    void setup(
+            int numSubpartitions,
+            BiConsumer<TieredStorageSubpartitionId, List<Buffer>> bufferFlusher);
+
+    /**
+     * Receives the records from tiered store producer, these records will be accumulated and
+     * transformed into finished buffers.
+     */
+    void receive(
+            ByteBuffer record, TieredStorageSubpartitionId subpartitionId, Buffer.DataType dataType)
+            throws IOException;
+
+    /**
+     * Close the accumulator. This will flush all the remaining data and release all the resources.
+     */
+    void close();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+/** Client of the Tiered Storage used by the consumer. */
+public class TieredStorageConsumerClient {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageMasterClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageMasterClient.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
+
+import java.util.List;
+
+/** Client of the Tiered Storage used by the master. */
+public class TieredStorageMasterClient {
+
+    private final List<TierMasterAgent> tiers;
+
+    public TieredStorageMasterClient(List<TierMasterAgent> tiers) {
+        this.tiers = tiers;
+    }
+
+    public void addPartition(TieredStoragePartitionId partitionId) {
+        tiers.forEach(tierMasterAgent -> tierMasterAgent.addPartition(partitionId));
+    }
+
+    public void releasePartition(TieredStoragePartitionId partitionId) {
+        tiers.forEach(tierMasterAgent -> tierMasterAgent.releasePartition(partitionId));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+import org.apache.flink.util.ExceptionUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/** Client of the Tiered Storage used by the producer. */
+public class TieredStorageProducerClient {
+    private final boolean isBroadcastOnly;
+
+    private final int numSubpartitions;
+
+    private final BufferAccumulator bufferAccumulator;
+
+    private final BufferCompressor bufferCompressor;
+
+    private final List<TierProducerAgent> tierProducerAgents;
+
+    public TieredStorageProducerClient(
+            int numSubpartitions,
+            boolean isBroadcastOnly,
+            BufferAccumulator bufferAccumulator,
+            @Nullable BufferCompressor bufferCompressor,
+            List<TierProducerAgent> tierProducerAgents) {
+        this.isBroadcastOnly = isBroadcastOnly;
+        this.numSubpartitions = numSubpartitions;
+        this.bufferAccumulator = bufferAccumulator;
+        this.bufferCompressor = bufferCompressor;
+        this.tierProducerAgents = tierProducerAgents;
+
+        bufferAccumulator.setup(numSubpartitions, this::writeAccumulatedBuffers);
+    }
+
+    /**
+     * Write records to the producer client. The {@link BufferAccumulator} will accumulate the
+     * records into buffers.
+     *
+     * <p>Note that isBroadcast indicates whether the record is broadcast, while isBroadcastOnly
+     * indicates whether the result partition is broadcast-only. When the result partition is not
+     * broadcast-only and the record is a broadcast record, the record will be written to all the
+     * subpartitions.
+     *
+     * @param record the written record data
+     * @param subpartitionId the subpartition identifier
+     * @param dataType the data type of the record
+     * @param isBroadcast whether the record is a broadcast record
+     */
+    public void write(
+            ByteBuffer record,
+            TieredStorageSubpartitionId subpartitionId,
+            Buffer.DataType dataType,
+            boolean isBroadcast)
+            throws IOException {
+
+        if (isBroadcast && !isBroadcastOnly) {
+            for (int i = 0; i < numSubpartitions; ++i) {
+                bufferAccumulator.receive(record.duplicate(), subpartitionId, dataType);
+            }
+        } else {
+            bufferAccumulator.receive(record, subpartitionId, dataType);
+        }
+    }
+
+    public void close() {
+        bufferAccumulator.close();
+        tierProducerAgents.forEach(TierProducerAgent::close);
+    }
+
+    /**
+     * Write the accumulated buffers of this subpartitionId to the appropriate tiers.
+     *
+     * @param subpartitionId the subpartition identifier
+     * @param accumulatedBuffers the accumulated buffers of this subpartition
+     */
+    private void writeAccumulatedBuffers(
+            TieredStorageSubpartitionId subpartitionId, List<Buffer> accumulatedBuffers) {
+        try {
+            for (Buffer finishedBuffer : accumulatedBuffers) {
+                writeAccumulatedBuffer(subpartitionId, finishedBuffer);
+            }
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e);
+        }
+    }
+
+    /**
+     * Write the accumulated buffer of this subpartitionId to an appropriate tier. After the tier is
+     * decided, the buffer will be written to the selected tier.
+     *
+     * @param subpartitionId the subpartition identifier
+     * @param accumulatedBuffer one accumulated buffer of this subpartition
+     */
+    private void writeAccumulatedBuffer(
+            TieredStorageSubpartitionId subpartitionId, Buffer accumulatedBuffer)
+            throws IOException {
+        // TODO, Try to write the accumulated buffer to the appropriate tier. After the tier is
+        // decided, then write the accumulated buffer to the tier.
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResource.java
@@ -16,19 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
-import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+/** The resource (e.g., local files, remote storage files, etc.) for the Tiered Storage. */
+public interface TieredStorageResource {
 
-/** A factory that creates all the components of a tier. */
-public interface TierFactory {
-
-    /** Creates the master-side agent of a Tier. */
-    TierMasterAgent createMasterAgent(TieredStorageResourceRegistry tieredStorageResourceRegistry);
-
-    /** Creates the producer-side agent of a Tier. */
-    TierProducerAgent createProducerAgent();
-
-    /** Creates the consumer-side agent of a Tier. */
-    TierConsumerAgent createConsumerAgent();
+    /** Release all the resources, e.g. delete the files, recycle the occupied memory, etc. */
+    void release();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageResourceRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageDataIdentifier;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A registry that maintains local or remote resources that correspond to a certain set of data in
+ * the Tiered Storage.
+ */
+public class TieredStorageResourceRegistry {
+
+    private final Map<TieredStorageDataIdentifier, List<TieredStorageResource>>
+            registeredResources = new HashMap<>();
+
+    /**
+     * Register a new resource for the given owner.
+     *
+     * @param owner identifier of the data that the resource corresponds to.
+     * @param tieredStorageResource the tiered storage resources to be registered.
+     */
+    public void registerResource(
+            TieredStorageDataIdentifier owner, TieredStorageResource tieredStorageResource) {
+        registeredResources
+                .computeIfAbsent(owner, (ignore) -> new ArrayList<>())
+                .add(tieredStorageResource);
+    }
+
+    /**
+     * Remove all resources for the given owner.
+     *
+     * @param owner identifier of the data that the resources correspond to.
+     */
+    public void clearResourceFor(TieredStorageDataIdentifier owner) {
+        List<TieredStorageResource> cleanersForOwner = registeredResources.remove(owner);
+
+        if (cleanersForOwner != null) {
+            cleanersForOwner.forEach(TieredStorageResource::release);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierConsumerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierConsumerAgent.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+
+/** The consumer-side agent of a Tier. */
+public interface TierConsumerAgent {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+
+/** A factory that creates all the components of a tier. */
+public interface TierFactory {
+
+    /** Creates the master-side agent of a Tier. */
+    TierMasterAgent createMasterAgent();
+
+    /** Creates the producer-side agent of a Tier. */
+    TierProducerAgent createProducerAgent();
+
+    /** Creates the consumer-side agent of a Tier. */
+    TierConsumerAgent createConsumerAgent();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierMasterAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierMasterAgent.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+
+/** The master-side agent of a Tier. */
+public interface TierMasterAgent {
+
+    /**
+     * Add a new tiered storage partition.
+     *
+     * @param partitionId the identifier of the new partition
+     */
+    void addPartition(TieredStoragePartitionId partitionId);
+
+    /**
+     * Release a tiered storage partition.
+     *
+     * @param partitionId the identifier of partition to be released
+     */
+    void releasePartition(TieredStoragePartitionId partitionId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierProducerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierProducerAgent.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import java.io.IOException;
+
+/** The producer-side agent of a Tier. */
+public interface TierProducerAgent {
+
+    /**
+     * Try to start a new segment in the Tier.
+     *
+     * @param subpartitionId subpartition id that the new segment belongs to
+     * @param segmentId id of the new segment
+     * @return true if the segment can be started, false otherwise.
+     */
+    boolean tryStartNewSegment(TieredStorageSubpartitionId subpartitionId, int segmentId);
+
+    /** Writes the finished {@link Buffer} to the consumer. */
+    boolean write(TieredStorageSubpartitionId subpartitionId, Buffer finishedBuffer)
+            throws IOException;
+
+    /**
+     * Close the agent.
+     *
+     * <p>Note this only releases resources directly hold by the agent, which excludes resources
+     * managed by the resource registry.
+     */
+    void close();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle.TieredInternalShuffleMaster;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.LocalExecutionPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.PartitionConnectionInfo;
@@ -49,6 +50,8 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
 
     private final int networkBufferSize;
 
+    private final TieredInternalShuffleMaster tieredInternalShuffleMaster;
+
     public NettyShuffleMaster(Configuration conf) {
         checkNotNull(conf);
         buffersPerInputChannel =
@@ -64,6 +67,7 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
         sortShuffleMinBuffers =
                 conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
         networkBufferSize = ConfigurationParserUtils.getPageSize(conf);
+        tieredInternalShuffleMaster = new TieredInternalShuffleMaster(conf);
 
         checkArgument(
                 !maxRequiredBuffersPerGate.isPresent() || maxRequiredBuffersPerGate.get() >= 1,
@@ -96,11 +100,20 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
                                 producerDescriptor, partitionDescriptor.getConnectionIndex()),
                         resultPartitionID);
 
+        tieredInternalShuffleMaster.addPartition(jobID, resultPartitionID);
+
         return CompletableFuture.completedFuture(shuffleDeploymentDescriptor);
     }
 
     @Override
-    public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {}
+    public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
+        tieredInternalShuffleMaster.releasePartition(shuffleDescriptor.getResultPartitionID());
+    }
+
+    @Override
+    public void unregisterJob(JobID jobID) {
+        tieredInternalShuffleMaster.unregisterJob(jobID);
+    }
 
     private static PartitionConnectionInfo createConnectionInfo(
             ProducerDescriptor producerDescriptor, int connectionIndex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingBufferAccumulator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingBufferAccumulator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.BufferAccumulator;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/** Test implementation for {@link BufferAccumulator}. */
+public class TestingBufferAccumulator implements BufferAccumulator {
+
+    @Override
+    public void setup(
+            int numSubpartitions,
+            BiConsumer<TieredStorageSubpartitionId, List<Buffer>> bufferFlusher) {}
+
+    @Override
+    public void receive(
+            ByteBuffer record, TieredStorageSubpartitionId subpartitionId, Buffer.DataType dataType)
+            throws IOException {}
+
+    @Override
+    public void close() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtilsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TieredStorageIdMappingUtils}. */
+public class TieredStorageIdMappingUtilsTest {
+
+    @Test
+    void testConvertDataSetId() {
+        IntermediateDataSetID dataSetID = new IntermediateDataSetID();
+        TieredStorageTopicId topicId = TieredStorageIdMappingUtils.convertId(dataSetID);
+        IntermediateDataSetID convertedDataSetID = TieredStorageIdMappingUtils.convertId(topicId);
+        assertThat(dataSetID).isEqualTo(convertedDataSetID);
+    }
+
+    @Test
+    void testConvertResultPartitionId() {
+        ResultPartitionID resultPartitionID = new ResultPartitionID();
+        TieredStoragePartitionId tieredStoragePartitionId =
+                TieredStorageIdMappingUtils.convertId(resultPartitionID);
+        ResultPartitionID convertedResultPartitionID =
+                TieredStorageIdMappingUtils.convertId(tieredStoragePartitionId);
+        assertThat(resultPartitionID).isEqualTo(convertedResultPartitionID);
+    }
+
+    @Test
+    void testConvertSubpartitionId() {
+        int subpartitionId = 2;
+        TieredStorageSubpartitionId tieredStorageSubpartitionId =
+                TieredStorageIdMappingUtils.convertId(subpartitionId);
+        int convertedSubpartitionId =
+                TieredStorageIdMappingUtils.convertId(tieredStorageSubpartitionId);
+        assertThat(subpartitionId).isEqualTo(convertedSubpartitionId);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle;
+
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.disk.FileChannelManager;
+import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.NoOpBufferAvailablityListener;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingBufferAccumulator;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageProducerClient;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TieredResultPartition}. */
+class TieredResultPartitionTest {
+
+    private static final int NUM_THREADS = 4;
+
+    private static final int NETWORK_BUFFER_SIZE = 1024;
+
+    private static final int NUM_TOTAL_BUFFERS = 1000;
+
+    private static final int NUM_TOTAL_BYTES_IN_READ_POOL = 32 * 1024 * 1024;
+
+    private FileChannelManager fileChannelManager;
+
+    private NetworkBufferPool globalPool;
+
+    private BatchShuffleReadBufferPool readBufferPool;
+
+    private ScheduledExecutorService readIOExecutor;
+
+    private TaskIOMetricGroup taskIOMetricGroup;
+
+    @TempDir public java.nio.file.Path tempDataPath;
+
+    @BeforeEach
+    void before() {
+        fileChannelManager =
+                new FileChannelManagerImpl(new String[] {tempDataPath.toString()}, "testing");
+        globalPool = new NetworkBufferPool(NUM_TOTAL_BUFFERS, NETWORK_BUFFER_SIZE);
+        readBufferPool =
+                new BatchShuffleReadBufferPool(NUM_TOTAL_BYTES_IN_READ_POOL, NETWORK_BUFFER_SIZE);
+        readIOExecutor =
+                new ScheduledThreadPoolExecutor(
+                        NUM_THREADS,
+                        new ExecutorThreadFactory("test-io-scheduler-thread"),
+                        (ignored, executor) -> {
+                            if (executor.isShutdown()) {
+                                // ignore rejected as shutdown.
+                            } else {
+                                throw new RejectedExecutionException();
+                            }
+                        });
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        fileChannelManager.close();
+        globalPool.destroy();
+        readBufferPool.destroy();
+        readIOExecutor.shutdown();
+    }
+
+    @Test
+    void testClose() throws Exception {
+        final int numBuffers = 1;
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        TieredResultPartition partition = createTieredStoreResultPartition(1, bufferPool, false);
+
+        partition.close();
+        assertThat(bufferPool.isDestroyed()).isTrue();
+    }
+
+    @Test
+    @Timeout(30)
+    void testRelease() throws Exception {
+        final int numSubpartitions = 2;
+        final int numBuffers = 10;
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        TieredResultPartition partition =
+                createTieredStoreResultPartition(numSubpartitions, bufferPool, false);
+
+        partition.emitRecord(ByteBuffer.allocate(NETWORK_BUFFER_SIZE * 5), 1);
+        partition.close();
+        assertThat(bufferPool.isDestroyed()).isTrue();
+
+        partition.release();
+
+        while (checkNotNull(fileChannelManager.getPaths()[0].listFiles()).length != 0) {
+            Thread.sleep(10);
+        }
+
+        assertThat(NUM_TOTAL_BUFFERS).isEqualTo(globalPool.getNumberOfAvailableMemorySegments());
+    }
+
+    @Test
+    void testCreateSubpartitionViewAfterRelease() throws Exception {
+        final int numBuffers = 10;
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        TieredResultPartition resultPartition =
+                createTieredStoreResultPartition(2, bufferPool, false);
+        resultPartition.release();
+        assertThatThrownBy(
+                        () ->
+                                resultPartition.createSubpartitionView(
+                                        0, new NoOpBufferAvailablityListener()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testEmitRecords() throws Exception {
+        BufferPool bufferPool = globalPool.createBufferPool(3, 3);
+        int bufferSize = NETWORK_BUFFER_SIZE;
+        try (TieredResultPartition partition =
+                createTieredStoreResultPartition(2, bufferPool, false)) {
+            partition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
+            partition.broadcastRecord(ByteBuffer.allocate(bufferSize));
+            IOMetrics ioMetrics = taskIOMetricGroup.createSnapshot();
+            assertThat(ioMetrics.getResultPartitionBytes()).hasSize(1);
+            ResultPartitionBytes partitionBytes =
+                    ioMetrics.getResultPartitionBytes().values().iterator().next();
+            assertThat(partitionBytes.getSubpartitionBytes())
+                    .containsExactly((long) 2 * bufferSize, bufferSize);
+        }
+    }
+
+    @Test
+    void testMetricsUpdateForBroadcastOnlyResultPartition() throws Exception {
+        BufferPool bufferPool = globalPool.createBufferPool(3, 3);
+        int bufferSize = NETWORK_BUFFER_SIZE;
+        try (TieredResultPartition partition =
+                createTieredStoreResultPartition(2, bufferPool, true)) {
+            partition.broadcastRecord(ByteBuffer.allocate(bufferSize));
+            IOMetrics ioMetrics = taskIOMetricGroup.createSnapshot();
+            assertThat(ioMetrics.getResultPartitionBytes()).hasSize(1);
+            ResultPartitionBytes partitionBytes =
+                    ioMetrics.getResultPartitionBytes().values().iterator().next();
+            assertThat(partitionBytes.getSubpartitionBytes())
+                    .containsExactly(bufferSize, bufferSize);
+        }
+    }
+
+    private TieredResultPartition createTieredStoreResultPartition(
+            int numSubpartitions, BufferPool bufferPool, boolean isBroadcastOnly)
+            throws IOException {
+        TieredResultPartition tieredResultPartition =
+                new TieredResultPartition(
+                        "TieredStoreResultPartitionTest",
+                        0,
+                        new ResultPartitionID(),
+                        ResultPartitionType.HYBRID_SELECTIVE,
+                        numSubpartitions,
+                        numSubpartitions,
+                        new ResultPartitionManager(),
+                        new BufferCompressor(NETWORK_BUFFER_SIZE, "LZ4"),
+                        () -> bufferPool,
+                        new TieredStorageProducerClient(
+                                numSubpartitions,
+                                isBroadcastOnly,
+                                new TestingBufferAccumulator(),
+                                null,
+                                new ArrayList<>()),
+                        new TieredStorageResourceRegistry());
+        taskIOMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup();
+        tieredResultPartition.setup();
+        tieredResultPartition.setMetricGroup(taskIOMetricGroup);
+        return tieredResultPartition;
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support writing records to the new tiered store architecture. 

To achieve the goal, the PR mainly includes the following two parts.

### The tiered storage architecture
The PR introduces the tiered storage architecture. It mainly includes the clients(producer-side, consumer-side, and master-sides), and the single-tier storage APIs(producer-side, consumer-side, and master-sides).

### The producer side of the architecture
For the producer side of the architecture, this PR introduces implements `TieredStorageProducerClient`. When writing records, the records from `TieredStorageResultPartition` will first write to `TieredStorageProducerClient`. These records are accumulated in `BufferAccumulator` into buffers. The buffers are written to different tiers according to the running state.


## Brief change log

  - * **[Commit 1, 2]** Introduce the Ids, utils, configurations in the tiered storage, i.e., `TieredStoragePartitionId`, `TieredStorageSubpartitionId`, etc.*
  - * **[Commit 3]** Introduce the interfaces in the tier for the tiered storage, mainly includes `TierProducerAgent`, `TierConsumerAgent`, `TierMasterAgent`.*
  - * **[Commit 4]** Introduce the storage clients for the tiered storage, i.e., `TieredStorageProducerClient`, etc.*
  - * **[Commit 5]** Introduce the new tiered result partition.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test of `TieredStoreResultPartitionTest` and `TieredStorageIdMappingUtilsTest`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
