### PR TITLE
[FLINK-31780][component=Runtime/Coordination] Allow users to disable 'Ensemble tracking' feature for ZooKeeper Curator framework

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
@@ -21,6 +21,12 @@
             <td>Defines the connection timeout for ZooKeeper in ms.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.ensemble-tracker</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Defines whether Curator should enable ensemble tracker. This can be useful in certain scenarios in which CuratorFramework is accessing to ZK clusters via load balancer or Virtual IPs. Default Curator EnsembleTracking logic watches CuratorEventType.GET_CONFIG events and changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string with unresolvable hostnames.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
             <td style="word-wrap: break-word;">3</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -45,6 +45,12 @@
             <td>Defines the connection timeout for ZooKeeper in ms.</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.ensemble-tracker</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Defines whether Curator should enable ensemble tracker. This can be useful in certain scenarios in which CuratorFramework is accessing to ZK clusters via load balancer or Virtual IPs. Default Curator EnsembleTracking logic watches CuratorEventType.GET_CONFIG events and changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string with unresolvable hostnames.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
             <td style="word-wrap: break-word;">3</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -199,6 +199,22 @@ public class HighAvailabilityOptions {
                                             TextElement.code("true"))
                                     .build());
 
+    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
+    public static final ConfigOption<Boolean> ZOOKEEPER_ENSEMBLE_TRACKING =
+            key("high-availability.zookeeper.client.ensemble-tracker")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines whether Curator should enable ensemble tracker. This can be useful in certain scenarios "
+                                                    + "in which CuratorFramework is accessing to ZK clusters via load balancer or Virtual IPs. "
+                                                    + "Default Curator EnsembleTracking logic watches CuratorEventType.GET_CONFIG events and "
+                                                    + "changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. "
+                                                    + "Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string "
+                                                    + "with unresolvable hostnames.")
+                                    .build());
+
     // ------------------------------------------------------------------------
     //  Deprecated options
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -256,6 +256,9 @@ public class ZooKeeperUtils {
 
         LOG.info("Using '{}' as Zookeeper namespace.", rootWithNamespace);
 
+        boolean ensembleTracking =
+                configuration.getBoolean(HighAvailabilityOptions.ZOOKEEPER_ENSEMBLE_TRACKING);
+
         final CuratorFrameworkFactory.Builder curatorFrameworkBuilder =
                 CuratorFrameworkFactory.builder()
                         .connectString(zkQuorum)
@@ -265,6 +268,7 @@ public class ZooKeeperUtils {
                         // Curator prepends a '/' manually and throws an Exception if the
                         // namespace starts with a '/'.
                         .namespace(trimStartingSlash(rootWithNamespace))
+                        .ensembleTracker(ensembleTracking)
                         .aclProvider(aclProvider);
 
         if (configuration.get(HighAvailabilityOptions.ZOOKEEPER_TOLERATE_SUSPENDED_CONNECTIONS)) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Given PR adds a new configuration to disable EnsembleTracking feature for Apache Curator. It would make possible to actually configure HA for Zookeeper, which is living behind VIP.

Currently HA with ZooKeeper can even lead to the JobManager failure. The scenario of the failure is next:
1. Flink connects to ZooKeeper via configured URL.
2. Ensemble tracking gets a new URL of ensemble, which is not obligatory accessible for Flink, because Zookeeper is under VIP.
3. In case of reconnect Flink fails to Zookeeper, moreover due to "UnresolvedHostException" Flink's jobManager is killed.

## Brief change log

- Adds a new configuration into HighAvailabilityOptions
- Use newly added ZOOKEEPER_ENSEMBLE_TRACKING flag to control Curator ensemble tracking
- Default value is enabling ensemble tracking for backward compatibility, see [Curator source code](https://github.com/apache/curator/blob/master/curator-framework/src/main/java/org/apache/curator/framework/CuratorFrameworkFactory.java#L72)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. 
The code path is executed in several test scenarios, e.g. ZooKeeperLeaderElectionITCase#testJobExecutionOnClusterWithLeaderChange.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
