### PR TITLE
[FLINK-31773][runtime] Separate DefaultLeaderElectionService.start(LeaderContender) into two separate methods for starting the driver and registering a contender

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -125,14 +125,14 @@ public interface HighAvailabilityServices
      *
      * @return Leader election service for the resource manager leader election
      */
-    LeaderElectionService getResourceManagerLeaderElectionService();
+    LeaderElectionService getResourceManagerLeaderElectionService() throws Exception;
 
     /**
      * Gets the leader election service for the cluster's dispatcher.
      *
      * @return Leader election service for the dispatcher leader election
      */
-    LeaderElectionService getDispatcherLeaderElectionService();
+    LeaderElectionService getDispatcherLeaderElectionService() throws Exception;
 
     /**
      * Gets the leader election service for the given job.
@@ -140,7 +140,7 @@ public interface HighAvailabilityServices
      * @param jobID The identifier of the job running the election.
      * @return Leader election service for the job manager leader election
      */
-    LeaderElectionService getJobManagerLeaderElectionService(JobID jobID);
+    LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) throws Exception;
 
     /**
      * Gets the leader election service for the cluster's rest endpoint.
@@ -194,7 +194,7 @@ public interface HighAvailabilityServices
      *
      * @return the leader election service used by the cluster's rest endpoint
      */
