### PR TITLE
[FLINK-31705][Build System] Remove Conjars as Maven mirror

### DIFF
--- a/tools/ci/alibaba-mirror-settings.xml
+++ b/tools/ci/alibaba-mirror-settings.xml
@@ -30,10 +30,5 @@ under the License.
       <url>http://172.17.0.1:8888/repository/confluent/</url>
       <mirrorOf>confluent</mirrorOf>
     </mirror>
-	  <mirror>
-		  <id>conjars-https</id>
-		  <url>https://conjars.org/repo/</url>
-		  <mirrorOf>conjars</mirrorOf>
-	  </mirror>
   </mirrors>
 </settings>

--- a/tools/ci/google-mirror-settings.xml
+++ b/tools/ci/google-mirror-settings.xml
@@ -24,10 +24,5 @@ under the License.
       <url>https://maven-central-eu.storage-download.googleapis.com/maven2/</url>
       <mirrorOf>central</mirrorOf>
     </mirror>
-    <mirror>
-      <id>conjars-https</id>
-      <url>https://conjars.org/repo/</url>
-      <mirrorOf>conjars</mirrorOf>
-    </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
## What is the purpose of the change

* Conjars repository doesn't exist anymore and Flink doesn't need it, so let's remove all references from Conjars in the codebase

## Brief change log

* Cleaned up Maven mirror for Azure and Alibaba CI

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
