### PR TITLE
[FLINK-31817] Skip meaningless testForUnsplittable in FileInputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -623,12 +623,18 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
                 for (BlockLocation block : blocks) {
                     hosts.addAll(Arrays.asList(block.getHosts()));
                 }
+                long len;
+                if (testForUnsplittable(file)) {
+                    len = READ_WHOLE_SPLIT_FLAG;
+                } else {
+                    len = file.getLen();
+                }
                 FileInputSplit fis =
                         new FileInputSplit(
                                 splitNum++,
                                 file.getPath(),
                                 0,
-                                READ_WHOLE_SPLIT_FLAG,
+                                len,
                                 hosts.toArray(new String[hosts.size()]));
                 inputSplits.add(fis);
             }


### PR DESCRIPTION
## What is the purpose of the change

In `FileInputFormat`, the function of `testForUnsplittable` is to detect whether the pathFile is unsplittable, and when pathFile is unsplittable, assign true to the member variable `unsplittable`

Currently this function will always be executed, in fact, we can only execute it when `Unsplittable` is false which can reduce the calls to `testForUnsplittable`

```java
protected boolean testForUnsplittable(FileStatus pathFile) {
    if (getInflaterInputStreamFactory(pathFile.getPath()) != null) {
        unsplittable = true;
        return true;
    }
    return false;
}
```

## Brief change log

- make `testForUnsplittable` pure: do not modify attributes, only make judgments
- check `unsplittable` before exec `testForUnsplittable` to reduce cost
- simple log fix

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - none
