### PR TITLE
[FLINK-31790] Respect the PartitionCommitPolicy for batch Filesystem …

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -19,6 +19,8 @@ package org.apache.flink.table.planner.runtime
 
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.connector.file.table.PartitionCommitPolicy
+import org.apache.flink.core.fs.{FileSystem, Path => FPath}
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase._
@@ -28,6 +30,7 @@ import org.apache.flink.testutils.junit.utils.TempDirUtils
 import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.io.TempDir
 
@@ -159,6 +162,20 @@ trait FileSystemITCaseBase {
          |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
+    )
+
+    tableEnv.executeSql(
+      s"""
+         |create table table_custom_partition_commit_policy (
+         |  x varchar, y int
+         |) PARTITIONED BY (x) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$getScheme://$resultPath',
+         |  ${formatProperties().mkString(",\n")},
+         |  'sink.partition-commit.policy.kind' = 'custom',
+         |  'sink.partition-commit.policy.class' = '${classOf[TestPolicy].getName}'
+         |)
+ """.stripMargin
     )
   }
 
@@ -514,6 +531,15 @@ trait FileSystemITCaseBase {
         row(19, 3, "x19")
       ))
   }
+
+  @TestTemplate
+  def testCustomPartitionCommitPolicy(): Unit = {
+    tableEnv
+      .executeSql("insert into table_custom_partition_commit_policy values ('p1', 1), ('p1', 2)")
+      .await()
+    val file = new File(s"$resultPath/x=p1/_custom_commit")
+    assertTrue(file.exists())
+  }
 }
 
 object FileSystemITCaseBase {
@@ -578,4 +604,14 @@ object FileSystemITCaseBase {
     row("x4", 4, 1, 1, 2),
     row("x5", 5, 1, 1, 2)
   )
+
+  class TestPolicy extends PartitionCommitPolicy {
+
+    /** Commit a partition. */
+    override def commit(context: PartitionCommitPolicy.Context): Unit = {
+      val fs = context.partitionPath().getFileSystem
+      fs.create(new FPath(context.partitionPath, "_custom_commit"), FileSystem.WriteMode.OVERWRITE)
+        .close()
+    }
+  }
 }


### PR DESCRIPTION
…mode

## What is the purpose of the change

This PR is meant to add the partition commit policy for the filesystem batch mode.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
