### PR TITLE
[FLINK-31703][Connectors/AWS][docs] Update AWS connector docs to v4.1.0 (1.17)

### DIFF
--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -172,7 +172,7 @@ kinesis:
     versions:
         - versions: universal
           maven: flink-connector-kinesis
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/4.0.0-1.17/flink-sql-connector-kinesis-4.0.0-1.17.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/4.1.0-1.16/flink-sql-connector-kinesis-4.1.0-1.16.jar
 
 aws-kinesis-firehose:
     name: Amazon Kinesis Data Firehose
@@ -180,7 +180,7 @@ aws-kinesis-firehose:
     versions:
         - version: universal
           maven: flink-connector-aws-kinesis-firehose
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/4.0.0-1.17/flink-sql-connector-aws-kinesis-firehose-4.0.0-1.17.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/4.1.0-1.16/flink-sql-connector-aws-kinesis-firehose-4.1.0-1.16.jar
 
 dynamodb:
     name: Amazon DynamoDB
@@ -188,7 +188,7 @@ dynamodb:
     versions:
         - version: universal
           maven: flink-connector-dynamodb
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/4.0.0-1.17/flink-sql-connector-dynamodb-4.0.0-1.17.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/4.1.0-1.16/flink-sql-connector-dynamodb-4.1.0-1.16.jar
 
 pulsar:
     name: Pulsar

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -44,7 +44,7 @@ mkdir tmp
 cd tmp
 
 integrate_connector_docs elasticsearch v3.0.0
-integrate_connector_docs aws v4.0
+integrate_connector_docs aws v4.1.0
 integrate_connector_docs cassandra v3.0.0
 integrate_connector_docs pulsar main
 integrate_connector_docs jdbc v3.0.0


### PR DESCRIPTION
## What is the purpose of the change

- Update AWS connectors docs build to pull from the 4.1.0 tag

## Brief change log

- Update AWS connectors docs build to pull from the 4.1.0 tag

## Verifying this change

Built locally and verified in local browser

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
