### PR TITLE
[FLINK-31301][planner] Add support of nested columns in column list o…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
 import org.apache.flink.sql.parser.ddl.{SqlCompilePlan, SqlReset, SqlSet, SqlUseModules}
-import org.apache.flink.sql.parser.dml.{RichSqlInsert, SqlBeginStatementSet, SqlCompileAndExecutePlan, SqlEndStatementSet, SqlExecute, SqlExecutePlan, SqlStatementSet}
+import org.apache.flink.sql.parser.dml._
 import org.apache.flink.sql.parser.dql._
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.hint.JoinStrategy

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1933,18 +1933,14 @@ public final class TestValuesTableFactory
                 assertThat(runtimeSink.equals("SinkFunction")).isTrue();
                 SinkFunction<RowData> sinkFunction;
                 if (primaryKeyIndices.length > 0) {
-                    // TODO FLINK-31301 currently partial-insert composite columns are not supported
-                    int[][] targetColumns = context.getTargetColumns().orElse(new int[0][]);
-                    checkArgument(
-                            Arrays.stream(targetColumns).allMatch(subArr -> subArr.length <= 1),
-                            "partial-insert composite columns are not supported yet!");
+                    int[][] targetColumns = context.getTargetColumns().orElse(new int[0][0]);
 
                     sinkFunction =
                             new KeyedUpsertingSinkFunction(
                                     tableName,
                                     converter,
                                     primaryKeyIndices,
-                                    Arrays.stream(targetColumns).mapToInt(a -> a[0]).toArray(),
+                                    targetColumns,
                                     expectedNum,
                                     tableSchema.getFieldCount());
                 } else {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
@@ -16,6 +16,239 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testPartialInsertCompositeType[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[ROW(null:BIGINT, $2.c2)], d=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], e=[null:DOUBLE], g=[null:INTEGER], h=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW($7.h2.h3, null:TIMESTAMP(6)))], f=[$5])
+   +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[a, b, ROW(null:BIGINT, c.c2) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(h.h2.h3, null:TIMESTAMP(6))) AS h, f])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, c, h, f], metadata=[]]], fields=[a, b, c, h, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeType[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[ROW(null:BIGINT, $2.c2)], d=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], e=[null:DOUBLE], g=[null:INTEGER], h=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW($7.h2.h3, null:TIMESTAMP(6)))], f=[$5])
+   +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[a, b, ROW(null:BIGINT, c.c2) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(h.h2.h3, null:TIMESTAMP(6))) AS h, f])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, c, h, f], metadata=[]]], fields=[a, b, c, h, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithOrderBy[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src ORDER BY a, b, h]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalSort(sort0=[$0], sort1=[$1], sort2=[$8], dir0=[ASC-nulls-first], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, $2.c2)], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW($7.h2.h3, null:TIMESTAMP(6)))], h=[$7])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[a, b, ROW(null:BIGINT, c.c2) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(h.h2.h3, null:TIMESTAMP(6))) AS h, f])
+   +- Sort(orderBy=[a ASC, b ASC, h ASC])
+      +- Exchange(distribution=[single])
+         +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, c, f, h], metadata=[]]], fields=[a, b, c, f, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithOrderBy[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src ORDER BY a, b, h]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalSort(sort0=[$0], sort1=[$1], sort2=[$8], dir0=[ASC-nulls-first], dir1=[ASC-nulls-first], dir2=[ASC-nulls-first])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, $2.c2)], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW($7.h2.h3, null:TIMESTAMP(6)))], h=[$7])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[a, b, ROW(null:BIGINT, c.c2) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(h.h2.h3, null:TIMESTAMP(6))) AS h, f])
+   +- Sort(orderBy=[a ASC, b ASC, h ASC])
+      +- Exchange(distribution=[single])
+         +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, c, f, h], metadata=[]]], fields=[a, b, c, f, h])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithUnion[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,'hello',f,123 FROM complex_type_src UNION SELECT a,b,'flink',f,456 FROM complex_type_src ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalUnion(all=[false])
+      :- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'hello')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(123, null:TIMESTAMP(6)))])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'flink')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(456, null:TIMESTAMP(6)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f], upsertMaterialize=[true])
++- Calc(select=[a, b, EXPR$2 AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, EXPR$7 AS h, f])
+   +- GroupAggregate(groupBy=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7], select=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7])
+      +- Exchange(distribution=[hash[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7]])
+         +- Union(all=[true], union=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7])
+            :- Calc(select=[a, b, ROW(null:BIGINT, 'hello') AS EXPR$2, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$3, null:DOUBLE AS EXPR$4, f, null:INTEGER AS EXPR$6, ROW(null:VARCHAR(2147483647), ROW(123, null:TIMESTAMP(6))) AS EXPR$7])
+            :  +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+            +- Calc(select=[a, b, ROW(null:BIGINT, 'flink') AS EXPR$2, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$3, null:DOUBLE AS EXPR$4, f, null:INTEGER AS EXPR$6, ROW(null:VARCHAR(2147483647), ROW(456, null:TIMESTAMP(6))) AS EXPR$7])
+               +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithUnion[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,'hello',f,123 FROM complex_type_src UNION SELECT a,b,'flink',f,456 FROM complex_type_src ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalUnion(all=[false])
+      :- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'hello')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(123, null:TIMESTAMP(6)))])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'flink')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(456, null:TIMESTAMP(6)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[a, b, EXPR$2 AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, EXPR$7 AS h, f])
+   +- HashAggregate(isMerge=[true], groupBy=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7], select=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7])
+      +- Exchange(distribution=[hash[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7]])
+         +- LocalHashAggregate(groupBy=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7], select=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7])
+            +- Union(all=[true], union=[a, b, EXPR$2, EXPR$3, EXPR$4, f, EXPR$6, EXPR$7])
+               :- Calc(select=[a, b, ROW(null:BIGINT, 'hello') AS EXPR$2, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$3, null:DOUBLE AS EXPR$4, f, null:INTEGER AS EXPR$6, ROW(null:VARCHAR(2147483647), ROW(123, null:TIMESTAMP(6))) AS EXPR$7])
+               :  +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+               +- Calc(select=[a, b, ROW(null:BIGINT, 'flink') AS EXPR$2, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$3, null:DOUBLE AS EXPR$4, f, null:INTEGER AS EXPR$6, ROW(null:VARCHAR(2147483647), ROW(456, null:TIMESTAMP(6))) AS EXPR$7])
+                  +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithUnionAll[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,'hello',f,123 FROM complex_type_src UNION ALL SELECT a,b,'flink',f,456 FROM complex_type_src ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalUnion(all=[true])
+      :- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'hello')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(123, null:TIMESTAMP(6)))])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'flink')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(456, null:TIMESTAMP(6)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Union(all=[true], union=[a, b, c, d, e, g, h, f])
+   :- Calc(select=[a, b, ROW(null:BIGINT, 'hello') AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(123, null:TIMESTAMP(6))) AS h, f])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+   +- Calc(select=[a, b, ROW(null:BIGINT, 'flink') AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(456, null:TIMESTAMP(6))) AS h, f])
+      +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithUnionAll[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) SELECT a,b,'hello',f,123 FROM complex_type_src UNION ALL SELECT a,b,'flink',f,456 FROM complex_type_src ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], g=[$6], h=[$7], f=[$5])
+   +- LogicalUnion(all=[true])
+      :- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'hello')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(123, null:TIMESTAMP(6)))])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+      +- LogicalProject(a=[$0], b=[$1], EXPR$2=[ROW(null:BIGINT, _UTF-16LE'flink')], EXPR$3=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$4=[null:DOUBLE], f=[$5], EXPR$6=[null:INTEGER], EXPR$7=[ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(456, null:TIMESTAMP(6)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, complex_type_src]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Union(all=[true], union=[a, b, c, d, e, g, h, f])
+   :- Calc(select=[a, b, ROW(null:BIGINT, 'hello') AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(123, null:TIMESTAMP(6))) AS h, f])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+   +- Calc(select=[a, b, ROW(null:BIGINT, 'flink') AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, ROW(null:VARCHAR(2147483647), ROW(456, null:TIMESTAMP(6))) AS h, f])
+      +- TableSourceScan(table=[[default_catalog, default_database, complex_type_src, project=[a, b, f], metadata=[]]], fields=[a, b, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithValues[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) VALUES(1, row('b1', 2), 'c2', 3, 4)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[1:BIGINT], b=[CAST(ROW(_UTF-16LE'b1', 2)):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" b1, INTEGER b2)], c=[CAST(ROW(null:BIGINT, _UTF-16LE'c2')):RecordType:peek_no_expand(BIGINT c1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" c2)], d=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], e=[null:DOUBLE], g=[null:INTEGER], h=[CAST(ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(4, null:TIMESTAMP(6)))):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" h1, RecordType:peek_no_expand(INTEGER h3, TIMESTAMP(6) h4) h2)], f=[CAST(3:BIGINT):BIGINT])
+   +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[1 AS a, CAST(ROW('b1', 2) AS RecordType:peek_no_expand(VARCHAR(2147483647) b1, INTEGER b2)) AS b, CAST(ROW(null:BIGINT, 'c2') AS RecordType:peek_no_expand(BIGINT c1, VARCHAR(2147483647) c2)) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, CAST(ROW(null:VARCHAR(2147483647), ROW(4, null:TIMESTAMP(6))) AS RecordType:peek_no_expand(VARCHAR(2147483647) h1, RecordType:peek_no_expand(INTEGER h3, TIMESTAMP(6) h4) h2)) AS h, CAST(3 AS BIGINT) AS f])
+   +- Values(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertCompositeTypeWithValues[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) VALUES(1, row('b1', 2), 'c2', 3, 4)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- LogicalProject(a=[1:BIGINT], b=[CAST(ROW(_UTF-16LE'b1', 2)):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" b1, INTEGER b2)], c=[CAST(ROW(null:BIGINT, _UTF-16LE'c2')):RecordType:peek_no_expand(BIGINT c1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" c2)], d=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], e=[null:DOUBLE], g=[null:INTEGER], h=[CAST(ROW(null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE", ROW(4, null:TIMESTAMP(6)))):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" h1, RecordType:peek_no_expand(INTEGER h3, TIMESTAMP(6) h4) h2)], f=[CAST(3:BIGINT):BIGINT])
+   +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.complex_type_sink], targetColumns=[[0],[1],[2,1],[5],[7,1,0]], fields=[a, b, c, d, e, g, h, f])
++- Calc(select=[1 AS a, CAST(ROW('b1', 2) AS RecordType:peek_no_expand(VARCHAR(2147483647) b1, INTEGER b2)) AS b, CAST(ROW(null:BIGINT, 'c2') AS RecordType:peek_no_expand(BIGINT c1, VARCHAR(2147483647) c2)) AS c, null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS d, null:DOUBLE AS e, null:INTEGER AS g, CAST(ROW(null:VARCHAR(2147483647), ROW(4, null:TIMESTAMP(6))) AS RecordType:peek_no_expand(VARCHAR(2147483647) h1, RecordType:peek_no_expand(INTEGER h3, TIMESTAMP(6) h4) h2)) AS h, CAST(3 AS BIGINT) AS f])
+   +- Values(tuples=[[{ 0 }]], values=[ZERO])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialInsertWithGroupBy[isBatch: false]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
@@ -59,19 +59,6 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
                               |)
                               |""".stripMargin)
   util.tableEnv.executeSql(s"""
