### PR TITLE
[FLINK-31165][table-planner] Improve the error message for order by clause

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalOverAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalOverAggregate.scala
@@ -88,7 +88,7 @@ class FlinkLogicalOverAggregateConverter(config: Config) extends ConverterRule(c
           winAggCall =>
             if (orderKeySize == 0 && winAggCall.op.isInstanceOf[SqlRankFunction]) {
               throw new ValidationException(
-                "Over Agg: The window rank function without order by. " +
+                "Over Agg: The window rank function requires order by clause with non-constant fields. " +
                   "please re-check the over window statement.")
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

This PR is cherry-picked from commit eeb446c0ed07c38175efdadf7e2e21702ff02b70


## Brief change log

Improve the error message in `FlinkLogicalOverAggreate`


## Verifying this change

This change added tests and can be verified as follows:

- `RankTest` to cover both streaming and batch scenarios.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializer: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
