### PR TITLE
[FLINK-31670][doc] Using v3.0.0-docs branch for es connector docs build.

### DIFF
--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -128,10 +128,10 @@ elastic:
     versions:
         - version: 6.x
           maven: flink-connector-elasticsearch6
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6/1.16.0/flink-sql-connector-elasticsearch6-1.16.0.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6/3.0.0-1.16/flink-sql-connector-elasticsearch6-3.0.0-1.16.jar
         - version: 7.x and later versions
           maven: flink-connector-elasticsearch7
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/1.16.0/flink-sql-connector-elasticsearch7-1.16.0.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/3.0.0-1.16/flink-sql-connector-elasticsearch7-3.0.0-1.16.jar
 
 hbase:
     name: HBase

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -43,7 +43,7 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-integrate_connector_docs elasticsearch v3.0.0
+integrate_connector_docs elasticsearch v3.0.0-docs
 integrate_connector_docs aws v4.1.0-docs
 integrate_connector_docs cassandra v3.0.0
 integrate_connector_docs pulsar main


### PR DESCRIPTION
## What is the purpose of the change

*In the [doc](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/elasticsearch/), It still use "flink-version" for flink-connector-elastiacsearch instead of the version in the external repository.*


## Brief change log

  - *Using v3.0.0-docs branch for es connector docs build.*


## Verifying this change

Manually test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
