### PR TITLE
[FLINK-28171] [flink-kubernates] enable add appProtocol via the configuration and verify it is not overridden by Default port defintion

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -39,7 +39,9 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.API_VERSION;
@@ -141,7 +143,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
 
         // Merge fields
         mainContainerBuilder
-                .addAllToPorts(getContainerPorts())
+                .addAllToPorts(getContainerPorts(container))
                 .addAllToEnv(getCustomizedEnvs())
                 .addNewEnv()
                 .withName(ENV_FLINK_POD_IP_ADDRESS)
@@ -154,20 +156,30 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
         return mainContainerBuilder.build();
     }
 
-    private List<ContainerPort> getContainerPorts() {
-        return Arrays.asList(
-                new ContainerPortBuilder()
-                        .withName(Constants.REST_PORT_NAME)
-                        .withContainerPort(kubernetesJobManagerParameters.getRestPort())
-                        .build(),
-                new ContainerPortBuilder()
-                        .withName(Constants.JOB_MANAGER_RPC_PORT_NAME)
-                        .withContainerPort(kubernetesJobManagerParameters.getRPCPort())
-                        .build(),
-                new ContainerPortBuilder()
-                        .withName(Constants.BLOB_SERVER_PORT_NAME)
-                        .withContainerPort(kubernetesJobManagerParameters.getBlobServerPort())
-                        .build());
+    private List<ContainerPort> getContainerPorts(Container container) {
+
+        List<ContainerPort> defaultContainerPorts =
+                Arrays.asList(
+                        new ContainerPortBuilder()
+                                .withName(Constants.REST_PORT_NAME)
+                                .withContainerPort(kubernetesJobManagerParameters.getRestPort())
+                                .build(),
+                        new ContainerPortBuilder()
+                                .withName(Constants.JOB_MANAGER_RPC_PORT_NAME)
+                                .withContainerPort(kubernetesJobManagerParameters.getRPCPort())
+                                .build(),
+                        new ContainerPortBuilder()
+                                .withName(Constants.BLOB_SERVER_PORT_NAME)
+                                .withContainerPort(
+                                        kubernetesJobManagerParameters.getBlobServerPort())
+                                .build());
+
+        Map<String, ContainerPort> containerPortMap =
+                container.getPorts().stream()
+                        .collect(Collectors.toMap(ContainerPort::getName, Function.identity()));
+        return defaultContainerPorts.stream()
+                .filter(x -> !containerPortMap.containsKey(x.getName()))
+                .collect(Collectors.toList());
     }
 
     private List<EnvVar> getCustomizedEnvs() {


### PR DESCRIPTION

## What is the purpose of the change
enable the job manager and task manager communicate in a Kubernetes cluster with Istio and mTLS enabled.

## Brief change log
Add the “appProtocol” in the task manager and job manager configuration, verify they are not overridden by the default definition in the decorators 

## Verifying this change
This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
