### PR TITLE
[FLINK-27144][runtime] Provide timeout details when calling FutureUtils.orTimeout

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -1049,7 +1049,10 @@ public class RestClusterClient<T> implements ClusterClient<T> {
         return FutureUtils.orTimeout(
                         webMonitorLeaderRetriever.getLeaderFuture(),
                         restClusterClientConfiguration.getAwaitLeaderTimeout(),
-                        TimeUnit.MILLISECONDS)
+                        TimeUnit.MILLISECONDS,
+                        String.format(
+                                "Waiting for leader address of WebMonitorEndpoint timed out after %d ms.",
+                                restClusterClientConfiguration.getAwaitLeaderTimeout()))
                 .thenApplyAsync(
                         leaderAddressSessionId -> {
                             final String url = leaderAddressSessionId.f0;

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -419,20 +419,6 @@ public class FutureUtils {
      * @param future to time out
      * @param timeout after which the given future is timed out
      * @param timeUnit time unit of the timeout
-     * @param <T> type of the given future
-     * @return The timeout enriched future
-     */
-    public static <T> CompletableFuture<T> orTimeout(
-            CompletableFuture<T> future, long timeout, TimeUnit timeUnit) {
-        return orTimeout(future, timeout, timeUnit, Executors.directExecutor(), null);
-    }
-
-    /**
-     * Times the given future out after the timeout.
-     *
-     * @param future to time out
-     * @param timeout after which the given future is timed out
-     * @param timeUnit time unit of the timeout
      * @param timeoutMsg timeout message for exception
      * @param <T> type of the given future
      * @return The timeout enriched future
@@ -443,25 +429,6 @@ public class FutureUtils {
             TimeUnit timeUnit,
             @Nullable String timeoutMsg) {
         return orTimeout(future, timeout, timeUnit, Executors.directExecutor(), timeoutMsg);
-    }
-
-    /**
-     * Times the given future out after the timeout.
-     *
-     * @param future to time out
-     * @param timeout after which the given future is timed out
-     * @param timeUnit time unit of the timeout
-     * @param timeoutFailExecutor executor that will complete the future exceptionally after the
-     *     timeout is reached
-     * @param <T> type of the given future
-     * @return The timeout enriched future
-     */
-    public static <T> CompletableFuture<T> orTimeout(
-            CompletableFuture<T> future,
-            long timeout,
-            TimeUnit timeUnit,
-            Executor timeoutFailExecutor) {
-        return orTimeout(future, timeout, timeUnit, timeoutFailExecutor, null);
     }
 
     /**

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
@@ -294,12 +294,13 @@ public class FutureUtilsTest extends TestLogger {
         final CompletableFuture<String> future = new CompletableFuture<>();
         final long timeout = 10L;
 
-        FutureUtils.orTimeout(future, timeout, TimeUnit.MILLISECONDS);
+        FutureUtils.orTimeout(future, timeout, TimeUnit.MILLISECONDS, "testOrTimeout");
 
         try {
             future.get();
         } catch (ExecutionException e) {
             assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
+            ExceptionUtils.assertThrowableWithMessage(e, "testOrTimeout");
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -325,7 +325,10 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
                             pendingRequest.getSlotFuture(),
                             timeout.toMilliseconds(),
                             TimeUnit.MILLISECONDS,
-                            componentMainThreadExecutor)
+                            componentMainThreadExecutor,
+                            String.format(
+                                    "Pending slot request %s timed out after %d ms.",
+                                    pendingRequest.getSlotRequestId(), timeout.toMilliseconds()))
                     .whenComplete(
                             (physicalSlot, throwable) -> {
                                 if (throwable instanceof TimeoutException) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/CompletedOperationCache.java
@@ -187,7 +187,10 @@ public class CompletedOperationCache<K extends OperationKey, R extends Serializa
                         FutureUtils.orTimeout(
                                 asyncWaitForResultsToBeAccessed(),
                                 cacheDuration.getSeconds(),
-                                TimeUnit.SECONDS);
+                                TimeUnit.SECONDS,
+                                String.format(
+                                        "Waiting for results to be accessed timed out after %s seconds.",
+                                        cacheDuration.getSeconds()));
             }
 
             return terminationFuture;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployer.java
@@ -280,7 +280,11 @@ public class DefaultExecutionDeployer implements ExecutionDeployer {
                         partitionRegistrationFuture,
                         partitionRegistrationTimeout.toMilliseconds(),
                         TimeUnit.MILLISECONDS,
-                        mainThreadExecutor);
+                        mainThreadExecutor,
+                        String.format(
+                                "Registering produced partitions for execution %s timed out after %d ms.",
+                                execution.getAttemptId(),
+                                partitionRegistrationTimeout.toMilliseconds()));
             } else {
                 return FutureUtils.completedVoidFuture();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -439,7 +439,12 @@ public class TaskManagerRunner implements FatalErrorHandler {
             closeAsync(Result.FAILURE);
 
             FutureUtils.orTimeout(
-                    terminationFuture, FATAL_ERROR_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                    terminationFuture,
+                    FATAL_ERROR_SHUTDOWN_TIMEOUT_MS,
+                    TimeUnit.MILLISECONDS,
+                    String.format(
+                            "Waiting for TaskManager shutting down timed out after %s ms.",
+                            FATAL_ERROR_SHUTDOWN_TIMEOUT_MS));
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -259,7 +259,12 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
 
     private static CompletableFuture<Acknowledge> askTimeoutFuture() {
         final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
-        FutureUtils.orTimeout(future, 500, TimeUnit.MILLISECONDS);
+        final long timeout = 500;
+        FutureUtils.orTimeout(
+                future,
+                timeout,
+                TimeUnit.MILLISECONDS,
+                String.format("Future timed out after %s ms.", timeout));
         return future;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, there are two versions of FutureUtils.orTimeout() that use null as an error message when the timeout happens. This makes it difficult to debug those timeouts, in particular during the shutdown. See [this](https://lists.apache.org/thread/5wxv2occohc6ky1g754n7o8b8ssjcqf5) thread for example.

 Replacing null with an actual message ease improve the debugging.

## Verifying this change
This pr only changes the logging when timeouts happens, no need for extra tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
