### PR TITLE
[FLINK-31744] Include JobVertex info in sparse EG 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
-import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
@@ -86,7 +85,6 @@ import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
-import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.shuffle.JobShuffleContext;
 import org.apache.flink.runtime.shuffle.JobShuffleContextImpl;
@@ -938,19 +936,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     public CompletableFuture<Acknowledge> notifyNewBlockedNodes(Collection<BlockedNode> newNodes) {
         blocklistHandler.addNewBlockedNodes(newNodes);
         return CompletableFuture.completedFuture(Acknowledge.get());
-    }
-
-    @Override
-    public CompletableFuture<Map<JobVertexID, Integer>> getMaxParallelismPerVertex() {
-        final Map<JobVertexID, Integer> maxParallelismPerVertex = new HashMap<>();
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            maxParallelismPerVertex.put(
-                    vertex.getID(),
-                    vertex.getMaxParallelism() != JobVertex.MAX_PARALLELISM_DEFAULT
-                            ? vertex.getMaxParallelism()
-                            : SchedulerBase.getDefaultMaxParallelism(vertex));
-        }
-        return CompletableFuture.completedFuture(maxParallelismPerVertex);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -55,7 +55,6 @@ import org.apache.flink.util.SerializedValue;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** {@link JobMaster} rpc gateway interface. */
@@ -301,13 +300,6 @@ public interface JobMasterGateway
      */
     CompletableFuture<?> stopTrackingAndReleasePartitions(
             Collection<ResultPartitionID> partitionIds);
