### PR TITLE
[FLINK-31799][docs] Python connector download link should refer to the url defined in externalized repository

### DIFF
--- a/docs/layouts/shortcodes/py_connector_download_link.html
+++ b/docs/layouts/shortcodes/py_connector_download_link.html
@@ -1,0 +1,62 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+Generates an XML snippet for the externalized connector python download table.
+*/}}
+{{ $name := .Get 0 }}
+{{ $connector_version := .Get 1 }}
+{{ $connector := index .Site.Data $name }}
+{{ $flink_version := .Site.Params.VersionTitle }}
+{{ $full_version := printf "%s-%s" $connector_version $flink_version }}
+
+<p>
+{{ if eq $.Site.Language.Lang "en" }}
+In order to use the {{ $connector.name }} in PyFlink jobs, the following
+dependencies are required:
+{{ else if eq $.Site.Language.Lang "zh" }}
+为了在 PyFlink 作业中使用 {{ $connector.name }} ，需要添加下列依赖：
+{{ end }}
+<table>
+    <thead>
+    <th style="text-align: left">Version</th>
+    <th style="text-align: left">PyFlink JAR</th>
+    </thead>
+    <tbody>
+    {{ range $connector.variants }}
+    <tr>
+        <td style="text-align: left">{{- .maven -}}</td>
+        {{ if $.Site.Params.IsStable }}
+        {{ if eq .sql_url nil}}
+        <td style="text-align:left">There is no sql jar available yet.</td>
+        {{ else }}
+        <td style="text-align:left"><a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a></td>
+        {{ end }}
+        {{ else }}
+        <td>Only available for stable releases.</td>
+        {{ end }}
+    </tr>
+    {{ end }}
+    </tbody>
+</table>
+{{ if eq .Site.Language.Lang "en" }}
+See <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/python/dependency_management/#jar-dependencies">Python dependency management</a>
+for more details on how to use JARs in PyFlink.
+{{ else if eq .Site.Language.Lang "zh" }}
+在 PyFlink 中如何添加 JAR 包依赖请参考 <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/python/dependency_management/#jar-dependencies">Python 依赖管理</a>。
+{{ end }}
+</p>

--- a/docs/layouts/shortcodes/py_download_link.html
+++ b/docs/layouts/shortcodes/py_download_link.html
@@ -81,6 +81,6 @@ dependencies are required:
 See <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/python/dependency_management/#jar-dependencies">Python dependency management</a>
 for more details on how to use JARs in PyFlink.
 {{ else if eq .Site.Language.Lang "zh" }}
-在 PyFlink 中如何添加 JAR 包依赖参见 <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/python/dependency_management/#jar-dependencies">Python 依赖管理</a>。
+在 PyFlink 中如何添加 JAR 包依赖请参考 <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/python/dependency_management/#jar-dependencies">Python 依赖管理</a>。
 {{ end }}
 </p>


### PR DESCRIPTION
## What is the purpose of the change

*Each externalized connector has its own yml file to manage the url of uber jar. We should introduce a new shortcode to support this.*


## Brief change log
- *Introduce `py_connector_download_link shortcode` for externalized connectors.*

## Verifying this change

Manually verified

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
