### PR TITLE
[FLINK-31785][runtime] Moves LeaderElectionService.stop into LeaderElection.close

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
@@ -203,12 +203,11 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
 
     private CompletableFuture<Void> stopLeaderElectionService() {
         try {
-            leaderElectionService.stop();
+            leaderElection.close();
+            return FutureUtils.completedVoidFuture();
         } catch (Exception e) {
             return FutureUtils.completedExceptionally(e);
         }
-
-        return FutureUtils.completedVoidFuture();
     }
 
     private void runActionIfRunning(Runnable runnable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -453,7 +453,8 @@ public class EmbeddedLeaderService {
         }
 
         @Override
-        public void stop() throws Exception {
+        public void remove(LeaderContender contender) {
+            Preconditions.checkArgument(contender == this.contender);
             removeContender(this);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -153,7 +153,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                         processTerminationFuture,
                         () -> {
                             classLoaderLease.release();
-                            leaderElectionService.stop();
+                            leaderElection.close();
                         });
 
         FutureUtils.forward(serviceTerminationFuture, terminationFuture);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/AbstractLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/AbstractLeaderElectionService.java
@@ -38,6 +38,9 @@ public abstract class AbstractLeaderElectionService implements LeaderElectionSer
      */
     protected abstract void register(LeaderContender contender) throws Exception;
 
+    /** Removes the passed {@code LeaderContender} from the {@code LeaderElectionService}. */
+    protected abstract void remove(LeaderContender contender);
+
     /** Confirms the leadership with the given session ID and address. */
     protected abstract void confirmLeadership(UUID leaderSessionID, String leaderAddress);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -55,4 +55,12 @@ class DefaultLeaderElection implements LeaderElection {
     public boolean hasLeadership(UUID leaderSessionId) {
         return parentService.hasLeadership(leaderSessionId);
     }
+
+    @Override
+    public void close() throws Exception {
+        if (leaderContender != null) {
+            parentService.remove(leaderContender);
+            leaderContender = null;
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -171,7 +171,8 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
     }
 
     @Override
-    public final void stop() throws Exception {
+    protected final void remove(LeaderContender contender) {
+        Preconditions.checkArgument(contender == this.leaderContender);
         LOG.info("Stopping DefaultLeaderElectionService.");
 
         synchronized (lock) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  * {@code LeaderElection} serves as a proxy between {@code LeaderElectionService} and {@link
  * LeaderContender}.
  */
-public interface LeaderElection {
+public interface LeaderElection extends AutoCloseable {
 
     /** Registers the passed {@link LeaderContender} with the leader election process. */
     void startLeaderElection(LeaderContender contender) throws Exception;
@@ -50,4 +50,11 @@ public interface LeaderElection {
      * @return true if the associated {@link LeaderContender} is the leader, otherwise false
      */
     boolean hasLeadership(UUID leaderSessionId);
+
+    /**
+     * Closes the {@code LeaderElection} by deregistering the {@link LeaderContender} from the
+     * underlying leader election. {@link LeaderContender#revokeLeadership()} will be called if the
+     * service still holds the leadership.
+     */
+    void close() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -40,12 +40,4 @@ public interface LeaderElectionService {
      * LeaderElectionService} instance.
      */
     LeaderElection createLeaderElection();
-
-    /**
-     * Stops the leader election service. Stopping the {@code LeaderElectionService} will trigger
-     * {@link LeaderContender#revokeLeadership()} if the service still holds the leadership.
-     *
-     * @throws Exception if an error occurs while stopping the {@code LeaderElectionService}.
-     */
-    void stop() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -48,10 +48,12 @@ public class StandaloneLeaderElectionService extends AbstractLeaderElectionServi
     }
 
     @Override
-    public void stop() {
-        if (contender != null) {
-            contender.revokeLeadership();
-            contender = null;
+    protected void remove(LeaderContender contender) {
+        Preconditions.checkArgument(contender == this.contender);
+
+        if (this.contender != null) {
+            this.contender.revokeLeadership();
+            this.contender = null;
         }
     }
 
@@ -60,7 +62,7 @@ public class StandaloneLeaderElectionService extends AbstractLeaderElectionServi
 
     @Override
     protected boolean hasLeadership(UUID leaderSessionId) {
-        return (contender != null
-                && HighAvailabilityServices.DEFAULT_LEADER_ID.equals(leaderSessionId));
+        return contender != null
+                && HighAvailabilityServices.DEFAULT_LEADER_ID.equals(leaderSessionId);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -329,7 +329,9 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
 
     private void stopLeaderElectionService() {
         try {
-            leaderElectionService.stop();
+            if (leaderElection != null) {
+                leaderElection.close();
+            }
         } catch (Exception e) {
             serviceTerminationFuture.completeExceptionally(
                     new FlinkException("Cannot stop leader election service.", e));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -1093,7 +1093,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                     }
 
                     try {
-                        leaderElectionService.stop();
+                        if (leaderElection != null) {
+                            leaderElection.close();
+                        }
                     } catch (Exception e) {
                         exception = ExceptionUtils.firstOrSuppressed(e, exception);
                     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher.runner;
 
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.leaderelection.LeaderElection;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -44,13 +45,15 @@ import static org.junit.Assert.fail;
 /** Tests for the {@link DefaultDispatcherRunner}. */
 public class DefaultDispatcherRunnerTest extends TestLogger {
 
-    private TestingLeaderElectionService testingLeaderElectionService;
+    private final TestingLeaderElectionService testingLeaderElectionService =
+            new TestingLeaderElectionService();
+    private LeaderElection leaderElection;
     private TestingFatalErrorHandler testingFatalErrorHandler;
     private TestingDispatcherLeaderProcessFactory testingDispatcherLeaderProcessFactory;
 
     @Before
     public void setup() {
-        testingLeaderElectionService = new TestingLeaderElectionService();
+        leaderElection = testingLeaderElectionService.createLeaderElection();
         testingFatalErrorHandler = new TestingFatalErrorHandler();
         testingDispatcherLeaderProcessFactory =
                 TestingDispatcherLeaderProcessFactory.defaultValue();
@@ -58,9 +61,9 @@ public class DefaultDispatcherRunnerTest extends TestLogger {
 
     @After
     public void teardown() throws Exception {
-        if (testingLeaderElectionService != null) {
-            testingLeaderElectionService.stop();
-            testingLeaderElectionService = null;
+        if (leaderElection != null) {
+            leaderElection.close();
+            leaderElection = null;
         }
 
         if (testingFatalErrorHandler != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -58,7 +58,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
 
             final LeaderElection leaderElection = leaderElectionService.createLeaderElection();
             leaderElection.startLeaderElection(contender);
-            leaderElectionService.stop();
+            leaderElection.close();
 
             try {
                 // check that no exception occurred
@@ -97,7 +97,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
 
             final CompletableFuture<Void> revokeLeadershipFuture =
                     embeddedLeaderService.revokeLeadership();
-            leaderElectionService.stop();
+            leaderElection.close();
 
             try {
                 // check that no exception occurred

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -98,9 +98,13 @@ public class LeaderElectionTest {
 
             assertThat(leaderElection.hasLeadership(leaderSessionId)).isTrue();
 
-            leaderElectionService.stop();
+            leaderElection.close();
 
             assertThat(leaderElection.hasLeadership(leaderSessionId)).isFalse();
+
+            assertThat(manualLeaderContender.waitForLeaderSessionId())
+                    .as("The leadership has been revoked from the contender.")
+                    .isEqualTo(ManualLeaderContender.NULL_LEADER_SESSION_ID);
         } finally {
             manualLeaderContender.rethrowError();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -42,8 +42,7 @@ class StandaloneLeaderElectionTest {
         TestingContender contender = new TestingContender(TEST_URL, leaderElectionService);
         TestingListener testingListener = new TestingListener();
 
-        try {
-            contender.startLeaderElection();
+        try (LeaderElection leaderElection = contender.startLeaderElection()) {
             leaderRetrievalService.start(testingListener);
 
             contender.waitForLeader();
@@ -58,7 +57,6 @@ class StandaloneLeaderElectionTest {
             assertThat(testingListener.getLeaderSessionID())
                     .isEqualTo(HighAvailabilityServices.DEFAULT_LEADER_ID);
         } finally {
-            leaderElectionService.stop();
             leaderRetrievalService.stop();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
@@ -80,7 +80,8 @@ public class TestingLeaderElection implements LeaderElection {
         return issuedLeaderSessionId != null;
     }
 
-    synchronized void triggerContenderCleanup() {
+    @Override
+    public synchronized void close() {
         if (hasLeadership() && this.contender != null) {
             this.contender.revokeLeadership();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -36,11 +36,6 @@ public class TestingLeaderElectionService implements LeaderElectionService {
         return startedLeaderElection;
     }
 
-    @Override
-    public synchronized void stop() throws Exception {
-        startedLeaderElection.triggerContenderCleanup();
-    }
-
     public synchronized CompletableFuture<LeaderInformation> isLeader(UUID leaderSessionID) {
         return startedLeaderElection.isLeader(leaderSessionID);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -141,13 +141,13 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
                 new DefaultLeaderElectionService(leaderElectionDriverFactory);
         leaderElectionService.startLeaderElectionBackend();
 
-        try {
-            final TestingConnectionStateListener connectionStateListener =
-                    new TestingConnectionStateListener();
-            client.getConnectionStateListenable().addListener(connectionStateListener);
+        final TestingConnectionStateListener connectionStateListener =
+                new TestingConnectionStateListener();
+        client.getConnectionStateListenable().addListener(connectionStateListener);
 
-            final TestingContender contender = new TestingContender();
-            leaderElectionService.createLeaderElection().startLeaderElection(contender);
+        final TestingContender contender = new TestingContender();
+        try (LeaderElection leaderElection = leaderElectionService.createLeaderElection()) {
+            leaderElection.startLeaderElection(contender);
 
             contender.awaitGrantLeadership();
 
@@ -165,7 +165,6 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
 
             validationLogic.accept(connectionStateListener, contender);
         } finally {
-            leaderElectionService.stop();
             leaderElectionService.close();
             curatorFrameworkWrapper.close();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -172,6 +172,7 @@ class ZooKeeperLeaderElectionTest {
 
         DefaultLeaderElectionService[] leaderElectionService =
                 new DefaultLeaderElectionService[num];
+        LeaderElection[] leaderElections = new LeaderElection[num];
         TestingContender[] contenders = new TestingContender[num];
         DefaultLeaderRetrievalService leaderRetrievalService = null;
 
@@ -192,7 +193,7 @@ class ZooKeeperLeaderElectionTest {
 
                 LOG.debug("Start leader election service for contender #{}.", i);
 
-                contenders[i].startLeaderElection();
+                leaderElections[i] = contenders[i].startLeaderElection();
             }
 
             String pattern = LEADER_ADDRESS + "_" + "(\\d+)";
@@ -219,7 +220,8 @@ class ZooKeeperLeaderElectionTest {
                         LOG.debug(
                                 "Stop leader election service of contender #{}.",
                                 numberSeenLeaders);
-                        leaderElectionService[index].stop();
+                        leaderElections[index].close();
+                        leaderElections[index] = null;
                         leaderElectionService[index].close();
                         leaderElectionService[index] = null;
 
@@ -239,9 +241,14 @@ class ZooKeeperLeaderElectionTest {
                 leaderRetrievalService.stop();
             }
 
+            for (LeaderElection leaderElection : leaderElections) {
+                if (leaderElection != null) {
+                    leaderElection.close();
+                }
+            }
+
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
-                    electionService.stop();
                     electionService.close();
                 }
             }
@@ -264,6 +271,7 @@ class ZooKeeperLeaderElectionTest {
 
         DefaultLeaderElectionService[] leaderElectionService =
                 new DefaultLeaderElectionService[num];
+        LeaderElection[] leaderElections = new LeaderElection[num];
         TestingContender[] contenders = new TestingContender[num];
         DefaultLeaderRetrievalService leaderRetrievalService = null;
 
@@ -282,7 +290,7 @@ class ZooKeeperLeaderElectionTest {
                         new TestingContender(
                                 LEADER_ADDRESS + "_" + i + "_0", leaderElectionService[i]);
 
-                contenders[i].startLeaderElection();
+                leaderElections[i] = contenders[i].startLeaderElection();
             }
 
             String pattern = LEADER_ADDRESS + "_" + "(\\d+)" + "_" + "(\\d+)";
@@ -303,8 +311,10 @@ class ZooKeeperLeaderElectionTest {
                             .isEqualTo(contenders[index].getLeaderSessionID());
 
                     // stop leader election service = revoke leadership
-                    leaderElectionService[index].stop();
+                    leaderElections[index].close();
+                    leaderElections[index] = null;
                     leaderElectionService[index].close();
+                    leaderElections[index] = null;
 
                     // create new leader election service which takes part in the leader election
                     leaderElectionService[index] =
@@ -314,7 +324,7 @@ class ZooKeeperLeaderElectionTest {
                                     LEADER_ADDRESS + "_" + index + "_" + (lastTry + 1),
                                     leaderElectionService[index]);
 
-                    contenders[index].startLeaderElection();
+                    leaderElections[index] = contenders[index].startLeaderElection();
                 } else {
                     throw new Exception("Did not find the leader's index.");
                 }
@@ -325,9 +335,14 @@ class ZooKeeperLeaderElectionTest {
                 leaderRetrievalService.stop();
             }
 
+            for (LeaderElection leaderElection : leaderElections) {
+                if (leaderElection != null) {
+                    leaderElection.close();
+                }
+            }
+
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
-                    electionService.stop();
                     electionService.close();
                 }
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -77,6 +77,7 @@ public class ResourceManagerServiceImplTest extends TestLogger {
 
     private TestingResourceManagerFactory.Builder rmFactoryBuilder;
     private TestingLeaderElectionService leaderElectionService;
+
     private ResourceManagerServiceImpl resourceManagerService;
 
     @BeforeClass
@@ -101,10 +102,6 @@ public class ResourceManagerServiceImplTest extends TestLogger {
     public void teardown() throws Exception {
         if (resourceManagerService != null) {
             resourceManagerService.close();
-        }
-
-        if (leaderElectionService != null) {
-            leaderElectionService.stop();
         }
 
         if (fatalErrorHandler.hasExceptionOccurred()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -94,9 +94,6 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         public LeaderElection createLeaderElection() {
             return NoOpLeaderElection.INSTANCE;
         }
-
-        @Override
-        public void stop() {}
     }
 
     private enum NoOpLeaderElection implements LeaderElection {
@@ -112,5 +109,8 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         public boolean hasLeadership(UUID leaderSessionId) {
             return false;
         }
+
+        @Override
+        public void close() {}
     }
 }


### PR DESCRIPTION
* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* === this PR === FLINK-31785
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* https://github.com/apache/flink/pull/22661

## What is the purpose of the change

This PR moves the leader election deregistration from the `LeaderElectionService` interface into `LeaderElectionService.LeaderElection`.

## Brief change log

* Introduced `AbstractLeaderElectionService.remove` method that is then used by `LeaderElection.close`
* Updated the tests accordingly.

## Verifying this change

* Existing tests should still succeed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
