### PR TITLE
[FLINK-30844][runtime] Increased TASK_CANCELLATION_TIMEOUT for testInterruptibleSharedLockInInvokeAndCancel

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -941,7 +941,7 @@ public class TaskTest extends TestLogger {
 
         final Configuration config = new Configuration();
         config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
+        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 1000);
 
         final Task task =
                 createTaskBuilder()


### PR DESCRIPTION

## What is the purpose of the change

Fixing testInterruptibleSharedLockInInvokeAndCancel test


## Brief change log

  - Increased TASK_CANCELLATION_TIMEOUT for testInterruptibleSharedLockInInvokeAndCancel since it looks that on the overloaded machine the current timeout is too small


## Verifying this change
It is test itself
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
