### PR TITLE
[FLINK-31755][planner] Make SqlRowOperator to create row with PEEK_FIELDS_NO_EXPAND struct type

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
@@ -19,6 +19,7 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
@@ -27,10 +28,8 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
-import org.apache.calcite.util.Pair;
 
 import java.util.AbstractList;
-import java.util.Map;
 
 /**
  * Copied to keep null semantics of table api and sql in sync. At the same time SQL standard says
@@ -68,10 +67,13 @@ import java.util.Map;
  *
  * Once Flink applies same logic for both table api and sql, this class should be removed.
  *
+ * <p>Changed2: Generates a row with StructKind.PEEK_FIELDS_NO_EXPAND type, which is aligned to the
+ * Flink's RowType
+ *
  * <p>Changed lines
  *
  * <ol>
- *   <li>Line 92 ~ 112
+ *   <li>Line 102 ~ 127
  * </ol>
  */
 public class SqlRowOperator extends SqlSpecialOperator {
@@ -96,15 +98,26 @@ public class SqlRowOperator extends SqlSpecialOperator {
         // The type of a ROW(e1,e2) expression is a record with the types
         // {e1type,e2type}.  According to the standard, field names are
         // implementation-defined.
+
         return opBinding
                 .getTypeFactory()
                 .createStructType(
-                        new AbstractList<Map.Entry<String, RelDataType>>() {
+                        StructKind.PEEK_FIELDS_NO_EXPAND,
+                        new AbstractList<RelDataType>() {
                             @Override
-                            public Map.Entry<String, RelDataType> get(int index) {
-                                return Pair.of(
-                                        SqlUtil.deriveAliasFromOrdinal(index),
-                                        opBinding.getOperandType(index));
+                            public RelDataType get(int index) {
+                                return opBinding.getOperandType(index);
+                            }
+
+                            @Override
+                            public int size() {
+                                return opBinding.getOperandCount();
+                            }
+                        },
+                        new AbstractList<String>() {
+                            @Override
+                            public String get(int index) {
+                                return SqlUtil.deriveAliasFromOrdinal(index);
                             }
 
                             @Override

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
@@ -72,6 +72,35 @@ Calc(select=[c0 AS c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIntersectAllWithRow">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(c) FROM T1 INTERSECT ALL SELECT ROW(f) FROM T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalIntersect(all=[true])
+:- LogicalProject(EXPR$0=[ROW($2)])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
++- LogicalProject(EXPR$0=[ROW($2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$00 AS EXPR$0])
++- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1)], correlate=[table($REPLICATE_ROWS$1($f0,EXPR$0))], select=[$f0,EXPR$0,EXPR$00], rowType=[RecordType(BIGINT $f0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$00)], joinType=[INNER])
+   +- Calc(select=[IF((vcol_left_cnt > vcol_right_cnt), vcol_right_cnt, vcol_left_cnt) AS $f0, EXPR$0], where=[((vcol_left_cnt >= 1) AND (vcol_right_cnt >= 1))])
+      +- HashAggregate(isMerge=[true], groupBy=[EXPR$0], select=[EXPR$0, Final_COUNT(count$0) AS vcol_left_cnt, Final_COUNT(count$1) AS vcol_right_cnt])
+         +- Exchange(distribution=[hash[EXPR$0]])
+            +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0, Partial_COUNT(vcol_left_marker) AS count$0, Partial_COUNT(vcol_right_marker) AS count$1])
+               +- Union(all=[true], union=[EXPR$0, vcol_left_marker, vcol_right_marker])
+                  :- Calc(select=[ROW(c) AS EXPR$0, true AS vcol_left_marker, null:BOOLEAN AS vcol_right_marker])
+                  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+                  +- Calc(select=[ROW(f) AS EXPR$0, null:BOOLEAN AS vcol_left_marker, true AS vcol_right_marker])
+                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntersectLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 INTERSECT SELECT f FROM T2]]>
@@ -193,6 +222,35 @@ Calc(select=[c0 AS c])
                   :- Calc(select=[c, 1 AS vcol_marker])
                   :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
                   +- Calc(select=[f, -1 AS vcol_marker])
+                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinusAllWithRow">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(c) FROM T1 EXCEPT ALL SELECT ROW(f) FROM T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalMinus(all=[true])
+:- LogicalProject(EXPR$0=[ROW($2)])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
++- LogicalProject(EXPR$0=[ROW($2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$00 AS EXPR$0])
++- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1)], correlate=[table($REPLICATE_ROWS$1(sum_vcol_marker,EXPR$0))], select=[sum_vcol_marker,EXPR$0,EXPR$00], rowType=[RecordType(BIGINT sum_vcol_marker, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$00)], joinType=[INNER])
+   +- Calc(select=[sum_vcol_marker, EXPR$0], where=[(sum_vcol_marker > 0)])
+      +- HashAggregate(isMerge=[true], groupBy=[EXPR$0], select=[EXPR$0, Final_SUM(sum$0) AS sum_vcol_marker])
+         +- Exchange(distribution=[hash[EXPR$0]])
+            +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0, Partial_SUM(vcol_marker) AS sum$0])
+               +- Union(all=[true], union=[EXPR$0, vcol_marker])
+                  :- Calc(select=[ROW(c) AS EXPR$0, 1 AS vcol_marker])
+                  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+                  +- Calc(select=[ROW(f) AS EXPR$0, -1 AS vcol_marker])
                      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.xml
@@ -71,6 +71,34 @@ Calc(select=[c0 AS c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIntersectAllWithRow">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(c) FROM T1 INTERSECT ALL SELECT ROW(f) FROM T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalIntersect(all=[true])
+:- LogicalProject(EXPR$0=[ROW($2)])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
++- LogicalProject(EXPR$0=[ROW($2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$00 AS EXPR$0])
++- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1)], correlate=[table($REPLICATE_ROWS$1($f0,EXPR$0))], select=[$f0,EXPR$0,EXPR$00], rowType=[RecordType(BIGINT $f0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$00)], joinType=[INNER])
+   +- Calc(select=[IF((vcol_left_cnt > vcol_right_cnt), vcol_right_cnt, vcol_left_cnt) AS $f0, EXPR$0], where=[((vcol_left_cnt >= 1) AND (vcol_right_cnt >= 1))])
+      +- GroupAggregate(groupBy=[EXPR$0], select=[EXPR$0, COUNT(vcol_left_marker) AS vcol_left_cnt, COUNT(vcol_right_marker) AS vcol_right_cnt])
+         +- Exchange(distribution=[hash[EXPR$0]])
+            +- Union(all=[true], union=[EXPR$0, vcol_left_marker, vcol_right_marker])
+               :- Calc(select=[ROW(c) AS EXPR$0, true AS vcol_left_marker, null:BOOLEAN AS vcol_right_marker])
+               :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+               +- Calc(select=[ROW(f) AS EXPR$0, null:BOOLEAN AS vcol_left_marker, true AS vcol_right_marker])
+                  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntersectLeftIsEmpty">
     <Resource name="sql">
       <![CDATA[SELECT c FROM T1 WHERE 1=0 INTERSECT SELECT f FROM T2]]>
@@ -191,6 +219,34 @@ Calc(select=[c0 AS c])
                :- Calc(select=[c, 1 AS vcol_marker])
                :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
                +- Calc(select=[f, -1 AS vcol_marker])
