### PR TITLE
[FLINK-31733][docs] Fix/Detect OpenAPI model name clashes 

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -1681,6 +1681,17 @@ components:
         processed:
           type: integer
           format: int64
+    CheckpointAlignmentSummary:
+      type: object
+      properties:
+        buffered:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        persisted:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        processed:
+          $ref: '#/components/schemas/StatsSummaryDto'
     CheckpointConfigInfo:
       type: object
       properties:
@@ -1730,6 +1741,13 @@ components:
         sync:
           type: integer
           format: int64
+    CheckpointDurationSummary:
+      type: object
+      properties:
+        async:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        sync:
+          $ref: '#/components/schemas/StatsSummaryDto'
     CheckpointInfo:
       type: object
       properties:
@@ -1792,6 +1810,21 @@ components:
           format: int64
       discriminator:
         propertyName: className
+    CheckpointStatisticsSummary:
+      type: object
+      properties:
+        alignment_buffered:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        checkpointed_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        end_to_end_duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        persisted_data:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        processed_data:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        state_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
     CheckpointStatsStatus:
       type: string
       enum:
@@ -1823,7 +1856,7 @@ components:
         latest:
           $ref: '#/components/schemas/LatestCheckpoints'
         summary:
-          $ref: '#/components/schemas/Summary'
+          $ref: '#/components/schemas/CheckpointStatisticsSummary'
     ClusterDataSetEntry:
       type: object
       properties:
@@ -2323,7 +2356,38 @@ components:
         vertices:
           type: array
           items:
-            $ref: '#/components/schemas/JobVertexDetailsInfo'
+            $ref: '#/components/schemas/JobDetailsVertexInfo'
+    JobDetailsVertexInfo:
+      type: object
+      properties:
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        id:
+          $ref: '#/components/schemas/JobVertexID'
+        maxParallelism:
+          type: integer
+          format: int32
+        metrics:
+          $ref: '#/components/schemas/IOMetricsInfo'
+        name:
+          type: string
+        parallelism:
+          type: integer
+          format: int32
+        start-time:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        tasks:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
     JobExceptionHistory:
       type: object
       properties:
@@ -2492,6 +2556,33 @@ components:
       properties:
         parallelism:
           $ref: '#/components/schemas/Parallelism'
+    JobVertexTaskManagerInfo:
+      type: object
+      properties:
+        aggregated:
+          $ref: '#/components/schemas/AggregatedTaskDetailsInfo'
+        duration:
+          type: integer
+          format: int64
+        end-time:
+          type: integer
+          format: int64
+        host:
+          type: string
+        metrics:
+          $ref: '#/components/schemas/IOMetricsInfo'
+        start-time:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ExecutionState'
+        status-counts:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        taskmanager-id:
+          type: string
     JobVertexTaskManagersInfo:
       type: object
       properties:
@@ -2505,7 +2596,7 @@ components:
         taskmanagers:
           type: array
           items:
-            $ref: '#/components/schemas/TaskManagersInfo'
+            $ref: '#/components/schemas/JobVertexTaskManagerInfo'
     LatestCheckpoints:
       type: object
       properties:
@@ -2909,21 +3000,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubtaskTimeInfo'
-    Summary:
-      type: object
-      properties:
-        alignment:
-          $ref: '#/components/schemas/CheckpointAlignment'
-        checkpoint_duration:
-          $ref: '#/components/schemas/CheckpointDuration'
-        checkpointed_size:
-          $ref: '#/components/schemas/StatsSummaryDto'
-        end_to_end_duration:
-          $ref: '#/components/schemas/StatsSummaryDto'
-        start_delay:
-          $ref: '#/components/schemas/StatsSummaryDto'
-        state_size:
-          $ref: '#/components/schemas/StatsSummaryDto'
     TaskCheckpointStatistics:
       type: object
       properties:
@@ -2999,7 +3075,22 @@ components:
           items:
             $ref: '#/components/schemas/SubtaskCheckpointStatistics'
         summary:
