### PR TITLE
[FLINK-31344][planner] Support to update nested columns in update sta…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -539,6 +539,7 @@
   # Return type of method implementation should be 'SqlNode'.
   # Example: SqlShowDatabases(), SqlShowTables().
   statementParserMethods: [
+    "FlinkSqlUpdate()"
     "RichSqlInsert()"
     "SqlBeginStatementSet()"
     "SqlEndStatementSet()"

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
@@ -127,6 +127,10 @@ public class SinkModifyOperation implements ModifyOperation {
         return modifyType == ModifyType.DELETE;
     }
 
+    public ModifyType getModifyType() {
+        return modifyType;
+    }
+
     public Map<String, String> getDynamicOptions() {
         return dynamicOptions;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -162,6 +162,9 @@ import static org.apache.calcite.util.Static.RESOURCE;
  *
  * <p>Lines 5352 ~ 5358, Flink enables TIMESTAMP and TIMESTAMP_LTZ for first orderBy column in
  * matchRecognize at {@link SqlValidatorImpl#validateMatchRecognize}.
+ *
+ * <p>Lines 4902 ~ 49220 Disable the validation for SqlUpdate RowType. We support the nested column
+ * and will validate it in the table environment.
  */
 public class SqlValidatorImpl implements SqlValidatorWithHints {
     // ~ Static fields/initializers ---------------------------------------------
@@ -4899,16 +4902,22 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
                         ? getTable(targetNamespace)
                         : relOptTable.unwrapOrThrow(SqlValidatorTable.class);
 
-        final RelDataType targetRowType =
-                createTargetRowType(table, call.getTargetColumnList(), true);
+        //        final RelDataType targetRowType =
+        //                createTargetRowType(table, call.getTargetColumnList(), true);
 
+        // only validate source select here.
+        // ignore row type which will be verified in table environment.
         final SqlSelect select = SqlNonNullableAccessors.getSourceSelect(call);
-        validateSelect(select, targetRowType);
 
-        final RelDataType sourceRowType = getValidatedNodeType(select);
-        checkTypeAssignment(scopes.get(select), table, sourceRowType, targetRowType, call);
+        validate(select);
 
-        checkConstraint(table, call, targetRowType);
+        //        validateSelect(select, targetRowType);
+        //
+        //        final RelDataType sourceRowType = getValidatedNodeType(select);
+        //        checkTypeAssignment(scopes.get(select), table, sourceRowType, targetRowType,
+        //    call);
+        //
+        //        checkConstraint(table, call, targetRowType);
 
         validateAccess(call.getTargetTable(), table, SqlAccessEnum.UPDATE);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/UpdateRowProjectionBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/UpdateRowProjectionBuilder.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.connectors;
+
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Build a new projection for updating based on the update exprs and required columns. */
+public class UpdateRowProjectionBuilder {
+
+    /** The delimiter to construct the access path. */
+    private static final String DELIMITER = "->";
+
+    /**
+     * The nested nodes of the required columns. The nodes typically can be
+     * <li>{@link RexInputRef} for non-updated column
+     * <li>Rex expression node for user-specified updated column
+     * <li>Row expression for the row column with partial updated column
+     */
+    private final Map<String, RexNode> requiredNodes = new HashMap<>();
+
+    /** All the complete access path of the fields, deriving from the RowType. */
+    private final List<List<Integer>> allPaths = new ArrayList<>();
+
+    /**
+     * Required columns' indexes.
+     *
+     * <p>Note: The required column can exceed the original table rowType, because we can attach
+     * readable metadata column derived from the table.
+     */
+    private final List<Integer> requiredColumnIndexes;
+
+    /** The columns count of the original sink table. */
+    private final int originColsCount;
+
+    /** The row type of the sink table after enriched. */
+    private final RowType rowType;
+
+    private final int[][] updatedColumnIndexes;
+
+    /** The input of the LogicalSink. */
+    private final LogicalProject project;
+
+    /** The filter of the update operation. */
+    @Nullable private final LogicalFilter filter;
+
+    /** The flink type factory. */
+    private final FlinkTypeFactory typeFactory;
+
+    /** The rex builder. */
+    private final RexBuilder rexBuilder;
+
+    public UpdateRowProjectionBuilder(
+            RowType rowType,
+            int[][] updatedColumnIndexes,
+            LogicalProject project,
+            @Nullable LogicalFilter filter,
+            int originColsCount,
+            List<Integer> requiredColumnIndexes,
+            RexBuilder rexBuilder,
+            FlinkTypeFactory typeFactory) {
+        this.rexBuilder = rexBuilder;
+        this.originColsCount = originColsCount;
+        this.requiredColumnIndexes = requiredColumnIndexes;
+        this.rowType = rowType;
+        this.typeFactory = typeFactory;
+        this.filter = filter;
+        this.updatedColumnIndexes = updatedColumnIndexes;
+        // the rex nodes for the project are like: index for all col, update expressions for the
+        // updated columns
+        this.project = project;
+        buildAllPath();
+        fillRequiredNodes();
+    }
+
+    /**
+     * Create the new project based on the update expr and the required column.
+     *
+     * @return new project
+     */
+    public Project create() {
+        List<Integer> path = new ArrayList<>();
+        List<RexNode> newNodes = new ArrayList<>();
+        List<String> fieldNames = new ArrayList<>();
+        for (int index : requiredColumnIndexes) {
+            fieldNames.add(rowType.getFields().get(index).getName());
+            path.add(index);
+            String accessPath = getAccessPath(path);
+            if (requiredNodes.containsKey(accessPath)) {
+                newNodes.add(wrapCaseWhen(requiredNodes.get(accessPath), index));
+                path.remove(path.size() - 1);
+            } else {
+                RexNode node = traverse(path, rowType.getFields().get(index));
+                newNodes.add(wrapCaseWhen(node, index));
+            }
+        }
+
+        return project.copy(
+                project.getTraitSet(),
+                // if filter is not null, we need to remove the filter in the plan since we
+                // have rewritten the expression to
+                // CASE WHEN filter THEN updated_expr ELSE col_expr END
+                filter != null ? filter.getInput() : project.getInput(),
+                newNodes,
+                RexUtil.createStructType(typeFactory, newNodes, fieldNames, null));
+    }
+
+    private RexNode traverse(List<Integer> path, RowType.RowField field) {
+        String accessPath = getAccessPath(path);
+        if (requiredNodes.containsKey(accessPath)) {
+            path.remove(path.size() - 1);
+            return requiredNodes.get(accessPath);
+        } else {
+            Preconditions.checkArgument(
+                    field.getType() instanceof RowType,
+                    String.format(
+                            "The field: %s type is %s, It's expected to be RowType",
+                            field.getName(), field.getType()));
+            RowType row = (RowType) field.getType();
+            List<RexNode> nodes = new ArrayList<>();
+            for (int i = 0; i < row.getFields().size(); i++) {
+                path.add(i);
+                nodes.add(traverse(path, row.getFields().get(i)));
+            }
+            RelDataType dataType =
+                    RexUtil.createStructType(typeFactory, nodes, row.getFieldNames(), null);
+            path.remove(path.size() - 1);
+            return rexBuilder.makeCall(dataType, FlinkSqlOperatorTable.ROW, nodes);
+        }
+    }
+
+    /**
+     * When the required column contains the updated field, and the filter is supplied, wrap the
+     * node into {@code CASE WHEN} call.
+     *
+     * @param node The node to be wrapped.
+     * @param requiredColumnIndex The required column index.
+     * @return The wrapped or original rex node.
+     */
+    private RexNode wrapCaseWhen(RexNode node, int requiredColumnIndex) {
+        List<Integer> related =
+                findUpdateIdxByRequiredColumn(updatedColumnIndexes, requiredColumnIndex);
+        if (related.isEmpty() || filter == null) {
+            return node;
+        }
+
+        RexInputRef inputRef = rexBuilder.makeInputRef(project.getInput(), requiredColumnIndex);
+        return rexBuilder.makeCall(
+                inputRef.getType(),
+                FlinkSqlOperatorTable.CASE,
+                Arrays.asList(filter.getCondition(), node, inputRef));
+    }
+
+    /** Get the related update clause index covered by required column. */
+    private List<Integer> findUpdateIdxByRequiredColumn(
+            int[][] targetUpdateIndexes, int requiredColumnIndex) {
+        List<Integer> related = new ArrayList<>();
+        for (int i = 0; i < targetUpdateIndexes.length; i++) {
+            if (targetUpdateIndexes[i][0] == requiredColumnIndex) {
+                related.add(i);
+            }
+        }
+        return related;
+    }
+
+    /** Pre-build the requiredNodes according to the update column info. */
+    private void fillRequiredNodes() {
+        for (Integer requiredIndex : requiredColumnIndexes) {
+            List<Integer> updateOrderedIds =
+                    findUpdateIdxByRequiredColumn(updatedColumnIndexes, requiredIndex);
+            // The required column contains the update col.
+            if (!updateOrderedIds.isEmpty()) {
+                // (1) Insert the update cols expr to requiredColumnNestedNodes.
+                for (Integer idx : updateOrderedIds) {
+                    int[] updatedColumnPath = updatedColumnIndexes[idx];
+                    // project layout is: original table's fields + update expressions.
+                    RexNode updateExpr = project.getProjects().get(originColsCount + idx);
+                    String accessPath =
+                            getAccessPath(
+                                    Arrays.stream(updatedColumnPath)
+                                            .boxed()
+                                            .collect(Collectors.toList()));
+                    requiredNodes.put(accessPath, updateExpr);
+                }
+
+                // (2) Insert the related nested cols of the required column index to
+                // requiredColumnNestedNodes.
+                List<List<Integer>> updatedRelatedPath =
+                        allPaths.stream()
+                                .filter(p -> p.get(0).equals(requiredIndex))
+                                .collect(Collectors.toList());
+                RexInputRef inputRef = rexBuilder.makeInputRef(project.getInput(), requiredIndex);
+                for (List<Integer> path : updatedRelatedPath) {
+                    String accessPath = getAccessPath(path);
+                    if (!requiredNodes.containsKey(accessPath)) {
+                        RexNode node = inputRef;
+                        if (path.size() >= 2) {
+                            for (int i = 1; i < path.size(); i++) {
+                                node = rexBuilder.makeFieldAccess(node, path.get(i));
+                            }
+                        }
+                        requiredNodes.put(accessPath, node);
+                    }
+                }
+            } else {
+                // just create input ref for non-update fields.
+                requiredNodes.put(
+                        getAccessPath(Collections.singletonList(requiredIndex)),
+                        rexBuilder.makeInputRef(project.getInput(), requiredIndex));
+            }
+        }
+    }
+
+    /** Construct the complete path of each field. */
+    private void buildAllPath() {
+        for (int i = 0; i < rowType.getChildren().size(); i++) {
+            List<Integer> path = new ArrayList<>();
+            buildPath(rowType.getChildren().get(i), i, path);
+        }
+    }
+
+    private void buildPath(LogicalType childType, int idxInRow, List<Integer> path) {
+        path.add(idxInRow);
+        // non struct type
+        if (childType.getChildren().isEmpty()) {
+            allPaths.add(new ArrayList<>(path));
+        } else {
+            for (int i = 0; i < childType.getChildren().size(); i++) {
+                buildPath(childType.getChildren().get(i), i, path);
+            }
+        }
+        path.remove(path.size() - 1);
+    }
+
+    private String getAccessPath(List<Integer> path) {
+        return path.stream().map(String::valueOf).collect(Collectors.joining(DELIMITER));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -18,8 +18,8 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
-import org.apache.flink.sql.parser.ddl.{SqlCompilePlan, SqlReset, SqlSet, SqlUseModules}
-import org.apache.flink.sql.parser.dml.{RichSqlInsert, SqlBeginStatementSet, SqlCompileAndExecutePlan, SqlEndStatementSet, SqlExecute, SqlExecutePlan, SqlStatementSet}
+import org.apache.flink.sql.parser.ddl._
+import org.apache.flink.sql.parser.dml._
 import org.apache.flink.sql.parser.dql._
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.hint.JoinStrategy

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelUpdateTest.xml
@@ -20,17 +20,17 @@ limitations under the License.
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
-+- LogicalProject(a=[IF(>($2, 123), 123, $0)], b=[IF(>($2, 123), _UTF-16LE'v2', $1)], c=[IF(>($2, 123), +($2, 1), $2)])
++- LogicalProject(a=[CASE(>($2, 123), 123, $0)], b=[CASE(>($2, 123), _UTF-16LE'v2', $1)], c=[CASE(>($2, 123), +($2, 1), $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
-+- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
++- Calc(select=[CASE(>(c, 123), 123, a) AS a, CASE(>(c, 123), 'v2', b) AS b, CASE(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fields=[a, b, c])
-+- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
++- Calc(select=[CASE((c > 123), 123, a) AS a, CASE((c > 123), 'v2', b) AS b, CASE((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Physical Execution Plan ==
@@ -45,7 +45,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fi
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
+    "contents" : "[]:Calc(select=[CASE((c > 123), 123, a) AS a, CASE((c > 123), 'v2', b) AS b, CASE((c > 123), (c + 1), c) AS c])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -134,17 +134,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0],[2]], fi
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
-+- LogicalProject(a=[IF(>($4, 123), 123, $2)], b=[IF(>($4, 123), _UTF-16LE'v2', $3)], c=[IF(>($4, 123), +($4, 1), $4)])
++- LogicalProject(a=[CASE(>($4, 123), 123, $2)], b=[CASE(>($4, 123), _UTF-16LE'v2', $3)], c=[CASE(>($4, 123), +($4, 1), $4)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
-+- Calc(select=[IF(>(c, 123), 123, a) AS a, IF(>(c, 123), 'v2', b) AS b, IF(>(c, 123), +(c, 1), c) AS c])
++- Calc(select=[CASE(>(c, 123), 123, a) AS a, CASE(>(c, 123), 'v2', b) AS b, CASE(>(c, 123), +(c, 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fields=[a, b, c])
-+- Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])
++- Calc(select=[CASE((c > 123), 123, a) AS a, CASE((c > 123), 'v2', b) AS b, CASE((c > 123), (c + 1), c) AS c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[f0, f1, a, b, c, f2, f3])
 
 == Physical Execution Plan ==
@@ -159,7 +159,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fi
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((c > 123), 123, a) AS a, IF((c > 123), 'v2', b) AS b, IF((c > 123), (c + 1), c) AS c])",
+    "contents" : "[]:Calc(select=[CASE((c > 123), 123, a) AS a, CASE((c > 123), 'v2', b) AS b, CASE((c > 123), (c + 1), c) AS c])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -244,21 +244,363 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[3],[2],[4]], fi
 }]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpdateWithCompositeType[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- LogicalProject(a=[$0], b=[CASE(=($1.b1, _UTF-16LE'123'), ROW(_UTF-16LE'v2', 1), $1)], c=[CASE(=($1.b1, _UTF-16LE'123'), ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4)), $2)], d=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- Calc(select=[a, CASE(=(b.b1, '123'), ROW('v2', 1), b) AS b, CASE(=(b.b1, '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, d])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- Calc(select=[a, CASE((b.b1 = '123'), ROW('v2', 1), b) AS b, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, d])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, CASE((b.b1 = '123'), ROW('v2', 1), b) AS b, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, d])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCompositeType[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- LogicalProject(a=[$0], b=[ROW(_UTF-16LE'v2', 1)], c=[ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4))], d=[$3])
+   +- LogicalFilter(condition=[=($1.b1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- Calc(select=[a, ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, d], where=[=(b.b1, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[a, b, c, d])
++- Calc(select=[a, ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, d], where=[(b.b1 = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, d], where=[(b.b1 = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCompositeTypeOnlyUpdateColumnRequired[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- LogicalProject(b=[CASE(=($1.b1, _UTF-16LE'123'), ROW(_UTF-16LE'v2', 1), $1)], c=[CASE(=($1.b1, _UTF-16LE'123'), ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4)), $2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- Calc(select=[CASE(=(b.b1, '123'), ROW('v2', 1), b) AS b, CASE(=(b.b1, '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- Calc(select=[CASE((b.b1 = '123'), ROW('v2', 1), b) AS b, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[CASE((b.b1 = '123'), ROW('v2', 1), b) AS b, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCompositeTypeOnlyUpdateColumnRequired[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- LogicalProject(b=[ROW(_UTF-16LE'v2', 1)], c=[ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4))])
+   +- LogicalFilter(condition=[=($1.b1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- Calc(select=[ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c], where=[=(b.b1, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[b, c])
++- Calc(select=[ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c], where=[(b.b1 = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[ROW('v2', 1) AS b, ROW(c.c1, ROW('1000', c.c2.c4)) AS c], where=[(b.b1 = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCompositeTypeWithMetadataColumn[updateMode = ALL_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- LogicalProject(meta_f1=[$4], meta_f2=[$5], c=[CASE(=($1.b1, _UTF-16LE'123'), ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4)), $2)], b=[CASE(=($1.b1, _UTF-16LE'123'), ROW(_UTF-16LE'v2', 1), $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- Calc(select=[meta_f1, meta_f2, CASE(=(b.b1, '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, CASE(=(b.b1, '123'), ROW('v2', 1), b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- Calc(select=[meta_f1, meta_f2, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, CASE((b.b1 = '123'), ROW('v2', 1), b) AS b])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, CASE((b.b1 = '123'), ROW(c.c1, ROW('1000', c.c2.c4)), c) AS c, CASE((b.b1 = '123'), ROW('v2', 1), b) AS b])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateWithCompositeTypeWithMetadataColumn[updateMode = UPDATED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- LogicalProject(meta_f1=[$4], meta_f2=[$5], c=[ROW($2.c1, ROW(_UTF-16LE'1000', $2.c2.c4))], b=[ROW(_UTF-16LE'v2', 1)])
+   +- LogicalFilter(condition=[=($1.b1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, complex_row_sink]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- Calc(select=[meta_f1, meta_f2, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, ROW('v2', 1) AS b], where=[=(b.b1, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.complex_row_sink], targetColumns=[[2,1,0],[1,0],[1,1]], fields=[meta_f1, meta_f2, c, b])
++- Calc(select=[meta_f1, meta_f2, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, ROW('v2', 1) AS b], where=[(b.b1 = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: complex_row_sink[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, complex_row_sink]], fields=[a, b, c, d, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, ROW(c.c1, ROW('1000', c.c2.c4)) AS c, ROW('v2', 1) AS b], where=[(b.b1 = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[UPDATE_AFTER])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpdateWithCustomColumns[updateMode = ALL_ROWS]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
-+- LogicalProject(b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
++- LogicalProject(b=[CASE(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
-+- Calc(select=[IF(=(b, '123'), 'v2', b) AS b, c])
++- Calc(select=[CASE(=(b, '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b, c])
-+- Calc(select=[IF((b = '123'), 'v2', b) AS b, c])
++- Calc(select=[CASE((b = '123'), 'v2', b) AS b, c])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
 
 == Physical Execution Plan ==
@@ -273,7 +615,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b,
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[IF((b = '123'), 'v2', b) AS b, c])",
+    "contents" : "[]:Calc(select=[CASE((b = '123'), 'v2', b) AS b, c])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -362,17 +704,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[b,
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- LogicalProject(a=[$0], b=[IF(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
++- LogicalProject(a=[$0], b=[CASE(AND(=($0, 123), =($1, _UTF-16LE'v1')), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- Calc(select=[a, IF(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
++- Calc(select=[a, CASE(AND(=(a, 123), =(b, 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
++- Calc(select=[a, CASE(((a = 123) AND (b = 'v1')), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
 
 == Physical Execution Plan ==
@@ -387,7 +729,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, IF(((a = 123) AND (b = 'v1')), 'v2', b) AS b])",
+    "contents" : "[]:Calc(select=[a, CASE(((a = 123) AND (b = 'v1')), 'v2', b) AS b])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -538,17 +880,17 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
-+- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[IF(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
++- LogicalProject(meta_f1=[$3], meta_f2=[$4], a=[$0], b=[CASE(=($1, _UTF-16LE'123'), _UTF-16LE'v2', $1)])
    +- LogicalTableScan(table=[[default_catalog, default_database, t]])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, IF(=(b, '123'), 'v2', b) AS b])
++- Calc(select=[meta_f1, meta_f2, a, CASE(=(b, '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[meta_f1, meta_f2, a, b])
-+- Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])
++- Calc(select=[meta_f1, meta_f2, a, CASE((b = '123'), 'v2', b) AS b])
    +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
 
 == Physical Execution Plan ==
@@ -563,7 +905,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[me
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, IF((b = '123'), 'v2', b) AS b])",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, a, CASE((b = '123'), 'v2', b) AS b])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,
@@ -851,7 +1193,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1],[0]], fields
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalSink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- LogicalProject(a=[$0], b=[IF(=(CAST($0):BIGINT, $SCALAR_QUERY({
++- LogicalProject(a=[$0], b=[CASE(=(CAST($0):BIGINT, $SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
   LogicalProject($f0=[0])
     LogicalTableScan(table=[[default_catalog, default_database, t1]])
@@ -860,7 +1202,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- Calc(select=[a, IF(=(CAST(a AS BIGINT), EXPR$0), 'v2', b) AS b])
++- Calc(select=[a, CASE(=(CAST(a AS BIGINT), EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
       +- Exchange(distribution=[broadcast])
@@ -872,7 +1214,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a, b])
-+- Calc(select=[a, IF((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])
++- Calc(select=[a, CASE((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])
    +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
       :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
       +- Exchange(distribution=[broadcast])
@@ -948,7 +1290,7 @@ Sink(table=[default_catalog.default_database.t], targetColumns=[[1]], fields=[a,
     "id" : ,
     "type" : "Calc[]",
     "pact" : "Operator",
-    "contents" : "[]:Calc(select=[a, IF((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])",
+    "contents" : "[]:Calc(select=[a, CASE((CAST(a AS BIGINT) = EXPR$0), 'v2', b) AS b])",
     "parallelism" : 1,
     "predecessors" : [ {
       "id" : ,


### PR DESCRIPTION
…tement

## What is the purpose of the change

This PR is meant to support update nested column in update. 


## Brief change log

- Add FlinkSqlUpdate parser section to overwrite the SqlUpdate 
- Remove the validate for `SqlUpdate` rowType in `SqlValidatorImpl.java`. It's done in the table environment, same to the SqlInsert
- Creating `Row` projection for the nested column 


## Verifying this change

- RowLevelUpdateTest
- UpdateTableITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
