### PR TITLE
[FLINK-31636][network] Upstream supports reading buffers from tiered store

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfSegmentEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfSegmentEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+
+/**
+ * {@link EndOfSegmentEvent} is used to notify the downstream switch tiers in tiered storage shuffle
+ * mode.
+ */
+@Internal
+public class EndOfSegmentEvent extends RuntimeEvent {
+
+    /** The singleton instance of this event. */
+    public static final EndOfSegmentEvent INSTANCE = new EndOfSegmentEvent();
+
+    private EndOfSegmentEvent() {}
+
+    @Override
+    public void write(DataOutputView out) throws IOException {
+        throw new UnsupportedOperationException("This method should never be called");
+    }
+
+    @Override
+    public void read(DataInputView in) throws IOException {
+        throw new UnsupportedOperationException("This method should never be called");
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public int hashCode() {
+        return 1965146672;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj.getClass() == EndOfSegmentEvent.class;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.EndOfSegmentEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.StopMode;
@@ -74,6 +75,8 @@ public class EventSerializer {
     private static final int VIRTUAL_CHANNEL_SELECTOR_EVENT = 7;
 
     private static final int END_OF_USER_RECORDS_EVENT = 8;
+
+    private static final int END_OF_SEGMENT = 9;
 
     private static final byte CHECKPOINT_TYPE_CHECKPOINT = 0;
 
@@ -139,6 +142,8 @@ public class EventSerializer {
             buf.putInt(selector.getOutputSubtaskIndex());
             buf.flip();
             return buf;
+        } else if (eventClass == EndOfSegmentEvent.class) {
+            return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_SEGMENT});
         } else {
             try {
                 final DataOutputSerializer serializer = new DataOutputSerializer(128);
@@ -183,6 +188,8 @@ public class EventSerializer {
                 return new EventAnnouncement(announcedEvent, sequenceNumber);
             } else if (type == VIRTUAL_CHANNEL_SELECTOR_EVENT) {
                 return new SubtaskConnectionDescriptor(buffer.getInt(), buffer.getInt());
+            } else if (type == END_OF_SEGMENT) {
+                return EndOfSegmentEvent.INSTANCE;
             } else if (type == OTHER_EVENT) {
                 try {
                     final DataInputDeserializer deserializer = new DataInputDeserializer(buffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -289,7 +289,10 @@ public interface Buffer {
          * Indicates that this subpartition state is fully recovered (emitted). Further data can be
          * consumed after unblocking.
          */
-        RECOVERY_COMPLETION(false, true, true, false, false);
+        RECOVERY_COMPLETION(false, true, true, false, false),
+
+        /** {@link #END_OF_SEGMENT} indicates that a segment is finished in a subpartition. */
+        END_OF_SEGMENT(false, true, false, false, false);
 
         private final boolean isBuffer;
         private final boolean isEvent;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -74,6 +74,14 @@ public interface ResultSubpartitionView {
     void notifyNewBufferSize(int newBufferSize);
 
     /**
+     * In tiered storage shuffle mode, only required segments will be sent to prevent the redundant
+     * buffer usage. Downstream will notify the upstream by this method to send required segments.
+     *
+     * @param segmentId segment id is the id indicating the required id.
+     */
+    default void notifyRequiredSegmentId(int segmentId) {}
+
+    /**
      * Availability of the {@link ResultSubpartitionView} and the backlog in the corresponding
      * {@link ResultSubpartition}.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -184,7 +184,7 @@ public abstract class InputChannel {
      * Returns the next buffer from the consumed subpartition or {@code Optional.empty()} if there
      * is no data to return.
      */
-    abstract Optional<BufferAndAvailability> getNextBuffer()
+    public abstract Optional<BufferAndAvailability> getNextBuffer()
             throws IOException, InterruptedException;
 
     /**
@@ -310,6 +310,16 @@ public abstract class InputChannel {
     public long unsynchronizedGetSizeOfQueuedBuffers() {
         return 0;
     }
+
+    /**
+     * Notify the upstream the id of required segment that should be sent to netty connection.
+     *
+     * <p>TODO, This method will be implemented by {@link LocalInputChannel} and {@link
+     * RemoteInputChannel} in the future.
+     *
+     * @param segmentId segment id indicates the id of segment.
+     */
+    public void notifyRequiredSegmentId(int segmentId) {}
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -194,7 +194,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     @Override
-    Optional<BufferAndAvailability> getNextBuffer() throws IOException {
+    public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
         ResultSubpartitionView subpartitionView = this.subpartitionView;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -190,7 +190,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     @Override
-    Optional<BufferAndAvailability> getNextBuffer() throws IOException {
+    public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
         return Optional.ofNullable(getNextRecoveredStateBuffer());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -208,7 +208,7 @@ public class RemoteInputChannel extends InputChannel {
     }
 
     @Override
-    Optional<BufferAndAvailability> getNextBuffer() throws IOException {
+    public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkPartitionRequestQueueInitialized();
 
         final SequenceBuffer next;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionId.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import java.util.Objects;
+import java.util.Random;
+
+/** {@link NettyConnectionId} indicates the unique id of netty connection. */
+public class NettyConnectionId {
+
+    private static final Random RANDOM_SEED = new Random();
+
+    private final long lowerPart;
+
+    private final long upperPart;
+
+    private NettyConnectionId(long lowerPart, long upperPart) {
+        this.lowerPart = lowerPart;
+        this.upperPart = upperPart;
+    }
+
+    public static NettyConnectionId newId() {
+        return new NettyConnectionId(RANDOM_SEED.nextLong(), RANDOM_SEED.nextLong());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NettyConnectionId that = (NettyConnectionId) o;
+        return lowerPart == that.lowerPart && upperPart == that.upperPart;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerPart, upperPart);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReader.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+
+import java.util.Optional;
+
+/** {@link NettyConnectionReader} is used by {@link TierConsumerAgent} to read buffer from netty. */
+public interface NettyConnectionReader {
+    /**
+     * Read a buffer from netty connection.
+     *
+     * @param segmentId segment id indicates the id of segment.
+     * @return {@link Optional#empty()} will be returned if there is no buffer sent from netty
+     *     connection otherwise a buffer will be returned.
+     */
+    Optional<Buffer> readBuffer(int segmentId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderAvailabilityAndPriorityHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderAvailabilityAndPriorityHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+/**
+ * {@link NettyConnectionReaderAvailabilityAndPriorityHelper} is used to help the reader notify the
+ * available and priority status of {@link NettyConnectionReader}, and update the priority sequence
+ * number of priority buffer.
+ */
+public interface NettyConnectionReaderAvailabilityAndPriorityHelper {
+
+    /**
+     * Notify the availability and priority status of {@link NettyConnectionReader}.
+     *
+     * @param channelIndex the index of input channel related to the connection.
+     * @param isPriority the value is to indicate the priority of reader.
+     */
+    void notifyReaderAvailableAndPriority(int channelIndex, boolean isPriority);
+
+    /**
+     * Update the latest sequence number of priority buffer read by the {@link
+     * NettyConnectionReader}, which helps determine if the reader should have priority.
+     *
+     * @param channelIndex the index of input channel related to the connection.
+     * @param sequenceNumber the sequence number of priority buffer.
+     */
+    void updatePrioritySequenceNumber(int channelIndex, int sequenceNumber);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.util.ExceptionUtils;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/** The default implementation of {@link NettyConnectionReader}. */
+public class NettyConnectionReaderImpl implements NettyConnectionReader {
+
+    /** The index of input channel related to the reader. */
+    private final int inputChannelIndex;
+
+    /** The provider to provide the input channel. */
+    private final Supplier<InputChannel> inputChannelProvider;
+
+    /** The helper is used to notify the available and priority status of reader. */
+    private final NettyConnectionReaderAvailabilityAndPriorityHelper helper;
+
+    /** The last required segment id. */
+    private int lastRequiredSegmentId = 0;
+
+    public NettyConnectionReaderImpl(
+            int inputChannelIndex,
+            Supplier<InputChannel> inputChannelProvider,
+            NettyConnectionReaderAvailabilityAndPriorityHelper helper) {
+        this.inputChannelIndex = inputChannelIndex;
+        this.inputChannelProvider = inputChannelProvider;
+        this.helper = helper;
+    }
+
+    @Override
+    public Optional<Buffer> readBuffer(int segmentId) {
+        if (segmentId > 0L && (segmentId != lastRequiredSegmentId)) {
+            lastRequiredSegmentId = segmentId;
+            inputChannelProvider.get().notifyRequiredSegmentId(segmentId);
+        }
+        Optional<InputChannel.BufferAndAvailability> bufferAndAvailability = Optional.empty();
+        try {
+            bufferAndAvailability = inputChannelProvider.get().getNextBuffer();
+        } catch (IOException | InterruptedException e) {
+            ExceptionUtils.rethrow(e, "Failed to read buffer.");
+        }
+        if (bufferAndAvailability.isPresent()) {
+            if (bufferAndAvailability.get().moreAvailable()) {
+                helper.notifyReaderAvailableAndPriority(
+                        inputChannelIndex, bufferAndAvailability.get().hasPriority());
+            }
+            if (bufferAndAvailability.get().hasPriority()) {
+                helper.updatePrioritySequenceNumber(
+                        inputChannelIndex, bufferAndAvailability.get().getSequenceNumber());
+            }
+        }
+        return bufferAndAvailability.map(InputChannel.BufferAndAvailability::buffer);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+import javax.annotation.Nullable;
+
+/**
+ * {@link NettyConnectionWriter} is used by {@link TierProducerAgent} to write buffers to netty
+ * connection. Buffers in the writer will be written to a queue structure and netty server will send
+ * buffers from it.
+ */
+public interface NettyConnectionWriter {
+    /**
+     * Write a buffer to netty connection.
+     *
+     * @param nettyPayload the payload send to netty connection.
+     */
+    void writeBuffer(NettyPayload nettyPayload);
+
+    /**
+     * Get the id of connection in the writer.
+     *
+     * @return the id of connection.
+     */
+    NettyConnectionId getNettyConnectionId();
+
+    /**
+     * Get the number of written but unsent buffers.
+     *
+     * @return the buffer number.
+     */
+    int numQueuedBuffers();
+
+    /**
+     * If error is null, remove and recycle all buffers in the writer. If error is not null, the
+     * error will be written after all buffers are removed and recycled.
+     *
+     * @param error error represents the exception information.
+     */
+    void close(@Nullable Throwable error);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.util.Queue;
+
+/** The default implementation of {@link NettyConnectionWriter}. */
+public class NettyConnectionWriterImpl implements NettyConnectionWriter {
+
+    private final Queue<NettyPayload> bufferQueue;
+
+    private final NettyConnectionId connectionId;
+
+    public NettyConnectionWriterImpl(Queue<NettyPayload> bufferQueue) {
+        this.bufferQueue = bufferQueue;
+        this.connectionId = NettyConnectionId.newId();
+    }
+
+    @Override
+    public NettyConnectionId getNettyConnectionId() {
+        return connectionId;
+    }
+
+    @Override
+    public int numQueuedBuffers() {
+        return bufferQueue.size();
+    }
+
+    @Override
+    public void writeBuffer(NettyPayload nettyPayload) {
+        bufferQueue.add(nettyPayload);
+    }
+
+    @Override
+    public void close(@Nullable Throwable error) {
+        NettyPayload nettyPayload;
+        while ((nettyPayload = bufferQueue.poll()) != null) {
+            nettyPayload.getBuffer().ifPresent(Buffer::recycleBuffer);
+        }
+        if (error != null) {
+            writeBuffer(NettyPayload.newError(error));
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyPayload.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyPayload.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The {@link NettyPayload} represents the payload that will be transferred to netty connection. It
+ * could indicate a combination of buffer, buffer index, and its subpartition id, and it could also
+ * indicate an error or a segment id.
+ */
+public class NettyPayload {
+
+    /**
+     * The data buffer. If the buffer is not null, bufferIndex and subpartitionId will be
+     * non-negative, error will be null, segmentId will be -1;
+     */
+    @Nullable private final Buffer buffer;
+
+    /**
+     * The error information. If the error is not null, buffer will be null, segmentId and
+     * bufferIndex and subpartitionId will be -1.
+     */
+    @Nullable private final Throwable error;
+
+    /**
+     * The index of buffer. If the buffer index is non-negative, buffer won't be null, error will be
+     * null, subpartitionId will be non-negative, segmentId will be -1.
+     */
+    private final int bufferIndex;
+
+    /**
+     * The id of subpartition. If the subpartition id is non-negative, buffer won't be null, error
+     * will be null, bufferIndex will be non-negative, segmentId will be -1.
+     */
+    private final int subpartitionId;
+
+    /**
+     * The id of segment. If the segment id is non-negative, buffer and error will be null,
+     * bufferIndex and subpartitionId will be -1.
+     */
+    private final int segmentId;
+
+    private NettyPayload(
+            @Nullable Buffer buffer,
+            int bufferIndex,
+            int subpartitionId,
+            @Nullable Throwable error,
+            int segmentId) {
+        this.buffer = buffer;
+        this.bufferIndex = bufferIndex;
+        this.subpartitionId = subpartitionId;
+        this.error = error;
+        this.segmentId = segmentId;
+    }
+
+    public static NettyPayload newBuffer(Buffer buffer, int bufferIndex, int subpartitionId) {
+        checkState(buffer != null && bufferIndex != -1 && subpartitionId != -1);
+        return new NettyPayload(buffer, bufferIndex, subpartitionId, null, -1);
+    }
+
+    public static NettyPayload newError(Throwable error) {
+        return new NettyPayload(null, -1, -1, checkNotNull(error), -1);
+    }
+
+    public static NettyPayload newSegment(int segmentId) {
+        checkState(segmentId != -1);
+        return new NettyPayload(null, -1, -1, null, segmentId);
+    }
+
+    public Optional<Buffer> getBuffer() {
+        return buffer != null ? Optional.of(buffer) : Optional.empty();
+    }
+
+    public Optional<Throwable> getError() {
+        return error != null ? Optional.of(error) : Optional.empty();
+    }
+
+    public int getBufferIndex() {
+        return bufferIndex;
+    }
+
+    public int getSubpartitionId() {
+        return subpartitionId;
+    }
+
+    public int getSegmentId() {
+        return segmentId;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyServiceProducer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyServiceProducer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+/**
+ * {@link NettyServiceProducer} is used as the callback to register {@link NettyConnectionWriter}
+ * and disconnect netty connection in {@link TierProducerAgent}.
+ */
+public interface NettyServiceProducer {
+
+    /**
+     * {@link NettyConnectionWriter} will be created when a netty connection is established for a
+     * subpartition.
+     *
+     * @param subpartitionId subpartition id indicates the id of subpartition.
+     * @param nettyConnectionWriter writer is used to write buffers to netty connection.
+     */
+    void connectionEstablished(
+            TieredStorageSubpartitionId subpartitionId,
+            NettyConnectionWriter nettyConnectionWriter);
+
+    /**
+     * {@link NettyConnectionWriter} related to a connection id will be notified when the netty
+     * connection is broken.
+     *
+     * @param connectionId connection id is the id of connection.
+     */
+    void connectionBroken(NettyConnectionId connectionId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyService.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle.TieredResultPartition;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+/** {@link TieredStorageNettyService} is used to create writers and readers to netty. */
+public interface TieredStorageNettyService {
+
+    /**
+     * {@link TierProducerAgent} will provide a callback named {@link NettyServiceProducer} to
+     * register to {@link TieredStorageNettyService}.
+     *
+     * @param partitionId partition id indicates the unique id of {@link TieredResultPartition}.
+     * @param serviceProducer serviceProducer is a callback from {@link TierProducerAgent} and used
+     *     to register a {@link NettyConnectionWriter} and disconnect the netty connection.
+     */
+    void registerProducer(
+            TieredStoragePartitionId partitionId, NettyServiceProducer serviceProducer);
+
+    /**
+     * {@link TierConsumerAgent} will register to {@link TieredStorageNettyService} and get a {@link
+     * NettyConnectionReader}.
+     *
+     * @param partitionId partition id indicates the unique id of {@link TieredResultPartition}.
+     * @param subpartitionId subpartition id indicates the unique id of subpartition.
+     * @return the netty connection reader.
+     */
+    NettyConnectionReader registerConsumer(
+            TieredStoragePartitionId partitionId, TieredStorageSubpartitionId subpartitionId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyServiceImpl.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle.TieredResultPartition;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The default implementation of {@link TieredStorageNettyService}. */
+public class TieredStorageNettyServiceImpl implements TieredStorageNettyService {
+
+    // ------------------------------------
+    //          For producer side
+    // ------------------------------------
+
+    private final Map<TieredStoragePartitionId, List<NettyServiceProducer>>
+            registeredServiceProducers = new ConcurrentHashMap<>();
+
+    private final Map<NettyConnectionId, BufferAvailabilityListener>
+            registeredAvailabilityListeners = new ConcurrentHashMap<>();
+
+    // ------------------------------------
+    //          For consumer side
+    // ------------------------------------
+
+    private final Map<TieredStoragePartitionId, Map<TieredStorageSubpartitionId, Integer>>
+            registeredChannelIndexes = new HashMap<>();
+
+    private final Map<
+                    TieredStoragePartitionId,
+                    Map<TieredStorageSubpartitionId, Supplier<InputChannel>>>
+            registeredInputChannelProviders = new HashMap<>();
+
+    private final Map<
+                    TieredStoragePartitionId,
+                    Map<
+                            TieredStorageSubpartitionId,
+                            NettyConnectionReaderAvailabilityAndPriorityHelper>>
+            registeredNettyConnectionReaderAvailabilityAndPriorityHelpers = new HashMap<>();
+
+    @Override
+    public void registerProducer(
+            TieredStoragePartitionId partitionId, NettyServiceProducer serviceProducer) {
+        registeredServiceProducers
+                .computeIfAbsent(partitionId, ignore -> new ArrayList<>())
+                .add(serviceProducer);
+    }
+
+    @Override
+    public NettyConnectionReader registerConsumer(
+            TieredStoragePartitionId partitionId, TieredStorageSubpartitionId subpartitionId) {
+        Integer channelIndex = registeredChannelIndexes.get(partitionId).remove(subpartitionId);
+        if (registeredChannelIndexes.get(partitionId).isEmpty()) {
+            registeredChannelIndexes.remove(partitionId);
+        }
+
+        Supplier<InputChannel> inputChannelProvider =
+                registeredInputChannelProviders.get(partitionId).remove(subpartitionId);
+        if (registeredInputChannelProviders.get(partitionId).isEmpty()) {
+            registeredInputChannelProviders.remove(partitionId);
+        }
+
+        NettyConnectionReaderAvailabilityAndPriorityHelper helper =
+                registeredNettyConnectionReaderAvailabilityAndPriorityHelpers
+                        .get(partitionId)
+                        .remove(subpartitionId);
+        if (registeredNettyConnectionReaderAvailabilityAndPriorityHelpers
+                .get(partitionId)
+                .isEmpty()) {
+            registeredNettyConnectionReaderAvailabilityAndPriorityHelpers.remove(partitionId);
+        }
+        return new NettyConnectionReaderImpl(channelIndex, inputChannelProvider, helper);
+    }
+
+    /**
+     * Create a {@link ResultSubpartitionView} for the netty server.
+     *
+     * @param partitionId partition id indicates the unique id of {@link TieredResultPartition}.
+     * @param subpartitionId subpartition id indicates the unique id of subpartition.
+     * @param availabilityListener listener is used to listen the available status of data.
+     * @return the {@link TieredStoreResultSubpartitionView}.
+     */
+    public ResultSubpartitionView createResultSubpartitionView(
+            TieredStoragePartitionId partitionId,
+            TieredStorageSubpartitionId subpartitionId,
+            BufferAvailabilityListener availabilityListener) {
+        List<NettyServiceProducer> serviceProducers = registeredServiceProducers.get(partitionId);
+        if (serviceProducers == null) {
+            return new TieredStoreResultSubpartitionView(
+                    availabilityListener, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        }
+        List<Queue<NettyPayload>> queues = new ArrayList<>();
+        List<NettyConnectionId> nettyConnectionIds = new ArrayList<>();
+        for (NettyServiceProducer serviceProducer : serviceProducers) {
+            LinkedBlockingQueue<NettyPayload> queue = new LinkedBlockingQueue<>();
+            NettyConnectionWriterImpl writer = new NettyConnectionWriterImpl(queue);
+            serviceProducer.connectionEstablished(subpartitionId, writer);
+            nettyConnectionIds.add(writer.getNettyConnectionId());
+            queues.add(queue);
+            registeredAvailabilityListeners.put(
+                    writer.getNettyConnectionId(), availabilityListener);
+        }
+        return new TieredStoreResultSubpartitionView(
+                availabilityListener,
+                queues,
+                nettyConnectionIds,
+                registeredServiceProducers.get(partitionId));
+    }
+
+    /**
+     * Notify the {@link ResultSubpartitionView} to send buffer.
+     *
+     * @param connectionId connection id indicates the id of connection.
+     */
+    public void notifyResultSubpartitionViewSendBuffer(NettyConnectionId connectionId) {
+        BufferAvailabilityListener listener = registeredAvailabilityListeners.get(connectionId);
+        if (listener != null) {
+            listener.notifyDataAvailable();
+        }
+    }
+
+    /**
+     * Set up input channels in {@link SingleInputGate}. The method will be invoked by the akka rpc
+     * thread at first, and then the method {@link
+     * TieredStorageNettyService#registerConsumer(TieredStoragePartitionId,
+     * TieredStorageSubpartitionId)} will be invoked by the same thread sequentially, which ensures
+     * thread safety.
+     *
+     * @param partitionIds partition ids indicates the ids of {@link TieredResultPartition}.
+     * @param subpartitionIds subpartition ids indicates the ids of subpartition.
+     */
+    public void setupInputChannels(
+            List<TieredStoragePartitionId> partitionIds,
+            List<TieredStorageSubpartitionId> subpartitionIds,
+            List<Supplier<InputChannel>> inputChannelProviders,
+            NettyConnectionReaderAvailabilityAndPriorityHelper helper) {
+        checkState(partitionIds.size() == subpartitionIds.size());
+        checkState(subpartitionIds.size() == inputChannelProviders.size());
+        for (int index = 0; index < partitionIds.size(); ++index) {
+            TieredStoragePartitionId partitionId = partitionIds.get(index);
+            TieredStorageSubpartitionId subpartitionId = subpartitionIds.get(index);
+
+            registeredChannelIndexes
+                    .computeIfAbsent(partitionId, ignored -> new HashMap<>())
+                    .put(subpartitionId, index);
+
+            registeredInputChannelProviders
+                    .computeIfAbsent(partitionId, ignored -> new HashMap<>())
+                    .put(subpartitionId, inputChannelProviders.get(index));
+
+            registeredNettyConnectionReaderAvailabilityAndPriorityHelpers
+                    .computeIfAbsent(partitionId, ignored -> new HashMap<>())
+                    .put(subpartitionId, helper);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStoreResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStoreResultSubpartitionView.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle.TieredResultPartition;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.END_OF_SEGMENT;
+
+/**
+ * The {@link TieredStoreResultSubpartitionView} is the implementation of {@link
+ * ResultSubpartitionView} of {@link TieredResultPartition}.
+ */
+public class TieredStoreResultSubpartitionView implements ResultSubpartitionView {
+
+    private final BufferAvailabilityListener availabilityListener;
+
+    private final List<Queue<NettyPayload>> nettyPayloadQueues;
+
+    private final List<NettyServiceProducer> serviceProducers;
+
+    private final List<NettyConnectionId> nettyConnectionIds;
+
+    private volatile boolean isReleased = false;
+
+    private int requiredSegmentId = 0;
+
+    private boolean stopSendingData = false;
+
+    private int queueIndexContainsCurrentSegment = -1;
+
+    private int currentSequenceNumber = -1;
+
+    public TieredStoreResultSubpartitionView(
+            BufferAvailabilityListener availabilityListener,
+            List<Queue<NettyPayload>> nettyPayloadQueues,
+            List<NettyConnectionId> nettyConnectionIds,
+            List<NettyServiceProducer> serviceProducers) {
+        this.availabilityListener = availabilityListener;
+        this.nettyPayloadQueues = nettyPayloadQueues;
+        this.nettyConnectionIds = nettyConnectionIds;
+        this.serviceProducers = serviceProducers;
+    }
+
+    @Nullable
+    @Override
+    public BufferAndBacklog getNextBuffer() throws IOException {
+        if (stopSendingData || !findCurrentNettyPayloadQueue()) {
+            return null;
+        }
+        Queue<NettyPayload> currentQueue = nettyPayloadQueues.get(queueIndexContainsCurrentSegment);
+        Optional<Buffer> nextBuffer = readNettyPayload(currentQueue);
+        if (nextBuffer.isPresent()) {
+            stopSendingData = nextBuffer.get().getDataType() == END_OF_SEGMENT;
+            if (stopSendingData) {
+                queueIndexContainsCurrentSegment = -1;
+            }
+            currentSequenceNumber++;
+            return BufferAndBacklog.fromBufferAndLookahead(
+                    nextBuffer.get(),
+                    getNettyPayloadNextDataType(currentQueue),
+                    currentQueue.size(),
+                    currentSequenceNumber);
+        }
+        return null;
+    }
+
+    @Override
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+        if (findCurrentNettyPayloadQueue()) {
+            Queue<NettyPayload> currentQueue =
+                    nettyPayloadQueues.get(queueIndexContainsCurrentSegment);
+            boolean availability = numCreditsAvailable > 0;
+            if (numCreditsAvailable <= 0
+                    && getNettyPayloadNextDataType(currentQueue) == Buffer.DataType.EVENT_BUFFER) {
+                availability = true;
+            }
+            return new AvailabilityWithBacklog(availability, currentQueue.size());
+        }
+        return new AvailabilityWithBacklog(false, 0);
+    }
+
+    @Override
+    public void notifyRequiredSegmentId(int segmentId) {
+        requiredSegmentId = segmentId;
+        stopSendingData = false;
+        availabilityListener.notifyDataAvailable();
+    }
+
+    @Override
+    public void releaseAllResources() throws IOException {
+        if (isReleased) {
+            return;
+        }
+        isReleased = true;
+        for (int index = 0; index < nettyPayloadQueues.size(); ++index) {
+            releaseQueue(
+                    nettyPayloadQueues.get(index),
+                    serviceProducers.get(index),
+                    nettyConnectionIds.get(index));
+        }
+    }
+
+    @Override
+    public boolean isReleased() {
+        return isReleased;
+    }
+
+    @Override
+    public Throwable getFailureCause() {
+        // nothing to do
+        return null;
+    }
+
+    @Override
+    public int unsynchronizedGetNumberOfQueuedBuffers() {
+        findCurrentNettyPayloadQueue();
+        return nettyPayloadQueues.get(queueIndexContainsCurrentSegment).size();
+    }
+
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        findCurrentNettyPayloadQueue();
+        return nettyPayloadQueues.get(queueIndexContainsCurrentSegment).size();
+    }
+
+    @Override
+    public void notifyDataAvailable() {
+        throw new UnsupportedOperationException(
+                "Method notifyDataAvailable should never be called.");
+    }
+
+    @Override
+    public void resumeConsumption() {
+        throw new UnsupportedOperationException("Method resumeConsumption should never be called.");
+    }
+
+    @Override
+    public void acknowledgeAllDataProcessed() {
+        // nothing to do.
+    }
+
+    @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        throw new UnsupportedOperationException(
+                "Method notifyNewBufferSize should never be called.");
+    }
+
+    // -------------------------------
+    //       Internal Methods
+    // -------------------------------
+
+    private Optional<Buffer> readNettyPayload(Queue<NettyPayload> nettyPayloadQueue)
+            throws IOException {
+        NettyPayload nettyPayload = nettyPayloadQueue.poll();
+        if (nettyPayload == null) {
+            return Optional.empty();
+        } else {
+            if (nettyPayload.getSegmentId() != -1) {
+                return readNettyPayload(nettyPayloadQueue);
+            }
+            Optional<Throwable> error = nettyPayload.getError();
+            if (error.isPresent()) {
+                releaseAllResources();
+                throw new IOException(error.get());
+            } else {
+                return nettyPayload.getBuffer();
+            }
+        }
+    }
+
+    private Buffer.DataType getNettyPayloadNextDataType(Queue<NettyPayload> nettyPayload) {
+        NettyPayload nextBuffer = nettyPayload.peek();
+        if (nextBuffer == null || !nextBuffer.getBuffer().isPresent()) {
+            return Buffer.DataType.NONE;
+        } else {
+            return nextBuffer.getBuffer().get().getDataType();
+        }
+    }
+
+    private void releaseQueue(
+            Queue<NettyPayload> nettyPayloadQueue,
+            NettyServiceProducer serviceProducer,
+            NettyConnectionId id) {
+        NettyPayload nettyPayload;
+        while ((nettyPayload = nettyPayloadQueue.poll()) != null) {
+            nettyPayload.getBuffer().ifPresent(Buffer::recycleBuffer);
+        }
+        serviceProducer.connectionBroken(id);
+    }
+
+    private boolean findCurrentNettyPayloadQueue() {
+        if (queueIndexContainsCurrentSegment != -1 && !stopSendingData) {
+            return true;
+        }
+        for (int queueIndex = 0; queueIndex < nettyPayloadQueues.size(); queueIndex++) {
+            NettyPayload firstNettyPayload = nettyPayloadQueues.get(queueIndex).peek();
+            if (firstNettyPayload == null
+                    || firstNettyPayload.getSegmentId() != requiredSegmentId) {
+                continue;
+            }
+            queueIndexContainsCurrentSegment = queueIndex;
+            return true;
+        }
+        return false;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.EndOfSegmentEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.StopMode;
@@ -114,6 +115,7 @@ public class EventSerializerTest {
                                 10)),
                 44),
         new SubtaskConnectionDescriptor(23, 42),
+        EndOfSegmentEvent.INSTANCE
     };
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -143,7 +143,8 @@ public class InputChannelTest {
         void requestSubpartition() throws IOException, InterruptedException {}
 
         @Override
-        Optional<BufferAndAvailability> getNextBuffer() throws IOException, InterruptedException {
+        public Optional<BufferAndAvailability> getNextBuffer()
+                throws IOException, InterruptedException {
             return Optional.empty();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.DATA_BUFFER;
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.NONE;
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.PRIORITIZED_EVENT_BUFFER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NettyConnectionReader}. */
+class NettyConnectionReaderTest {
+
+    private static final int INPUT_CHANNEL_INDEX = 0;
+
+    private CompletableFuture<Tuple2<Integer, Boolean>> availableAndPriorityConsumer;
+
+    private CompletableFuture<Tuple2<Integer, Integer>> prioritySequenceNumberConsumer;
+
+    private CompletableFuture<Integer> requiredSegmentIdFuture;
+
+    @BeforeEach
+    void before() {
+        availableAndPriorityConsumer = new CompletableFuture<>();
+        prioritySequenceNumberConsumer = new CompletableFuture<>();
+        requiredSegmentIdFuture = new CompletableFuture<>();
+    }
+
+    @Test
+    void testReadBufferOfNonPriorityDataType() {
+        int bufferNumber = 1;
+        Supplier<InputChannel> inputChannelSupplier =
+                createInputChannelSupplier(bufferNumber, false, requiredSegmentIdFuture);
+        NettyConnectionReader reader =
+                createNettyConnectionReader(
+                        inputChannelSupplier,
+                        createAvailableAndPriorityConsumer(availableAndPriorityConsumer),
+                        createPrioritySequenceNumberConsumer(prioritySequenceNumberConsumer));
+        Optional<Buffer> buffer = reader.readBuffer(0);
+        assertThat(buffer).isPresent();
+        assertThat(buffer.get().isBuffer()).isTrue();
+        assertThat(requiredSegmentIdFuture).isNotDone();
+        assertThat(availableAndPriorityConsumer).isNotDone();
+        assertThat(prioritySequenceNumberConsumer).isNotDone();
+    }
+
+    @Test
+    void testReadBufferOfPriorityDataType() throws ExecutionException, InterruptedException {
+        int bufferNumber = 2;
+        Supplier<InputChannel> inputChannelSupplier =
+                createInputChannelSupplier(bufferNumber, true, requiredSegmentIdFuture);
+        NettyConnectionReader reader =
+                createNettyConnectionReader(
+                        inputChannelSupplier,
+                        createAvailableAndPriorityConsumer(availableAndPriorityConsumer),
+                        createPrioritySequenceNumberConsumer(prioritySequenceNumberConsumer));
+        Optional<Buffer> buffer = reader.readBuffer(0);
+        assertThat(buffer).isPresent();
+        assertThat(buffer.get().isBuffer()).isFalse();
+        assertThat(requiredSegmentIdFuture).isNotDone();
+        Tuple2<Integer, Boolean> result1 = availableAndPriorityConsumer.get();
+        assertThat(result1.f0).isEqualTo(INPUT_CHANNEL_INDEX);
+        assertThat(result1.f1).isEqualTo(true);
+        Tuple2<Integer, Integer> result2 = prioritySequenceNumberConsumer.get();
+        assertThat(result2.f0).isEqualTo(INPUT_CHANNEL_INDEX);
+        assertThat(result2.f1).isEqualTo(0);
+    }
+
+    @Test
+    void testReadEmptyBuffer() {
+        int bufferNumber = 0;
+        Supplier<InputChannel> inputChannelSupplier =
+                createInputChannelSupplier(bufferNumber, false, requiredSegmentIdFuture);
+        NettyConnectionReader reader =
+                createNettyConnectionReader(
+                        inputChannelSupplier,
+                        (inputChannelIndex, priority) ->
+                                availableAndPriorityConsumer.complete(
+                                        Tuple2.of(inputChannelIndex, priority)),
+                        (inputChannelIndex, sequenceNumber) ->
+                                prioritySequenceNumberConsumer.complete(
+                                        Tuple2.of(inputChannelIndex, sequenceNumber)));
+        Optional<Buffer> buffer = reader.readBuffer(0);
+        assertThat(buffer).isNotPresent();
+        assertThat(requiredSegmentIdFuture).isNotDone();
+        assertThat(availableAndPriorityConsumer).isNotDone();
+        assertThat(prioritySequenceNumberConsumer).isNotDone();
+    }
+
+    @Test
+    void testReadDifferentSegments() throws ExecutionException, InterruptedException {
+        int bufferNumber = 0;
+        Supplier<InputChannel> inputChannelSupplier =
+                createInputChannelSupplier(bufferNumber, false, requiredSegmentIdFuture);
+        NettyConnectionReader reader =
+                createNettyConnectionReader(
+                        inputChannelSupplier,
+                        createAvailableAndPriorityConsumer(availableAndPriorityConsumer),
+                        createPrioritySequenceNumberConsumer(prioritySequenceNumberConsumer));
+        reader.readBuffer(0);
+        assertThat(requiredSegmentIdFuture).isNotDone();
+        reader.readBuffer(1);
+        assertThat(requiredSegmentIdFuture.get()).isEqualTo(1);
+    }
+
+    private static BiConsumer<Integer, Boolean> createAvailableAndPriorityConsumer(
+            CompletableFuture<Tuple2<Integer, Boolean>> availableAndPriorityConsumer) {
+        return (inputChannelIndex, priority) ->
+                availableAndPriorityConsumer.complete(Tuple2.of(inputChannelIndex, priority));
+    }
+
+    private static BiConsumer<Integer, Integer> createPrioritySequenceNumberConsumer(
+            CompletableFuture<Tuple2<Integer, Integer>> prioritySequenceNumberConsumer) {
+        return (inputChannelIndex, sequenceNumber) ->
+                prioritySequenceNumberConsumer.complete(
+                        Tuple2.of(inputChannelIndex, sequenceNumber));
+    }
+
+    private static Supplier<InputChannel> createInputChannelSupplier(
+            int bufferNumber,
+            boolean priority,
+            CompletableFuture<Integer> requiredSegmentIdFuture) {
+        TestInputChannel inputChannel =
+                new TestInputChannel(
+                        new SingleInputGateBuilder().build(),
+                        INPUT_CHANNEL_INDEX,
+                        requiredSegmentIdFuture);
+        try {
+            for (int index = 0; index < bufferNumber; ++index) {
+                inputChannel.read(
+                        new NetworkBuffer(
+                                MemorySegmentFactory.allocateUnpooledSegment(0),
+                                FreeingBufferRecycler.INSTANCE,
+                                priority ? PRIORITIZED_EVENT_BUFFER : DATA_BUFFER),
+                        index == bufferNumber - 1
+                                ? NONE
+                                : priority ? PRIORITIZED_EVENT_BUFFER : DATA_BUFFER);
+            }
+        } catch (IOException | InterruptedException e) {
+            ExceptionUtils.rethrow(e, "Failed to create test input channel.");
+        }
+        return () -> inputChannel;
+    }
+
+    private static NettyConnectionReader createNettyConnectionReader(
+            Supplier<InputChannel> inputChannelSupplier,
+            BiConsumer<Integer, Boolean> availableAndPriorityConsumer,
+            BiConsumer<Integer, Integer> prioritySequenceNumberConsumer) {
+        TestingNettyConnectionReaderAvailabilityAndPriorityHelper.Builder builder =
+                new TestingNettyConnectionReaderAvailabilityAndPriorityHelper.Builder()
+                        .setAvailableAndPriorityConsumer(availableAndPriorityConsumer)
+                        .setPrioritySequenceNumberConsumer(prioritySequenceNumberConsumer);
+        return new NettyConnectionReaderImpl(
+                INPUT_CHANNEL_INDEX, inputChannelSupplier, builder.build());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NettyConnectionWriter}. */
+public class NettyConnectionWriterTest {
+
+    private static final int SUBPARTITION_ID = 0;
+
+    @Test
+    void testWriteBuffer() {
+        int bufferNumber = 10;
+        ArrayDeque<NettyPayload> nettyPayloadQueue = new ArrayDeque<>();
+        NettyConnectionWriter nettyConnectionWriter =
+                new NettyConnectionWriterImpl(nettyPayloadQueue);
+        writeBufferToWriter(bufferNumber, nettyConnectionWriter);
+        assertThat(nettyPayloadQueue).hasSize(bufferNumber);
+        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(bufferNumber);
+    }
+
+    @Test
+    void testGetNettyConnectionId() {
+        ArrayDeque<NettyPayload> nettyPayloadQueue = new ArrayDeque<>();
+        NettyConnectionWriter nettyConnectionWriter =
+                new NettyConnectionWriterImpl(nettyPayloadQueue);
+        assertThat(nettyConnectionWriter.getNettyConnectionId()).isNotNull();
+    }
+
+    @Test
+    void testClose() {
+        int bufferNumber = 10;
+        ArrayDeque<NettyPayload> nettyPayloadQueue = new ArrayDeque<>();
+        NettyConnectionWriter nettyConnectionWriter =
+                new NettyConnectionWriterImpl(nettyPayloadQueue);
+        writeBufferToWriter(bufferNumber, nettyConnectionWriter);
+        nettyConnectionWriter.close(null);
+        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(0);
+        writeBufferToWriter(bufferNumber, nettyConnectionWriter);
+        nettyConnectionWriter.close(new IOException());
+        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(1);
+    }
+
+    private static void writeBufferToWriter(
+            int bufferNumber, NettyConnectionWriter nettyConnectionWriter) {
+        for (int index = 0; index < bufferNumber; ++index) {
+            nettyConnectionWriter.writeBuffer(
+                    NettyPayload.newBuffer(
+                            BufferBuilderTestUtils.buildSomeBuffer(0), index, SUBPARTITION_ID));
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyPayloadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyPayloadTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link NettyPayload}. */
+class NettyPayloadTest {
+
+    @Test
+    void testGetBuffer() {
+        Buffer buffer = BufferBuilderTestUtils.buildSomeBuffer(0);
+        NettyPayload nettyPayload = NettyPayload.newBuffer(buffer, 0, 0);
+        assertThat(nettyPayload.getBuffer()).isPresent();
+        assertThat(nettyPayload.getBuffer()).hasValue(buffer);
+        assertThatThrownBy(() -> NettyPayload.newBuffer(null, 0, 0))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> NettyPayload.newBuffer(buffer, -1, 0))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> NettyPayload.newBuffer(buffer, 0, -1))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testGetError() {
+        Throwable error = new RuntimeException("test exception");
+        NettyPayload nettyPayload = NettyPayload.newError(error);
+        assertThat(nettyPayload.getError()).isPresent();
+        assertThat(nettyPayload.getError()).hasValue(error);
+        assertThatThrownBy(() -> NettyPayload.newError(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testGetBufferIndex() {
+        Buffer buffer = BufferBuilderTestUtils.buildSomeBuffer(0);
+        int bufferIndex = 0;
+        int subpartitionId = 1;
+        NettyPayload nettyPayload = NettyPayload.newBuffer(buffer, bufferIndex, subpartitionId);
+        assertThat(nettyPayload.getBufferIndex()).isEqualTo(bufferIndex);
+    }
+
+    @Test
+    void testGetSubpartitionId() {
+        Buffer buffer = BufferBuilderTestUtils.buildSomeBuffer(0);
+        int bufferIndex = 0;
+        int subpartitionId = 1;
+        NettyPayload nettyPayload = NettyPayload.newBuffer(buffer, bufferIndex, subpartitionId);
+        assertThat(nettyPayload.getSubpartitionId()).isEqualTo(subpartitionId);
+    }
+
+    @Test
+    void testGetSegmentId() {
+        int segmentId = 1;
+        NettyPayload nettyPayload = NettyPayload.newSegment(segmentId);
+        assertThat(nettyPayload.getSegmentId()).isEqualTo(segmentId);
+        assertThatThrownBy(() -> NettyPayload.newSegment(-1))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReaderAvailabilityAndPriorityHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReaderAvailabilityAndPriorityHelper.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import java.util.function.BiConsumer;
+
+/** Test implementation for {@link NettyConnectionReaderAvailabilityAndPriorityHelper}. */
+public class TestingNettyConnectionReaderAvailabilityAndPriorityHelper
+        implements NettyConnectionReaderAvailabilityAndPriorityHelper {
+
+    private final BiConsumer<Integer, Boolean> availableAndPriorityConsumer;
+
+    private final BiConsumer<Integer, Integer> prioritySequenceNumberConsumer;
+
+    private TestingNettyConnectionReaderAvailabilityAndPriorityHelper(
+            BiConsumer<Integer, Boolean> availableAndPriorityConsumer,
+            BiConsumer<Integer, Integer> prioritySequenceNumberConsumer) {
+        this.availableAndPriorityConsumer = availableAndPriorityConsumer;
+        this.prioritySequenceNumberConsumer = prioritySequenceNumberConsumer;
+    }
+
+    @Override
+    public void notifyReaderAvailableAndPriority(int channelIndex, boolean isPriority) {
+        availableAndPriorityConsumer.accept(channelIndex, isPriority);
+    }
+
+    @Override
+    public void updatePrioritySequenceNumber(int channelIndex, int sequenceNumber) {
+        prioritySequenceNumberConsumer.accept(channelIndex, sequenceNumber);
+    }
+
+    /** Builder for {@link TestingNettyConnectionReaderAvailabilityAndPriorityHelper}. */
+    public static class Builder {
+
+        private BiConsumer<Integer, Boolean> availableAndPriorityConsumer =
+                (channelIndex, isPriority) -> {};
+
+        private BiConsumer<Integer, Integer> prioritySequenceNumberConsumer =
+                (channelIndex, sequenceNumber) -> {};
+
+        public Builder() {}
+
+        public Builder setAvailableAndPriorityConsumer(
+                BiConsumer<Integer, Boolean> availableAndPriorityConsumer) {
+            this.availableAndPriorityConsumer = availableAndPriorityConsumer;
+            return this;
+        }
+
+        public Builder setPrioritySequenceNumberConsumer(
+                BiConsumer<Integer, Integer> prioritySequenceNumberConsumer) {
+            this.prioritySequenceNumberConsumer = prioritySequenceNumberConsumer;
+            return this;
+        }
+
+        public TestingNettyConnectionReaderAvailabilityAndPriorityHelper build() {
+            return new TestingNettyConnectionReaderAvailabilityAndPriorityHelper(
+                    availableAndPriorityConsumer, prioritySequenceNumberConsumer);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyServiceProducer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyServiceProducer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/** Test implementation for {@link NettyServiceProducer}. */
+public class TestingNettyServiceProducer implements NettyServiceProducer {
+
+    private final BiConsumer<TieredStorageSubpartitionId, NettyConnectionWriter>
+            connectionEstablishedConsumer;
+
+    private final Consumer<NettyConnectionId> connectionBrokenConsumer;
+
+    private TestingNettyServiceProducer(
+            BiConsumer<TieredStorageSubpartitionId, NettyConnectionWriter>
+                    connectionEstablishedConsumer,
+            Consumer<NettyConnectionId> connectionBrokenConsumer) {
+        this.connectionEstablishedConsumer = connectionEstablishedConsumer;
+        this.connectionBrokenConsumer = connectionBrokenConsumer;
+    }
+
+    @Override
+    public void connectionEstablished(
+            TieredStorageSubpartitionId subpartitionId,
+            NettyConnectionWriter nettyConnectionWriter) {
+        connectionEstablishedConsumer.accept(subpartitionId, nettyConnectionWriter);
+    }
+
+    @Override
+    public void connectionBroken(NettyConnectionId connectionId) {
+        connectionBrokenConsumer.accept(connectionId);
+    }
+
+    /** Builder for {@link TestingNettyServiceProducer}. */
+    public static class Builder {
+
+        private BiConsumer<TieredStorageSubpartitionId, NettyConnectionWriter>
+                connectionEstablishConsumer = (subpartitionId, nettyConnectionWriter) -> {};
+
+        private Consumer<NettyConnectionId> connectionBrokenConsumer = connectionId -> {};
+
+        public Builder setConnectionEstablishConsumer(
+                BiConsumer<TieredStorageSubpartitionId, NettyConnectionWriter>
+                        connectionEstablishConsumer) {
+            this.connectionEstablishConsumer = connectionEstablishConsumer;
+            return this;
+        }
+
+        public Builder setConnectionBrokenConsumer(
+                Consumer<NettyConnectionId> connectionBrokenConsumer) {
+            this.connectionBrokenConsumer = connectionBrokenConsumer;
+            return this;
+        }
+
+        public TestingNettyServiceProducer build() {
+            return new TestingNettyServiceProducer(
+                    connectionEstablishConsumer, connectionBrokenConsumer);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStoreResultSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStoreResultSubpartitionViewTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.END_OF_SEGMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TieredStoreResultSubpartitionView}. */
+public class TieredStoreResultSubpartitionViewTest {
+
+    private static final int TIER_NUMBER = 2;
+
+    private CompletableFuture<Void> availabilityListener;
+
+    private List<Queue<NettyPayload>> nettyPayloadQueues;
+
+    private List<CompletableFuture<NettyConnectionId>> connectionBrokenConsumers;
+
+    private TieredStoreResultSubpartitionView tieredStoreResultSubpartitionView;
+
+    @BeforeEach
+    void before() {
+        availabilityListener = new CompletableFuture<>();
+        nettyPayloadQueues = createNettyPayloadQueues();
+        connectionBrokenConsumers =
+                Arrays.asList(new CompletableFuture<>(), new CompletableFuture<>());
+        tieredStoreResultSubpartitionView =
+                new TieredStoreResultSubpartitionView(
+                        createBufferAvailabilityListener(availabilityListener),
+                        nettyPayloadQueues,
+                        createNettyConnectionIds(),
+                        createNettyServiceProducers(connectionBrokenConsumers));
+    }
+
+    @Test
+    void testGetNextBuffer() throws IOException {
+        checkBufferAndBacklog(tieredStoreResultSubpartitionView.getNextBuffer(), 1);
+        checkBufferAndBacklog(tieredStoreResultSubpartitionView.getNextBuffer(), 0);
+        tieredStoreResultSubpartitionView.notifyRequiredSegmentId(1);
+        assertThat(availabilityListener).isDone();
+        checkBufferAndBacklog(tieredStoreResultSubpartitionView.getNextBuffer(), 1);
+        checkBufferAndBacklog(tieredStoreResultSubpartitionView.getNextBuffer(), 0);
+        assertThat(tieredStoreResultSubpartitionView.getNextBuffer()).isNull();
+    }
+
+    @Test
+    void testGetNextBufferFailed() {
+        Throwable expectedError = new IOException();
+        nettyPayloadQueues = createNettyPayloadQueuesWithError(expectedError);
+        tieredStoreResultSubpartitionView =
+                new TieredStoreResultSubpartitionView(
+                        createBufferAvailabilityListener(availabilityListener),
+                        nettyPayloadQueues,
+                        createNettyConnectionIds(),
+                        createNettyServiceProducers(connectionBrokenConsumers));
+        assertThatThrownBy(tieredStoreResultSubpartitionView::getNextBuffer)
+                .hasCause(expectedError);
+        assertThat(connectionBrokenConsumers.get(0)).isDone();
+    }
+
+    @Test
+    void testGetAvailabilityAndBacklog() {
+        ResultSubpartitionView.AvailabilityWithBacklog availabilityAndBacklog1 =
+                tieredStoreResultSubpartitionView.getAvailabilityAndBacklog(0);
+        assertThat(availabilityAndBacklog1.getBacklog()).isEqualTo(3);
+        assertThat(availabilityAndBacklog1.isAvailable()).isEqualTo(false);
+        ResultSubpartitionView.AvailabilityWithBacklog availabilityAndBacklog2 =
+                tieredStoreResultSubpartitionView.getAvailabilityAndBacklog(2);
+        assertThat(availabilityAndBacklog2.getBacklog()).isEqualTo(3);
+        assertThat(availabilityAndBacklog2.isAvailable()).isEqualTo(true);
+    }
+
+    @Test
+    void testNotifyRequiredSegmentId() {
+        tieredStoreResultSubpartitionView.notifyRequiredSegmentId(1);
+        assertThat(availabilityListener).isDone();
+    }
+
+    @Test
+    void testReleaseAllResources() throws IOException {
+        tieredStoreResultSubpartitionView.releaseAllResources();
+        assertThat(nettyPayloadQueues.get(0)).hasSize(0);
+        assertThat(nettyPayloadQueues.get(1)).hasSize(0);
+        assertThat(connectionBrokenConsumers.get(0)).isDone();
+        assertThat(connectionBrokenConsumers.get(1)).isDone();
+        assertThat(tieredStoreResultSubpartitionView.isReleased()).isTrue();
+    }
+
+    @Test
+    void testGetNumberOfQueuedBuffers() {
+        assertThat(tieredStoreResultSubpartitionView.getNumberOfQueuedBuffers()).isEqualTo(3);
+        assertThat(tieredStoreResultSubpartitionView.unsynchronizedGetNumberOfQueuedBuffers())
+                .isEqualTo(3);
+    }
+
+    private static void checkBufferAndBacklog(BufferAndBacklog bufferAndBacklog, int backlog) {
+        assertThat(bufferAndBacklog).isNotNull();
+        assertThat(bufferAndBacklog.buffer()).isNotNull();
+        assertThat(bufferAndBacklog.buffersInBacklog()).isEqualTo(backlog);
+    }
+
+    private static BufferAvailabilityListener createBufferAvailabilityListener(
+            CompletableFuture<Void> notifier) {
+        return () -> notifier.complete(null);
+    }
+
+    private static List<Queue<NettyPayload>> createNettyPayloadQueues() {
+        List<Queue<NettyPayload>> nettyPayloadQueues = new ArrayList<>();
+        for (int index = 0; index < TIER_NUMBER; ++index) {
+            Queue<NettyPayload> queue = new ArrayDeque<>();
+            queue.add(NettyPayload.newSegment(index));
+            queue.add(NettyPayload.newBuffer(BufferBuilderTestUtils.buildSomeBuffer(0), 0, index));
+            queue.add(
+                    NettyPayload.newBuffer(
+                            new NetworkBuffer(
+                                    MemorySegmentFactory.allocateUnpooledSegment(0),
+                                    FreeingBufferRecycler.INSTANCE,
+                                    END_OF_SEGMENT),
+                            1,
+                            index));
+            nettyPayloadQueues.add(queue);
+        }
+        return nettyPayloadQueues;
+    }
+
+    private static List<Queue<NettyPayload>> createNettyPayloadQueuesWithError(Throwable error) {
+        List<Queue<NettyPayload>> nettyPayloadQueues = new ArrayList<>();
+        for (int index = 0; index < TIER_NUMBER; ++index) {
+            Queue<NettyPayload> queue = new ArrayDeque<>();
+            queue.add(NettyPayload.newSegment(index));
+            queue.add(NettyPayload.newError(error));
+            nettyPayloadQueues.add(queue);
+        }
+        return nettyPayloadQueues;
+    }
+
+    private static List<NettyConnectionId> createNettyConnectionIds() {
+        List<NettyConnectionId> nettyConnectionIds = new ArrayList<>();
+        for (int index = 0; index < TIER_NUMBER; ++index) {
+            nettyConnectionIds.add(NettyConnectionId.newId());
+        }
+        return nettyConnectionIds;
+    }
+
+    private static List<NettyServiceProducer> createNettyServiceProducers(
+            List<CompletableFuture<NettyConnectionId>> connectionBrokenConsumers) {
+        List<NettyServiceProducer> nettyServiceProducers = new ArrayList<>();
+        for (int index = 0; index < connectionBrokenConsumers.size(); ++index) {
+            int indexNumber = index;
+            nettyServiceProducers.add(
+                    new TestingNettyServiceProducer.Builder()
+                            .setConnectionBrokenConsumer(
+                                    connectionId ->
+                                            connectionBrokenConsumers
+                                                    .get(indexNumber)
+                                                    .complete(connectionId))
+                            .build());
+        }
+        return nettyServiceProducers;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingBufferAccumulator;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingTierProducerAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyServiceImpl;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageProducerClient;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
@@ -208,7 +209,8 @@ class TieredResultPartitionTest {
                                 new TestingBufferAccumulator(),
                                 null,
                                 Collections.singletonList(tierProducerAgent)),
-                        new TieredStorageResourceRegistry());
+                        new TieredStorageResourceRegistry(),
+                        new TieredStorageNettyServiceImpl());
         taskIOMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup();
         tieredResultPartition.setup();


### PR DESCRIPTION
## What is the purpose of the change

### Introduce the basic netty service framework

To achieve this purpose, we could break down the implementation into 2 stages and achieve them sequentially.

#### Stage1: Introduce the NettyService framework.

#### Stage2: Introduce the EndOfSegmentEvent.

#### Stage3: Introduce the TieredStoreResultSubpartitionView
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)