### PR TITLE
[FLINK-17337][table] Support emitting UPDATE_BEFORE and UPDATE_AFTER records in streaming LEFT/RIGHT/FULL OUTER JOIN

### DIFF
--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/KeyEqualityGeneratedJoinCondition.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/KeyEqualityGeneratedJoinCondition.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.generated;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * {@link GeneratedJoinCondition} that returns a {@link JoinCondition} comparing rows keys using
+ * provided {@link KeySelector}s. It is only used for easy testing.
+ */
+public class KeyEqualityGeneratedJoinCondition extends GeneratedJoinCondition {
+
+    private final KeySelector<RowData, RowData> keySelector1;
+    private final KeySelector<RowData, RowData> keySelector2;
+
+    public KeyEqualityGeneratedJoinCondition(
+            KeySelector<RowData, RowData> keySelector1,
+            KeySelector<RowData, RowData> keySelector2) {
+        super("", "", new Object[0]);
+        this.keySelector1 = keySelector1;
+        this.keySelector2 = keySelector2;
+    }
+
+    @Override
+    public JoinCondition newInstance(ClassLoader classLoader) {
+        return new JoinByKeyEquationCondition();
+    }
+
+    /** Join condition for comparing keys of RowData. */
+    private class JoinByKeyEquationCondition extends AbstractRichFunction implements JoinCondition {
+
+        @Override
+        public boolean apply(RowData in1, RowData in2) {
+            try {
+                return keySelector1.getKey(in1).equals(keySelector2.getKey(in2));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.KeyEqualityGeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+
+/** Tests for {@link StreamingJoinOperator}. */
+public class StreamingJoinOperatorTest {
+
+    private final DataType inputRowDataType =
+            ROW(FIELD("f0", INT()), FIELD("f1", STRING())).bridgedTo(RowData.class);
+
+    private final DataType keyRowDataType = ROW(FIELD("f0", INT())).bridgedTo(RowData.class);
+
+    private final RowDataHarnessAssertor assertor =
+            new RowDataHarnessAssertor(
+                    new LogicalType[] {
+                        INT().getLogicalType(),
+                        STRING().getLogicalType(),
+                        INT().getLogicalType(),
+                        STRING().getLogicalType()
+                    });
+
+    @Test
+    void testInnerJoinWithUniqueKey() throws Exception {
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(false, false, true);
+
+        testHarness.open();
+
+        testHarness.processElement1(insertRecord(1, "s1"));
+        testHarness.processElement2(insertRecord(1, "s11"));
+        testHarness.processElement1(updateBeforeRecord(1, "s1"));
+        testHarness.processElement1(updateAfterRecord(1, "s2"));
+        testHarness.processElement2(insertRecord(1, "s12"));
+        testHarness.processElement1(deleteRecord(1, "s2"));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(1, "s1", 1, "s11"));
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s11")); // row kind forwarded
+        expectedOutput.add(updateAfterRecord(1, "s2", 1, "s11")); // row kind forwarded
+        expectedOutput.add(insertRecord(1, "s2", 1, "s12"));
+        expectedOutput.add(deleteRecord(1, "s2", 1, "s12")); // 1 row in state cuz  has key
+
+        assertor.assertOutputEquals("wrong output", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    @Test
+    void testInnerJoinWithoutUniqueKey() throws Exception {
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(false, false, false);
+
+        testHarness.open();
+
+        testHarness.processElement1(insertRecord(1, "s1"));
+        testHarness.processElement2(insertRecord(1, "s11"));
+        testHarness.processElement1(updateBeforeRecord(1, "s1"));
+        testHarness.processElement1(updateAfterRecord(1, "s2"));
+        testHarness.processElement2(insertRecord(1, "s12"));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(1, "s1", 1, "s11"));
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s11")); // row kind forwarded
+        expectedOutput.add(updateAfterRecord(1, "s2", 1, "s11")); // row kind forwarded
+        expectedOutput.add(insertRecord(1, "s2", 1, "s12"));
+
+        assertor.assertOutputEquals("wrong output", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement1(updateBeforeRecord(1, "s2")); // updated join key
+        testHarness.processElement1(updateAfterRecord(2, "s2")); // no pair for key '2'
+
+        // next 2 rows can be in any order
+        expectedOutput.clear();
+        // in case of update on join key we can have UPDATE_BEFORE without subsequent UPDATE_AFTER
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s11")); // 2 rows in state cuz no key
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s12")); // 2 rows in state cuz no key
+
+        List<Object> result = new ArrayList<>(testHarness.getOutput()).subList(4, 6);
+        assertor.assertOutputEqualsSorted("wrong output", expectedOutput, result);
+        testHarness.close();
+    }
+
+    @Test
+    void testLeftOuterJoinWithUniqueKey() throws Exception {
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(true, false, true);
+
+        testHarness.open();
+
+        testHarness.processElement1(insertRecord(1, "s1"));
+        testHarness.processElement2(insertRecord(1, "s11"));
+        testHarness.processElement2(updateBeforeRecord(1, "s11"));
+        testHarness.processElement2(updateAfterRecord(1, "s22"));
+        testHarness.processElement1(insertRecord(1, "s2"));
+        testHarness.processElement2(deleteRecord(1, "s22"));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s1", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s1", 1, "s11"));
+        // update on non-outer side leads to 4 output records, probably can be optimized
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s11"));
+        expectedOutput.add(updateAfterRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s1", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s1", 1, "s22"));
+
+        expectedOutput.add(insertRecord(1, "s2", 1, "s22"));
+
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s22"));
+        expectedOutput.add(updateAfterRecord(1, "s2", null, null));
+
+        assertor.assertOutputEquals("wrong output", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    @Test
+    void testLeftOuterJoinWithoutUniqueKey() throws Exception {
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(true, false, false);
+
+        testHarness.open();
+
+        testHarness.processElement1(insertRecord(1, "s1"));
+        testHarness.processElement2(insertRecord(1, "s11"));
+        testHarness.processElement2(deleteRecord(1, "s11"));
+        testHarness.processElement2(insertRecord(1, "s22"));
+
+        testHarness.processElement1(insertRecord(1, "s2"));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s1", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s1", 1, "s11"));
+        // update on non-outer side leads to 4 output records, probably can be optimized
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s11")); // -U instead of -D
+        expectedOutput.add(updateAfterRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s1", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s1", 1, "s22"));
+
+        expectedOutput.add(insertRecord(1, "s2", 1, "s22"));
+
+        assertor.assertOutputEquals("wrong output", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement2(deleteRecord(1, "s22"));
+
+        // next -U/+U pairs can be in any order
+        expectedOutput.clear();
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s22"));
+        expectedOutput.add(updateAfterRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s22"));
+        expectedOutput.add(updateAfterRecord(1, "s2", null, null));
+
+        List<Object> result = new ArrayList<>(testHarness.getOutput()).subList(8, 12);
+        assertor.assertOutputEqualsSorted("wrong output", expectedOutput, result);
+        testHarness.close();
+    }
+
+    @Test
+    void testFullOuterJoinWithUniqueKey() throws Exception {
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(true, true, true);
+
+        testHarness.open();
+
+        testHarness.processElement1(insertRecord(1, "s1"));
+        testHarness.processElement2(insertRecord(1, "s11"));
+        testHarness.processElement1(updateBeforeRecord(1, "s1"));
+        testHarness.processElement1(updateAfterRecord(1, "s2"));
+        testHarness.processElement2(updateBeforeRecord(1, "s11"));
+        testHarness.processElement2(updateAfterRecord(1, "s22"));
+        testHarness.processElement1(deleteRecord(1, "s2"));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(1, "s1", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s1", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s1", 1, "s11"));
+        // update on non-outer side leads to 4 output records, probably can be optimized
+        expectedOutput.add(updateBeforeRecord(1, "s1", 1, "s11"));
+        expectedOutput.add(updateAfterRecord(null, null, 1, "s11"));
+        expectedOutput.add(updateBeforeRecord(null, null, 1, "s11"));
+        expectedOutput.add(updateAfterRecord(1, "s2", 1, "s11"));
+
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s11"));
+        expectedOutput.add(updateAfterRecord(1, "s2", null, null));
+        expectedOutput.add(updateBeforeRecord(1, "s2", null, null));
+        expectedOutput.add(updateAfterRecord(1, "s2", 1, "s22"));
+
+        expectedOutput.add(updateBeforeRecord(1, "s2", 1, "s22"));
+        expectedOutput.add(updateAfterRecord(null, null, 1, "s22"));
+
+        assertor.assertOutputEquals("wrong output", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData>
+            createTestHarness(boolean leftIsOuter, boolean rightIsOuter, boolean withUniqueKey)
+                    throws Exception {
+        InternalTypeInfo<RowData> inputTypeInfo =
+                InternalTypeInfo.of(inputRowDataType.getLogicalType());
+        InternalTypeInfo<RowData> keyTypeInfo =
+                InternalTypeInfo.of(keyRowDataType.getLogicalType());
+        KeySelector<RowData, RowData> keySelector =
+                HandwrittenSelectorUtil.getRowDataSelector(
+                        new int[] {0},
+                        keyRowDataType.getLogicalType().getChildren().toArray(new LogicalType[0]));
+        JoinInputSideSpec inputSideSpec =
+                withUniqueKey
+                        ? JoinInputSideSpec.withUniqueKeyContainedByJoinKey(
+                                keyTypeInfo, keySelector)
+                        : JoinInputSideSpec.withoutUniqueKey();
+
+        StreamingJoinOperator streamingJoinOperator =
+                new StreamingJoinOperator(
+                        inputTypeInfo,
+                        inputTypeInfo,
+                        new KeyEqualityGeneratedJoinCondition(keySelector, keySelector),
+                        inputSideSpec,
+                        inputSideSpec,
+                        leftIsOuter,
+                        rightIsOuter,
+                        new boolean[] {true},
+                        0);
+        return new KeyedTwoInputStreamOperatorTestHarness<>(
+                streamingJoinOperator, keySelector, keySelector, keyTypeInfo);
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request adds a support of emitting UPDATE_BEFORE and UPDATE_AFTER records in streaming LEFT/RIGHT/FULL OTHER JOIN. Previously, we explicitly was changing RowKind of output records to INSERT/DELETE for simplicity. Emitting UPDATE_BEFORE/UPDATE_AFTER records can be considered as on optimization in case when we have an UPSERT stream (without UPDATE_BEFORE).
Additionally, this pull request closes the bug https://issues.apache.org/jira/browse/FLINK-31729 (unexpected UPDATE_BEFORE record with subsequent INSERT record), because it won't be present with the new logic.

## Brief change log
  - Refactor method StreamingJoinOperator#processElement to support emitting UPDATE_BEFORE/UPDATE_AFTER records 
    - New logic: Forward input RowKind in all join kinds and, additionally, for outer join explicitly set -U & +U to retract / emit rows with null other side
    - Code was shortened and simplified
  - Update pseudo-code above refactored method

## Verifying this change

Existing tests: 
- org.apache.flink.table.planner.runtime.stream.sql.JoinITCase

As previously there were no unit tests on `StreamingJoinOperator` (there were only IT cases), it was decided to write a test class that covers already present logic as well - `StreamingJoinOperatorTest`.


This change added tests and can be verified as follows:

  - Test for inner join with unique join key (it just forward input RowKind)
  - Test for inner join with non-unique join key (can be multiple associated records from other side by specific key)
  - Test for left outer join with unique join key (forwards input RowKind and -U/+U in case of null non-outer side)
  - Test for left outer join with non-unique join key (-//- + can be multiple associated records from other side by specific key)
  - Test for full outer join with unique join key (forwards input RowKind and -U/+U in case of null left/right side)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
