### PR TITLE
[FLINK-31741][jdbc-driver] Support data converter for value in statement result

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DataConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.utils;
+
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Timestamp;
+import java.util.Map;
+
+/** Convert data from row data for result set. */
+public interface DataConverter {
+
+    /** Returns the boolean value at the given position. */
+    boolean getBoolean(RowData rowData, int pos);
+
+    /** Returns the byte value at the given position. */
+    byte getByte(RowData rowData, int pos);
+
+    /** Returns the short value at the given position. */
+    short getShort(RowData rowData, int pos);
+
+    /** Returns the integer value at the given position. */
+    int getInt(RowData rowData, int pos);
+
+    /** Returns the long value at the given position. */
+    long getLong(RowData rowData, int pos);
+
+    /** Returns the float value at the given position. */
+    float getFloat(RowData rowData, int pos);
+
+    /** Returns the double value at the given position. */
+    double getDouble(RowData rowData, int pos);
+
+    /** Returns the string value at the given position. */
+    String getString(RowData rowData, int pos);
+
+    /**
+     * Returns the decimal value at the given position.
+     *
+     * <p>The precision and scale are required to determine whether the decimal value was stored in
+     * a compact representation (see {@link DecimalData}).
+     */
+    BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale);
+
+    /**
+     * Returns the timestamp value at the given position.
+     *
+     * <p>The precision is required to determine whether the timestamp value was stored in a compact
+     * representation (see {@link TimestampData}).
+     */
+    Timestamp getTimestamp(RowData rowData, int pos, int precision);
+
+    /** Returns the binary value at the given position. */
+    byte[] getBinary(RowData rowData, int pos);
+
+    /** Returns the array value at the given position. */
+    Array getArray(RowData rowData, int pos);
+
+    /** Returns the map value at the given position. */
+    Map<?, ?> getMap(RowData rowData, int pos);
+
+    /**
+     * Returns the row value at the given position.
+     *
+     * <p>The number of fields is required to correctly extract the row.
+     */
+    RowData getRow(RowData rowData, int pos, int numFields);
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DefaultDataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DefaultDataConverter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.jdbc.utils;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -34,58 +33,59 @@ public class DefaultDataConverter implements DataConverter {
 
     @Override
     public boolean getBoolean(RowData rowData, int pos) {
-        return rowData.getBoolean(pos);
+        return !rowData.isNullAt(pos) && rowData.getBoolean(pos);
     }
 
     @Override
     public byte getByte(RowData rowData, int pos) {
-        return rowData.getByte(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getByte(pos);
     }
 
     @Override
     public short getShort(RowData rowData, int pos) {
-        return rowData.getShort(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getShort(pos);
     }
 
     @Override
     public int getInt(RowData rowData, int pos) {
-        return rowData.getInt(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getInt(pos);
     }
 
     @Override
     public long getLong(RowData rowData, int pos) {
-        return rowData.getLong(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getLong(pos);
     }
 
     @Override
     public float getFloat(RowData rowData, int pos) {
-        return rowData.getFloat(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getFloat(pos);
     }
 
     @Override
     public double getDouble(RowData rowData, int pos) {
-        return rowData.getDouble(pos);
+        return rowData.isNullAt(pos) ? 0 : rowData.getDouble(pos);
     }
 
     @Override
     public String getString(RowData rowData, int pos) {
-        StringData stringData = rowData.getString(pos);
-        return stringData == null ? null : stringData.toString();
+        return rowData.isNullAt(pos) ? null : rowData.getString(pos).toString();
     }
 
     @Override
     public BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale) {
-        return rowData.getDecimal(pos, precision, scale).toBigDecimal();
+        return rowData.isNullAt(pos)
+                ? null
+                : rowData.getDecimal(pos, precision, scale).toBigDecimal();
     }
 
     @Override
     public Timestamp getTimestamp(RowData rowData, int pos, int precision) {
-        return rowData.getTimestamp(pos, precision).toTimestamp();
+        return rowData.isNullAt(pos) ? null : rowData.getTimestamp(pos, precision).toTimestamp();
     }
 
     @Override
     public byte[] getBinary(RowData rowData, int pos) {
-        return rowData.getBinary(pos);
+        return rowData.isNullAt(pos) ? null : rowData.getBinary(pos);
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DefaultDataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/DefaultDataConverter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Timestamp;
+import java.util.Map;
+
+/** Default data converter for result set. */
+public class DefaultDataConverter implements DataConverter {
+    public static final DataConverter CONVERTER = new DefaultDataConverter();
+
+    private DefaultDataConverter() {}
+
+    @Override
+    public boolean getBoolean(RowData rowData, int pos) {
+        return rowData.getBoolean(pos);
+    }
+
+    @Override
+    public byte getByte(RowData rowData, int pos) {
+        return rowData.getByte(pos);
+    }
+
+    @Override
+    public short getShort(RowData rowData, int pos) {
+        return rowData.getShort(pos);
+    }
+
+    @Override
+    public int getInt(RowData rowData, int pos) {
+        return rowData.getInt(pos);
+    }
+
+    @Override
+    public long getLong(RowData rowData, int pos) {
+        return rowData.getLong(pos);
+    }
+
+    @Override
+    public float getFloat(RowData rowData, int pos) {
+        return rowData.getFloat(pos);
+    }
+
+    @Override
+    public double getDouble(RowData rowData, int pos) {
+        return rowData.getDouble(pos);
+    }
+
+    @Override
+    public String getString(RowData rowData, int pos) {
+        StringData stringData = rowData.getString(pos);
+        return stringData == null ? null : stringData.toString();
+    }
+
+    @Override
+    public BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale) {
+        return rowData.getDecimal(pos, precision, scale).toBigDecimal();
+    }
+
+    @Override
+    public Timestamp getTimestamp(RowData rowData, int pos, int precision) {
+        return rowData.getTimestamp(pos, precision).toTimestamp();
+    }
+
+    @Override
+    public byte[] getBinary(RowData rowData, int pos) {
+        return rowData.getBinary(pos);
+    }
+
+    @Override
+    public Array getArray(RowData rowData, int pos) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<?, ?> getMap(RowData rowData, int pos) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RowData getRow(RowData rowData, int pos, int numFields) {
+        return rowData.getRow(pos, numFields);
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.utils;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Timestamp;
+import java.util.Map;
+
+/** Converter string value to different value. */
+public class StringDataConverter implements DataConverter {
+    public static final DataConverter CONVERTER = new StringDataConverter();
+
+    private StringDataConverter() {}
+
+    @Override
+    public boolean getBoolean(RowData rowData, int pos) {
+        return Boolean.parseBoolean(getString(rowData, pos));
+    }
+
+    @Override
+    public byte getByte(RowData rowData, int pos) {
+        return Byte.parseByte(getString(rowData, pos));
+    }
+
+    @Override
+    public short getShort(RowData rowData, int pos) {
+        return Short.parseShort(getString(rowData, pos));
+    }
+
+    @Override
+    public int getInt(RowData rowData, int pos) {
+        return Integer.parseInt(getString(rowData, pos));
+    }
+
+    @Override
+    public long getLong(RowData rowData, int pos) {
+        return Long.parseLong(getString(rowData, pos));
+    }
+
+    @Override
+    public float getFloat(RowData rowData, int pos) {
+        return Float.parseFloat(getString(rowData, pos));
+    }
+
+    @Override
+    public double getDouble(RowData rowData, int pos) {
+        return Double.parseDouble(getString(rowData, pos));
+    }
+
+    @Override
+    public String getString(RowData rowData, int pos) {
+        StringData stringData = rowData.getString(pos);
+        return stringData == null ? null : stringData.toString();
+    }
+
+    @Override
+    public BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale) {
+        return new BigDecimal(getString(rowData, pos)).setScale(scale);
+    }
+
+    @Override
+    public byte[] getBinary(RowData rowData, int pos) {
+        return getString(rowData, pos).getBytes();
+    }
+
+    @Override
+    public Timestamp getTimestamp(RowData rowData, int pos, int precision) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Array getArray(RowData rowData, int pos) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<?, ?> getMap(RowData rowData, int pos) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RowData getRow(RowData rowData, int pos, int numFields) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.jdbc.utils;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -39,56 +38,49 @@ public class StringDataConverter implements DataConverter {
 
     @Override
     public byte getByte(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Byte.parseByte(strVal);
+        return rowData.isNullAt(pos) ? 0 : Byte.parseByte(getString(rowData, pos));
     }
 
     @Override
     public short getShort(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Short.parseShort(strVal);
+        return rowData.isNullAt(pos) ? 0 : Short.parseShort(getString(rowData, pos));
     }
 
     @Override
     public int getInt(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Integer.parseInt(strVal);
+        return rowData.isNullAt(pos) ? 0 : Integer.parseInt(getString(rowData, pos));
     }
 
     @Override
     public long getLong(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Long.parseLong(strVal);
+        return rowData.isNullAt(pos) ? 0 : Long.parseLong(getString(rowData, pos));
     }
 
     @Override
     public float getFloat(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Float.parseFloat(strVal);
+        return rowData.isNullAt(pos) ? 0 : Float.parseFloat(getString(rowData, pos));
     }
 
     @Override
     public double getDouble(RowData rowData, int pos) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? 0 : Double.parseDouble(strVal);
+        return rowData.isNullAt(pos) ? 0 : Double.parseDouble(getString(rowData, pos));
     }
 
     @Override
     public String getString(RowData rowData, int pos) {
-        StringData stringData = rowData.getString(pos);
-        return stringData == null ? null : stringData.toString();
+        return rowData.isNullAt(pos) ? null : rowData.getString(pos).toString();
     }
 
     @Override
     public BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale) {
-        String strVal = getString(rowData, pos);
-        return strVal == null ? null : new BigDecimal(getString(rowData, pos)).setScale(scale);
+        return rowData.isNullAt(pos)
+                ? null
+                : new BigDecimal(getString(rowData, pos)).setScale(scale);
     }
 
     @Override
     public byte[] getBinary(RowData rowData, int pos) {
-        StringData stringData = rowData.getString(pos);
-        return stringData == null ? null : stringData.toBytes();
+        return rowData.isNullAt(pos) ? null : rowData.getString(pos).toBytes();
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/StringDataConverter.java
@@ -39,32 +39,38 @@ public class StringDataConverter implements DataConverter {
 
     @Override
     public byte getByte(RowData rowData, int pos) {
-        return Byte.parseByte(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Byte.parseByte(strVal);
     }
 
     @Override
     public short getShort(RowData rowData, int pos) {
-        return Short.parseShort(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Short.parseShort(strVal);
     }
 
     @Override
     public int getInt(RowData rowData, int pos) {
-        return Integer.parseInt(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Integer.parseInt(strVal);
     }
 
     @Override
     public long getLong(RowData rowData, int pos) {
-        return Long.parseLong(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Long.parseLong(strVal);
     }
 
     @Override
     public float getFloat(RowData rowData, int pos) {
-        return Float.parseFloat(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Float.parseFloat(strVal);
     }
 
     @Override
     public double getDouble(RowData rowData, int pos) {
-        return Double.parseDouble(getString(rowData, pos));
+        String strVal = getString(rowData, pos);
+        return strVal == null ? 0 : Double.parseDouble(strVal);
     }
 
     @Override
@@ -75,12 +81,14 @@ public class StringDataConverter implements DataConverter {
 
     @Override
     public BigDecimal getDecimal(RowData rowData, int pos, int precision, int scale) {
-        return new BigDecimal(getString(rowData, pos)).setScale(scale);
+        String strVal = getString(rowData, pos);
+        return strVal == null ? null : new BigDecimal(getString(rowData, pos)).setScale(scale);
     }
 
     @Override
     public byte[] getBinary(RowData rowData, int pos) {
-        return getString(rowData, pos).getBytes();
+        StringData stringData = rowData.getString(pos);
+        return stringData == null ? null : stringData.toBytes();
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.jdbc.utils.DefaultDataConverter;
+import org.apache.flink.table.jdbc.utils.StringDataConverter;
 import org.apache.flink.util.CloseableIterator;
 
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,6 +48,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /** Tests for {@link FlinkResultSet}. */
 public class FlinkResultSetTest {
     private static final int RECORD_SIZE = 5000;
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("v1", DataTypes.BOOLEAN()),
+                    Column.physical("v2", DataTypes.TINYINT()),
+                    Column.physical("v3", DataTypes.SMALLINT()),
+                    Column.physical("v4", DataTypes.INT()),
+                    Column.physical("v5", DataTypes.BIGINT()),
+                    Column.physical("v6", DataTypes.FLOAT()),
+                    Column.physical("v7", DataTypes.DOUBLE()),
+                    Column.physical("v8", DataTypes.DECIMAL(10, 5)),
+                    Column.physical("v9", DataTypes.STRING()),
+                    Column.physical("v10", DataTypes.BYTES()));
 
     @Test
     public void testResultSetPrimitiveData() throws Exception {
@@ -71,105 +86,110 @@ public class FlinkResultSetTest {
                                                                 StringData.fromString(v.toString()),
                                                                 v.toString().getBytes()))
                                 .iterator());
-        int resultCount = 0;
         try (ResultSet resultSet =
                 new FlinkResultSet(
                         new TestingStatement(),
                         new StatementResult(
-                                ResolvedSchema.of(
-                                        Column.physical("v1", DataTypes.BOOLEAN()),
-                                        Column.physical("v2", DataTypes.TINYINT()),
-                                        Column.physical("v3", DataTypes.SMALLINT()),
-                                        Column.physical("v4", DataTypes.INT()),
-                                        Column.physical("v5", DataTypes.BIGINT()),
-                                        Column.physical("v6", DataTypes.FLOAT()),
-                                        Column.physical("v7", DataTypes.DOUBLE()),
-                                        Column.physical("v8", DataTypes.DECIMAL(10, 5)),
-                                        Column.physical("v9", DataTypes.STRING()),
-                                        Column.physical("v10", DataTypes.BYTES())),
-                                data,
-                                true,
-                                ResultKind.SUCCESS,
-                                JobID.generate()))) {
-            while (resultSet.next()) {
-                Integer val = resultSet.getInt("v4");
-                assertEquals(val, resultCount);
-                resultCount++;
+                                SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()),
+                        DefaultDataConverter.CONVERTER)) {
+            validateResultData(resultSet);
+        }
+    }
 
-                // Get and validate each column value
-                assertEquals(val % 2 == 0, resultSet.getBoolean(1));
-                assertEquals(val % 2 == 0, resultSet.getBoolean("v1"));
-                assertEquals(val.byteValue(), resultSet.getByte(2));
-                assertEquals(val.byteValue(), resultSet.getByte("v2"));
-                assertEquals(val.shortValue(), resultSet.getShort(3));
-                assertEquals(val.shortValue(), resultSet.getShort("v3"));
-                assertEquals(val, resultSet.getInt(4));
-                assertEquals(val, resultSet.getInt("v4"));
-                assertEquals(val.longValue(), resultSet.getLong(5));
-                assertEquals(val.longValue(), resultSet.getLong("v5"));
-                assertTrue(resultSet.getFloat(6) - val - 0.1 < 0.0001);
-                assertTrue(resultSet.getFloat("v6") - val - 0.1 < 0.0001);
-                assertTrue(resultSet.getDouble(7) - val - 0.22 < 0.0001);
-                assertTrue(resultSet.getDouble("v7") - val - 0.22 < 0.0001);
-                assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal(8));
-                assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal("v8"));
-                assertEquals(val.toString(), resultSet.getString(9));
-                assertEquals(val.toString(), resultSet.getString("v9"));
-                assertEquals(val.toString(), new String(resultSet.getBytes(10)));
-                assertEquals(val.toString(), new String(resultSet.getBytes("v10")));
+    @Test
+    public void testStringResultSetPrimitiveData() throws Exception {
+        CloseableIterator<RowData> data =
+                CloseableIterator.adapterForIterator(
+                        IntStream.range(0, RECORD_SIZE)
+                                .boxed()
+                                .map(
+                                        v ->
+                                                stringRowData(
+                                                        v % 2 == 0,
+                                                        v.byteValue(),
+                                                        v.shortValue(),
+                                                        v,
+                                                        v.longValue(),
+                                                        (float) (v + 0.1),
+                                                        v + 0.22,
+                                                        DecimalData.fromBigDecimal(
+                                                                new BigDecimal(v + ".55555"),
+                                                                10,
+                                                                5),
+                                                        StringData.fromString(v.toString()),
+                                                        v.toString()))
+                                .iterator());
+        try (ResultSet resultSet =
+                new FlinkResultSet(
+                        new TestingStatement(),
+                        new StatementResult(
+                                SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()),
+                        StringDataConverter.CONVERTER)) {
+            validateResultData(resultSet);
+        }
+    }
 
-                // Get data according to wrong data type
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(1),
-                        "java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(2),
-                        "java.lang.ClassCastException: java.lang.Byte cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(3),
-                        "java.lang.ClassCastException: java.lang.Short cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(4),
-                        "java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getInt(5),
-                        "java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Int");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(6),
-                        "java.lang.ClassCastException: java.lang.Float cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(7),
-                        "java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(8),
-                        "java.lang.ClassCastException: java.lang.BigDecimal cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(9),
-                        "java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Long");
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong(10),
-                        "java.lang.ClassCastException: java.lang.byte[] cannot be cast to java.lang.Long");
+    private RowData stringRowData(Object... values) {
+        return GenericRowData.of(
+                Arrays.stream(values).map(v -> StringData.fromString(v.toString())).toArray());
+    }
 
-                // Get not exist column
-                assertThrowsExactly(
-                        SQLDataException.class,
-                        () -> resultSet.getLong("id1"),
-                        "Column[id1] is not exist");
-                assertThrowsExactly(
-                        SQLException.class, () -> resultSet.getLong(11), "Column[11] is not exist");
-                assertThrowsExactly(
-                        SQLException.class, () -> resultSet.getLong(-1), "Column[-1] is not exist");
-            }
+    private static void validateResultData(ResultSet resultSet) throws SQLException {
+        int resultCount = 0;
+        while (resultSet.next()) {
+            Integer val = resultSet.getInt("v4");
+            assertEquals(val, resultCount);
+            resultCount++;
+
+            // Get and validate each column value
+            assertEquals(val % 2 == 0, resultSet.getBoolean(1));
+            assertEquals(val % 2 == 0, resultSet.getBoolean("v1"));
+            assertEquals(val.byteValue(), resultSet.getByte(2));
+            assertEquals(val.byteValue(), resultSet.getByte("v2"));
+            assertEquals(val.shortValue(), resultSet.getShort(3));
+            assertEquals(val.shortValue(), resultSet.getShort("v3"));
+            assertEquals(val, resultSet.getInt(4));
+            assertEquals(val, resultSet.getInt("v4"));
+            assertEquals(val.longValue(), resultSet.getLong(5));
+            assertEquals(val.longValue(), resultSet.getLong("v5"));
+            assertTrue(resultSet.getFloat(6) - val - 0.1 < 0.0001);
+            assertTrue(resultSet.getFloat("v6") - val - 0.1 < 0.0001);
+            assertTrue(resultSet.getDouble(7) - val - 0.22 < 0.0001);
+            assertTrue(resultSet.getDouble("v7") - val - 0.22 < 0.0001);
+            assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal(8));
+            assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal("v8"));
+            assertEquals(val.toString(), resultSet.getString(9));
+            assertEquals(val.toString(), resultSet.getString("v9"));
+            assertEquals(val.toString(), new String(resultSet.getBytes(10)));
+            assertEquals(val.toString(), new String(resultSet.getBytes("v10")));
+
+            // Get data according to wrong data type
+            assertThrowsExactly(
+                    SQLDataException.class,
+                    () -> resultSet.getLong(1),
+                    "java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Long");
+            assertThrowsExactly(
+                    SQLDataException.class,
+                    () -> resultSet.getLong(6),
+                    "java.lang.ClassCastException: java.lang.Float cannot be cast to java.lang.Long");
+            assertThrowsExactly(
+                    SQLDataException.class,
+                    () -> resultSet.getLong(7),
+                    "java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long");
+            assertThrowsExactly(
+                    SQLDataException.class,
+                    () -> resultSet.getLong(8),
+                    "java.lang.ClassCastException: java.lang.BigDecimal cannot be cast to java.lang.Long");
+
+            // Get not exist column
+            assertThrowsExactly(
+                    SQLDataException.class,
+                    () -> resultSet.getLong("id1"),
+                    "Column[id1] is not exist");
+            assertThrowsExactly(
+                    SQLException.class, () -> resultSet.getLong(11), "Column[11] is not exist");
+            assertThrowsExactly(
+                    SQLException.class, () -> resultSet.getLong(-1), "Column[-1] is not exist");
         }
         assertEquals(resultCount, RECORD_SIZE);
     }

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
@@ -39,9 +39,12 @@ import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -126,6 +129,37 @@ public class FlinkResultSetTest {
                                 SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()),
                         StringDataConverter.CONVERTER)) {
             validateResultData(resultSet);
+        }
+    }
+
+    @Test
+    public void testStringResultSetNullData() throws Exception {
+        CloseableIterator<RowData> data =
+                CloseableIterator.adapterForIterator(
+                        Collections.singletonList(
+                                        (RowData)
+                                                GenericRowData.of(
+                                                        null, null, null, null, null, null, null,
+                                                        null, null, null))
+                                .iterator());
+        try (ResultSet resultSet =
+                new FlinkResultSet(
+                        new TestingStatement(),
+                        new StatementResult(
+                                SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()),
+                        StringDataConverter.CONVERTER)) {
+            assertTrue(resultSet.next());
+            assertFalse(resultSet.getBoolean(1));
+            assertEquals((byte) 0, resultSet.getByte(2));
+            assertEquals((short) 0, resultSet.getShort(3));
+            assertEquals(0, resultSet.getInt(4));
+            assertEquals(0L, resultSet.getLong(5));
+            assertEquals((float) 0.0, resultSet.getFloat(6));
+            assertEquals(0.0, resultSet.getDouble(7));
+            assertNull(resultSet.getBigDecimal(8));
+            assertNull(resultSet.getString(9));
+            assertNull(resultSet.getBytes(10));
+            assertFalse(resultSet.next());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to convert string value in `StatementResult` to different value for `ResultSet`


## Brief change log

  - Added `DataConverter` api
  - Added `DefaultDataConverter` and `StringDataConverter`


## Verifying this change

This change added tests and can be verified as follows:
  - Added test `FlinkResultSetTest.testStringResultSetPrimitiveData`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