-                              |create table complex_type_src (
-                              |  `a` BIGINT,
-                              |  `b` ROW<b1 STRING, b2 INT>,
-                              |  `c` ROW<c1 BIGINT, c2 STRING>,
-                              |  `d` MAP<STRING, STRING>,
-                              |  `e` DOUBLE,
-                              |  `f` BIGINT,
-                              |  `g` INT
-                              |) with (
-                              |  'connector' = 'values'
-                              |)
-                              |""".stripMargin)
-  util.tableEnv.executeSql(s"""
                               |create table complex_type_sink (
                               |  `a` BIGINT,
                               |  `b` ROW<b1 STRING, b2 INT>,
@@ -80,6 +67,7 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
                               |  `e` DOUBLE,
                               |  `f` BIGINT METADATA,
                               |  `g` INT,
+                              |  `h` ROW< h1 VARCHAR, h2 ROW < h3 INT, h4 TIMESTAMP>>,
                               |  primary key (`a`) not enforced
                               |) with (
                               |  'connector' = 'values',
@@ -102,6 +90,22 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
                               |  'sink-insert-only' = 'false',
                               |  'writable-metadata' = 'f:BIGINT, g:INT'
                               |)""".stripMargin)
+  // source
+  util.tableEnv.executeSql(s"""
+                              |create table complex_type_src (
+                              |  `a` BIGINT,
+                              |  `b` ROW<b1 STRING, b2 INT>,
+                              |  `c` ROW<c1 BIGINT, c2 STRING>,
+                              |  `d` MAP<STRING, STRING>,
+                              |  `e` DOUBLE,
+                              |  `f` BIGINT,
+                              |  `g` INT,
+                              |  `h` ROW< h1 VARCHAR, h2 ROW < h3 INT, h4 TIMESTAMP>>
+                              |) with (
+                              |  'connector' = 'values',
+                              |  'bounded' = '$isBatch'
+                              |)
+                              |""".stripMargin)
 
   @Test
   def testPartialInsertWithComplexReorder(): Unit = {
@@ -200,12 +204,90 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
         "SELECT e,a,d FROM MyTable GROUP BY a,b,c,d,e")
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testPartialInsertCompositeType(): Unit = {
-    // TODO this should be updated after FLINK-31301 fixed
-    util.verifyExplainInsert(
-      "INSERT INTO complex_type_sink (a,b.b1,c.c2,f) " +
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) " +
+        "SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithUnion(): Unit = {
+    testPartialInsertCompositeTypeWithSetOperator("UNION")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithUnionAll(): Unit = {
+    testPartialInsertCompositeTypeWithSetOperator("UNION ALL")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithIntersectAll(): Unit = {
+    testPartialInsertCompositeTypeWithSetOperator("INTERSECT ALL")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithWithExceptAll(): Unit = {
+    testPartialInsertCompositeTypeWithSetOperator("EXCEPT ALL")
+  }
+
+  private def testPartialInsertCompositeTypeWithSetOperator(operator: String): Unit = {
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) " +
+        "SELECT a,b,'hello',f,123 FROM complex_type_src " +
+        operator + " " +
+        "SELECT a,b,'flink',f,456 FROM complex_type_src ")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithOrderBy(): Unit = {
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) " +
+        "SELECT a,b,c.c2,f,h.h2.h3 FROM complex_type_src ORDER BY a, b, h")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeWithValues(): Unit = {
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink (a,b,c.c2,f,h.h2.h3) VALUES(1, row('b1', 2), 'c2', 3, 4)")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeColumnNotFound(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "SQL validation failed. From line 1, column 34 to line 1, column 38: Unknown target column 'b.b10'")
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink (a,b.b10,c.c2,f) " +
         "SELECT a,b.b1,c.c2,f FROM complex_type_src")
+  }
+
+  @Test
+  def testPartialInsertCompositeTypeNotNullCheck(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "At line 0, column 0: Column 'h1' has no default value and does not allow NULLs")
+    util.tableEnv.executeSql(
+      s"""
+         |create table complex_type_sink_not_null (
+         |  `a` BIGINT,
+         |  `b` ROW<b1 STRING, b2 INT>,
+         |  `c` ROW<c1 BIGINT, c2 STRING>,
+         |  `d` MAP<STRING, STRING>,
+         |  `e` DOUBLE,
+         |  `f` BIGINT METADATA,
+         |  `g` INT,
+         |  `h` ROW< h1 VARCHAR NOT NULL, h2 ROW < h3 INT, h4 TIMESTAMP>> NOT NULL,
+         |  primary key (`a`) not enforced
+         |) with (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false',
+         |  'writable-metadata' = 'f:bigint'
+         |)
+         |""".stripMargin)
+    util.verifyRelPlanInsert(
+      "INSERT INTO complex_type_sink_not_null (a,b,c.c2,f,h.h2.h3) VALUES(1, row('b1', 2), 'c2', 3, 4)")
+
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
@@ -223,11 +223,15 @@ class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
 
   @Test
   def testPartialInsertCompositeTypeWithIntersectAll(): Unit = {
+    // TODO fix by FLINK-31755
+    expectedException.expect(classOf[RuntimeException])
     testPartialInsertCompositeTypeWithSetOperator("INTERSECT ALL")
   }
 
   @Test
   def testPartialInsertCompositeTypeWithWithExceptAll(): Unit = {
+    // TODO fix by FLINK-31755
+    expectedException.expect(classOf[RuntimeException])
     testPartialInsertCompositeTypeWithSetOperator("EXCEPT ALL")
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeTestBase.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.api.DataTypes
-import org.apache.flink.table.planner.calcite.{FlinkRexBuilder, FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.planner.calcite.{FlinkRexBuilder, FlinkTypeFactory}
 import org.apache.flink.table.planner.plan.utils.InputTypeBuilder.inputOf
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -383,4 +383,77 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       List("+I[1, jason, 3, X, 43]", "+I[2, andy, 2, Y, 32]", "+I[3, clark, 1, Z, 29]")
     assertEquals(expected2.sorted, result2.sorted)
   }
+
+  @Test
+  def testPartialInsertCompositeType(): Unit = {
+    val srcDataId = TestValuesTableFactory.registerData(
+      Seq(
+        row(1L, "jason", 3L, "X", 43),
+        row(2L, "andy", 2L, "Y", 32),
+        row(3L, "clark", 1L, "Z", 29)
+      ))
+    tEnv.executeSql(s"""
+                       |CREATE TABLE test_source (
+                       |  id bigint,
+                       |  person String,
+                       |  votes bigint,
+                       |  city String,
+                       |  age int)
+                       |WITH (
+                       |  'connector' = 'values',
+                       |  'data-id' = '$srcDataId'
+                       |)
+                       |""".stripMargin)
+    tEnv.executeSql("""
+                      |CREATE TABLE test_sink (
+                      |  id bigint,
+                      |  r1 ROW< person String, votes bigint>,
+                      |  r2 ROW< city String, age int>,
+                      |  primary key(id) not enforced
+                      |) WITH (
+                      |  'connector' = 'values',
+                      |  'sink-insert-only' = 'false'
+                      |)
+                      |""".stripMargin)
+
+    tEnv
+      .executeSql("""
+                    |insert into test_sink (id, r1.person, r2.city)
+                    |  select
+                    |    id,
+                    |    person,
+                    |    city
+                    |  from
+                    |    test_source
+                    |""".stripMargin)
+      .await()
+
+    val result = TestValuesTableFactory.getResults("test_sink")
+    val expected = List(
+      "+I[1, +I[jason, null], +I[X, null]]",
+      "+I[2, +I[andy, null], +I[Y, null]]",
+      "+I[3, +I[clark, null], +I[Z, null]]")
+    assertEquals(expected.sorted, result.sorted)
+
+    tEnv
+      .executeSql("""
+                    |insert into test_sink (id, r1.votes, r2.age)
+                    |  select
+                    |    id,
+                    |    votes,
+                    |    age 
+                    |  from
+                    |    test_source
+                    |""".stripMargin)
+      .await()
+
+    val result2 = TestValuesTableFactory.getResults("test_sink")
+    val expected2 =
+      List(
+        "+I[1, +I[jason, 3], +I[X, 43]]",
+        "+I[2, +I[andy, 2], +I[Y, 32]]",
+        "+I[3, +I[clark, 1], +I[Z, 29]]")
+    assertEquals(expected2.sorted, result2.sorted)
+
+  }
 }


### PR DESCRIPTION
…f insert statement

## What is the purpose of the change

This PR is meant to support nested column as the insert target columns like `insert into (r1.a, r2.b) select a, b from src`

## Verifying this change

- Planner test in `PartialInsertTest`
- ITTest in `TableSinkITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

