### PR TITLE
[BP-1.16][FLINK-30989][runtime] Some config options related to sorting and spilling are not valid.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
@@ -150,7 +150,7 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
             IOManager ioManager,
             boolean objectReuse,
             double managedMemoryFraction,
-            Configuration jobConfiguration,
+            Configuration taskManagerConfiguration,
             ExecutionConfig executionConfig) {
         int keyLength = keySerializer.getLength();
         final TypeComparator<Tuple2<byte[], StreamRecord<Object>>> comparator;
@@ -196,11 +196,11 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
                                                                         / numberOfInputs)
                                                         .enableSpilling(
                                                                 ioManager,
-                                                                jobConfiguration.get(
+                                                                taskManagerConfiguration.get(
                                                                         AlgorithmOptions
                                                                                 .SORT_SPILLING_THRESHOLD))
                                                         .maxNumFileHandles(
-                                                                jobConfiguration.get(
+                                                                taskManagerConfiguration.get(
                                                                                 AlgorithmOptions
                                                                                         .SPILLING_MAX_FAN)
                                                                         / numberOfInputs)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -86,7 +86,7 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
             IOManager ioManager,
             boolean objectReuse,
             double managedMemoryFraction,
-            Configuration jobConfiguration,
+            Configuration taskManagerConfiguration,
             TaskInvokable containingTask,
             ExecutionConfig executionConfig) {
         try {
@@ -115,12 +115,13 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
                             .memoryFraction(managedMemoryFraction)
                             .enableSpilling(
                                     ioManager,
-                                    jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+                                    taskManagerConfiguration.get(
+                                            AlgorithmOptions.SORT_SPILLING_THRESHOLD))
                             .maxNumFileHandles(
-                                    jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
+                                    taskManagerConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
                             .objectReuse(objectReuse)
                             .largeRecords(
-                                    jobConfiguration.get(
+                                    taskManagerConfiguration.get(
                                             AlgorithmOptions.USE_LARGE_RECORDS_HANDLER))
                             .build();
         } catch (MemoryAllocationException e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -176,7 +176,7 @@ public class StreamMultipleInputProcessorFactory {
                                     ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
-                            jobConfig,
+                            taskManagerConfig,
                             executionConfig);
 
             StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -155,7 +155,7 @@ public class StreamTwoInputProcessorFactory {
                                     ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
-                            jobConfig,
+                            taskManagerConfig,
                             executionConfig);
             inputSelectable = selectableSortingInputs.getInputSelectable();
             StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -147,7 +147,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                         ManagedMemoryUseCase.OPERATOR,
                         getEnvironment().getTaskConfiguration(),
                         userCodeClassLoader),
-                getJobConfiguration(),
+                getEnvironment().getTaskManagerInfo().getConfiguration(),
                 this,
                 getExecutionConfig());
     }


### PR DESCRIPTION
Backport FLINK-30989 to release-1.16.
