### PR TITLE
[BP-1.16][FLINK-31779][docs] Track stable branch of externalized connector instead of specific release tag

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -41,10 +41,10 @@ cd tmp
 
 # Since there's no documentation yet available for a release branch,
 # we only get the documentation from the main branch
-integrate_connector_docs elasticsearch v3.0.0-docs
-integrate_connector_docs aws v4.1.0-docs
-integrate_connector_docs opensearch v1.0.0
-integrate_connector_docs mongodb v1.0.0-docs
+integrate_connector_docs elasticsearch v3.0
+integrate_connector_docs aws v4.1
+integrate_connector_docs opensearch v1.0
+integrate_connector_docs mongodb v1.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
Backport FLINK-31779 to release-1.16.
