### PR TITLE
[FLINK-31738] Prevent 'Type' name clash in generated clients

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -1104,7 +1104,7 @@ paths:
         required: false
         style: form
         schema:
-          $ref: '#/components/schemas/Type'
+          $ref: '#/components/schemas/ThreadStates'
       - name: subtaskindex
         in: query
         description: Positive integer value that identifies a subtask.
@@ -3196,6 +3196,12 @@ components:
           type: string
         threadName:
           type: string
+    ThreadStates:
+      type: string
+      enum:
+      - FULL
+      - ON_CPU
+      - OFF_CPU
     TriggerId:
       pattern: "[0-9a-f]{32}"
       type: string
@@ -3204,12 +3210,6 @@ components:
       properties:
         request-id:
           $ref: '#/components/schemas/TriggerId'
-    Type:
-      type: string
-      enum:
-      - FULL
-      - ON_CPU
-      - OFF_CPU
     UploadStatus:
       type: string
       enum:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/FlameGraphTypeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/FlameGraphTypeQueryParameter.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
 /** Flame Graph type query parameter. */
@@ -48,6 +50,7 @@ public class FlameGraphTypeQueryParameter
     }
 
     /** Flame Graph type. */
+    @Schema(name = "ThreadStates")
     public enum Type {
         /** Type of the Flame Graph that includes threads in all possible states. */
         FULL,


### PR DESCRIPTION
Generating a client with the openapi generators causes compile errors because the generated file imports java.reflect.Type, but also the generated "Type" model.

For convenience it would be neat to give this enum a slightly different name, because working around this issue is surprisingly annoying.
