### PR TITLE
[FLINK-31628][runtime] Check the heap index to avoid the same channel status being added/removed repeatedly.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -24,14 +24,12 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link StatusWatermarkValve}. While tests in {@link
@@ -48,23 +46,23 @@ import static org.junit.Assert.assertTrue;
  * logic of {@link StatusWatermarkValve}. The behaviours that a series of input calls to the valve
  * is trying to test is explained as inline comments within the tests.
  */
-public class StatusWatermarkValveTest {
+class StatusWatermarkValveTest {
 
     /**
      * Tests that watermarks correctly advance with increasing watermarks for a single input valve.
      */
     @Test
-    public void testSingleInputIncreasingWatermarks() throws Exception {
+    void testSingleInputIncreasingWatermarks() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
         valve.inputWatermark(new Watermark(0), 0, valveOutput);
-        assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(0));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(25), 0, valveOutput);
-        assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(25));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -72,19 +70,19 @@ public class StatusWatermarkValveTest {
      * valve.
      */
     @Test
-    public void testSingleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
+    void testSingleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
         valve.inputWatermark(new Watermark(25), 0, valveOutput);
-        assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(25));
 
         valve.inputWatermark(new Watermark(18), 0, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(42), 0, valveOutput);
-        assertEquals(new Watermark(42), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(42));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -92,66 +90,65 @@ public class StatusWatermarkValveTest {
      * inputs do not yield output for a single input valve.
      */
     @Test
-    public void testSingleInputWatermarkStatusToggling() throws Exception {
+    void testSingleInputWatermarkStatusToggling() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
         // this also implicitly verifies that input channels start as ACTIVE
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
-        assertEquals(WatermarkStatus.IDLE, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
-        assertEquals(WatermarkStatus.ACTIVE, valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.ACTIVE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /** Tests that the watermark of an input channel remains intact while in the IDLE status. */
     @Test
-    public void testSingleInputWatermarksIntactDuringIdleness() throws Exception {
+    void testSingleInputWatermarksIntactDuringIdleness() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(1);
 
         valve.inputWatermark(new Watermark(25), 0, valveOutput);
-        assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(25));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
-        assertEquals(WatermarkStatus.IDLE, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
 
         valve.inputWatermark(new Watermark(50), 0, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
-        assertEquals(25, valve.getInputChannelStatus(0).watermark);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+        assertThat(valve.getInputChannelStatus(0).watermark).isEqualTo(25);
 
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
-        assertEquals(WatermarkStatus.ACTIVE, valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.ACTIVE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(50), 0, valveOutput);
-        assertEquals(new Watermark(50), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(50));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /** Tests that the valve yields a watermark only when all inputs have received a watermark. */
     @Test
-    public void testMultipleInputYieldsWatermarkOnlyWhenAllChannelsReceivesWatermarks()
-            throws Exception {
+    void testMultipleInputYieldsWatermarkOnlyWhenAllChannelsReceivesWatermarks() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(0), 0, valveOutput);
         valve.inputWatermark(new Watermark(0), 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // now, all channels have watermarks
         valve.inputWatermark(new Watermark(0), 2, valveOutput);
-        assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(0));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -159,51 +156,51 @@ public class StatusWatermarkValveTest {
      * watermark across inputs advances.
      */
     @Test
-    public void testMultipleInputIncreasingWatermarks() throws Exception {
+    void testMultipleInputIncreasingWatermarks() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(0), 0, valveOutput);
         valve.inputWatermark(new Watermark(0), 1, valveOutput);
         valve.inputWatermark(new Watermark(0), 2, valveOutput);
-        assertEquals(new Watermark(0), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(0));
 
         valve.inputWatermark(new Watermark(12), 0, valveOutput);
         valve.inputWatermark(new Watermark(8), 2, valveOutput);
         valve.inputWatermark(new Watermark(10), 2, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(15), 1, valveOutput);
         // lowest watermark across all channels is now channel 2, with watermark @ 10
-        assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(17), 2, valveOutput);
         // lowest watermark across all channels is now channel 0, with watermark @ 12
-        assertEquals(new Watermark(12), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(12));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(20), 0, valveOutput);
         // lowest watermark across all channels is now channel 1, with watermark @ 15
-        assertEquals(new Watermark(15), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(15));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /** Tests that for a multiple input valve, decreasing watermarks will yield no output. */
     @Test
-    public void testMultipleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
+    void testMultipleInputDecreasingWatermarksYieldsNoOutput() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(25), 0, valveOutput);
         valve.inputWatermark(new Watermark(10), 1, valveOutput);
         valve.inputWatermark(new Watermark(17), 2, valveOutput);
-        assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
 
         valve.inputWatermark(new Watermark(12), 0, valveOutput);
         valve.inputWatermark(new Watermark(8), 1, valveOutput);
         valve.inputWatermark(new Watermark(15), 2, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -211,33 +208,33 @@ public class StatusWatermarkValveTest {
      * inputs do not yield output for a multiple input valve.
      */
     @Test
-    public void testMultipleInputWatermarkStatusToggling() throws Exception {
+    void testMultipleInputWatermarkStatusToggling() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(2);
 
         // this also implicitly verifies that all input channels start as active
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // now, all channels are IDLE
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
-        assertEquals(WatermarkStatus.IDLE, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // as soon as at least one input becomes active again, the ACTIVE marker should be forwarded
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
-        assertEquals(WatermarkStatus.ACTIVE, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.ACTIVE);
 
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
         // already back to ACTIVE, should yield no output
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -245,28 +242,28 @@ public class StatusWatermarkValveTest {
      * computed and advanced from the remaining active inputs.
      */
     @Test
-    public void testMultipleInputWatermarkAdvancingWithPartiallyIdleChannels() throws Exception {
+    void testMultipleInputWatermarkAdvancingWithPartiallyIdleChannels() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(15), 0, valveOutput);
         valve.inputWatermark(new Watermark(10), 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
         // min watermark should be computed from remaining ACTIVE channels
-        assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(18), 1, valveOutput);
         // now, min watermark should be 15 from channel #0
-        assertEquals(new Watermark(15), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(15));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermark(new Watermark(20), 0, valveOutput);
         // now, min watermark should be 18 from channel #1
-        assertEquals(new Watermark(18), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(18));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -274,24 +271,23 @@ public class StatusWatermarkValveTest {
      * soon remaining active channels can yield a new min watermark.
      */
     @Test
-    public void testMultipleInputWatermarkAdvancingAsChannelsIndividuallyBecomeIdle()
-            throws Exception {
+    void testMultipleInputWatermarkAdvancingAsChannelsIndividuallyBecomeIdle() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(25), 0, valveOutput);
         valve.inputWatermark(new Watermark(10), 1, valveOutput);
         valve.inputWatermark(new Watermark(17), 2, valveOutput);
-        assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
         // only channel 0 & 2 is ACTIVE; 17 is the overall min watermark now
-        assertEquals(new Watermark(17), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(17));
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
         // only channel 0 is ACTIVE; 25 is the overall min watermark now
-        assertEquals(new Watermark(25), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(25));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -304,7 +300,7 @@ public class StatusWatermarkValveTest {
      * independent of the order that the inputs become idle.
      */
     @Test
-    public void testMultipleInputFlushMaxWatermarkAndWatermarkStatusOnceAllInputsBecomeIdle()
+    void testMultipleInputFlushMaxWatermarkAndWatermarkStatusOnceAllInputsBecomeIdle()
             throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
@@ -320,7 +316,7 @@ public class StatusWatermarkValveTest {
         valve.inputWatermark(new Watermark(10), 0, valveOutput);
         valve.inputWatermark(new Watermark(5), 1, valveOutput);
         valve.inputWatermark(new Watermark(3), 2, valveOutput);
-        assertEquals(new Watermark(3), valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(3));
 
         // -------------------------------------------------------------------------------------------
         // Order of becoming IDLE:
@@ -330,12 +326,12 @@ public class StatusWatermarkValveTest {
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
-        assertEquals(new Watermark(10), valveOutput.popLastSeenOutput());
-        assertEquals(WatermarkStatus.IDLE, valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -343,40 +339,40 @@ public class StatusWatermarkValveTest {
      * watermark before they are considered for min watermark computation again.
      */
     @Test
-    public void testMultipleInputWatermarkRealignmentAfterResumeActive() throws Exception {
+    void testMultipleInputWatermarkRealignmentAfterResumeActive() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
         valve.inputWatermark(new Watermark(10), 0, valveOutput);
         valve.inputWatermark(new Watermark(7), 1, valveOutput);
         valve.inputWatermark(new Watermark(3), 2, valveOutput);
-        assertEquals(new Watermark(3), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(3));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
-        assertEquals(new Watermark(7), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(7));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // let channel 2 become active again; since the min watermark has now advanced to 7,
         // channel 2 should have been marked as non-aligned.
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 2, valveOutput);
-        assertFalse(valve.getInputChannelStatus(2).isWatermarkAligned);
+        assertThat(valve.getInputChannelStatus(2).isWatermarkAligned).isFalse();
 
         // during the realignment process, watermarks should still be accepted by channel 2 (but
         // shouldn't yield new watermarks)
         valve.inputWatermark(new Watermark(5), 2, valveOutput);
-        assertEquals(5, valve.getInputChannelStatus(2).watermark);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valve.getInputChannelStatus(2).watermark).isEqualTo(5);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // let channel 2 catch up with the min watermark; now should be realigned
         valve.inputWatermark(new Watermark(9), 2, valveOutput);
-        assertTrue(valve.getInputChannelStatus(2).isWatermarkAligned);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valve.getInputChannelStatus(2).isWatermarkAligned).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // check that realigned inputs is now taken into account for watermark advancement
         valve.inputWatermark(new Watermark(12), 1, valveOutput);
-        assertEquals(new Watermark(9), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(9));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     /**
@@ -385,7 +381,7 @@ public class StatusWatermarkValveTest {
      * watermark in that case.
      */
     @Test
-    public void testNoOutputWhenAllActiveChannelsAreUnaligned() throws Exception {
+    void testNoOutputWhenAllActiveChannelsAreUnaligned() throws Exception {
         StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
         StatusWatermarkValve valve = new StatusWatermarkValve(3);
 
@@ -394,19 +390,19 @@ public class StatusWatermarkValveTest {
 
         // make channel 2 ACTIVE, it is now in "catch up" mode (unaligned watermark)
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
-        assertEquals(new Watermark(7), valveOutput.popLastSeenOutput());
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(7));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // make channel 2 ACTIVE again, it is still unaligned
         valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 2, valveOutput);
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
 
         // make channel 0 and 1 IDLE, now channel 2 is the only ACTIVE channel but it's unaligned
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
         valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
 
         // we should not see any output
-        assertEquals(null, valveOutput.popLastSeenOutput());
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
     private static class StatusWatermarkOutput implements PushingAsyncDataInput.DataOutput {


### PR DESCRIPTION
## What is the purpose of the change
Check the heap index to avoid the same channel status being added/removed repeatedly.

## Verifying this change
Add test `StatusWatermarkValveTest#testUnalignedActiveChannelBecomesIdle`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
