### PR TITLE
[FLINK-31320][table]Modify DATE_FORMAT system (built-in) function to accepts DATEs

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -481,9 +481,9 @@ temporal:
   - sql: (timepoint1, temporal1) OVERLAPS (timepoint2, temporal2)
     table: temporalOverlaps(TIMEPOINT1, TEMPORAL1, TIMEPOINT2, TEMPORAL2)
     description: Returns TRUE if two time intervals defined by (timepoint1, temporal1) and (timepoint2, temporal2) overlap. The temporal values could be either a time point or a time interval. E.g., (TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR) returns TRUE; (TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR) returns FALSE.
-  - sql: DATE_FORMAT(timestamp, string)
-    table: dateFormat(TIMESTAMP, STRING)
-    description: Converts timestamp to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
+  - sql: DATE_FORMAT(date_expr, string)
+    table: dateFormat(DATE_EXPR, STRING)
+    description: Converts date, timestamp or string to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -599,10 +599,10 @@ temporal:
       时间值可以是时间点或时间间隔。例如
       `(TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR)` 返回 TRUE；
       `(TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR)` 返回 FALSE。
-  - sql: DATE_FORMAT(timestamp, string)
-    table: dateFormat(TIMESTAMP, STRING)
+  - sql: DATE_FORMAT(date_expr, string)
+    table: dateFormat(DATE_EXPR, STRING)
     description: |
-      将时间戳 timestamp 转换为日期格式字符串 string 指定格式的字符串值。格式字符串与 Java 的 SimpleDateFormat 兼容。
+      将 date, timestamp or string 转换为日期格式字符串 string 指定格式的字符串值。格式字符串与 Java 的 SimpleDateFormat 兼容。
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -399,18 +399,19 @@ public final class Expressions {
     }
 
     /**
-     * Formats a timestamp as a string using a specified format. The format must be compatible with
-     * MySQL's date formatting syntax as used by the date_parse function.
+     * Formats a date, timestamp or string as a string using a specified format. The format must be
+     * compatible with MySQL's date formatting syntax as used by the date_parse function.
      *
      * <p>For example {@code dataFormat($("time"), "%Y, %d %M")} results in strings formatted as
      * "2017, 05 May".
      *
-     * @param timestamp The timestamp to format as string.
+     * @param dateExpr A date, timestamp or string. If a string, the data must be in a format that
+     *     can be cast to a timestamp
      * @param format The format of the string.
      * @return The formatted timestamp as string.
      */
