### PR TITLE
[BP-1.17][FLINK-31779][docs] Track stable branch of externalized connector instead of specific release tag

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -43,15 +43,15 @@ rm -rf tmp
 mkdir tmp
 cd tmp
 
-integrate_connector_docs elasticsearch v3.0.0-docs
-integrate_connector_docs aws v4.1.0-docs
-integrate_connector_docs cassandra v3.0.0
-integrate_connector_docs pulsar v3.0.0-docs
-integrate_connector_docs jdbc v3.0.0
-integrate_connector_docs rabbitmq v3.0.0
-integrate_connector_docs gcp-pubsub v3.0.0
-integrate_connector_docs mongodb v1.0.0-docs
-integrate_connector_docs opensearch v1.0.0
+integrate_connector_docs elasticsearch v3.0
+integrate_connector_docs aws v4.1
+integrate_connector_docs cassandra v3.0
+integrate_connector_docs pulsar v3.0
+integrate_connector_docs jdbc v3.0
+integrate_connector_docs rabbitmq v3.0
+integrate_connector_docs gcp-pubsub v3.0
+integrate_connector_docs mongodb v1.0
+integrate_connector_docs opensearch v1.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
Backport FLINK-31779 to release-1.17