-          $ref: '#/components/schemas/Summary'
+          $ref: '#/components/schemas/TaskCheckpointStatisticsWithSubtaskDetailsSummary'
+    TaskCheckpointStatisticsWithSubtaskDetailsSummary:
+      type: object
+      properties:
+        alignment:
+          $ref: '#/components/schemas/CheckpointAlignmentSummary'
+        checkpoint_duration:
+          $ref: '#/components/schemas/CheckpointDurationSummary'
+        checkpointed_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        end_to_end_duration:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        start_delay:
+          $ref: '#/components/schemas/StatsSummaryDto'
+        state_size:
+          $ref: '#/components/schemas/StatsSummaryDto'
     TaskExecutorMemoryConfiguration:
       type: object
       properties:

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -51,6 +51,7 @@ import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.jackson.TypeNameResolver;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -103,7 +104,10 @@ public class OpenApiSpecGenerator {
                 JacksonMapperFactory.createObjectMapper()
                         .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         modelConverterContext =
-                new ModelConverterContextImpl(Collections.singletonList(new ModelResolver(mapper)));
+                new ModelConverterContextImpl(
+                        Collections.singletonList(
+                                new ModelResolver(
+                                        mapper, new NameClashDetectingTypeNameResolver())));
     }
 
     @VisibleForTesting
@@ -493,5 +497,31 @@ public class OpenApiSpecGenerator {
                 return PathItem.HttpMethod.PUT;
         }
         throw new IllegalArgumentException("not supported");
+    }
+
+    /** A {@link TypeNameResolver} that detects name-clashes between top-level and inner classes. */
+    public static class NameClashDetectingTypeNameResolver extends TypeNameResolver {
+        private final Map<String, String> seenClassNamesToFQCN = new HashMap<>();
+
+        @Override
+        protected String getNameOfClass(Class<?> cls) {
+            final String modelName = super.getNameOfClass(cls);
+
+            final String fqcn = cls.getCanonicalName();
+            final String previousFqcn = seenClassNamesToFQCN.put(modelName, fqcn);
+
+            if (previousFqcn != null && !fqcn.equals(previousFqcn)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Detected name clash for model name '%s'.%n"
+                                        + "\tClasses:%n"
+                                        + "\t\t- %s%n"
+                                        + "\t\t- %s%n"
+                                        + "\tEither rename the classes or annotate them with '%s' and set a unique 'name'.",
+                                modelName, fqcn, previousFqcn, Schema.class.getCanonicalName()));
+            }
+
+            return modelName;
+        }
     }
 }

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
@@ -21,6 +21,10 @@ package org.apache.flink.docs.rest;
 import org.apache.flink.docs.rest.data.TestAdditionalFieldsMessageHeaders;
 import org.apache.flink.docs.rest.data.TestEmptyMessageHeaders;
 import org.apache.flink.docs.rest.data.TestExcludeMessageHeaders;
+import org.apache.flink.docs.rest.data.clash.inner.TestNameClashingMessageHeaders1;
+import org.apache.flink.docs.rest.data.clash.inner.TestNameClashingMessageHeaders2;
+import org.apache.flink.docs.rest.data.clash.top.pkg1.TestTopLevelNameClashingMessageHeaders1;
+import org.apache.flink.docs.rest.data.clash.top.pkg2.TestTopLevelNameClashingMessageHeaders2;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
 
@@ -117,5 +121,33 @@ class OpenApiSpecGeneratorTest {
                         x ->
                                 assertThat(x.getAdditionalProperties())
                                         .isInstanceOf(StringSchema.class));