-
-    /**
-     * Returns the max parallelism for each vertex.
-     *
-     * @return Future which that contains the max parallelism for each vertex.
-     */
-    CompletableFuture<Map<JobVertexID, Integer>> getMaxParallelismPerVertex();
 
     /**
      * Read current {@link JobResourceRequirements job resource requirements}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -832,13 +832,15 @@ public class AdaptiveScheduler
     @Override
     public ArchivedExecutionGraph getArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
-        return ArchivedExecutionGraph.createSparseArchivedExecutionGraph(
+        return ArchivedExecutionGraph.createSparseArchivedExecutionGraphWithJobVertices(
                 jobInformation.getJobID(),
                 jobInformation.getName(),
                 jobStatus,
                 cause,
                 jobInformation.getCheckpointingSettings(),
-                initializationTimestamp);
+                initializationTimestamp,
+                jobGraph.getVertices(),
+                initialParallelismStore);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1249,7 +1249,7 @@ public class DispatcherTest extends AbstractDispatcherTest {
                                                 ((RestHandlerException) e).getHttpResponseStatus())
                                         .isSameAs(HttpResponseStatus.INTERNAL_SERVER_ERROR));
 
-        // verify that persits errors prevents the requirement from being applied
+        // verify that persist errors prevents the requirement from being applied
         assertThatFuture(dispatcherGateway.requestJobResourceRequirements(jobId))
                 .eventuallySucceeds()
                 .isNotEqualTo(attemptedNewRequirements);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -98,7 +98,6 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
-import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
 import org.apache.flink.runtime.scheduler.TestingSchedulerNGFactory;
@@ -2036,42 +2035,6 @@ class JobMasterTest {
             assertThat(firstReceivedBlockedNodeFutureOfB.get())
                     .containsExactlyInAnyOrder(blockedNode1, blockedNode2);
             assertThat(secondReceivedBlockedNodeFutureOfA).isNotDone();
-        }
-    }
-
-    @Test
-    public void testGetMaxParallelismPerVertexRespectsUserSpecifiedParallelism() throws Exception {
-        JobVertex vertexWithoutMaxParallelism = new JobVertex("vertex1");
-        vertexWithoutMaxParallelism.setInvokableClass(NoOpInvokable.class);
-        vertexWithoutMaxParallelism.setParallelism(1);
-        JobVertex vertexWithMaxParallelism = new JobVertex("vertex2");
-        vertexWithMaxParallelism.setInvokableClass(NoOpInvokable.class);
-        vertexWithMaxParallelism.setParallelism(1);
-        vertexWithMaxParallelism.setMaxParallelism(4000);
-        final JobGraph jobGraph =
-                JobGraphTestUtils.streamingJobGraph(
-                        vertexWithoutMaxParallelism, vertexWithMaxParallelism);
-
-        try (final JobMaster jobMaster =
-                new JobMasterBuilder(jobGraph, rpcService)
-                        .withConfiguration(configuration)
-                        .createJobMaster()) {
-            jobMaster.start();
-            final JobMasterGateway jobMasterGateway =
-                    jobMaster.getSelfGateway(JobMasterGateway.class);
-
-            assertThatFuture(jobMasterGateway.getMaxParallelismPerVertex())
-                    .eventuallySucceeds()
-                    .satisfies(
-                            maxParallelism ->
-                                    assertThat(maxParallelism)
-                                            .containsEntry(
-                                                    vertexWithMaxParallelism.getID(),
-                                                    vertexWithMaxParallelism.getMaxParallelism())
-                                            .containsEntry(
-                                                    vertexWithoutMaxParallelism.getID(),
-                                                    SchedulerBase.getDefaultMaxParallelism(
-                                                            vertexWithoutMaxParallelism)));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -68,7 +68,6 @@ import javax.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -191,8 +190,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     private final Function<Collection<BlockedNode>, CompletableFuture<Acknowledge>>
             notifyNewBlockedNodesFunction;
 
-    private final Supplier<CompletableFuture<Map<JobVertexID, Integer>>>
-            maxParallelismPerVertexSupplier;
     private final Supplier<CompletableFuture<JobResourceRequirements>>
             requestJobResourceRequirementsSupplier;
     private final Function<JobResourceRequirements, CompletableFuture<Acknowledge>>
@@ -303,9 +300,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
                     Function<Collection<BlockedNode>, CompletableFuture<Acknowledge>>
                             notifyNewBlockedNodesFunction,
             @Nonnull
-                    Supplier<CompletableFuture<Map<JobVertexID, Integer>>>
-                            maxParallelismPerVertexSupplier,
-            @Nonnull
                     Supplier<CompletableFuture<JobResourceRequirements>>
                             requestJobResourceRequirementsSupplier,
             @Nonnull
@@ -340,7 +334,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
         this.deliverCoordinationRequestFunction = deliverCoordinationRequestFunction;
         this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
         this.notifyNewBlockedNodesFunction = notifyNewBlockedNodesFunction;
-        this.maxParallelismPerVertexSupplier = maxParallelismPerVertexSupplier;
         this.requestJobResourceRequirementsSupplier = requestJobResourceRequirementsSupplier;
         this.updateJobResourceRequirementsFunction = updateJobResourceRequirementsFunction;
     }
@@ -566,11 +559,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Override
     public CompletableFuture<Acknowledge> notifyNewBlockedNodes(Collection<BlockedNode> newNodes) {
         return notifyNewBlockedNodesFunction.apply(newNodes);
-    }
-
-    @Override
-    public CompletableFuture<Map<JobVertexID, Integer>> getMaxParallelismPerVertex() {
-        return maxParallelismPerVertexSupplier.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -453,7 +453,6 @@ public class TestingJobMasterGatewayBuilder {
                 deliverCoordinationRequestFunction,
                 notifyNotEnoughResourcesConsumer,
                 notifyNewBlockedNodesFunction,
-                maxParallelismPerVertexSupplier,
                 requestJobResourceRequirementsSupplier,
                 updateJobResourceRequirementsFunction);
     }


### PR DESCRIPTION
Include all JobVertex-level information in the sparse execution graph, created by the Adaptive Scheduler when in the WaitingForResources state, like the vertex id/name and the maxParallelism.
This reduces the difference in behavior between the schedulers.

This also removes the functional need for the recently introduced `JobMasterGaterway#getMaxParallelismPerVertex`.
I propose to remove this method.
We could keep it though if we are concerned that the creation of the sparse EG is too expensive.