### PR TITLE
[BP-1.16][FLINK-31293] LocalBufferPool request overdraft buffer only when no available buffer and pool size is reached.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
  * A buffer pool used to manage a number of {@link Buffer} instances from the {@link
  * NetworkBufferPool}.
  *
- * <p>Buffer requests are mediated to the network buffer pool to ensure dead-lock free operation of
+ * <p>Buffer requests are mediated to the network buffer pool to ensure deadlock free operation of
  * the network stack by limiting the number of buffers per local buffer pool. It also implements the
  * default mechanism for buffer recycling, which ensures that every buffer is ultimately returned to
  * the network buffer pool.
@@ -85,8 +85,7 @@ class LocalBufferPool implements BufferPool {
      * org.apache.flink.runtime.io.network.partition.consumer.BufferManager#bufferQueue} via the
      * {@link #registeredListeners} callback.
      */
-    private final ArrayDeque<MemorySegment> availableMemorySegments =
-            new ArrayDeque<MemorySegment>();
+    private final ArrayDeque<MemorySegment> availableMemorySegments = new ArrayDeque<>();
 
     /**
      * Buffer availability listeners, which need to be notified when a Buffer becomes available.
@@ -144,8 +143,7 @@ class LocalBufferPool implements BufferPool {
      * @param networkBufferPool global network buffer pool to get buffers from
      * @param numberOfRequiredMemorySegments minimum number of network buffers
      */
-    LocalBufferPool(NetworkBufferPool networkBufferPool, int numberOfRequiredMemorySegments)
-            throws IOException {
+    LocalBufferPool(NetworkBufferPool networkBufferPool, int numberOfRequiredMemorySegments) {
         this(
                 networkBufferPool,
                 numberOfRequiredMemorySegments,
@@ -166,8 +164,7 @@ class LocalBufferPool implements BufferPool {
     LocalBufferPool(
             NetworkBufferPool networkBufferPool,
             int numberOfRequiredMemorySegments,
-            int maxNumberOfMemorySegments)
-            throws Exception {
+            int maxNumberOfMemorySegments) {
         this(
                 networkBufferPool,
                 numberOfRequiredMemorySegments,
@@ -194,8 +191,7 @@ class LocalBufferPool implements BufferPool {
             int maxNumberOfMemorySegments,
             int numberOfSubpartitions,
             int maxBuffersPerChannel,
-            int maxOverdraftBuffersPerGate)
-            throws IOException {
+            int maxOverdraftBuffersPerGate) {
         checkArgument(
                 numberOfRequiredMemorySegments > 0,
                 "Required number of memory segments (%s) should be larger than 0.",
@@ -542,7 +538,7 @@ class LocalBufferPool implements BufferPool {
             return AvailabilityStatus.UNAVAILABLE_NEED_NOT_REQUESTING_NOTIFICATION;
         }
         boolean needRequestingNotificationOfGlobalPoolAvailable = false;
-        // There aren't availableMemorySegments and we continue to request new memory segment from
+        // There aren't availableMemorySegments, and we continue to request new memory segment from
         // global pool.
         if (!requestMemorySegmentFromGlobal()) {
             // If we can not get a buffer from global pool, we should request from it when it
@@ -605,7 +601,7 @@ class LocalBufferPool implements BufferPool {
             BufferListener listener, MemorySegment segment) {
         // We do not know which locks have been acquired before the recycle() or are needed in the
         // notification and which other threads also access them.
-        // -> call notifyBufferAvailable() outside of the synchronized block to avoid a deadlock
+        // -> call notifyBufferAvailable() outside the synchronized block to avoid a deadlock
         // (FLINK-9676)
         return listener.notifyBufferAvailable(new NetworkBuffer(segment, this));
     }
@@ -669,7 +665,7 @@ class LocalBufferPool implements BufferPool {
             if (isDestroyed) {
                 // FLINK-19964: when two local buffer pools are released concurrently, one of them
                 // gets buffers assigned
-                // make sure that checkAndUpdateAvailability is not called as it would pro-actively
+                // make sure that checkAndUpdateAvailability is not called as it would proactively
                 // acquire one buffer from NetworkBufferPool.
                 return;
             }
@@ -759,8 +755,8 @@ class LocalBufferPool implements BufferPool {
 
     private static class SubpartitionBufferRecycler implements BufferRecycler {
 
-        private int channel;
-        private LocalBufferPool bufferPool;
+        private final int channel;
+        private final LocalBufferPool bufferPool;
 
         SubpartitionBufferRecycler(int channel, LocalBufferPool bufferPool) {
             this.channel = channel;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/TestingBufferListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/TestingBufferListener.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import java.util.function.Function;
+
+/** Mock {@link BufferListener} for testing. */
+public class TestingBufferListener implements BufferListener {
+
+    private final Function<Buffer, Boolean> notifyBufferAvailableFunction;
+
+    private final Runnable notifyBufferDestroyedRunnable;
+
+    private TestingBufferListener(
+            Function<Buffer, Boolean> notifyBufferAvailableFunction,
+            Runnable notifyBufferDestroyedRunnable) {
+        this.notifyBufferAvailableFunction = notifyBufferAvailableFunction;
+        this.notifyBufferDestroyedRunnable = notifyBufferDestroyedRunnable;
+    }
+
+    @Override
+    public boolean notifyBufferAvailable(Buffer buffer) {
+        return notifyBufferAvailableFunction.apply(buffer);
+    }
+
+    @Override
+    public void notifyBufferDestroyed() {
+        notifyBufferDestroyedRunnable.run();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link TestingBufferListener}. */
+    public static class Builder {
+        private Function<Buffer, Boolean> notifyBufferAvailableFunction = (ignore) -> false;
+
+        private Runnable notifyBufferDestroyedRunnable = () -> {};
+
+        public Builder setNotifyBufferAvailableFunction(
+                Function<Buffer, Boolean> notifyBufferAvailableFunction) {
+            this.notifyBufferAvailableFunction = notifyBufferAvailableFunction;
+            return this;
+        }
+
+        public Builder setNotifyBufferDestroyedRunnable(Runnable notifyBufferDestroyedRunnable) {
+            this.notifyBufferDestroyedRunnable = notifyBufferDestroyedRunnable;
+            return this;
+        }
+
+        public TestingBufferListener build() {
+            return new TestingBufferListener(
+                    notifyBufferAvailableFunction, notifyBufferDestroyedRunnable);
+        }
+    }
+}


### PR DESCRIPTION
Backport FLINK-31293 to release-1.16.