+    }
+
+    @Test
+    void testModelNameClashByInnerClassesDetected() {
+        assertThatThrownBy(
+                        () ->
+                                OpenApiSpecGenerator.createDocumentation(
+                                        "title",
+                                        DocumentingRestEndpoint.forRestHandlerSpecifications(
+                                                new TestNameClashingMessageHeaders1(),
+                                                new TestNameClashingMessageHeaders2()),
+                                        RuntimeRestAPIVersion.V0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("clash");
+    }
+
+    @Test
+    void testModelNameClashByTopLevelClassesDetected() {
+        assertThatThrownBy(
+                        () ->
+                                OpenApiSpecGenerator.createDocumentation(
+                                        "title",
+                                        DocumentingRestEndpoint.forRestHandlerSpecifications(
+                                                new TestTopLevelNameClashingMessageHeaders1(),
+                                                new TestTopLevelNameClashingMessageHeaders2()),
+                                        RuntimeRestAPIVersion.V0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("clash");
     }
 }

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
@@ -18,15 +18,11 @@
 
 package org.apache.flink.docs.rest;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.docs.rest.data.TestAdditionalFieldsMessageHeaders;
 import org.apache.flink.docs.rest.data.TestEmptyMessageHeaders;
 import org.apache.flink.docs.rest.data.TestExcludeMessageHeaders;
-import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
-
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -36,10 +32,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,7 +45,11 @@ class OpenApiSpecGeneratorTest {
 
         final Path file = tmpDir.resolve("openapi_spec.yaml");
         OpenApiSpecGenerator.createDocumentationFile(
-                title, new TestExcludeDocumentingRestEndpoint(), RuntimeRestAPIVersion.V0, file);
+                title,
+                DocumentingRestEndpoint.forRestHandlerSpecifications(
+                        new TestEmptyMessageHeaders("/test/empty1", "This is a testing REST API.")),
+                RuntimeRestAPIVersion.V0,
+                file);
         final String actual = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
 
         assertThat(actual).contains("title: " + title);
@@ -63,7 +59,19 @@ class OpenApiSpecGeneratorTest {
     void testExcludeFromDocumentation(@TempDir Path tmpDir) throws Exception {
         final Path file = tmpDir.resolve("openapi_spec.yaml");
         OpenApiSpecGenerator.createDocumentationFile(
-                "title", new TestExcludeDocumentingRestEndpoint(), RuntimeRestAPIVersion.V0, file);
+                "title",
+                DocumentingRestEndpoint.forRestHandlerSpecifications(
+                        new TestEmptyMessageHeaders("/test/empty1", "This is a testing REST API."),
+                        new TestEmptyMessageHeaders(
+                                "/test/empty2", "This is another testing REST API."),
+                        new TestExcludeMessageHeaders(
+                                "/test/exclude1",
+                                "This REST API should not appear in the generated documentation."),
+                        new TestExcludeMessageHeaders(
+                                "/test/exclude2",
+                                "This REST API should also not appear in the generated documentation.")),
+                RuntimeRestAPIVersion.V0,
+                file);
         final String actual = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
 
         assertThat(actual).contains("/test/empty1");
@@ -79,33 +87,6 @@ class OpenApiSpecGeneratorTest {
                         "This REST API should also not appear in the generated documentation.");
     }
 
-    private static class TestExcludeDocumentingRestEndpoint implements DocumentingRestEndpoint {
-
-        @Override
-        public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(
-                CompletableFuture<String> localAddressFuture) {
-            return Arrays.asList(
-                    Tuple2.of(
-                            new TestEmptyMessageHeaders(
-                                    "/test/empty1", "This is a testing REST API."),
-                            null),
-                    Tuple2.of(
-                            new TestEmptyMessageHeaders(
-                                    "/test/empty2", "This is another testing REST API."),
-                            null),
-                    Tuple2.of(
-                            new TestExcludeMessageHeaders(
-                                    "/test/exclude1",
-                                    "This REST API should not appear in the generated documentation."),
-                            null),
-                    Tuple2.of(
-                            new TestExcludeMessageHeaders(
-                                    "/test/exclude2",
-                                    "This REST API should also not appear in the generated documentation."),
-                            null));
-        }
-    }
-
     @Test
     void testDuplicateOperationIdsAreRejected(@TempDir Path tmpDir) {
         final Path file = tmpDir.resolve("openapi_spec.yaml");
@@ -113,45 +94,28 @@ class OpenApiSpecGeneratorTest {
                         () ->
                                 OpenApiSpecGenerator.createDocumentationFile(
                                         "title",
-                                        new TestDuplicateOperationIdDocumentingRestEndpoint(),
+                                        DocumentingRestEndpoint.forRestHandlerSpecifications(
+                                                new TestEmptyMessageHeaders("operation1"),
+                                                new TestEmptyMessageHeaders("operation1")),
                                         RuntimeRestAPIVersion.V0,
                                         file))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Duplicate OperationId");
     }
 
-    private static class TestDuplicateOperationIdDocumentingRestEndpoint
-            implements DocumentingRestEndpoint {
-
-        @Override
-        public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(
-                CompletableFuture<String> localAddressFuture) {
-            return Arrays.asList(
-                    Tuple2.of(new TestEmptyMessageHeaders("operation1"), null),
-                    Tuple2.of(new TestEmptyMessageHeaders("operation1"), null));
-        }
-    }
-
     @Test
     void testAdditionalFields(@TempDir Path tmpDir) throws Exception {
         final OpenAPI documentation =
                 OpenApiSpecGenerator.createDocumentation(
-                        "title", new TestAdditionalFieldsRestEndpoint(), RuntimeRestAPIVersion.V0);
+                        "title",
+                        DocumentingRestEndpoint.forRestHandlerSpecifications(
+                                new TestAdditionalFieldsMessageHeaders("operation1")),
+                        RuntimeRestAPIVersion.V0);
         assertThat(documentation.getComponents().getSchemas())
                 .extractingByKey("AdditionalFieldsRequestBody")
                 .satisfies(
                         x ->
                                 assertThat(x.getAdditionalProperties())
                                         .isInstanceOf(StringSchema.class));
-    }
-
-    private static class TestAdditionalFieldsRestEndpoint implements DocumentingRestEndpoint {
-
-        @Override
-        public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(
-                CompletableFuture<String> localAddressFuture) {
-            return Collections.singletonList(
-                    Tuple2.of(new TestAdditionalFieldsMessageHeaders("operation1"), null));
-        }
     }
 }

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/RestAPIDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/RestAPIDocGeneratorTest.java
@@ -19,23 +19,16 @@
 package org.apache.flink.docs.rest;
 
 import org.apache.flink.annotation.docs.FlinkJsonSchema;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.docs.rest.data.TestEmptyMessageHeaders;
 import org.apache.flink.docs.rest.data.TestExcludeMessageHeaders;
-import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
 import org.apache.flink.util.FileUtils;
 
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
-
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +39,18 @@ class RestAPIDocGeneratorTest {
     void testExcludeFromDocumentation() throws Exception {
         File file = File.createTempFile("rest_v0_", ".html");
         RestAPIDocGenerator.createHtmlFile(
-                new TestExcludeDocumentingRestEndpoint(), RuntimeRestAPIVersion.V0, file.toPath());
+                DocumentingRestEndpoint.forRestHandlerSpecifications(
+                        new TestEmptyMessageHeaders("/test/empty1", "This is a testing REST API."),
+                        new TestEmptyMessageHeaders(
+                                "/test/empty2", "This is another testing REST API."),
+                        new TestExcludeMessageHeaders(
+                                "/test/exclude1",
+                                "This REST API should not appear in the generated documentation."),
+                        new TestExcludeMessageHeaders(
+                                "/test/exclude2",
+                                "This REST API should also not appear in the generated documentation.")),
+                RuntimeRestAPIVersion.V0,
+                file.toPath());
         String actual = FileUtils.readFile(file, "UTF-8");
 
         assertThat(actual).containsSequence("/test/empty1");
@@ -76,33 +80,6 @@ class RestAPIDocGeneratorTest {
                                 + "    \"type\" : \"string\"\n"
                                 + "  }\n"
                                 + "}");
-    }
-
-    private static class TestExcludeDocumentingRestEndpoint implements DocumentingRestEndpoint {
-
-        @Override
-        public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(
-                CompletableFuture<String> localAddressFuture) {
-            return Arrays.asList(
-                    Tuple2.of(
-                            new TestEmptyMessageHeaders(
-                                    "/test/empty1", "This is a testing REST API."),
-                            null),
-                    Tuple2.of(
-                            new TestEmptyMessageHeaders(
-                                    "/test/empty2", "This is another testing REST API."),
-                            null),
-                    Tuple2.of(
-                            new TestExcludeMessageHeaders(
-                                    "/test/exclude1",
-                                    "This REST API should not appear in the generated documentation."),
-                            null),
-                    Tuple2.of(
-                            new TestExcludeMessageHeaders(
-                                    "/test/exclude2",
-                                    "This REST API should also not appear in the generated documentation."),
-                            null));
-        }
     }
 
     @FlinkJsonSchema.AdditionalFields(type = String.class)

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/BaseTestMessageHeaders.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/BaseTestMessageHeaders.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+
+/** A {@link MessageHeaders} for testing purpose. */
+public abstract class BaseTestMessageHeaders<T extends RequestBody>
+        implements RuntimeMessageHeaders<T, EmptyResponseBody, EmptyMessageParameters> {
+
+    private static final String URL = "/test/empty";
+    private static final String DESCRIPTION = "This is an empty testing REST API.";
+
+    private final String url;
+    private final String description;
+    private final String operationId;
+
+    public BaseTestMessageHeaders() {
+        this(URL, DESCRIPTION, UUID.randomUUID().toString());
+    }
+
+    private BaseTestMessageHeaders(String url, String description, String operationId) {
+        this.url = url;
+        this.description = description;
+        this.operationId = operationId;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String operationId() {
+        return operationId;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return url;
+    }
+
+    @Override
+    public Collection<RuntimeRestAPIVersion> getSupportedAPIVersions() {
+        return Collections.singleton(RuntimeRestAPIVersion.V0);
+    }
+}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/inner/TestNameClashingMessageHeaders1.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/inner/TestNameClashingMessageHeaders1.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.inner;
+
+import org.apache.flink.docs.rest.data.BaseTestMessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+/** A {@link MessageHeaders} for testing purpose. */
+public class TestNameClashingMessageHeaders1
+        extends BaseTestMessageHeaders<TestNameClashingMessageHeaders1.ClashingRequestBody> {
+
+    @Override
+    public Class<ClashingRequestBody> getRequestClass() {
+        return ClashingRequestBody.class;
+    }
+
+    /**
+     * A {@link RequestBody} whose name clashes with {@link
+     * org.apache.flink.docs.rest.data.clash.inner.TestNameClashingMessageHeaders2.ClashingRequestBody}.
+     */
+    public static class ClashingRequestBody implements RequestBody {}
+}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/inner/TestNameClashingMessageHeaders2.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/inner/TestNameClashingMessageHeaders2.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.inner;
+
+import org.apache.flink.docs.rest.data.BaseTestMessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+/** A {@link MessageHeaders} for testing purpose. */
+public class TestNameClashingMessageHeaders2
+        extends BaseTestMessageHeaders<TestNameClashingMessageHeaders2.ClashingRequestBody> {
+
+    @Override
+    public Class<ClashingRequestBody> getRequestClass() {
+        return ClashingRequestBody.class;
+    }
+
+    /**
+     * A {@link RequestBody} whose name clashes with {@link
+     * org.apache.flink.docs.rest.data.clash.inner.TestNameClashingMessageHeaders1.ClashingRequestBody}.
+     */
+    public static class ClashingRequestBody implements RequestBody {}
+}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg1/ClashingRequestBody.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg1/ClashingRequestBody.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.top.pkg1;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+/**
+ * A {@link RequestBody} whose name clashes with {@link
+ * org.apache.flink.docs.rest.data.clash.top.pkg2.ClashingRequestBody}.
+ */
+public class ClashingRequestBody implements RequestBody {}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg1/TestTopLevelNameClashingMessageHeaders1.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg1/TestTopLevelNameClashingMessageHeaders1.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.top.pkg1;
+
+import org.apache.flink.docs.rest.data.BaseTestMessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+/** A {@link MessageHeaders} for testing purpose. */
+public class TestTopLevelNameClashingMessageHeaders1
+        extends BaseTestMessageHeaders<ClashingRequestBody> {
+
+    @Override
+    public Class<ClashingRequestBody> getRequestClass() {
+        return ClashingRequestBody.class;
+    }
+}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg2/ClashingRequestBody.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg2/ClashingRequestBody.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.top.pkg2;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+/**
+ * A {@link RequestBody} whose name clashes with {@link
+ * org.apache.flink.docs.rest.data.clash.top.pkg1.ClashingRequestBody}.
+ */
+public class ClashingRequestBody implements RequestBody {}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg2/TestTopLevelNameClashingMessageHeaders2.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/clash/top/pkg2/TestTopLevelNameClashingMessageHeaders2.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data.clash.top.pkg2;
+
+import org.apache.flink.docs.rest.data.BaseTestMessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+/** A {@link MessageHeaders} for testing purpose. */
+public class TestTopLevelNameClashingMessageHeaders2
+        extends BaseTestMessageHeaders<ClashingRequestBody> {
+
+    @Override
+    public Class<ClashingRequestBody> getRequestClass() {
+        return ClashingRequestBody.class;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersInfo.java
@@ -30,6 +30,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -96,6 +98,7 @@ public class JobVertexTaskManagersInfo implements ResponseBody {
     // ---------------------------------------------------
 
     /** Detailed information about task managers. */
+    @Schema(name = "JobVertexTaskManagerInfo")
     public static class TaskManagersInfo {
         public static final String TASK_MANAGERS_FIELD_HOST = "host";
         public static final String TASK_MANAGERS_FIELD_STATUS = "status";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
@@ -25,6 +25,8 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.annotation.Nullable;
 
 import java.util.List;
@@ -198,6 +200,7 @@ public class CheckpointingStatistics implements ResponseBody {
     }
 
     /** Checkpoint summary. */
+    @Schema(name = "CheckpointStatisticsSummary")
     public static final class Summary {
 
         public static final String FIELD_NAME_CHECKPOINTED_SIZE = "checkpointed_size";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
@@ -24,6 +24,8 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -111,6 +113,7 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
     // -----------------------------------------------------------------------------------
 
     /** Summary of the checkpoint statistics for a given task. */
+    @Schema(name = "TaskCheckpointStatisticsWithSubtaskDetailsSummary")
     public static final class Summary {
 
         public static final String FIELD_NAME_CHECKPOINTED_SIZE = "checkpointed_size";
@@ -219,6 +222,7 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
     }
 
     /** Duration of a checkpoint split up into its synchronous and asynchronous part. */
+    @Schema(name = "CheckpointDurationSummary")
     public static final class CheckpointDuration {
 
         public static final String FIELD_NAME_SYNCHRONOUS_DURATION = "sync";
@@ -268,6 +272,7 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
     }
 
     /** Alignment information for a specific checkpoint at a given task. */
+    @Schema(name = "CheckpointAlignmentSummary")
     public static final class CheckpointAlignment {
 
         public static final String FIELD_NAME_BUFFERED_DATA = "buffered";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -38,6 +38,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonRaw
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -259,6 +261,7 @@ public class JobDetailsInfo implements ResponseBody {
     // ---------------------------------------------------
 
     /** Detailed information about a job vertex. */
+    @Schema(name = "JobDetailsVertexInfo")
     public static final class JobVertexDetailsInfo {
 
         public static final String FIELD_NAME_JOB_VERTEX_ID = "id";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingRestEndpoint.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -49,5 +50,12 @@ public interface DocumentingRestEndpoint {
                                         spec1.getTargetRestEndpointURL(),
                                         spec2.getTargetRestEndpointURL()))
                 .collect(Collectors.toList());
+    }
+
+    static DocumentingRestEndpoint forRestHandlerSpecifications(RestHandlerSpecification... specs) {
+        return localAddressFuture ->
+                Arrays.stream(specs)
+                        .map(spec -> Tuple2.of(spec, (ChannelInboundHandler) null))
+                        .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Fixes 5 cases where a name clash caused certain classes to not be documented properly. Name clashes were silently ignored by the generator.

The offending classes are now annotated to provide a unique name, and the generator was enhanced to detect such clashes.