### PR TITLE
[hotfix][annotations] Fix the Flink version enum for v1.18

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
+++ b/flink-annotations/src/main/java/org/apache/flink/FlinkVersion.java
@@ -55,7 +55,7 @@ public enum FlinkVersion {
     v1_15("1.15"),
     v1_16("1.16"),
     v1_17("1.17"),
-    V1_18("1.18");
+    v1_18("1.18");
 
     private final String versionStr;
 


### PR DESCRIPTION
## What is the purpose of the change

This is a trivial fix for the `FlinkVersion` enum, which should start with lowercase.


## Brief change log

Change `V1_18` to `v1_18`.


## Verifying this change


This change is a trivial fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