-    public static ApiExpression dateFormat(Object timestamp, Object format) {
-        return apiCall(BuiltInFunctionDefinitions.DATE_FORMAT, timestamp, format);
+    public static ApiExpression dateFormat(Object dateExpr, Object format) {
+        return apiCall(BuiltInFunctionDefinitions.DATE_FORMAT, dateExpr, format);
     }
 
     /**

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -545,15 +545,16 @@ trait ImplicitExpressionConversions {
    *
    * For example dataFormat('time, "%Y, %d %M") results in strings formatted as "2017, 05 May".
    *
-   * @param timestamp
-   *   The timestamp to format as string.
+   * @param dateExpr
+   *   A date, timestamp or string. If a string, the data must be in a format that can be cast to a
+   *   timestamp.
    * @param format
    *   The format of the string.
    * @return
    *   The formatted timestamp as string.
    */
-  def dateFormat(timestamp: Expression, format: Expression): Expression = {
-    Expressions.dateFormat(timestamp, format)
+  def dateFormat(dateExpr: Expression, format: Expression): Expression = {
+    Expressions.dateFormat(dateExpr, format)
   }
 
   /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1631,6 +1631,9 @@ public final class BuiltInFunctionDefinitions {
                     .inputTypeStrategy(
                             or(
                                     sequence(
+                                            logical(LogicalTypeRoot.DATE),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
                                             logical(LogicalTypeFamily.TIMESTAMP),
                                             logical(LogicalTypeFamily.CHARACTER_STRING)),
                                     sequence(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -755,6 +755,25 @@ public class DateTimeUtils {
         }
     }
 
+    public static String formatDateString(Integer date, String toFormat) {
+
+        final StringBuilder buf = new StringBuilder(10);
+        formatDate(buf, date);
+        TimeZone timeZone = TimeZone.getTimeZone(ZoneId.of("UTC"));
+        SimpleDateFormat fromFormatter = FORMATTER_CACHE.get(DATE_FORMAT_STRING);
+        fromFormatter.setTimeZone(timeZone);
+        SimpleDateFormat toFormatter = FORMATTER_CACHE.get(toFormat);
+        toFormatter.setTimeZone(timeZone);
+        try {
+            return toFormatter.format(fromFormatter.parse(buf.toString()));
+        } catch (ParseException e) {
+            LOG.error(
+                    "Exception when formatting: '" + date.toString() + "' to: '" + toFormat + "'",
+                    e);
+            return null;
+        }
+    }
+
     public static String formatTimestampString(String dateStr, String toFormat, TimeZone tz) {
         // use yyyy-MM-dd HH:mm:ss as default
         return formatTimestampString(dateStr, TIMESTAMP_FORMAT_STRING, toFormat, tz);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -578,6 +578,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     VARCHAR_FORCE_NULLABLE,
                     InferTypes.RETURN_TYPE,
                     OperandTypes.or(
+                            OperandTypes.family(SqlTypeFamily.DATE, SqlTypeFamily.STRING),
                             OperandTypes.family(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.STRING),
                             OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
                     SqlFunctionCategory.TIMEDATE);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -290,6 +290,13 @@ object BuiltInMethods {
     classOf[TimestampData],
     classOf[String])
 
+  val FORMAT_DATE_STRING_FORMAT_STRING_STRING =
+    Types.lookupMethod(
+      classOf[DateTimeUtils],
+      "formatDateString",
+      classOf[Integer],
+      classOf[String])
+
   val FORMAT_TIMESTAMP_DATA_WITH_TIME_ZONE = Types.lookupMethod(
     classOf[DateTimeUtils],
     "formatTimestamp",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.codegen.GenerateUtils.{generateCallIfArgsN
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens._
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable._
 import org.apache.flink.table.runtime.functions.SqlFunctionUtils
-import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isTimestamp, isTimestampWithLocalZone}
+import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isDate, isTimestamp, isTimestampWithLocalZone}
 import org.apache.flink.table.types.logical._
 
 import org.apache.calcite.sql.SqlOperator
@@ -219,6 +219,12 @@ object StringCallGen {
             isTimestampWithLocalZone(operands.head.resultType) &&
             isCharacterString(operands(1).resultType) =>
         methodGen(BuiltInMethods.FORMAT_TIMESTAMP_DATA_WITH_TIME_ZONE)
+
+      case DATE_FORMAT
+          if operands.size == 2 &&
+            isDate(operands.head.resultType) &&
+            isCharacterString(operands(1).resultType) =>
+        methodGen(BuiltInMethods.FORMAT_DATE_STRING_FORMAT_STRING_STRING)
 
       case DATE_FORMAT
           if operands.size == 2 &&

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
@@ -217,11 +217,11 @@ case class TemporalOverlaps(
   }
 }
 
-case class DateFormat(timestamp: PlannerExpression, format: PlannerExpression)
+case class DateFormat(dateExpr: PlannerExpression, format: PlannerExpression)
   extends PlannerExpression {
-  override private[flink] def children = timestamp :: format :: Nil
+  override private[flink] def children = dateExpr :: format :: Nil
 
-  override def toString: String = s"$timestamp.dateFormat($format)"
+  override def toString: String = s"$dateExpr.dateFormat($format)"
 
   override private[flink] def resultType = STRING_TYPE_INFO
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -550,7 +550,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')", "2018/03/14 01:02:03")
     testSqlApi("DATE_FORMAT(TO_DATE('2023-04-05'), 'yyyy/MM/dd HH:mm:ss')", "2023/04/05 00:00:00")
     testSqlApi("DATE_FORMAT(TO_DATE('2023-04-05'), 'yyyy:MM:dd')", "2023:04:05")
-    testSqlApi("DATE_FORMAT(CURRENT_DATE, 'yyyy/MM/dd HH:mm:ss')", "2023/04/05 00:00:00")
     testAllApis(
       dateFormat("2018-03-14 01:02:03", "yyyy/MM/dd HH:mm:ss"),
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -548,6 +548,9 @@ class TemporalTypesTest extends ExpressionTestBase {
     tableConfig.setLocalTimeZone(ZoneId.of("UTC"))
 
     testSqlApi("DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')", "2018/03/14 01:02:03")
+    testSqlApi("DATE_FORMAT(TO_DATE('2023-04-05'), 'yyyy/MM/dd HH:mm:ss')", "2023/04/05 00:00:00")
+    testSqlApi("DATE_FORMAT(TO_DATE('2023-04-05'), 'yyyy:MM:dd')", "2023:04:05")
+    testSqlApi("DATE_FORMAT(CURRENT_DATE, 'yyyy/MM/dd HH:mm:ss')", "2023/04/05 00:00:00")
     testAllApis(
       dateFormat("2018-03-14 01:02:03", "yyyy/MM/dd HH:mm:ss"),
       "DATE_FORMAT('2018-03-14 01:02:03', 'yyyy/MM/dd HH:mm:ss')",

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.TimestampType;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.ARRAY;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DATE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.MAP;
@@ -84,6 +85,10 @@ public class TypeCheckUtils {
 
     public static boolean isTimestamp(LogicalType type) {
         return type.getTypeRoot() == TIMESTAMP_WITHOUT_TIME_ZONE;
+    }
+
+    public static boolean isDate(LogicalType type) {
+        return type.getTypeRoot() == DATE;
     }
 
     public static boolean isTimestampWithLocalZone(LogicalType type) {


### PR DESCRIPTION
## What is the purpose of the change

The current DATE_FORMAT function only supports TIMESTAMPs. Ideally, it should be able to format DATE's as well as TIMESTAMPs.
Like the description of DATE_FORMAT in Spark
```
Converts a date/timestamp/string to a value of string in the format specified by the date  format given by the second argument.
```

## Brief change log
- Modify DATE_FORMAT system (built-in) function to accepts DATEs

```sql
SELECT DATE_FORMAT(CURRENT_DATE, 'yyyy/MM/dd HH:mm:ss')
```
## Verifying this change
This change added tests in TemporalTypesTest#testDateFormat

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
## Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)


