### PR TITLE
[FLINK-31776][runtime] Introduces LeaderElection interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.FlinkException;
@@ -43,6 +44,7 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
     private final Object lock = new Object();
 
     private final LeaderElectionService leaderElectionService;
+    private LeaderElection leaderElection;
 
     private final FatalErrorHandler fatalErrorHandler;
 
@@ -75,7 +77,8 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
     }
 
     void start() throws Exception {
-        leaderElectionService.start(this);
+        leaderElection = leaderElectionService.createLeaderElection();
+        leaderElection.startLeaderElection(this);
     }
 
     @Override
@@ -178,8 +181,8 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
                         .getLeaderAddressFuture()
                         .thenAccept(
                                 leaderAddress -> {
-                                    if (leaderElectionService.hasLeadership(leaderSessionID)) {
-                                        leaderElectionService.confirmLeadership(
+                                    if (leaderElection.hasLeadership(leaderSessionID)) {
+                                        leaderElection.confirmLeadership(
                                                 leaderSessionID, leaderAddress);
                                     }
                                 }));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.highavailability.nonha.embedded;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.leaderelection.AbstractLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
@@ -437,7 +438,7 @@ public class EmbeddedLeaderService {
     //  election and retrieval service implementations
     // ------------------------------------------------------------------------
 
-    private class EmbeddedLeaderElectionService implements LeaderElectionService {
+    private class EmbeddedLeaderElectionService extends AbstractLeaderElectionService {
 
         volatile LeaderContender contender;
 
@@ -446,7 +447,7 @@ public class EmbeddedLeaderService {
         volatile boolean running;
 
         @Override
-        public void start(LeaderContender contender) throws Exception {
+        protected void register(LeaderContender contender) throws Exception {
             checkNotNull(contender);
             addContender(this, contender);
         }
@@ -457,14 +458,14 @@ public class EmbeddedLeaderService {
         }
 
         @Override
-        public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+        protected void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
             checkNotNull(leaderSessionID);
             checkNotNull(leaderAddress);
             confirmLeader(this, leaderSessionID, leaderAddress);
         }
 
         @Override
-        public boolean hasLeadership(UUID leaderSessionId) {
+        protected boolean hasLeadership(UUID leaderSessionId) {
             return isLeader && leaderSessionId.equals(currentLeaderSessionId);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -464,7 +464,7 @@ public class EmbeddedLeaderService {
         }
 
         @Override
-        public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+        public boolean hasLeadership(UUID leaderSessionId) {
             return isLeader && leaderSessionId.equals(currentLeaderSessionId);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
@@ -26,6 +27,7 @@ import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
@@ -81,6 +83,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     private final JobMasterServiceProcessFactory jobMasterServiceProcessFactory;
 
     private final LeaderElectionService leaderElectionService;
+    private LeaderElection leaderElection;
 
     private final JobResultStore jobResultStore;
 
@@ -164,7 +167,15 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
     @Override
     public void start() throws Exception {
         LOG.debug("Start leadership runner for job {}.", getJobID());
-        leaderElectionService.start(this);
+        leaderElection = leaderElectionService.createLeaderElection();
+        leaderElection.startLeaderElection(this);
+    }
+
+    // TODO: This method can be removed with the migration of the LeaderElection instantiation into
+    // the HighAvailabilityServices in FLINK-31797
+    @VisibleForTesting
+    public LeaderElection getLeaderElection() {
+        return leaderElection;
     }
 
     @Override
@@ -333,8 +344,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                             synchronized (lock) {
                                 if (isValidLeader(leaderSessionId)) {
                                     LOG.debug("Confirm leadership {}.", leaderSessionId);
-                                    leaderElectionService.confirmLeadership(
-                                            leaderSessionId, address);
+                                    leaderElection.confirmLeadership(leaderSessionId, address);
                                 } else {
                                     LOG.trace(
                                             "Ignore confirming leadership because the leader {} is no longer valid.",
@@ -497,7 +507,9 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
 
     @GuardedBy("lock")
     private boolean isValidLeader(UUID expectedLeaderId) {
-        return isRunning() && leaderElectionService.hasLeadership(expectedLeaderId);
+        return isRunning()
+                && leaderElection != null
+                && leaderElection.hasLeadership(expectedLeaderId);
     }
 
     private <T> void forwardIfValidLeader(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/AbstractLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/AbstractLeaderElectionService.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.UUID;
+
+/**
+ * {@code AbstractLeaderElectionService} provides a generic implementation of the {@link
+ * LeaderElection} handling.
+ */
+public abstract class AbstractLeaderElectionService implements LeaderElectionService {
+
+    @Override
+    public LeaderElection createLeaderElection() {
+        return new DefaultLeaderElection(this);
+    }
+
+    /**
+     * Registers the given {@link LeaderContender} with the underlying {@code
+     * LeaderElectionService}. Leadership changes are starting to be reported to the {@code
+     * LeaderContender}.
+     */
+    protected abstract void register(LeaderContender contender) throws Exception;
+
+    /** Confirms the leadership with the given session ID and address. */
+    protected abstract void confirmLeadership(UUID leaderSessionID, String leaderAddress);
+
+    /**
+     * Checks whether the {@code LeaderElectionService} has the leadership acquired for the given
+     * session ID.
+     *
+     * @return {@code true} if the service has leadership with the passed session ID acquired;
+     *     {@code false} otherwise.
+     */
+    protected abstract boolean hasLeadership(UUID leaderSessionId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.UUID;
+
+/**
+ * {@code DefaultLeaderElection} implements the {@link LeaderElection} based on the {@link
+ * AbstractLeaderElectionService}.
+ */
+class DefaultLeaderElection implements LeaderElection {
+
+    private final AbstractLeaderElectionService parentService;
+    @Nullable private LeaderContender leaderContender;
+
+    DefaultLeaderElection(AbstractLeaderElectionService parentService) {
+        this.parentService = parentService;
+    }
+
+    @Override
+    public void startLeaderElection(LeaderContender contender) throws Exception {
+        Preconditions.checkState(
+                leaderContender == null, "There shouldn't be any LeaderContender registered, yet.");
+        leaderContender = Preconditions.checkNotNull(contender);
+
+        parentService.register(leaderContender);
+    }
+
+    @Override
+    public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+        parentService.confirmLeadership(leaderSessionID, leaderAddress);
+    }
+
+    @Override
+    public boolean hasLeadership(UUID leaderSessionId) {
+        return parentService.hasLeadership(leaderSessionId);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -45,8 +45,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>{@code DefaultLeaderElectionService} handles a single {@link LeaderContender}.
  */
-public class DefaultLeaderElectionService
-        implements LeaderElectionService, LeaderElectionEventHandler, AutoCloseable {
+public class DefaultLeaderElectionService extends AbstractLeaderElectionService
+        implements LeaderElectionEventHandler, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultLeaderElectionService.class);
 
@@ -56,8 +56,8 @@ public class DefaultLeaderElectionService
 
     /**
      * {@code leaderContender} being {@code null} indicates that no {@link LeaderContender} is
-     * registered that participates in the leader election, yet. See {@link #start(LeaderContender)}
-     * and {@link #stop()} for lifecycle management.
+     * registered that participates in the leader election, yet. See {@link
+     * #register(LeaderContender)} and {@link #stop()} for lifecycle management.
      *
      * <p>{@code @Nullable} isn't used here to avoid having multiple warnings spread over this class
      * in a supporting IDE.
@@ -144,7 +144,7 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    public final void start(LeaderContender contender) throws Exception {
+    protected void register(LeaderContender contender) throws Exception {
         checkNotNull(contender, "Contender must not be null.");
 
         synchronized (lock) {
@@ -236,7 +236,7 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+    protected void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
         LOG.debug("Confirm leader session ID {} for leader {}.", leaderSessionID, leaderAddress);
 
         checkNotNull(leaderSessionID);
@@ -267,7 +267,7 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    public boolean hasLeadership(UUID leaderSessionId) {
+    protected boolean hasLeadership(UUID leaderSessionId) {
         synchronized (lock) {
             if (leaderElectionDriver != null) {
                 if (leaderContender != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -27,7 +27,6 @@ import org.apache.flink.util.concurrent.FutureUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -268,7 +267,7 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+    public boolean hasLeadership(UUID leaderSessionId) {
         synchronized (lock) {
             if (leaderElectionDriver != null) {
                 if (leaderContender != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.UUID;
+
+/**
+ * {@code LeaderElection} serves as a proxy between {@code LeaderElectionService} and {@link
+ * LeaderContender}.
+ */
+public interface LeaderElection {
+
+    /** Registers the passed {@link LeaderContender} with the leader election process. */
+    void startLeaderElection(LeaderContender contender) throws Exception;
+
+    /**
+     * Confirms that the {@link LeaderContender} has accepted the leadership identified by the given
+     * leader session id. It also publishes the leader address under which the leader is reachable.
+     *
+     * <p>The intention of this method is to establish an order between setting the new leader
+     * session ID in the {@link LeaderContender} and publishing the new leader session ID and the
+     * related leader address to the leader retrieval services.
+     *
+     * @param leaderSessionID The new leader session ID
+     * @param leaderAddress The address of the new leader
+     */
+    void confirmLeadership(UUID leaderSessionID, String leaderAddress);
+
+    /**
+     * Returns {@code true} if the service's {@link LeaderContender} has the leadership under the
+     * given leader session ID acquired.
+     *
+     * @param leaderSessionId identifying the current leader
+     * @return true if the associated {@link LeaderContender} is the leader, otherwise false
+     */
+    boolean hasLeadership(UUID leaderSessionId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -28,48 +28,24 @@ import java.util.UUID;
  * instantiate its own leader election service.
  *
  * <p>Once a contender has been granted leadership he has to confirm the received leader session ID
- * by calling the method {@link #confirmLeadership(UUID, String)}. This will notify the leader
- * election service, that the contender has accepted the leadership specified and that the leader
- * session id as well as the leader address can now be published for leader retrieval services.
+ * by calling the method {@link LeaderElection#confirmLeadership(UUID, String)}. This will notify
+ * the leader election service, that the contender has accepted the leadership specified and that
+ * the leader session id as well as the leader address can now be published for leader retrieval
+ * services.
  */
 public interface LeaderElectionService {
 
     /**
-     * Registers the passed {@link LeaderContender} with this {@code LeaderElectionService}. This
-     * method can only be called once.
-     *
-     * @param contender LeaderContender which applies for the leadership
+     * Creates a new {@link LeaderElection} instance that is registered to this {@code
+     * LeaderElectionService} instance.
      */
-    void start(LeaderContender contender) throws Exception;
+    LeaderElection createLeaderElection();
 
     /**
-     * Ends the participation of the registered {@link LeaderContender} in the leader election
-     * process. This will trigger {@link LeaderContender#revokeLeadership()} if the service still
-     * holds the leadership.
+     * Stops the leader election service. Stopping the {@code LeaderElectionService} will trigger
+     * {@link LeaderContender#revokeLeadership()} if the service still holds the leadership.
      *
      * @throws Exception if an error occurs while stopping the {@code LeaderElectionService}.
      */
     void stop() throws Exception;
-
-    /**
-     * Confirms that the {@link LeaderContender} has accepted the leadership identified by the given
-     * leader session id. It also publishes the leader address under which the leader is reachable.
-     *
-     * <p>The rational behind this method is to establish an order between setting the new leader
-     * session ID in the {@link LeaderContender} and publishing the new leader session ID as well as
-     * the leader address to the leader retrieval services.
-     *
-     * @param leaderSessionID The new leader session ID
-     * @param leaderAddress The address of the new leader
-     */
-    void confirmLeadership(UUID leaderSessionID, String leaderAddress);
-
-    /**
-     * Returns true if the {@link LeaderContender} with which the service has been started owns
-     * currently the leadership under the given leader session id.
-     *
-     * @param leaderSessionId identifying the current leader
-     * @return true if the associated {@link LeaderContender} is the leader, otherwise false
-     */
-    boolean hasLeadership(UUID leaderSessionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import javax.annotation.Nonnull;
-
 import java.util.UUID;
 
 /**
@@ -73,5 +71,5 @@ public interface LeaderElectionService {
      * @param leaderSessionId identifying the current leader
      * @return true if the associated {@link LeaderContender} is the leader, otherwise false
      */
-    boolean hasLeadership(@Nonnull UUID leaderSessionId);
+    boolean hasLeadership(UUID leaderSessionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -29,12 +29,12 @@ import java.util.UUID;
  * grants him the leadership upon start up. Furthermore, there is no communication needed between
  * multiple standalone leader election services.
  */
-public class StandaloneLeaderElectionService implements LeaderElectionService {
+public class StandaloneLeaderElectionService extends AbstractLeaderElectionService {
 
     private LeaderContender contender = null;
 
     @Override
-    public void start(LeaderContender newContender) throws Exception {
+    protected void register(LeaderContender newContender) throws Exception {
         if (contender != null) {
             // Service was already started
             throw new IllegalArgumentException(
@@ -56,10 +56,10 @@ public class StandaloneLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
+    protected void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
 
     @Override
-    public boolean hasLeadership(UUID leaderSessionId) {
+    protected boolean hasLeadership(UUID leaderSessionId) {
         return (contender != null
                 && HighAvailabilityServices.DEFAULT_LEADER_ID.equals(leaderSessionId));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.util.Preconditions;
 
-import javax.annotation.Nonnull;
-
 import java.util.UUID;
 
 /**
@@ -61,7 +59,7 @@ public class StandaloneLeaderElectionService implements LeaderElectionService {
     public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
 
     @Override
-    public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+    public boolean hasLeadership(UUID leaderSessionId) {
         return (contender != null
                 && HighAvailabilityServices.DEFAULT_LEADER_ID.equals(leaderSessionId));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
@@ -205,6 +206,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
     private final MetricFetcher metricFetcher;
 
     private final LeaderElectionService leaderElectionService;
+    private LeaderElection leaderElection;
 
     private final FatalErrorHandler fatalErrorHandler;
 
@@ -1044,7 +1046,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
     @Override
     public void startInternal() throws Exception {
-        leaderElectionService.start(this);
+        leaderElection = leaderElectionService.createLeaderElection();
+        leaderElection.startLeaderElection(this);
+
         startExecutionGraphCacheCleanupTask();
 
         if (hasWebUI) {
@@ -1110,7 +1114,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                 "{} was granted leadership with leaderSessionID={}",
                 getRestBaseUrl(),
                 leaderSessionID);
-        leaderElectionService.confirmLeadership(leaderSessionID, getRestBaseUrl());
+        leaderElection.confirmLeadership(leaderSessionID, getRestBaseUrl());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -302,12 +302,6 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         waitForJobToFinish(leaderElectionService, dispatcherGateway, jobId);
         firstCleanupTriggered.await();
 
-        // Remove job master leadership.
-        leaderElectionService.notLeader();
-
-        // This will clear internal state of election service, so a new contender can register.
-        leaderElectionService.stop();
-
         assertThat(
                 "The cleanup should have been triggered only once.",
                 actualGlobalCleanupCallCount.get(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -52,7 +52,6 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceExtension;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperExtension;
@@ -272,18 +271,18 @@ class ZooKeeperDefaultDispatcherRunnerTest {
     private DispatcherGateway grantLeadership(
             TestingLeaderElectionService dispatcherLeaderElectionService)
             throws InterruptedException, java.util.concurrent.ExecutionException {
-        final UUID leaderSessionId = UUID.randomUUID();
-        dispatcherLeaderElectionService.isLeader(leaderSessionId);
-        final LeaderConnectionInfo leaderConnectionInfo =
-                dispatcherLeaderElectionService.getConfirmationFuture().get();
-
-        return testingRpcServiceExtensionWrapper
-                .getCustomExtension()
-                .getTestingRpcService()
-                .connect(
-                        leaderConnectionInfo.getAddress(),
-                        DispatcherId.fromUuid(leaderSessionId),
-                        DispatcherGateway.class)
+        return dispatcherLeaderElectionService
+                .isLeader(UUID.randomUUID())
+                .thenCompose(
+                        leaderInformation ->
+                                testingRpcServiceExtensionWrapper
+                                        .getCustomExtension()
+                                        .getTestingRpcService()
+                                        .connect(
+                                                leaderInformation.getLeaderAddress(),
+                                                DispatcherId.fromUuid(
+                                                        leaderInformation.getLeaderSessionID()),
+                                                DispatcherGateway.class))
                 .get();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.highavailability.nonha.embedded;
 
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -55,7 +56,8 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
 
             final TestingLeaderContender contender = new TestingLeaderContender();
 
-            leaderElectionService.start(contender);
+            final LeaderElection leaderElection = leaderElectionService.createLeaderElection();
+            leaderElection.startLeaderElection(contender);
             leaderElectionService.stop();
 
             try {
@@ -87,7 +89,8 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
 
             final TestingLeaderContender contender = new TestingLeaderContender();
 
-            leaderElectionService.start(contender);
+            final LeaderElection leaderElection = leaderElectionService.createLeaderElection();
+            leaderElection.startLeaderElection(contender);
 
             // wait for the leadership
             contender.getLeaderSessionFuture().get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.highavailability.nonha.standalone;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -74,8 +75,11 @@ public class StandaloneHaServicesTest extends TestLogger {
         LeaderElectionService rmLeaderElectionService =
                 standaloneHaServices.getResourceManagerLeaderElectionService();
 
-        jmLeaderElectionService.start(jmLeaderContender);
-        rmLeaderElectionService.start(rmLeaderContender);
+        final LeaderElection jmLeaderElection = jmLeaderElectionService.createLeaderElection();
+        jmLeaderElection.startLeaderElection(jmLeaderContender);
+
+        final LeaderElection rmLeaderElection = rmLeaderElectionService.createLeaderElection();
+        rmLeaderElection.startLeaderElection(rmLeaderContender);
 
         verify(jmLeaderContender).grantLeadership(eq(HighAvailabilityServices.DEFAULT_LEADER_ID));
         verify(rmLeaderContender).grantLeadership(eq(HighAvailabilityServices.DEFAULT_LEADER_ID));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.jobmaster.factories.TestingJobMasterServiceProce
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionDriver;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -168,7 +169,7 @@ class JobMasterServiceLeadershipRunnerTest {
 
         leaderElectionService.notLeader();
 
-        final CompletableFuture<UUID> leaderFuture =
+        final CompletableFuture<LeaderInformation> leaderFuture =
                 leaderElectionService.isLeader(UUID.randomUUID());
 
         // the new leadership should wait first for the suspension to happen
@@ -537,7 +538,7 @@ class JobMasterServiceLeadershipRunnerTest {
 
         jobManagerRunner.start();
 
-        final CompletableFuture<UUID> leaderFuture =
+        final CompletableFuture<LeaderInformation> leaderFuture =
                 leaderElectionService.isLeader(UUID.randomUUID());
 
         leaderElectionService.notLeader();
@@ -761,8 +762,12 @@ class JobMasterServiceLeadershipRunnerTest {
             currentLeaderDriver.isLeader();
 
             while (currentLeaderDriver.getLeaderInformation().getLeaderSessionID() == null
-                    || !defaultLeaderElectionService.hasLeadership(
-                            currentLeaderDriver.getLeaderInformation().getLeaderSessionID())) {
+                    || !jobManagerRunner
+                            .getLeaderElection()
+                            .hasLeadership(
+                                    currentLeaderDriver
+                                            .getLeaderInformation()
+                                            .getLeaderSessionID())) {
                 Thread.sleep(100);
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DefaultLeaderElectionTest {
+
+    @Test
+    void testContenderRegistration() throws Exception {
+        final AtomicReference<LeaderContender> contenderRef = new AtomicReference<>();
+        final AbstractLeaderElectionService parentService =
+                TestingAbstractLeaderElectionService.newBuilder()
+                        .setRegisterConsumer(contenderRef::set)
+                        .build();
+        final DefaultLeaderElection testInstance = new DefaultLeaderElection(parentService);
+
+        final LeaderContender contender = TestingGenericLeaderContender.newBuilder().build();
+        testInstance.startLeaderElection(contender);
+
+        assertThat(contenderRef.get()).isSameAs(contender);
+    }
+
+    @Test
+    void testContenderRegistrationNull() {
+        assertThatThrownBy(
+                        () ->
+                                new DefaultLeaderElection(
+                                                TestingAbstractLeaderElectionService.newBuilder()
+                                                        .build())
+                                        .startLeaderElection(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testContenderRegistrationFailure() {
+        final Exception expectedException =
+                new Exception("Expected exception during contender registration.");
+        final AbstractLeaderElectionService parentService =
+                TestingAbstractLeaderElectionService.newBuilder()
+                        .setRegisterConsumer(
+                                contender -> {
+                                    throw expectedException;
+                                })
+                        .build();
+        final DefaultLeaderElection testInstance = new DefaultLeaderElection(parentService);
+
+        assertThatThrownBy(
+                        () ->
+                                testInstance.startLeaderElection(
+                                        TestingGenericLeaderContender.newBuilder().build()))
+                .isEqualTo(expectedException);
+    }
+
+    @Test
+    void testLeaderConfirmation() {
+        final AtomicReference<UUID> leaderSessionIDRef = new AtomicReference<>();
+        final AtomicReference<String> leaderAddressRef = new AtomicReference<>();
+        final AbstractLeaderElectionService parentService =
+                TestingAbstractLeaderElectionService.newBuilder()
+                        .setConfirmLeadershipConsumer(
+                                (leaderSessionID, address) -> {
+                                    leaderSessionIDRef.set(leaderSessionID);
+                                    leaderAddressRef.set(address);
+                                })
+                        .build();
+        final DefaultLeaderElection testInstance = new DefaultLeaderElection(parentService);
+
+        final UUID expectedLeaderSessionID = UUID.randomUUID();
+        final String expectedAddress = "random-address";
+        testInstance.confirmLeadership(expectedLeaderSessionID, expectedAddress);
+
+        assertThat(leaderSessionIDRef.get()).isEqualTo(expectedLeaderSessionID);
+        assertThat(leaderAddressRef.get()).isEqualTo(expectedAddress);
+    }
+
+    @Test
+    void testHasLeadershipTrue() {
+        testHasLeadership(true);
+    }
+
+    @Test
+    void testHasLeadershipFalse() {
+        testHasLeadership(false);
+    }
+
+    private void testHasLeadership(boolean expectedReturnValue) {
+        final AtomicReference<UUID> leaderSessionIDRef = new AtomicReference<>();
+        final AbstractLeaderElectionService parentService =
+                TestingAbstractLeaderElectionService.newBuilder()
+                        .setHasLeadershipFunction(
+                                leaderSessionID -> {
+                                    leaderSessionIDRef.set(leaderSessionID);
+                                    return expectedReturnValue;
+                                })
+                        .build();
+        final DefaultLeaderElection testInstance = new DefaultLeaderElection(parentService);
+
+        final UUID expectedLeaderSessionID = UUID.randomUUID();
+        assertThat(testInstance.hasLeadership(expectedLeaderSessionID))
+                .isEqualTo(expectedReturnValue);
+        assertThat(leaderSessionIDRef.get()).isEqualTo(expectedLeaderSessionID);
+    }
+
+    private static class TestingAbstractLeaderElectionService
+            extends AbstractLeaderElectionService {
+
+        private final ThrowingConsumer<LeaderContender, Exception> registerConsumer;
+        private final BiConsumer<UUID, String> confirmLeadershipConsumer;
+        private final Function<UUID, Boolean> hasLeadershipFunction;
+
+        private TestingAbstractLeaderElectionService(
+                ThrowingConsumer<LeaderContender, Exception> registerConsumer,
+                BiConsumer<UUID, String> confirmLeadershipConsumer,
+                Function<UUID, Boolean> hasLeadershipFunction) {
+            super();
+
+            this.registerConsumer = registerConsumer;
+            this.confirmLeadershipConsumer = confirmLeadershipConsumer;
+            this.hasLeadershipFunction = hasLeadershipFunction;
+        }
+
+        @Override
+        protected void register(LeaderContender contender) throws Exception {
+            registerConsumer.accept(contender);
+        }
+
+        @Override
+        protected void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+            confirmLeadershipConsumer.accept(leaderSessionID, leaderAddress);
+        }
+
+        @Override
+        protected boolean hasLeadership(UUID leaderSessionId) {
+            return hasLeadershipFunction.apply(leaderSessionId);
+        }
+
+        @Override
+        public void stop() {
+            throw new UnsupportedOperationException("stop is not supported.");
+        }
+
+        public static Builder newBuilder() {
+            return new Builder()
+                    .setRegisterConsumer(
+                            contender -> {
+                                throw new UnsupportedOperationException("register not supported");
+                            })
+                    .setConfirmLeadershipConsumer(
+                            (leaderSessionID, address) -> {
+                                throw new UnsupportedOperationException(
+                                        "confirmLeadership not supported");
+                            })
+                    .setHasLeadershipFunction(
+                            leaderSessionID -> {
+                                throw new UnsupportedOperationException(
+                                        "hasLeadership not supported");
+                            });
+        }
+
+        private static class Builder {
+
+            private ThrowingConsumer<LeaderContender, Exception> registerConsumer =
+                    ignoredContender -> {};
+            private BiConsumer<UUID, String> confirmLeadershipConsumer =
+                    (ignoredSessionID, ignoredAddress) -> {};
+            private Function<UUID, Boolean> hasLeadershipFunction = ignoredSessiondID -> false;
+
+            private Builder() {}
+
+            public Builder setRegisterConsumer(
+                    ThrowingConsumer<LeaderContender, Exception> registerConsumer) {
+                this.registerConsumer = registerConsumer;
+                return this;
+            }
+
+            public Builder setConfirmLeadershipConsumer(
+                    BiConsumer<UUID, String> confirmLeadershipConsumer) {
+                this.confirmLeadershipConsumer = confirmLeadershipConsumer;
+                return this;
+            }
+
+            public Builder setHasLeadershipFunction(Function<UUID, Boolean> hasLeadershipFunction) {
+                this.hasLeadershipFunction = hasLeadershipFunction;
+                return this;
+            }
+
+            public TestingAbstractLeaderElectionService build() {
+                return new TestingAbstractLeaderElectionService(
+                        registerConsumer, confirmLeadershipConsumer, hasLeadershipFunction);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -86,22 +86,21 @@ public class LeaderElectionTest {
         final ManualLeaderContender manualLeaderContender = new ManualLeaderContender();
 
         try {
-            assertThat(leaderElectionService.hasLeadership(UUID.randomUUID())).isFalse();
-
-            leaderElectionService.start(manualLeaderContender);
+            final LeaderElection leaderElection = leaderElectionService.createLeaderElection();
+            leaderElection.startLeaderElection(manualLeaderContender);
 
             final UUID leaderSessionId = manualLeaderContender.waitForLeaderSessionId();
 
-            assertThat(leaderElectionService.hasLeadership(leaderSessionId)).isTrue();
-            assertThat(leaderElectionService.hasLeadership(UUID.randomUUID())).isFalse();
+            assertThat(leaderElection.hasLeadership(leaderSessionId)).isTrue();
+            assertThat(leaderElection.hasLeadership(UUID.randomUUID())).isFalse();
 
-            leaderElectionService.confirmLeadership(leaderSessionId, "foobar");
+            leaderElection.confirmLeadership(leaderSessionId, "foobar");
 
-            assertThat(leaderElectionService.hasLeadership(leaderSessionId)).isTrue();
+            assertThat(leaderElection.hasLeadership(leaderSessionId)).isTrue();
 
             leaderElectionService.stop();
 
-            assertThat(leaderElectionService.hasLeadership(leaderSessionId)).isFalse();
+            assertThat(leaderElection.hasLeadership(leaderSessionId)).isFalse();
         } finally {
             manualLeaderContender.rethrowError();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -43,7 +43,7 @@ class StandaloneLeaderElectionTest {
         TestingListener testingListener = new TestingListener();
 
         try {
-            leaderElectionService.start(contender);
+            contender.startLeaderElection();
             leaderRetrievalService.start(testingListener);
 
             contender.waitForLeader();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -32,6 +32,7 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
 
     private final String address;
     private final LeaderElectionService leaderElectionService;
+    private LeaderElection leaderElection;
 
     private UUID leaderSessionID = null;
 
@@ -41,13 +42,20 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
         this.leaderElectionService = leaderElectionService;
     }
 
+    public LeaderElection startLeaderElection() throws Exception {
+        leaderElection = leaderElectionService.createLeaderElection();
+        leaderElection.startLeaderElection(this);
+
+        return leaderElection;
+    }
+
     @Override
     public void grantLeadership(UUID leaderSessionID) {
         LOG.debug("Was granted leadership with session ID {}.", leaderSessionID);
 
         this.leaderSessionID = leaderSessionID;
 
-        leaderElectionService.confirmLeadership(leaderSessionID, address);
+        leaderElection.confirmLeadership(leaderSessionID, address);
 
         leaderEventQueue.offer(LeaderInformation.known(leaderSessionID, address));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@code TestingLeaderElection} implements simple leader election for test cases where no {@code
+ * LeaderElectionService} is required.
+ */
+public class TestingLeaderElection implements LeaderElection {
+
+    /**
+     * Is {@code null} if the {@code LeaderElection} isn't started.
+     *
+     * @see LeaderElection#startLeaderElection(LeaderContender)
+     */
+    @Nullable private LeaderContender contender = null;
+
+    @Nullable private CompletableFuture<LeaderInformation> confirmationFuture = null;
+
+    /**
+     * Is {@code null} if the leadership wasn't acquired.
+     *
+     * @see TestingLeaderElection#isLeader(UUID)
+     * @see TestingLeaderElection#notLeader()
+     */
+    @Nullable private UUID issuedLeaderSessionId = null;
+
+    private CompletableFuture<Void> startFuture = new CompletableFuture<>();
+
+    @Override
+    public synchronized void startLeaderElection(LeaderContender contender) throws Exception {
+        Preconditions.checkNotNull(contender);
+        Preconditions.checkState(this.contender == null, "Only one contender is supported.");
+
+        this.contender = contender;
+
+        if (hasLeadership()) {
+            contender.grantLeadership(issuedLeaderSessionId);
+        }
+
+        startFuture.complete(null);
+    }
+
+    @Override
+    public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+        if (confirmationFuture != null && !confirmationFuture.isDone()) {
+            confirmationFuture.complete(LeaderInformation.known(leaderSessionID, leaderAddress));
+        }
+    }
+
+    @Override
+    public synchronized boolean hasLeadership(UUID leaderSessionId) {
+        return hasLeadership() && leaderSessionId.equals(issuedLeaderSessionId);
+    }
+
+    private boolean hasLeadership() {
+        return issuedLeaderSessionId != null;
+    }
+
+    synchronized void triggerContenderCleanup() {
+        if (hasLeadership() && this.contender != null) {
+            this.contender.revokeLeadership();
+        }
+
+        if (confirmationFuture != null) {
+            // the confirmationFuture is kind of bound to the LeaderContender which response to the
+            // grantLeadership call - resetting the LeaderElection should also inform the contender
+            // of such a state change
+            confirmationFuture.cancel(true);
+            confirmationFuture = null;
+        }
+
+        this.contender = null;
+        startFuture.cancel(false);
+        startFuture = new CompletableFuture<>();
+    }
+
+    /**
+     * Acquires the leadership with the given {@code leaderSessionID}.
+     *
+     * @return the contender's {@link LeaderInformation} after the leadership was confirmed. Waiting
+     *     for the {@code CompletableFuture} to complete will leave the test code in a state where
+     *     the {@link LeaderContender} confirmed the leadership. This simulates the information
+     *     being written to the HA backend.
+     */
+    public synchronized CompletableFuture<LeaderInformation> isLeader(UUID leaderSessionID) {
+        if (confirmationFuture != null) {
+            confirmationFuture.cancel(false);
+        }
+
+        confirmationFuture = new CompletableFuture<>();
+        issuedLeaderSessionId = leaderSessionID;
+
+        if (contender != null) {
+            contender.grantLeadership(leaderSessionID);
+        }
+
+        return confirmationFuture;
+    }
+
+    /**
+     * Returns the confirmed leader information future.
+     *
+     * @return the future for the {@link #confirmLeadership(UUID, String)} call that corresponds to
+     *     the most-recent {@link #isLeader(UUID)} call or {@code null} if no leadership was
+     *     acquired, yet.
+     * @deprecated This is out-dated API that shall be removed with {@link
+     *     TestingLeaderElectionService} (see FLINK-31797).
+     */
+    @Deprecated
+    @Nullable
+    CompletableFuture<LeaderInformation> getConfirmedLeaderInformation() {
+        return confirmationFuture;
+    }
+
+    /** Revokes the leadership. */
+    public synchronized void notLeader() {
+        Preconditions.checkState(
+                hasLeadership(),
+                "Leadership should have been acquired before calling this method.");
+        issuedLeaderSessionId = null;
+
+        if (contender != null) {
+            contender.revokeLeadership();
+        }
+    }
+
+    /**
+     * Returns the start future indicating whether this leader election service has been started or
+     * not.
+     *
+     * @return Future which is completed once this service has been started.
+     * @see TestingLeaderElection#startLeaderElection(LeaderContender)
+     */
+    public synchronized CompletableFuture<Void> getStartFuture() {
+        return startFuture;
+    }
+
+    /**
+     * Returns {@code true} if no contender is registered write now and the service is, therefore,
+     * stopped; otherwise {@code false}.
+     */
+    public synchronized boolean isStopped() {
+        return contender == null;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.Preconditions;
 
-import javax.annotation.Nonnull;
-
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -81,7 +79,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
     }
 
     @Override
-    public synchronized boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+    public synchronized boolean hasLeadership(UUID leaderSessionId) {
         return hasLeadership && leaderSessionId.equals(issuedLeaderSessionId);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
@@ -30,87 +29,41 @@ import java.util.concurrent.CompletableFuture;
  */
 public class TestingLeaderElectionService implements LeaderElectionService {
 
-    private LeaderContender contender = null;
-    private boolean hasLeadership = false;
-    private CompletableFuture<LeaderConnectionInfo> confirmationFuture = null;
-    private CompletableFuture<Void> startFuture = new CompletableFuture<>();
-    private UUID issuedLeaderSessionId = null;
-
-    /**
-     * Gets a future that completes when leadership is confirmed.
-     *
-     * <p>Note: the future is created upon calling {@link #isLeader(UUID)}.
-     */
-    public synchronized CompletableFuture<LeaderConnectionInfo> getConfirmationFuture() {
-        return confirmationFuture;
-    }
+    private final TestingLeaderElection startedLeaderElection = new TestingLeaderElection();
 
     @Override
-    public synchronized void start(LeaderContender contender) {
-        Preconditions.checkState(!getStartFuture().isDone());
-
-        this.contender = contender;
-
-        if (hasLeadership) {
-            contender.grantLeadership(issuedLeaderSessionId);
-        }
-
-        startFuture.complete(null);
+    public synchronized LeaderElection createLeaderElection() {
+        return startedLeaderElection;
     }
 
     @Override
     public synchronized void stop() throws Exception {
-        if (hasLeadership && contender != null) {
-            contender.revokeLeadership();
-        }
-
-        contender = null;
-        hasLeadership = false;
-        issuedLeaderSessionId = null;
-        startFuture.cancel(false);
-        startFuture = new CompletableFuture<>();
+        startedLeaderElection.triggerContenderCleanup();
     }
 
-    @Override
-    public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
-        if (confirmationFuture != null) {
-            confirmationFuture.complete(new LeaderConnectionInfo(leaderSessionID, leaderAddress));
-        }
-    }
-
-    @Override
-    public synchronized boolean hasLeadership(UUID leaderSessionId) {
-        return hasLeadership && leaderSessionId.equals(issuedLeaderSessionId);
-    }
-
-    public synchronized CompletableFuture<UUID> isLeader(UUID leaderSessionID) {
-        if (confirmationFuture != null) {
-            confirmationFuture.cancel(false);
-        }
-        confirmationFuture = new CompletableFuture<>();
-        hasLeadership = true;
-        issuedLeaderSessionId = leaderSessionID;
-
-        if (contender != null) {
-            contender.grantLeadership(leaderSessionID);
-        }
-
-        return confirmationFuture.thenApply(LeaderConnectionInfo::getLeaderSessionId);
+    public synchronized CompletableFuture<LeaderInformation> isLeader(UUID leaderSessionID) {
+        return startedLeaderElection.isLeader(leaderSessionID);
     }
 
     public synchronized void notLeader() {
-        hasLeadership = false;
-
-        if (contender != null) {
-            contender.revokeLeadership();
-        }
+        startedLeaderElection.notLeader();
     }
 
     public synchronized String getAddress() {
-        if (confirmationFuture.isDone()) {
-            return confirmationFuture.join().getAddress();
+        return getConfirmedLeaderInformation().join().getLeaderAddress();
+    }
+
+    public synchronized CompletableFuture<LeaderInformation> getConfirmedLeaderInformation() {
+        final CompletableFuture<LeaderInformation> confirmedLeaderInformation =
+                startedLeaderElection.getConfirmedLeaderInformation();
+
+        Preconditions.checkState(
+                confirmedLeaderInformation != null, "The leadership wasn't acquired, yet.");
+
+        if (confirmedLeaderInformation.isDone()) {
+            return confirmedLeaderInformation;
         } else {
-            throw new IllegalStateException("TestingLeaderElectionService has not been started.");
+            throw new IllegalStateException("The leadership wasn't confirmed, yet.");
         }
     }
 
@@ -121,10 +74,10 @@ public class TestingLeaderElectionService implements LeaderElectionService {
      * @return Future which is completed once this service has been started
      */
     public synchronized CompletableFuture<Void> getStartFuture() {
-        return startFuture;
+        return startedLeaderElection.getStartFuture();
     }
 
     public synchronized boolean isStopped() {
-        return contender == null;
+        return startedLeaderElection.isStopped();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -147,7 +147,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
             client.getConnectionStateListenable().addListener(connectionStateListener);
 
             final TestingContender contender = new TestingContender();
-            leaderElectionService.start(contender);
+            leaderElectionService.createLeaderElection().startLeaderElection(contender);
 
             contender.awaitGrantLeadership();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -192,7 +192,7 @@ class ZooKeeperLeaderElectionTest {
 
                 LOG.debug("Start leader election service for contender #{}.", i);
 
-                leaderElectionService[i].start(contenders[i]);
+                contenders[i].startLeaderElection();
             }
 
             String pattern = LEADER_ADDRESS + "_" + "(\\d+)";
@@ -282,7 +282,7 @@ class ZooKeeperLeaderElectionTest {
                         new TestingContender(
                                 LEADER_ADDRESS + "_" + i + "_0", leaderElectionService[i]);
 
-                leaderElectionService[i].start(contenders[i]);
+                contenders[i].startLeaderElection();
             }
 
             String pattern = LEADER_ADDRESS + "_" + "(\\d+)" + "_" + "(\\d+)";
@@ -314,7 +314,7 @@ class ZooKeeperLeaderElectionTest {
                                     LEADER_ADDRESS + "_" + index + "_" + (lastTry + 1),
                                     leaderElectionService[index]);
 
-                    leaderElectionService[index].start(contenders[index]);
+                    contenders[index].startLeaderElection();
                 } else {
                     throw new Exception("Did not find the leader's index.");
                 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -191,7 +191,9 @@ class ZooKeeperLeaderRetrievalTest {
                 externalProcessDriver.notLeader();
                 externalProcessDriver.close();
 
-                leaderElectionService.start(correctLeaderAddressContender);
+                // leaderElection is unused right now because it doesn't need to be closed, yet.
+                // The close call will be introduced with FLINK-31785
+                correctLeaderAddressContender.startLeaderElection();
 
                 thread.join();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.util.TestLogger;
 
@@ -47,12 +48,11 @@ public class ResourceManagerHATest extends TestLogger {
             resourceManagerService.start();
 
             final UUID leaderId = UUID.randomUUID();
-            resourceManagerService.isLeader(leaderId);
+            final LeaderInformation confirmedLeaderInformation =
+                    resourceManagerService.isLeader(leaderId).join();
 
             // after grant leadership, verify resource manager is started with the fencing token
-            assertEquals(
-                    leaderId,
-                    leaderElectionService.getConfirmationFuture().get().getLeaderSessionId());
+            assertEquals(leaderId, confirmedLeaderInformation.getLeaderSessionID());
             assertTrue(resourceManagerService.getResourceManagerFencingToken().isPresent());
             assertEquals(
                     leaderId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -108,21 +108,15 @@ public class ResourceManagerJobMasterTest extends TestLogger {
                         .build();
 
         resourceManagerService.start();
-        resourceManagerService.isLeader(UUID.randomUUID());
+        resourceManagerService.isLeader(UUID.randomUUID()).join();
 
-        leaderElectionService
-                .getConfirmationFuture()
-                .thenRun(
-                        () -> {
-                            resourceManagerGateway =
-                                    resourceManagerService
-                                            .getResourceManagerGateway()
-                                            .orElseThrow(
-                                                    () ->
-                                                            new AssertionError(
-                                                                    "RM not available after confirming leadership."));
-                        })
-                .get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+        resourceManagerGateway =
+                resourceManagerService
+                        .getResourceManagerGateway()
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "RM not available after confirming leadership."));
     }
 
     @After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
@@ -50,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
@@ -59,8 +57,6 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for the partition-lifecycle logic in the {@link ResourceManager}. */
 public class ResourceManagerPartitionLifecycleTest extends TestLogger {
-
-    private static final Time TIMEOUT = Time.minutes(2L);
 
     private static TestingRpcService rpcService;
 
@@ -113,8 +109,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
                             createTaskExecutorHeartbeatPayload(dataSetID, 2, resultPartitionID));
 
                     Collection<IntermediateDataSetID> intermediateDataSetIDS =
-                            clusterPartitionReleaseFuture.get(
-                                    TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+                            clusterPartitionReleaseFuture.get();
                     assertThat(intermediateDataSetIDS, contains(dataSetID));
                 });
     }
@@ -145,8 +140,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
                     resourceManagerGateway.disconnectTaskManager(
                             taskManagerId2, new RuntimeException("test exception"));
                     Collection<IntermediateDataSetID> intermediateDataSetIDS =
-                            clusterPartitionReleaseFuture.get(
-                                    TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+                            clusterPartitionReleaseFuture.get();
                     assertThat(intermediateDataSetIDS, contains(dataSetID));
                 });
     }
@@ -218,7 +212,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
         // first make the ResourceManager the leader
         resourceManagerService.isLeader(UUID.randomUUID());
 
-        leaderElectionService.getConfirmationFuture().get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+        leaderElectionService.getConfirmationFuture().get();
 
         return resourceManagerService
                 .getResourceManagerGateway()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -210,9 +210,7 @@ public class ResourceManagerPartitionLifecycleTest extends TestLogger {
         resourceManagerService.start();
 
         // first make the ResourceManager the leader
-        resourceManagerService.isLeader(UUID.randomUUID());
-
-        leaderElectionService.getConfirmationFuture().get();
+        resourceManagerService.isLeader(UUID.randomUUID()).join();
 
         return resourceManagerService
                 .getResourceManagerGateway()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -138,21 +138,15 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
                         .build();
 
         rmService.start();
-        rmService.isLeader(UUID.randomUUID());
+        rmService.isLeader(UUID.randomUUID()).join();
 
-        leaderElectionService
-                .getConfirmationFuture()
-                .thenRun(
-                        () -> {
-                            rmGateway =
-                                    rmService
-                                            .getResourceManagerGateway()
-                                            .orElseThrow(
-                                                    () ->
-                                                            new AssertionError(
-                                                                    "RM not available after confirming leadership."));
-                        })
-                .get(TIMEOUT.getSize(), TIMEOUT.getUnit());
+        rmGateway =
+                rmService
+                        .getResourceManagerGateway()
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "RM not available after confirming leadership."));
     }
 
     @After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
@@ -108,8 +109,8 @@ public class TestingResourceManagerService implements ResourceManagerService {
         return Optional.ofNullable(rmService.getLeaderResourceManager());
     }
 
-    public void isLeader(UUID uuid) {
-        leaderElectionService.isLeader(uuid);
+    public CompletableFuture<LeaderInformation> isLeader(UUID uuid) {
+        return leaderElectionService.isLeader(uuid);
     }
 
     public void notLeader() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -37,8 +37,6 @@ import org.apache.flink.util.ConfigurationException;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
-import javax.annotation.Nonnull;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -101,7 +99,7 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         public void confirmLeadership(final UUID leaderSessionID, final String leaderAddress) {}
 
         @Override
-        public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+        public boolean hasLeadership(UUID leaderSessionId) {
             return false;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.NoOpTransientBlobService;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
@@ -90,13 +91,22 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         INSTANCE;
 
         @Override
-        public void start(final LeaderContender contender) throws Exception {}
+        public LeaderElection createLeaderElection() {
+            return NoOpLeaderElection.INSTANCE;
+        }
 
         @Override
-        public void stop() throws Exception {}
+        public void stop() {}
+    }
+
+    private enum NoOpLeaderElection implements LeaderElection {
+        INSTANCE;
 
         @Override
-        public void confirmLeadership(final UUID leaderSessionID, final String leaderAddress) {}
+        public void startLeaderElection(LeaderContender contender) {}
+
+        @Override
+        public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
 
         @Override
         public boolean hasLeadership(UUID leaderSessionId) {


### PR DESCRIPTION
PR order:
- https://github.com/apache/flink/pull/21742
- https://github.com/apache/flink/pull/22379
- https://github.com/apache/flink/pull/22422
- https://github.com/apache/flink/pull/22380
- https://github.com/apache/flink/pull/22623
- === this PR === FLINK-31776
- https://github.com/apache/flink/pull/22390
- https://github.com/apache/flink/pull/22404
- https://github.com/apache/flink/pull/22601
- https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* https://github.com/apache/flink/pull/22661

## What is the purpose of the change

This change introduces a new interface `LeaderElectionService.LeaderElection` which serves as a proxy between the `LeaderContender` and the `LeaderElectionService`. Future PRs will introduce a contender ID which can hidden in `LeaderElection`. That way, `LeaderContender` wouldn't be aware of this implementation detail of the `DefaultLeaderElectionService`

## Brief change log

* Moved `confirmLeadership` and `hasLeadership(UUID)` into new interface
* `LeaderContender` registration moved out of `LeaderElectionService.createLeaderElection(..)` into `LeaderElection.startLeaderElection`
* `LeaderElection` implements `AutoCloseable` to cover the deregistration of the `LeaderContender` from the `LeaderElectionService`
* Introduced `AbstractLeaderElectionService` as a generic implementation of `LeaderElectionService` that deals with the `LeaderElection` lifecycle management and provdes helper methods

## Verifying this change

* Tests were updated and should still pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable