### PR TITLE
[FLINK-31758][doc] Handles $full_version for sql_url in document.

### DIFF
--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -52,7 +52,7 @@
           </div> 
         </td>
         <td style="text-align: left">
-          <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+          <a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a>
         </td>
       </tr>
       {{ end }}


### PR DESCRIPTION
## What is the purpose of the change

*After [FLINK-30378](https://issues.apache.org/jira/browse/FLINK-30378), we can load sql connector data from external connector's own data file. However, we did not replace `$full_version`, resulting in an incorrect URL in the download link. for example: `https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-mongodb/$full_version/flink-sql-connector-mongodb-$full_version.jar`.*


## Brief change log

  - *Handles $full_version for sql_url in document.*

## Verifying this change

Manually test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
