### PR TITLE
[FLINK-31765][runtime][test] Disable changelog backend for RocksDB migration tests

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobSnapshotMigrationITCase.java
@@ -136,6 +136,12 @@ public class StatefulJobSnapshotMigrationITCase extends SnapshotMigrationTestBas
         switch (snapshotSpec.getStateBackendType()) {
             case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME:
                 env.setStateBackend(new EmbeddedRocksDBStateBackend());
+
+                if (executionMode == ExecutionMode.CREATE_SNAPSHOT) {
+                    // disable changelog backend for now to ensure determinism in test data
+                    // generation (see FLINK-31766)
+                    env.enableChangelogStateBackend(false);
+                }
                 break;
             case StateBackendLoader.MEMORY_STATE_BACKEND_NAME:
                 env.setStateBackend(new MemoryStateBackend());
@@ -150,7 +156,6 @@ public class StatefulJobSnapshotMigrationITCase extends SnapshotMigrationTestBas
         env.enableCheckpointing(500);
         env.setParallelism(parallelism);
         env.setMaxParallelism(parallelism);
-        env.enableChangelogStateBackend(false);
 
         SourceFunction<Tuple2<Long, Long>> nonParallelSource;
         SourceFunction<Tuple2<Long, Long>> parallelSource;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobWBroadcastStateMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobWBroadcastStateMigrationITCase.java
@@ -131,6 +131,12 @@ public class StatefulJobWBroadcastStateMigrationITCase extends SnapshotMigration
         switch (snapshotSpec.getStateBackendType()) {
             case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME:
                 env.setStateBackend(new EmbeddedRocksDBStateBackend());
+
+                if (executionMode == ExecutionMode.CREATE_SNAPSHOT) {
+                    // disable changelog backend for now to ensure determinism in test data
+                    // generation (see FLINK-31766)
+                    env.enableChangelogStateBackend(false);
+                }
                 break;
             case StateBackendLoader.MEMORY_STATE_BACKEND_NAME:
                 env.setStateBackend(new MemoryStateBackend());

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.tuple.Tuple2
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.migration.CustomEnum.CustomEnum
+import org.apache.flink.api.scala.migration.StatefulJobSavepointMigrationITCase.executionMode
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend
 import org.apache.flink.runtime.state.{FunctionInitializationContext, FunctionSnapshotContext, StateBackendLoader}
@@ -146,6 +147,12 @@ class StatefulJobSavepointMigrationITCase(snapshotSpec: SnapshotSpec)
     snapshotSpec.getStateBackendType match {
       case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME =>
         env.setStateBackend(new EmbeddedRocksDBStateBackend())
+
+        if (executionMode == ExecutionMode.CREATE_SNAPSHOT) {
+          // disable changelog backend for now to ensure determinism in test data generation
+          // (see FLINK-31766)
+          env.enableChangelogStateBackend(false);
+        }
       case StateBackendLoader.MEMORY_STATE_BACKEND_NAME =>
         env.setStateBackend(new MemoryStateBackend())
       case StateBackendLoader.HASHMAP_STATE_BACKEND_NAME =>

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.tuple.Tuple2
 import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.api.scala.migration.CustomEnum.CustomEnum
+import org.apache.flink.api.scala.migration.StatefulJobWBroadcastStateMigrationITCase.executionMode
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend
 import org.apache.flink.runtime.state.{FunctionInitializationContext, FunctionSnapshotContext, StateBackendLoader}
@@ -149,6 +150,11 @@ class StatefulJobWBroadcastStateMigrationITCase(snapshotSpec: SnapshotSpec)
     snapshotSpec.getStateBackendType match {
       case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME =>
         env.setStateBackend(new EmbeddedRocksDBStateBackend())
+
+        if (executionMode == ExecutionMode.CREATE_SNAPSHOT) {
+          // disable changelog backend for now to ensure determinism in test data generation (see FLINK-31766)
+          env.enableChangelogStateBackend(false)
+        }
       case StateBackendLoader.MEMORY_STATE_BACKEND_NAME =>
         env.setStateBackend(new MemoryStateBackend())
       case StateBackendLoader.HASHMAP_STATE_BACKEND_NAME =>


### PR DESCRIPTION
## What is the purpose of the change

FLINK-31593 revealed some non-determinism in the checkpoint generation for migration tests. The actual issue is covered in FLINK-31766. As a workaround, we're disabling changelog backend for now.

## Brief change log

* Went through any still existing tests based on 369088f0 and disabled changelog backend for RocksDB backend-based tests only.

## Verifying this change

Test data can be generated and verified for those tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable