### PR TITLE
[FLINK-31588][checkpoint] Correct the unaligned checkpoint type after aligned barrier timeout to unaligned barrier on PipelinedSubpartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
@@ -40,7 +40,6 @@ public class CheckpointMetricsBuilder {
     private long syncDurationMillis = -1L;
     private long asyncDurationMillis = -1L;
     private long checkpointStartDelayNanos = -1L;
-    private boolean unalignedCheckpoint = false;
     private long totalBytesPersisted = -1L;
     private long bytesPersistedOfThisCheckpoint = -1L;
 
@@ -119,11 +118,6 @@ public class CheckpointMetricsBuilder {
         return checkpointStartDelayNanos;
     }
 
-    public CheckpointMetricsBuilder setUnalignedCheckpoint(boolean unalignedCheckpoint) {
-        this.unalignedCheckpoint = unalignedCheckpoint;
-        return this;
-    }
-
     public CheckpointMetricsBuilder setTotalBytesPersisted(long totalBytesPersisted) {
         this.totalBytesPersisted = totalBytesPersisted;
         return this;
@@ -147,7 +141,7 @@ public class CheckpointMetricsBuilder {
                 syncDurationMillis,
                 asyncDurationMillis,
                 checkpointStartDelayNanos,
-                unalignedCheckpoint,
+                bytesPersistedDuringAlignment > 0,
                 bytesPersistedOfThisCheckpoint,
                 totalBytesPersisted);
     }
@@ -160,7 +154,7 @@ public class CheckpointMetricsBuilder {
                 syncDurationMillis,
                 asyncDurationMillis,
                 checkpointStartDelayNanos,
-                unalignedCheckpoint,
+                bytesPersistedDuringAlignment > 0,
                 bytesPersistedOfThisCheckpoint,
                 totalBytesPersisted);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link CheckpointMetrics} class. */
+public class CheckpointMetricsTest {
+
+    @Test
+    public void testUnalignedCheckpointType() throws Exception {
+        CheckpointMetricsBuilder metricsBuilder = new CheckpointMetricsBuilder();
+        metricsBuilder.setBytesProcessedDuringAlignment(0L);
+        metricsBuilder.setAlignmentDurationNanos(0L);
+        metricsBuilder.setBytesPersistedOfThisCheckpoint(0L);
+        metricsBuilder.setTotalBytesPersisted(0L);
+
+        // The checkpoint shouldn't be unaligned checkpoint when builder doesn't set
+        // bytesPersistedDuringAlignment
+        assertThat(metricsBuilder.build().getUnalignedCheckpoint()).isFalse();
+        assertThat(metricsBuilder.buildIncomplete().getUnalignedCheckpoint()).isFalse();
+
+        assertUnalignedCheckpointType(metricsBuilder, 0L);
+        assertUnalignedCheckpointType(metricsBuilder, 1L);
+        assertUnalignedCheckpointType(metricsBuilder, 5L);
+        assertUnalignedCheckpointType(metricsBuilder, 10L);
+        assertUnalignedCheckpointType(metricsBuilder, 100L);
+    }
+
+    private void assertUnalignedCheckpointType(
+            CheckpointMetricsBuilder metricsBuilder, long bytesPersistedDuringAlignment) {
+        boolean expectedUnalignedCheckpointType = bytesPersistedDuringAlignment > 0;
+        metricsBuilder.setBytesPersistedDuringAlignment(bytesPersistedDuringAlignment);
+
+        assertThat(metricsBuilder.build().getUnalignedCheckpoint())
+                .isEqualTo(expectedUnalignedCheckpointType);
+        assertThat(metricsBuilder.buildIncomplete().getUnalignedCheckpoint())
+                .isEqualTo(expectedUnalignedCheckpointType);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -735,7 +735,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 checkpointOptions.isUnalignedCheckpoint());
 
         checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
-        checkpointMetrics.setUnalignedCheckpoint(checkpointOptions.isUnalignedCheckpoint());
         return true;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Correct the unaligned checkpoint type after aligned barrier timeout to unaligned barrier on PipelinedSubpartition.

## Brief change log

Correct the unaligned checkpoint type after aligned barrier timeout to unaligned barrier on PipelinedSubpartition.

## Verifying this change

This change improved old tests and can be verified as follows:

  - PipelinedSubpartitionTest#testConsumeTimeoutableCheckpointBarrierQuickly
  - PipelinedSubpartitionTest#testTimeoutAlignedToUnalignedBarrier

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