+                  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMinusAllWithRow">
+    <Resource name="sql">
+      <![CDATA[SELECT ROW(c) FROM T1 EXCEPT ALL SELECT ROW(f) FROM T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalMinus(all=[true])
+:- LogicalProject(EXPR$0=[ROW($2)])
+:  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]])
++- LogicalProject(EXPR$0=[ROW($2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[EXPR$00 AS EXPR$0])
++- Correlate(invocation=[$REPLICATE_ROWS$1($0, $1)], correlate=[table($REPLICATE_ROWS$1(sum_vcol_marker,EXPR$0))], select=[sum_vcol_marker,EXPR$0,EXPR$00], rowType=[RecordType(BIGINT sum_vcol_marker, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$0, RecordType:peek_no_expand(VARCHAR(2147483647) EXPR$0) EXPR$00)], joinType=[INNER])
+   +- Calc(select=[sum_vcol_marker, EXPR$0], where=[(sum_vcol_marker > 0)])
+      +- GroupAggregate(groupBy=[EXPR$0], select=[EXPR$0, SUM(vcol_marker) AS sum_vcol_marker])
+         +- Exchange(distribution=[hash[EXPR$0]])
+            +- Union(all=[true], union=[EXPR$0, vcol_marker])
+               :- Calc(select=[ROW(c) AS EXPR$0, 1 AS vcol_marker])
+               :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+               +- Calc(select=[ROW(f) AS EXPR$0, -1 AS vcol_marker])
                   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.scala
@@ -56,6 +56,11 @@ class SetOperatorsTest extends TableTestBase {
     util.verifyExecPlan("SELECT c FROM T1 INTERSECT ALL SELECT f FROM T2")
   }
 
+  @Test
+  def testIntersectAllWithRow(): Unit = {
+    util.verifyExecPlan("SELECT ROW(c) FROM T1 INTERSECT ALL SELECT ROW(f) FROM T2")
+  }
+
   @Test(expected = classOf[ValidationException])
   def testIntersectDifferentFieldTypes(): Unit = {
     // must fail. Intersect inputs have different field types.
@@ -65,6 +70,11 @@ class SetOperatorsTest extends TableTestBase {
   @Test
   def testMinusAll(): Unit = {
     util.verifyExecPlan("SELECT c FROM T1 EXCEPT ALL SELECT f FROM T2")
+  }
+
+  @Test
+  def testMinusAllWithRow(): Unit = {
+    util.verifyExecPlan("SELECT ROW(c) FROM T1 EXCEPT ALL SELECT ROW(f) FROM T2")
   }
 
   @Test(expected = classOf[ValidationException])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SetOperatorsTest.scala
@@ -54,6 +54,11 @@ class SetOperatorsTest extends TableTestBase {
     util.verifyExecPlan("SELECT c FROM T1 INTERSECT ALL SELECT f FROM T2")
   }
 
+  @Test
+  def testIntersectAllWithRow(): Unit = {
+    util.verifyExecPlan("SELECT ROW(c) FROM T1 INTERSECT ALL SELECT ROW(f) FROM T2")
+  }
+
   @Test(expected = classOf[ValidationException])
   def testIntersectDifferentFieldTypes(): Unit = {
     // must fail. Intersect inputs have different field types.
@@ -63,6 +68,11 @@ class SetOperatorsTest extends TableTestBase {
   @Test
   def testMinusAll(): Unit = {
     util.verifyExecPlan("SELECT c FROM T1 EXCEPT ALL SELECT f FROM T2")
+  }
+
+  @Test
+  def testMinusAllWithRow(): Unit = {
+    util.verifyExecPlan("SELECT ROW(c) FROM T1 EXCEPT ALL SELECT ROW(f) FROM T2")
   }
 
   @Test(expected = classOf[ValidationException])


### PR DESCRIPTION
## What is the purpose of the change

This PR is meant to fix the `RewriteIntersectAllRule` can not work with the ROW type.

## Brief change log

Copied `SqlRowOperator` from calcite and adapt the return type to `PEEK_FIELDS_NO_EXPAND`

## Verifying this change

- SetOperatorsTest#testIntersectAllWithRow
- SetOperatorsTest#testMinusAllWithRow

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
