### PR TITLE
[FLINK-31779][docs] Track stable branch of externalized connector instead of specific release tag

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -43,15 +43,15 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-integrate_connector_docs elasticsearch v3.0.0-docs
-integrate_connector_docs aws v4.1.0-docs
-integrate_connector_docs cassandra v3.0.0
-integrate_connector_docs pulsar v3.0.0-docs
-integrate_connector_docs jdbc v3.0.0
-integrate_connector_docs rabbitmq v3.0.0
-integrate_connector_docs gcp-pubsub v3.0.0
-integrate_connector_docs mongodb v1.0.0-docs
-integrate_connector_docs opensearch v1.0.0
+integrate_connector_docs elasticsearch v3.0
+integrate_connector_docs aws v4.1
+integrate_connector_docs cassandra v3.0
+integrate_connector_docs pulsar v3.0
+integrate_connector_docs jdbc v3.0
+integrate_connector_docs rabbitmq v3.0
+integrate_connector_docs gcp-pubsub v3.0
+integrate_connector_docs mongodb v1.0
+integrate_connector_docs opensearch v1.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
## What is the purpose of the change

*Docs for externalized connectors should point to the branch where that version of the connector doc are published, otherwise documentation fixes are not visible until a new release is made. After this, we can safely delete all dedicated doc branches.*


## Brief change log

  - *Track stable branch of externalized connector instead of specific release tag.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
