### PR TITLE
[FLINK-27204][flink-runtime] Refract FileSystemJobResultStore to execute I/O operations on the ioExecutor

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapITCase.java
@@ -171,8 +171,10 @@ class ApplicationDispatcherBootstrapITCase {
         // having a dirty entry in the JobResultStore should make the ApplicationDispatcherBootstrap
         // implementation fail to submit the job
         final JobResultStore jobResultStore = new EmbeddedJobResultStore();
-        jobResultStore.createDirtyResult(
-                new JobResultEntry(TestingJobResultStore.createSuccessfulJobResult(jobId)));
+        jobResultStore
+                .createDirtyResultAsync(
+                        new JobResultEntry(TestingJobResultStore.createSuccessfulJobResult(jobId)))
+                .get();
         final EmbeddedHaServicesWithLeadershipControl haServices =
                 new EmbeddedHaServicesWithLeadershipControl(EXECUTOR_EXTENSION.getExecutor()) {
 
@@ -202,8 +204,8 @@ class ApplicationDispatcherBootstrapITCase {
                         "The job's main method shouldn't have been succeeded due to a DuplicateJobSubmissionException.")
                 .hasAtLeastOneElementOfType(DuplicateJobSubmissionException.class);
 
-        assertThat(jobResultStore.hasDirtyJobResultEntry(jobId)).isFalse();
-        assertThat(jobResultStore.hasCleanJobResultEntry(jobId)).isTrue();
+        assertThat(jobResultStore.hasDirtyJobResultEntryAsync(jobId).get()).isFalse();
+        assertThat(jobResultStore.hasCleanJobResultEntryAsync(jobId).get()).isTrue();
     }
 
     @Test

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -921,6 +921,26 @@ public class FutureUtils {
                 executor);
     }
 
+    /**
+     * Returns a future which is completed when {@link RunnableWithException} is finished.
+     *
+     * @param runnable represents the task
+     * @param executor to execute the runnable
+     * @return Future which is completed when runnable is finished
+     */
+    public static CompletableFuture<Void> runAsync(
+            RunnableWithException runnable, Executor executor) {
+        return CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        runnable.run();
+                    } catch (Throwable e) {
+                        throw new CompletionException(e);
+                    }
+                },
+                executor);
+    }
+
     // ------------------------------------------------------------------------
     //  Converting futures
     // ------------------------------------------------------------------------

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
@@ -107,7 +107,7 @@ public class KubernetesLeaderElectionHaServices extends AbstractHaServices {
                         configuration),
                 ioExecutor,
                 blobStoreService,
-                FileSystemJobResultStore.fromConfiguration(configuration));
+                FileSystemJobResultStore.fromConfiguration(configuration, ioExecutor));
 
         this.kubeClient = checkNotNull(kubeClient);
         this.clusterId = checkNotNull(clusterId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFact
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleaner;
 import org.apache.flink.runtime.dispatcher.cleanup.ResourceCleanerFactory;
 import org.apache.flink.runtime.entrypoint.ClusterEntryPointExceptionUtils;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -513,36 +514,40 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
     public CompletableFuture<Acknowledge> submitJob(JobGraph jobGraph, Time timeout) {
         final JobID jobID = jobGraph.getJobID();
         log.info("Received JobGraph submission '{}' ({}).", jobGraph.getName(), jobID);
-
-        try {
-            if (isInGloballyTerminalState(jobID)) {
-                log.warn(
-                        "Ignoring JobGraph submission '{}' ({}) because the job already reached a globally-terminal state (i.e. {}) in a previous execution.",
-                        jobGraph.getName(),
-                        jobID,
-                        Arrays.stream(JobStatus.values())
-                                .filter(JobStatus::isGloballyTerminalState)
-                                .map(JobStatus::name)
-                                .collect(Collectors.joining(", ")));
-                return FutureUtils.completedExceptionally(
-                        DuplicateJobSubmissionException.ofGloballyTerminated(jobID));
-            } else if (jobManagerRunnerRegistry.isRegistered(jobID)
-                    || submittedAndWaitingTerminationJobIDs.contains(jobID)) {
-                // job with the given jobID is not terminated, yet
-                return FutureUtils.completedExceptionally(
-                        DuplicateJobSubmissionException.of(jobID));
-            } else if (isPartialResourceConfigured(jobGraph)) {
-                return FutureUtils.completedExceptionally(
-                        new JobSubmissionException(
-                                jobID,
-                                "Currently jobs is not supported if parts of the vertices have "
-                                        + "resources configured. The limitation will be removed in future versions."));
-            } else {
-                return internalSubmitJob(jobGraph);
-            }
-        } catch (FlinkException e) {
-            return FutureUtils.completedExceptionally(e);
-        }
+        return isInGloballyTerminalState(jobID)
+                .thenComposeAsync(
+                        isTerminated -> {
+                            if (isTerminated) {
+                                log.warn(
+                                        "Ignoring JobGraph submission '{}' ({}) because the job already "
+                                                + "reached a globally-terminal state (i.e. {}) in a "
+                                                + "previous execution.",
+                                        jobGraph.getName(),
+                                        jobID,
+                                        Arrays.stream(JobStatus.values())
+                                                .filter(JobStatus::isGloballyTerminalState)
+                                                .map(JobStatus::name)
+                                                .collect(Collectors.joining(", ")));
+                                return FutureUtils.completedExceptionally(
+                                        DuplicateJobSubmissionException.ofGloballyTerminated(
+                                                jobID));
+                            } else if (jobManagerRunnerRegistry.isRegistered(jobID)
+                                    || submittedAndWaitingTerminationJobIDs.contains(jobID)) {
+                                // job with the given jobID is not terminated, yet
+                                return FutureUtils.completedExceptionally(
+                                        DuplicateJobSubmissionException.of(jobID));
+                            } else if (isPartialResourceConfigured(jobGraph)) {
+                                return FutureUtils.completedExceptionally(
+                                        new JobSubmissionException(
+                                                jobID,
+                                                "Currently jobs is not supported if parts of the vertices "
+                                                        + "have resources configured. The limitation will be "
+                                                        + "removed in future versions."));
+                            } else {
+                                return internalSubmitJob(jobGraph);
+                            }
+                        },
+                        getMainThreadExecutor());
     }
 
     @Override
@@ -565,17 +570,11 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
      * Checks whether the given job has already been executed.
      *
      * @param jobId identifying the submitted job
-     * @return true if the job has already finished, either successfully or as a failure
-     * @throws FlinkException if the job scheduling status cannot be retrieved
+     * @return a successfully completed future with {@code true} if the job has already finished,
+     *     either successfully or as a failure
      */
-    private boolean isInGloballyTerminalState(JobID jobId) throws FlinkException {
-        try {
-            return jobResultStore.hasJobResultEntry(jobId);
-        } catch (IOException e) {
-            throw new FlinkException(
-                    String.format("Failed to retrieve job scheduling status for job %s.", jobId),
-                    e);
-        }
+    private CompletableFuture<Boolean> isInGloballyTerminalState(JobID jobId) {
+        return jobResultStore.hasJobResultEntryAsync(jobId);
     }
 
     private boolean isPartialResourceConfigured(JobGraph jobGraph) {
@@ -1258,7 +1257,21 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         if (cleanupJobState.isGlobalCleanup()) {
             return globalResourceCleaner
                     .cleanupAsync(jobId)
-                    .thenRunAsync(() -> markJobAsClean(jobId), ioExecutor)
+                    .thenCompose(unused -> jobResultStore.markResultAsCleanAsync(jobId))
+                    .handle(
+                            (unusedVoid, e) -> {
+                                if (e == null) {
+                                    log.debug(
+                                            "Cleanup for the job '{}' has finished. Job has been marked as clean.",
+                                            jobId);
+                                } else {
+                                    log.warn(
+                                            "Could not properly mark job {} result as clean.",
+                                            jobId,
+                                            e);
+                                }
+                                return null;
+                            })
                     .thenRunAsync(
                             () ->
                                     runPostJobGloballyTerminated(
@@ -1266,16 +1279,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
                             getMainThreadExecutor());
         } else {
             return localResourceCleaner.cleanupAsync(jobId);
-        }
-    }
-
-    private void markJobAsClean(JobID jobId) {
-        try {
-            jobResultStore.markResultAsClean(jobId);
-            log.debug(
-                    "Cleanup for the job '{}' has finished. Job has been marked as clean.", jobId);
-        } catch (IOException e) {
-            log.warn("Could not properly mark job {} result as clean.", jobId, e);
         }
     }
 
@@ -1363,10 +1366,9 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
 
     private CompletableFuture<CleanupJobState> registerGloballyTerminatedJobInJobResultStore(
             ExecutionGraphInfo executionGraphInfo) {
-        final CompletableFuture<Void> writeFuture = new CompletableFuture<>();
         final JobID jobId = executionGraphInfo.getJobId();
 
-        final ArchivedExecutionGraph archivedExecutionGraph =
+        final AccessExecutionGraph archivedExecutionGraph =
                 executionGraphInfo.getArchivedExecutionGraph();
 
         final JobStatus terminalJobStatus = archivedExecutionGraph.getState();
@@ -1376,41 +1378,68 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
                 jobId,
                 terminalJobStatus);
 
-        ioExecutor.execute(
-                () -> {
-                    try {
-                        if (jobResultStore.hasCleanJobResultEntry(jobId)) {
-                            log.warn(
-                                    "Job {} is already marked as clean but clean up was triggered again.",
-                                    jobId);
-                        } else if (!jobResultStore.hasDirtyJobResultEntry(jobId)) {
-                            jobResultStore.createDirtyResult(
-                                    new JobResultEntry(
-                                            JobResult.createFrom(archivedExecutionGraph)));
-                            log.info(
-                                    "Job {} has been registered for cleanup in the JobResultStore after reaching a terminal state.",
-                                    jobId);
-                        }
-                    } catch (IOException e) {
-                        writeFuture.completeExceptionally(e);
-                        return;
-                    }
-                    writeFuture.complete(null);
-                });
+        return jobResultStore
+                .hasCleanJobResultEntryAsync(jobId)
+                .thenCompose(
+                        hasCleanJobResultEntry ->
+                                createDirtyJobResultEntryIfMissingAsync(
+                                        archivedExecutionGraph, hasCleanJobResultEntry))
+                .handleAsync(
+                        (ignored, error) -> {
+                            if (error != null) {
+                                fatalErrorHandler.onFatalError(
+                                        new FlinkException(
+                                                String.format(
+                                                        "The job %s couldn't be marked as pre-cleanup finished in JobResultStore.",
+                                                        executionGraphInfo.getJobId()),
+                                                error));
+                            }
+                            return CleanupJobState.globalCleanup(terminalJobStatus);
+                        },
+                        getMainThreadExecutor());
+    }
 
-        return writeFuture.handleAsync(
-                (ignored, error) -> {
-                    if (error != null) {
-                        fatalErrorHandler.onFatalError(
-                                new FlinkException(
-                                        String.format(
-                                                "The job %s couldn't be marked as pre-cleanup finished in JobResultStore.",
-                                                executionGraphInfo.getJobId()),
-                                        error));
-                    }
-                    return CleanupJobState.globalCleanup(terminalJobStatus);
-                },
-                getMainThreadExecutor());
+    /**
+     * Creates a dirty entry in the {@link #jobResultStore} if there's no entry at all for the given
+     * {@code executionGraph} in the {@code JobResultStore}.
+     *
+     * @param executionGraph The {@link AccessExecutionGraph} for which the {@link JobResult} shall
+     *     be persisted.
+     * @param hasCleanJobResultEntry The decision the dirty entry check is based on.
+     * @return {@code CompletableFuture} that completes as soon as the entry exists.
+     */
+    private CompletableFuture<Void> createDirtyJobResultEntryIfMissingAsync(
+            AccessExecutionGraph executionGraph, boolean hasCleanJobResultEntry) {
+        final JobID jobId = executionGraph.getJobID();
+        if (hasCleanJobResultEntry) {
+            log.warn("Job {} is already marked as clean but clean up was triggered again.", jobId);
+            return FutureUtils.completedVoidFuture();
+        } else {
+            return jobResultStore
+                    .hasDirtyJobResultEntryAsync(jobId)
+                    .thenCompose(
+                            hasDirtyJobResultEntry ->
+                                    createDirtyJobResultEntryAsync(
+                                            executionGraph, hasDirtyJobResultEntry));
+        }
+    }
+
+    /**
+     * Creates a dirty entry in the {@link #jobResultStore} based on the passed {@code
+     * hasDirtyJobResultEntry} flag.
+     *
+     * @param executionGraph The {@link AccessExecutionGraph} that is used to generate the entry.
+     * @param hasDirtyJobResultEntry The decision the entry creation is based on.
+     * @return {@code CompletableFuture} that completes as soon as the entry exists.
+     */
+    private CompletableFuture<Void> createDirtyJobResultEntryAsync(
+            AccessExecutionGraph executionGraph, boolean hasDirtyJobResultEntry) {
+        if (hasDirtyJobResultEntry) {
+            return FutureUtils.completedVoidFuture();
+        }
+
+        return jobResultStore.createDirtyResultAsync(
+                new JobResultEntry(JobResult.createFrom(executionGraph)));
     }
 
     private void writeToExecutionGraphInfoStore(ExecutionGraphInfo executionGraphInfo) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedJobResultStore.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.util.concurrent.Executors;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -49,7 +48,7 @@ public class EmbeddedJobResultStore extends AbstractThreadsafeJobResultStore {
     }
 
     @Override
-    public void markResultAsCleanInternal(JobID jobId) throws IOException, NoSuchElementException {
+    public void markResultAsCleanInternal(JobID jobId) throws NoSuchElementException {
         final JobResultEntry jobResultEntry = dirtyJobResults.remove(jobId);
         if (jobResultEntry != null) {
             cleanJobResults.put(jobId, jobResultEntry);
@@ -62,17 +61,17 @@ public class EmbeddedJobResultStore extends AbstractThreadsafeJobResultStore {
     }
 
     @Override
-    public boolean hasDirtyJobResultEntryInternal(JobID jobId) throws IOException {
+    public boolean hasDirtyJobResultEntryInternal(JobID jobId) {
         return dirtyJobResults.containsKey(jobId);
     }
 
     @Override
-    public boolean hasCleanJobResultEntryInternal(JobID jobId) throws IOException {
+    public boolean hasCleanJobResultEntryInternal(JobID jobId) {
         return cleanJobResults.containsKey(jobId);
     }
 
     @Override
-    public Set<JobResult> getDirtyResultsInternal() throws IOException {
+    public Set<JobResult> getDirtyResultsInternal() {
         return dirtyJobResults.values().stream()
                 .map(JobResultEntry::getJobResult)
                 .collect(Collectors.toSet());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedJobResultStore.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.highavailability.AbstractThreadsafeJobResultStor
 import org.apache.flink.runtime.highavailability.JobResultEntry;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.util.concurrent.Executors;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,6 +38,10 @@ public class EmbeddedJobResultStore extends AbstractThreadsafeJobResultStore {
     private final Map<JobID, JobResultEntry> dirtyJobResults = new HashMap<>();
 
     private final Map<JobID, JobResultEntry> cleanJobResults = new HashMap<>();
+
+    public EmbeddedJobResultStore() {
+        super(Executors.directExecutor());
+    }
 
     @Override
     public void createDirtyResultInternal(JobResultEntry jobResultEntry) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
@@ -77,7 +77,7 @@ public class ZooKeeperLeaderElectionHaServices extends AbstractHaServices {
                                 ZooKeeperUtils.getLeaderPath())),
                 executor,
                 blobStoreService,
-                FileSystemJobResultStore.fromConfiguration(configuration));
+                FileSystemJobResultStore.fromConfiguration(configuration, executor));
         this.curatorFrameworkWrapper = checkNotNull(curatorFrameworkWrapper);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElection;
+import org.apache.flink.runtime.leaderelection.LeadershipLostException;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -43,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -262,34 +262,60 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     @GuardedBy("lock")
     private void startJobMasterServiceProcessAsync(UUID leaderSessionId) {
         sequentialOperation =
-                sequentialOperation.thenRun(
-                        () ->
-                                runIfValidLeader(
-                                        leaderSessionId,
-                                        ThrowingRunnable.unchecked(
+                sequentialOperation.thenCompose(
+                        unused ->
+                                supplyAsyncIfValidLeader(
+                                                leaderSessionId,
                                                 () ->
-                                                        verifyJobSchedulingStatusAndCreateJobMasterServiceProcess(
-                                                                leaderSessionId)),
-                                        "verify job scheduling status and create JobMasterServiceProcess"));
-
+                                                        jobResultStore.hasJobResultEntryAsync(
+                                                                getJobID()),
+                                                () ->
+                                                        FutureUtils.completedExceptionally(
+                                                                new LeadershipLostException(
+                                                                        "The leadership is lost.")))
+                                        .handle(
+                                                (hasJobResult, throwable) -> {
+                                                    if (throwable
+                                                            instanceof LeadershipLostException) {
+                                                        printLogIfNotValidLeader(
+                                                                "verify job result entry",
+                                                                leaderSessionId);
+                                                        return null;
+                                                    } else if (throwable != null) {
+                                                        ExceptionUtils.rethrow(throwable);
+                                                    }
+                                                    if (hasJobResult) {
+                                                        handleJobAlreadyDoneIfValidLeader(
+                                                                leaderSessionId);
+                                                    } else {
+                                                        createNewJobMasterServiceProcessIfValidLeader(
+                                                                leaderSessionId);
+                                                    }
+                                                    return null;
+                                                }));
         handleAsyncOperationError(sequentialOperation, "Could not start the job manager.");
     }
 
-    @GuardedBy("lock")
-    private void verifyJobSchedulingStatusAndCreateJobMasterServiceProcess(UUID leaderSessionId)
-            throws FlinkException {
-        try {
-            if (jobResultStore.hasJobResultEntry(getJobID())) {
-                jobAlreadyDone(leaderSessionId);
-            } else {
-                createNewJobMasterServiceProcess(leaderSessionId);
-            }
-        } catch (IOException e) {
-            throw new FlinkException(
-                    String.format(
-                            "Could not retrieve the job scheduling status for job %s.", getJobID()),
-                    e);
-        }
+    private void handleJobAlreadyDoneIfValidLeader(UUID leaderSessionId) {
+        runIfValidLeader(
+                leaderSessionId, () -> jobAlreadyDone(leaderSessionId), "check completed job");
+    }
+
+    private void createNewJobMasterServiceProcessIfValidLeader(UUID leaderSessionId) {
+        runIfValidLeader(
+                leaderSessionId,
+                () ->
+                        ThrowingRunnable.unchecked(
+                                        () -> createNewJobMasterServiceProcess(leaderSessionId))
+                                .run(),
+                "create new job master service process");
+    }
+
+    private void printLogIfNotValidLeader(String actionDescription, UUID leaderSessionId) {
+        LOG.trace(
+                "Ignore leader action '{}' because the leadership runner is no longer the valid leader for {}.",
+                actionDescription,
+                leaderSessionId);
     }
 
     private ExecutionGraphInfo createExecutionGraphInfoWithJobStatus(JobStatus jobStatus) {
@@ -337,34 +363,25 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
             UUID leaderSessionId, CompletableFuture<String> leaderAddressFuture) {
         FutureUtils.assertNoException(
                 leaderAddressFuture.thenAccept(
-                        address -> {
-                            synchronized (lock) {
-                                if (isValidLeader(leaderSessionId)) {
-                                    LOG.debug("Confirm leadership {}.", leaderSessionId);
-                                    leaderElection.confirmLeadership(leaderSessionId, address);
-                                } else {
-                                    LOG.trace(
-                                            "Ignore confirming leadership because the leader {} is no longer valid.",
-                                            leaderSessionId);
-                                }
-                            }
-                        }));
+                        address ->
+                                runIfValidLeader(
+                                        leaderSessionId,
+                                        () -> {
+                                            LOG.debug("Confirm leadership {}.", leaderSessionId);
+                                            leaderElection.confirmLeadership(
+                                                    leaderSessionId, address);
+                                        },
+                                        "confirming leadership")));
     }
 
     private void forwardResultFuture(
             UUID leaderSessionId, CompletableFuture<JobManagerRunnerResult> resultFuture) {
         resultFuture.whenComplete(
-                (jobManagerRunnerResult, throwable) -> {
-                    synchronized (lock) {
-                        if (isValidLeader(leaderSessionId)) {
-                            onJobCompletion(jobManagerRunnerResult, throwable);
-                        } else {
-                            LOG.trace(
-                                    "Ignore result future forwarding because the leader {} is no longer valid.",
-                                    leaderSessionId);
-                        }
-                    }
-                });
+                (jobManagerRunnerResult, throwable) ->
+                        runIfValidLeader(
+                                leaderSessionId,
+                                () -> onJobCompletion(jobManagerRunnerResult, throwable),
+                                "result future forwarding"));
     }
 
     @GuardedBy("lock")
@@ -489,17 +506,37 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     }
 
     private void runIfValidLeader(
-            UUID expectedLeaderId, Runnable action, String actionDescription) {
+            UUID expectedLeaderId, Runnable action, Runnable noLeaderFallback) {
         synchronized (lock) {
             if (isValidLeader(expectedLeaderId)) {
                 action.run();
             } else {
-                LOG.trace(
-                        "Ignore leader action '{}' because the leadership runner is no longer the valid leader for {}.",
-                        actionDescription,
-                        expectedLeaderId);
+                noLeaderFallback.run();
             }
         }
+    }
+
+    private void runIfValidLeader(
+            UUID expectedLeaderId, Runnable action, String noLeaderFallbackCommandDescription) {
+        runIfValidLeader(
+                expectedLeaderId,
+                action,
+                () ->
+                        printLogIfNotValidLeader(
+                                noLeaderFallbackCommandDescription, expectedLeaderId));
+    }
+
+    private <T> CompletableFuture<T> supplyAsyncIfValidLeader(
+            UUID expectedLeaderId,
+            Supplier<CompletableFuture<T>> supplier,
+            Supplier<CompletableFuture<T>> noLeaderFallback) {
+        final CompletableFuture<T> resultFuture = new CompletableFuture<>();
+        runIfValidLeader(
+                expectedLeaderId,
+                () -> FutureUtils.forward(supplier.get(), resultFuture),
+                () -> FutureUtils.forward(noLeaderFallback.get(), resultFuture));
+
+        return resultFuture;
     }
 
     @GuardedBy("lock")
@@ -515,22 +552,17 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
             CompletableFuture<T> target,
             String forwardDescription) {
         source.whenComplete(
-                (t, throwable) -> {
-                    synchronized (lock) {
-                        if (isValidLeader(expectedLeaderId)) {
-                            if (throwable != null) {
-                                target.completeExceptionally(throwable);
-                            } else {
-                                target.complete(t);
-                            }
-                        } else {
-                            LOG.trace(
-                                    "Ignore forwarding '{}' because the leadership runner is no longer the valid leader for {}.",
-                                    forwardDescription,
-                                    expectedLeaderId);
-                        }
-                    }
-                });
+                (t, throwable) ->
+                        runIfValidLeader(
+                                expectedLeaderId,
+                                () -> {
+                                    if (throwable != null) {
+                                        target.completeExceptionally(throwable);
+                                    } else {
+                                        target.complete(t);
+                                    }
+                                },
+                                forwardDescription));
     }
 
     enum State {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -312,7 +312,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     }
 
     private void printLogIfNotValidLeader(String actionDescription, UUID leaderSessionId) {
-        LOG.trace(
+        LOG.debug(
                 "Ignore leader action '{}' because the leadership runner is no longer the valid leader for {}.",
                 actionDescription,
                 leaderSessionId);
@@ -479,7 +479,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
             if (isRunning()) {
                 action.run();
             } else {
-                LOG.trace(
+                LOG.debug(
                         "Ignore '{}' because the leadership runner is no longer running.",
                         actionDescription);
             }
@@ -492,7 +492,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
             if (isRunning()) {
                 return Optional.of(supplier.get());
             } else {
-                LOG.trace(
+                LOG.debug(
                         "Ignore '{}' because the leadership runner is no longer running.",
                         supplierDescription);
                 return Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
@@ -166,13 +165,6 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     public void start() throws Exception {
         LOG.debug("Start leadership runner for job {}.", getJobID());
         leaderElection.startLeaderElection(this);
-    }
-
-    // TODO: This method can be removed with the migration of the LeaderElection instantiation into
-    // the HighAvailabilityServices in FLINK-31797
-    @VisibleForTesting
-    public LeaderElection getLeaderElection() {
-        return leaderElection;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeadershipLostException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeadershipLostException.java
@@ -16,27 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.highavailability;
+package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.concurrent.Executors;
+/** This exception is used in the scenario that the leadership is lost. */
+public class LeadershipLostException extends LeaderElectionException {
 
-import org.junit.jupiter.api.io.TempDir;
+    private static final long serialVersionUID = 1L;
 
-import java.io.File;
-import java.io.IOException;
+    public LeadershipLostException(String message) {
+        super(message);
+    }
 
-/**
- * Tests for the {@link FileSystemJobResultStore} implementation of the {@link JobResultStore}'s
- * contracts.
- */
-public class FileSystemJobResultStoreContractTest implements JobResultStoreContractTest {
-    @TempDir File temporaryFolder;
+    public LeadershipLostException(Throwable cause) {
+        super(cause);
+    }
 
-    @Override
-    public JobResultStore createJobResultStore() throws IOException {
-        Path path = new Path(temporaryFolder.toURI());
-        return new FileSystemJobResultStore(
-                path.getFileSystem(), path, false, Executors.directExecutor());
+    public LeadershipLostException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -199,7 +199,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
                 IsEmptyCollection.empty());
 
         CommonTestUtils.waitUntilCondition(
-                () -> haServices.getJobResultStore().hasJobResultEntry(jobId));
+                () -> haServices.getJobResultStore().hasJobResultEntryAsync(jobId).get());
     }
 
     @Test
@@ -208,8 +208,10 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         final JobID jobId = jobGraph.getJobID();
 
         final JobResultStore jobResultStore = new EmbeddedJobResultStore();
-        jobResultStore.createDirtyResult(
-                new JobResultEntry(TestingJobResultStore.createSuccessfulJobResult(jobId)));
+        jobResultStore
+                .createDirtyResultAsync(
+                        new JobResultEntry(TestingJobResultStore.createSuccessfulJobResult(jobId)))
+                .get();
         haServices.setJobResultStore(jobResultStore);
 
         // Instantiates JobManagerRunner
@@ -233,7 +235,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
 
         assertThat(
                 "The JobResultStore should have this job still marked as dirty.",
-                haServices.getJobResultStore().hasDirtyJobResultEntry(jobId),
+                haServices.getJobResultStore().hasDirtyJobResultEntryAsync(jobId).get(),
                 CoreMatchers.is(true));
 
         final DispatcherGateway dispatcherGateway =
@@ -248,7 +250,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         jobManagerRunnerCleanupFuture.complete(null);
 
         CommonTestUtils.waitUntilCondition(
-                () -> haServices.getJobResultStore().hasCleanJobResultEntry(jobId));
+                () -> haServices.getJobResultStore().hasCleanJobResultEntryAsync(jobId).get());
     }
 
     @Test
@@ -342,7 +344,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
                 IsEmptyCollection.empty());
         assertTrue(
                 "The JobResultStore has the job listed as clean.",
-                haServices.getJobResultStore().hasJobResultEntry(jobId));
+                haServices.getJobResultStore().hasJobResultEntryAsync(jobId).get());
 
         assertThat(successfulJobGraphCleanup.get(), equalTo(jobId));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -335,8 +335,11 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                                     try {
                                                         markAsDirtyLatch.await();
                                                     } catch (InterruptedException e) {
-                                                        throw new RuntimeException(e);
+                                                        Thread.currentThread().interrupt();
+                                                        return FutureUtils.completedExceptionally(
+                                                                e);
                                                     }
+                                                    return FutureUtils.completedVoidFuture();
                                                 })
                                         .build());
 
@@ -358,7 +361,11 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
         final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
-                        .withMarkResultAsCleanConsumer(markAsCleanFuture::complete)
+                        .withMarkResultAsCleanConsumer(
+                                jobID -> {
+                                    markAsCleanFuture.complete(jobID);
+                                    return FutureUtils.completedVoidFuture();
+                                })
                         .build();
         final OneShotLatch localCleanupLatch = new OneShotLatch();
         final OneShotLatch globalCleanupLatch = new OneShotLatch();
@@ -547,9 +554,9 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
                         .withCreateDirtyResultConsumer(
-                                jobResult -> {
-                                    throw new IOException("Expected IOException.");
-                                })
+                                jobResult ->
+                                        FutureUtils.completedExceptionally(
+                                                new IOException("Expected IOException.")))
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
@@ -579,11 +586,15 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         final CompletableFuture<JobResultEntry> dirtyJobFuture = new CompletableFuture<>();
         final JobResultStore jobResultStore =
                 TestingJobResultStore.builder()
-                        .withCreateDirtyResultConsumer(dirtyJobFuture::complete)
-                        .withMarkResultAsCleanConsumer(
-                                jobId -> {
-                                    throw new IOException("Expected IOException.");
+                        .withCreateDirtyResultConsumer(
+                                jobResultEntry -> {
+                                    dirtyJobFuture.complete(jobResultEntry);
+                                    return FutureUtils.completedVoidFuture();
                                 })
+                        .withMarkResultAsCleanConsumer(
+                                jobId ->
+                                        FutureUtils.completedExceptionally(
+                                                new IOException("Expected IOException.")))
                         .build();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -224,7 +224,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final JobResult jobResult =
                 TestingJobResultStore.createJobResult(
                         jobGraph.getJobID(), ApplicationStatus.SUCCEEDED);
-        haServices.getJobResultStore().createDirtyResult(new JobResultEntry(jobResult));
+        haServices.getJobResultStore().createDirtyResultAsync(new JobResultEntry(jobResult)).get();
         assertDuplicateJobSubmission();
     }
 
@@ -233,8 +233,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         final JobResult jobResult =
                 TestingJobResultStore.createJobResult(
                         jobGraph.getJobID(), ApplicationStatus.SUCCEEDED);
-        haServices.getJobResultStore().createDirtyResult(new JobResultEntry(jobResult));
-        haServices.getJobResultStore().markResultAsClean(jobGraph.getJobID());
+        haServices.getJobResultStore().createDirtyResultAsync(new JobResultEntry(jobResult)).get();
+        haServices.getJobResultStore().markResultAsCleanAsync(jobGraph.getJobID()).get();
 
         assertDuplicateJobSubmission();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -656,7 +656,7 @@ class JobMasterServiceLeadershipRunnerTest {
         final JobID jobId = new JobID();
         final JobResult jobResult =
                 TestingJobResultStore.createJobResult(jobId, ApplicationStatus.UNKNOWN);
-        jobResultStore.createDirtyResult(new JobResultEntry(jobResult));
+        jobResultStore.createDirtyResultAsync(new JobResultEntry(jobResult)).get();
         try (JobManagerRunner jobManagerRunner =
                 newJobMasterServiceLeadershipRunnerBuilder()
                         .setJobMasterServiceProcessFactory(


### PR DESCRIPTION
## What is the purpose of the change

*At present, FileSystemJobResultStore executes I/O operations through FileSystem directly. We should refract the interface of JobResultStore to make I/O operations be executed asynchronously. This would move the responsibility of I/O operation from the Dispatcher into the JobResultStore.*


## Brief change log

  - *Refract the JobResultStore interface.*
  - *Refract all codes that calls JobResultStore.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
