### PR TITLE
[FLINK-31703][Connectors/AWS][docs] Update AWS connector docs to v4.1.0 (1.16)

### DIFF
--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -172,7 +172,7 @@ kinesis:
     versions:
         - version: 4.0.0
           maven: flink-connector-kinesis
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/4.0.0-1.16/flink-sql-connector-kinesis-4.0.0-1.16.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/4.1.0-1.16/flink-sql-connector-kinesis-4.1.0-1.16.jar
 
 firehose:
     name: Amazon Kinesis Data Firehose
@@ -180,7 +180,7 @@ firehose:
     versions:
         - version: 4.0.0
           maven: flink-connector-aws-kinesis-firehose
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/4.0.0-1.16/flink-sql-connector-aws-kinesis-firehose-4.0.0-1.16.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/4.1.0-1.16/flink-sql-connector-aws-kinesis-firehose-4.1.0-1.16.jar
 
 dynamodb:
     name: Amazon DynamoDB
@@ -188,7 +188,7 @@ dynamodb:
     versions:
         - version: 4.0.0
           maven: flink-connector-dynamodb
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/4.0.0-1.16/flink-sql-connector-dynamodb-4.0.0-1.16.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/4.1.0-1.16/flink-sql-connector-dynamodb-4.1.0-1.16.jar
 
 pulsar:
     name: Pulsar

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -42,7 +42,7 @@ cd tmp
 # Since there's no documentation yet available for a release branch,
 # we only get the documentation from the main branch
 integrate_connector_docs elasticsearch v3.0.0
-integrate_connector_docs aws v4.0
+integrate_connector_docs aws v4.1.0
 integrate_connector_docs opensearch v1.0.0
 integrate_connector_docs mongodb v1.0.0-docs
 


### PR DESCRIPTION
## What is the purpose of the change

- Update AWS connectors docs build to pull from the 4.1.0 tag

## Brief change log

- Update AWS connectors docs build to pull from the 4.1.0 tag

## Verifying this change

Built locally and verified in local browser

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
