### PR TITLE
[FLINK-31704][Connectors/Pulsar] Pulsar docs should be pulled from dedicated branch

### DIFF
--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -194,7 +194,7 @@ pulsar:
     name: Pulsar
     category: connector
     maven: flink-connector-pulsar
-    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/$version/flink-sql-connector-pulsar-$version.jar
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/3.0.0-1.16/flink-sql-connector-pulsar-3.0.0-1.16.jar
 
 rabbitmq:
     name: RabbitMQ

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -46,7 +46,7 @@ cd tmp
 integrate_connector_docs elasticsearch v3.0.0
 integrate_connector_docs aws v4.1.0-docs
 integrate_connector_docs cassandra v3.0.0
-integrate_connector_docs pulsar main
+integrate_connector_docs pulsar v3.0.0-docs
 integrate_connector_docs jdbc v3.0.0
 integrate_connector_docs rabbitmq v3.0.0
 integrate_connector_docs gcp-pubsub v3.0.0


### PR DESCRIPTION
## What is the purpose of the change

*Pulsar docs are pulled from the main [branch](https://github.com/apache/flink/blob/release-1.17/docs/setup_docs.sh#L49). This is dangerous for final versions since we may include features in the docs that are not supported. Update Pulsar to pull from a dedicated branch or tag.*


## Brief change log

  - *Bump pulsar doc to v3.0.0-docs branch.*

## Verifying this change

Manual verification locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
