### PR TITLE
[FLINK-31768][runtime] Removes contender description

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
@@ -52,9 +52,7 @@ public class KubernetesLeaderElectionDriverFactory implements LeaderElectionDriv
 
     @Override
     public KubernetesLeaderElectionDriver createLeaderElectionDriver(
-            LeaderElectionEventHandler leaderEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            String leaderContenderDescription) {
+            LeaderElectionEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderElectionDriver(
                 kubeClient,
                 configMapSharedWatcher,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -156,7 +156,7 @@ class KubernetesHighAvailabilityTestBase {
                             watchCallbackExecutorService,
                             leaderConfig);
             return factory.createLeaderElectionDriver(
-                    electionEventHandler, electionEventHandler::handleError, LEADER_ADDRESS);
+                    electionEventHandler, electionEventHandler::handleError);
         }
 
         private LeaderRetrievalDriver createLeaderRetrievalDriver() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -91,9 +91,7 @@ public class DefaultLeaderElectionService
             leaderContender = contender;
             leaderElectionDriver =
                     leaderElectionDriverFactory.createLeaderElectionDriver(
-                            this,
-                            new LeaderElectionFatalErrorHandler(),
-                            leaderContender.getDescription());
+                            this, new LeaderElectionFatalErrorHandler());
             LOG.info("Starting DefaultLeaderElectionService with {}.", leaderElectionDriver);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriverFactory.java
@@ -29,14 +29,11 @@ public interface LeaderElectionDriverFactory {
      * Kubernetes.
      *
      * @param leaderEventHandler handler for the leader election driver to process leader events.
-     * @param leaderContenderDescription leader contender description.
      * @param fatalErrorHandler fatal error handler
      * @throws Exception when create a specific {@link LeaderElectionDriver} implementation and
      *     start the necessary services.
      */
     LeaderElectionDriver createLeaderElectionDriver(
-            LeaderElectionEventHandler leaderEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            String leaderContenderDescription)
+            LeaderElectionEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapterFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverAdapterFactory.java
@@ -35,9 +35,7 @@ final class MultipleComponentLeaderElectionDriverAdapterFactory
 
     @Override
     public LeaderElectionDriver createLeaderElectionDriver(
-            LeaderElectionEventHandler leaderEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            String leaderContenderDescription)
+            LeaderElectionEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new MultipleComponentLeaderElectionDriverAdapter(
                 leaderName, singleLeaderElectionService, leaderEventHandler);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -72,8 +72,6 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     private final FatalErrorHandler fatalErrorHandler;
 
-    private final String leaderContenderDescription;
-
     private volatile boolean running;
 
     /**
@@ -83,21 +81,18 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
      * @param path ZooKeeper node path for the leader election
      * @param leaderElectionEventHandler Event handler for processing leader change events
      * @param fatalErrorHandler Fatal error handler
-     * @param leaderContenderDescription Leader contender description
      */
     public ZooKeeperLeaderElectionDriver(
             CuratorFramework client,
             String path,
             LeaderElectionEventHandler leaderElectionEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            String leaderContenderDescription)
+            FatalErrorHandler fatalErrorHandler)
             throws Exception {
         checkNotNull(path);
         this.client = checkNotNull(client);
         this.connectionInformationPath = ZooKeeperUtils.generateConnectionInformationPath(path);
         this.leaderElectionEventHandler = checkNotNull(leaderElectionEventHandler);
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
-        this.leaderContenderDescription = checkNotNull(leaderContenderDescription);
 
         leaderLatchPath = ZooKeeperUtils.generateLeaderLatchPath(path);
         leaderLatch = new LeaderLatch(client, leaderLatchPath);
@@ -225,9 +220,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
             case LOST:
                 // Maybe we have to throw an exception here to terminate the JobManager
                 LOG.warn(
-                        "Connection to ZooKeeper lost. The contender "
-                                + leaderContenderDescription
-                                + " no longer participates in the leader election.");
+                        "Connection to ZooKeeper lost. The contender no longer participates in the leader election.");
                 break;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
@@ -40,11 +40,9 @@ public class ZooKeeperLeaderElectionDriverFactory implements LeaderElectionDrive
 
     @Override
     public ZooKeeperLeaderElectionDriver createLeaderElectionDriver(
-            LeaderElectionEventHandler leaderEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            String leaderContenderDescription)
+            LeaderElectionEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new ZooKeeperLeaderElectionDriver(
-                client, path, leaderEventHandler, fatalErrorHandler, leaderContenderDescription);
+                client, path, leaderEventHandler, fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -100,8 +100,7 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
         @Override
         public LeaderElectionDriver createLeaderElectionDriver(
                 LeaderElectionEventHandler leaderEventHandler,
-                FatalErrorHandler fatalErrorHandler,
-                String leaderContenderDescription) {
+                FatalErrorHandler fatalErrorHandler) {
             currentLeaderDriver =
                     new TestingLeaderElectionDriver(leaderEventHandler, fatalErrorHandler);
             return currentLeaderDriver;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -775,9 +775,7 @@ class ZooKeeperLeaderElectionTest {
         final ZooKeeperLeaderElectionDriver leaderElectionDriver =
                 ZooKeeperUtils.createLeaderElectionDriverFactory(client)
                         .createLeaderElectionDriver(
-                                electionEventHandler,
-                                electionEventHandler::handleError,
-                                LEADER_ADDRESS);
+                                electionEventHandler, electionEventHandler::handleError);
         electionEventHandler.init(leaderElectionDriver);
         return leaderElectionDriver;
     }


### PR DESCRIPTION
PR order:
- https://github.com/apache/flink/pull/21742  
- === THIS PR === FLINK-31768
- https://github.com/apache/flink/pull/22422
- https://github.com/apache/flink/pull/22380
- https://github.com/apache/flink/pull/22384

## What is the purpose of the change

Cleans `LeaderElectionDriverFactory` interface to prepare `DefaultLeaderElectionService` refactoring of FLINK-31733 . The change removes contender description everywhere. The only time it was actually used was in the deprecated class `ZooKeeperLeaderElectionDriver`.

## Brief change log

* removes contender description

## Verifying this change

* Trivial change: no functionality was changed except for the log output.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: n
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable