### PR TITLE
[FLINK-31778][table-planner] Fix RowToRowCastRule

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -221,7 +221,10 @@ class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, R
                                     elseBodyWriter.stmt(writeNull));
         }
 
-        writer.stmt(methodCall(writerTerm, "complete")).assignStmt(returnVariable, rowTerm);
+        // Copy the result row in the end to avoid reference issues
+        // in case this code generation is invoked in a loop.
+        writer.stmt(methodCall(writerTerm, "complete"))
+                .assignStmt(returnVariable, methodCall(rowTerm, "copy"));
         return writer.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -1356,6 +1356,64 @@ class CastRulesTest {
                                                                 new BigDecimal(3), 10, 2)
                                                     })
                                         })),
+                CastTestSpecBuilder.testCastTo(ARRAY(ROW(INT().notNull())))
+                        .fromCase(
+                                ARRAY(ROW(INT().notNull())),
+                                new GenericArrayData(
+                                        new GenericRowData[] {
+                                            GenericRowData.of(1), GenericRowData.of(2)
+                                        }),
+                                new GenericArrayData(
+                                        new GenericRowData[] {
+                                            GenericRowData.of(1), GenericRowData.of(2)
+                                        })),
+                CastTestSpecBuilder.testCastTo(ARRAY(ROW(ROW(INT().notNull()))))
+                        .fromCase(
+                                ARRAY(ROW(ROW(INT().notNull()))),
+                                new GenericArrayData(
+                                        new GenericRowData[] {
+                                            GenericRowData.of(
+                                                    GenericRowData.of(1), GenericRowData.of(2)),
+                                            GenericRowData.of(
+                                                    GenericRowData.of(3), GenericRowData.of(4))
+                                        }),
+                                new GenericArrayData(
+                                        new GenericRowData[] {
+                                            GenericRowData.of(
+                                                    GenericRowData.of(1), GenericRowData.of(2)),
+                                            GenericRowData.of(
+                                                    GenericRowData.of(3), GenericRowData.of(4))
+                                        })),
+                CastTestSpecBuilder.testCastTo(ARRAY(MAP(INT().notNull(), STRING().notNull())))
+                        .fromCase(
+                                ARRAY(MAP(INT().notNull(), INT().notNull())),
+                                new GenericArrayData(
+                                        new Object[] {mapData(entry(1, 2)), mapData(entry(3, 4))}),
+                                new GenericArrayData(
+                                        new Object[] {
+                                            mapData(entry(1, fromString("2"))),
+                                            mapData(entry(3, fromString("4")))
+                                        })),
+                CastTestSpecBuilder.testCastTo(ARRAY(MAP(INT().notNull(), STRING().notNull())))
+                        .fromCase(
+                                ARRAY(MAP(INT().notNull(), INT().notNull())),
+                                new GenericArrayData(
+                                        new Object[] {mapData(entry(1, 2)), mapData(entry(3, 4))}),
+                                new GenericArrayData(
+                                        new Object[] {
+                                            mapData(entry(1, fromString("2"))),
+                                            mapData(entry(3, fromString("4")))
+                                        })),
+                CastTestSpecBuilder.testCastTo(ARRAY(MULTISET(STRING().notNull())))
+                        .fromCase(
+                                ARRAY(MULTISET(INT())),
+                                new GenericArrayData(
+                                        new Object[] {mapData(entry(1, 2)), mapData(entry(2, 3))}),
+                                new GenericArrayData(
+                                        new Object[] {
+                                            mapData(entry(fromString("1"), 2)),
+                                            mapData(entry(fromString("2"), 3))
+                                        })),
                 CastTestSpecBuilder.testCastTo(MAP(DOUBLE().notNull(), DOUBLE().notNull()))
                         .fromCase(
                                 MAP(INT().nullable(), INT().nullable()),
@@ -1376,6 +1434,14 @@ class CastRulesTest {
                                 MAP(TIMESTAMP().nullable(), DOUBLE().nullable()),
                                 mapData(entry(TIMESTAMP, 123.456)),
                                 mapData(entry(TIMESTAMP_STRING, fromString("123.456")))),
+                CastTestSpecBuilder.testCastTo(MAP(STRING().nullable(), ROW(DOUBLE().nullable())))
+                        .fromCase(
+                                MAP(STRING().nullable(), ROW(STRING().nullable())),
+                                mapData(
+                                        entry(
+                                                fromString("str"),
+                                                GenericRowData.of(fromString("123.456")))),
+                                mapData(entry(fromString("str"), GenericRowData.of(123.456)))),
                 CastTestSpecBuilder.testCastTo(MAP(STRING().notNull(), STRING().nullable()))
                         .fail(
                                 MAP(INT().nullable(), DOUBLE().nullable()),
@@ -1401,6 +1467,23 @@ class CastRulesTest {
                                 MULTISET(INT().nullable()),
                                 mapData(entry(null, 1)),
                                 mapData(entry(null, 1))),
+                CastTestSpecBuilder.testCastTo(MULTISET(ROW(ARRAY(INT().nullable()))))
+                        .fromCase(
+                                MULTISET(ROW(ARRAY(STRING().nullable()))),
+                                mapData(
+                                        entry(
+                                                GenericRowData.of(
+                                                        new GenericArrayData(
+                                                                new Object[] {
+                                                                    fromString("1"), null
+                                                                })),
+                                                2)),
+                                mapData(
+                                        entry(
+                                                GenericRowData.of(
+                                                        new GenericArrayData(
+                                                                new Object[] {1, null})),
+                                                2))),
                 CastTestSpecBuilder.testCastTo(MULTISET(STRING().notNull()))
                         .fail(
                                 MULTISET(INT().nullable()),


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes the issue of incorrect results when casting ARRAY(ROW) --> ARRAY(ROW)


## Brief change log
- Altering codegen to copy the result row instead of referencing it
- Adding more cast tests with rows

## Verifying this change

This change added tests and can be verified as follows:
- Extended casting tests to check casting of rows in various scenarios, including the one that produced the bug

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
