### PR TITLE
[FLINK-31708][API / Type Serialization System] make DataInputView#read(byte[], int, int) return 0 if len is 0.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputDeserializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputDeserializer.java
@@ -378,7 +378,7 @@ public class DataInputDeserializer implements DataInputView, java.io.Serializabl
         }
 
         if (this.position >= this.end) {
-            return -1;
+            return len == 0 ? 0 : -1;
         } else {
             int toRead = Math.min(this.end - this.position, len);
             System.arraycopy(this.buffer, this.position, b, off, toRead);

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
@@ -44,7 +44,12 @@ public interface DataInputView extends DataInput {
 
     /**
      * Reads up to {@code len} bytes of memory and stores it into {@code b} starting at offset
-     * {@code off}. It returns the number of read bytes or -1 if there is no more data left.
+     * {@code off}.
+     *
+     * <p>If <code>len</code> is zero, then no bytes are read and <code>0</code> is returned;
+     * otherwise, there is an attempt to read at least one byte. If there is no more data left, the
+     * value <code>-1</code> is returned; otherwise, at least one byte is read and stored into
+     * <code>b</code>.
      *
      * @param b byte array to store the data to
      * @param off offset into byte array

--- a/flink-core/src/main/java/org/apache/flink/types/Record.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Record.java
@@ -1584,7 +1584,7 @@ public final class Record implements Value, CopyableValue<Record> {
             }
 
             if (this.position >= this.end) {
-                return -1;
+                return len == 0 ? 0 : -1;
             } else {
                 int toRead = Math.min(this.end - this.position, len);
                 System.arraycopy(this.memory, this.position, b, off, toRead);

--- a/flink-core/src/test/java/org/apache/flink/core/memory/DataInputDeserializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/DataInputDeserializerTest.java
@@ -54,4 +54,14 @@ public class DataInputDeserializerTest {
         }
         Assert.assertEquals(0, dis.available());
     }
+
+    @Test
+    public void testReadWithLenZero() throws IOException {
+        byte[] bytes = new byte[] {};
+        DataInputDeserializer dis = new DataInputDeserializer(bytes, 0, bytes.length);
+        Assert.assertEquals(0, dis.available());
+
+        byte[] bytesForRead = new byte[] {};
+        Assert.assertEquals(0, dis.read(bytes, 0, 0)); // do not throw when read with len 0
+    }
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/DataInputDeserializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/DataInputDeserializerTest.java
@@ -57,11 +57,11 @@ public class DataInputDeserializerTest {
 
     @Test
     public void testReadWithLenZero() throws IOException {
-        byte[] bytes = new byte[] {};
+        byte[] bytes = new byte[0];
         DataInputDeserializer dis = new DataInputDeserializer(bytes, 0, bytes.length);
         Assert.assertEquals(0, dis.available());
 
-        byte[] bytesForRead = new byte[] {};
-        Assert.assertEquals(0, dis.read(bytes, 0, 0)); // do not throw when read with len 0
+        byte[] bytesForRead = new byte[0];
+        Assert.assertEquals(0, dis.read(bytesForRead, 0, 0)); // do not throw when read with len 0
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Refine semantic of [`DataInputView#read(byte[] b, int off, int len)`](https://github.com/apache/flink/blob/release-1.17.0/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java#L55) interface when len is 0 and no more data is available.
There are 4 Classes that implement this method, and their hehavior is different when len is 0 and no more data is available:
* AbstractPagedInputView: [return 0](https://github.com/apache/flink/blob/release-1.17.0/flink-runtime/src/main/java/org/apache/flink/runtime/memory/AbstractPagedInputView.java#L217-L221)
* DataInputDeserializer: [return -1](https://github.com/apache/flink/blob/release-1.17.0/flink-core/src/main/java/org/apache/flink/core/memory/DataInputDeserializer.java#L380-L381)
* InternalDeSerializer: [return -1](https://github.com/apache/flink/blob/release-1.17.0/flink-core/src/main/java/org/apache/flink/types/Record.java#L1586-L1587)
* NonSpanningWrapper: [return 0](https://github.com/apache/flink/blob/release-1.17.0/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/NonSpanningWrapper.java#L307-L311)

There is a chance that when deserializing an protobuf generated empty object, `DataInputDeserializer#read(byte[],int,int)` would return -1, and then cause job failure. (Detail is posted in [issue](https://issues.apache.org/jira/browse/FLINK-29347))
The reason cause this problem is much like: https://github.com/apache/flink/pull/20860.

I think the interface should be clarified, and we can use the same semantic as [InputStream](https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read(byte[],%20int,%20int)):
```
If len is zero, then no bytes are read and 0 is returned;
otherwise, there is an attempt to read at least one byte.
If no byte is available because the stream is at end of file, the value -1 is returned
...
```

## Brief change log

  - Add comment in `DataInputView#read(byte[] byte, int off, int len)` and clarify behavior when len == 0 and no more data available.
  - Make `DataInputDeserializer#read(byte[] byte, int off, int len)` return 0 if len == 0 and no more data available.
  - Make `InternalDeSerializer#read(byte[] byte, int off, int len)` return 0 if len == 0 and no more data available.


## Verifying this change

This change added tests and can be verified as follows:

  - Unittest is added for `DataInputDeserializer#read`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