-    default LeaderElectionService getClusterRestEndpointLeaderElectionService() {
+    default LeaderElectionService getClusterRestEndpointLeaderElectionService() throws Exception {
         // for backwards compatibility we delegate to getWebMonitorLeaderElectionService
         // all implementations of this interface should override
         // getClusterRestEndpointLeaderElectionService, though

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -37,16 +37,17 @@ import java.util.UUID;
 public interface LeaderElectionService {
 
     /**
-     * Starts the leader election service. This method can only be called once.
+     * Registers the passed {@link LeaderContender} with this {@code LeaderElectionService}. This
+     * method can only be called once.
      *
      * @param contender LeaderContender which applies for the leadership
-     * @throws Exception
      */
     void start(LeaderContender contender) throws Exception;
 
     /**
-     * Stops the leader election service. Stopping the {@code LeaderElectionService} will trigger
-     * {@link LeaderContender#revokeLeadership()} if the service still holds the leadership.
+     * Ends the participation of the registered {@link LeaderContender} in the leader election
+     * process. This will trigger {@link LeaderContender#revokeLeadership()} if the service still
+     * holds the leadership.
      *
      * @throws Exception if an error occurs while stopping the {@code LeaderElectionService}.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.UUID;
+
+/** {@code LeaderElectionUtils} collects helper methods to handle LeaderElection-related issues. */
+public class LeaderElectionUtils {
+
+    /**
+     * Converts the passed {@link LeaderInformation} into a human-readable representation that can
+     * be used in log messages.
+     */
+    public static String convertToString(LeaderInformation leaderInformation) {
+        return leaderInformation.isEmpty()
+                ? "<no leader>"
+                : convertToString(
+                        leaderInformation.getLeaderSessionID(),
+                        leaderInformation.getLeaderAddress());
+    }
+
+    public static String convertToString(UUID sessionId, String address) {
+        return String.format(
+                "%s@%s",
+                Preconditions.checkNotNull(sessionId), Preconditions.checkNotNull(address));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -82,7 +81,8 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
 
     private ResourceManagerServiceImpl(
             ResourceManagerFactory<?> resourceManagerFactory,
-            ResourceManagerProcessContext rmProcessContext) {
+            ResourceManagerProcessContext rmProcessContext)
+            throws Exception {
         this.resourceManagerFactory = checkNotNull(resourceManagerFactory);
         this.rmProcessContext = checkNotNull(rmProcessContext);
 
@@ -354,7 +354,7 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
             MetricRegistry metricRegistry,
             String hostname,
             Executor ioExecutor)
-            throws ConfigurationException {
+            throws Exception {
 
         return new ResourceManagerServiceImpl(
                 resourceManagerFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -403,8 +403,8 @@ public class ZooKeeperUtils {
      * @param client The {@link CuratorFramework} ZooKeeper client to use
      * @return {@link DefaultLeaderElectionService} instance.
      */
-    public static DefaultLeaderElectionService createLeaderElectionService(
-            CuratorFramework client) {
+    public static DefaultLeaderElectionService createLeaderElectionService(CuratorFramework client)
+            throws Exception {
 
         return createLeaderElectionService(client, "");
     }
@@ -418,8 +418,12 @@ public class ZooKeeperUtils {
      * @return {@link DefaultLeaderElectionService} instance.
      */
     public static DefaultLeaderElectionService createLeaderElectionService(
-            final CuratorFramework client, final String path) {
-        return new DefaultLeaderElectionService(createLeaderElectionDriverFactory(client, path));
+            final CuratorFramework client, final String path) throws Exception {
+        final DefaultLeaderElectionService leaderElectionService =
+                new DefaultLeaderElectionService(createLeaderElectionDriverFactory(client, path));
+        leaderElectionService.startLeaderElectionBackend();
+
+        return leaderElectionService;
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -192,7 +192,7 @@ public class LeaderElectionTest {
         }
 
         @Override
-        public LeaderElectionService createLeaderElectionService() {
+        public LeaderElectionService createLeaderElectionService() throws Exception {
             return ZooKeeperUtils.createLeaderElectionService(
                     curatorFrameworkWrapper.asCuratorFramework());
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
@@ -80,7 +80,10 @@ public class TestingGenericLeaderContender implements LeaderContender {
     public static class Builder {
         private Consumer<UUID> grantLeadershipConsumer = ignoredSessionID -> {};
         private Runnable revokeLeadershipRunnable = () -> {};
-        private Consumer<Exception> handleErrorConsumer = ignoredError -> {};
+        private Consumer<Exception> handleErrorConsumer =
+                error -> {
+                    throw new AssertionError(error);
+                };
         private Supplier<String> getDescriptionSupplier = () -> "testing contender";
 
         private Builder() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderBase.java
@@ -66,6 +66,10 @@ public class TestingLeaderBase {
         error = errorQueue.take();
     }
 
+    public void clearError() {
+        error = null;
+    }
+
     public void handleError(Throwable ex) {
         errorQueue.offer(ex);
     }
@@ -78,6 +82,24 @@ public class TestingLeaderBase {
     @Nullable
     public Throwable getError() {
         return error == null ? errorQueue.poll() : error;
+    }
+
+    /**
+     * Method for exposing errors that were caught during the test execution and need to be exposed
+     * within the test.
+     *
+     * @throws AssertionError with the actual unhandled error as the cause if such an error was
+     *     caught during the test code execution.
+     */
+    public void throwErrorIfPresent() {
+        final String assertionErrorMessage = "An unhandled error was caught during test execution.";
+        if (error != null) {
+            throw new AssertionError(assertionErrorMessage, error);
+        }
+
+        if (!errorQueue.isEmpty()) {
+            throw new AssertionError(assertionErrorMessage, errorQueue.poll());
+        }
     }
 
     public boolean isLeader() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -139,6 +139,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
                 new ZooKeeperLeaderElectionDriverFactory(client, PATH);
         DefaultLeaderElectionService leaderElectionService =
                 new DefaultLeaderElectionService(leaderElectionDriverFactory);
+        leaderElectionService.startLeaderElectionBackend();
 
         try {
             final TestingConnectionStateListener connectionStateListener =
@@ -165,6 +166,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
             validationLogic.accept(connectionStateListener, contender);
         } finally {
             leaderElectionService.stop();
+            leaderElectionService.close();
             curatorFrameworkWrapper.close();
 
             if (problem == Problem.LOST_CONNECTION) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -220,6 +220,7 @@ class ZooKeeperLeaderElectionTest {
                                 "Stop leader election service of contender #{}.",
                                 numberSeenLeaders);
                         leaderElectionService[index].stop();
+                        leaderElectionService[index].close();
                         leaderElectionService[index] = null;
 
                         numberSeenLeaders++;
@@ -241,6 +242,7 @@ class ZooKeeperLeaderElectionTest {
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
                     electionService.stop();
+                    electionService.close();
                 }
             }
         }
@@ -302,6 +304,8 @@ class ZooKeeperLeaderElectionTest {
 
                     // stop leader election service = revoke leadership
                     leaderElectionService[index].stop();
+                    leaderElectionService[index].close();
+
                     // create new leader election service which takes part in the leader election
                     leaderElectionService[index] =
                             ZooKeeperUtils.createLeaderElectionService(createZooKeeperClient());
@@ -324,6 +328,7 @@ class ZooKeeperLeaderElectionTest {
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
                     electionService.stop();
+                    electionService.close();
                 }
             }
         }


### PR DESCRIPTION
PR order:
- https://github.com/apache/flink/pull/21742
- https://github.com/apache/flink/pull/22379
- https://github.com/apache/flink/pull/22422
- === this PR === FLINK-31773
- https://github.com/apache/flink/pull/22384
- https://github.com/apache/flink/pull/22390 (FLINK-31785/FLINK-31786)
- https://github.com/apache/flink/pull/22404
- https://github.com/apache/flink/pull/22601

## What is the purpose of the change

This change is about having a clear separation of the `LeaderElectionDriver` lifecycle and the contender registration. This is necessary because we move the driver initialization into `HighAvailabilityServices` where its lifecycle should be maintained.

## Brief change log

* Introduces a clear separation between the `LeaderElectionDriver`'s lifecycle management and the `LeaderContender` registration in `DefaultLeaderElectionService`
* Moves the driver initialization into the `HighAvailabilityServices`:
  * I didn't put that one in a separate PR because it would have required larger temporary code changes due to the fact that the leader election-related methods of HighAvailabilityServices return `LeaderElectionService` instead of `DefaultLeaderElectionService`. The `startLeaderElectionBackend` is not present in the `LeaderElectionService` interface (it's a specific detail of the `DefaultLeaderElectionService`). A few tests (more specifically [ZooKeeperLeaderRetrievalTest:184](https://github.com/apache/flink/blob/381b626a8d3e3b7426de76d0eefba3eba1cba1ba/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java#L184)) on the `HighAvailabilityService` to retrieve a `LeaderElectionService`. In these tests, we wouldn't have been able to call the `startLeaderElectionBackend` within the test code but have to rely on it being called within `HighAvailabilityServices`.

## Verifying this change

* Failing tests are updated
* Additional Preconditions are added to ensure consistent behavior

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable