### PR TITLE
[FLINK-31543][jdbc-driver] Introduce statement for flink jdbc driver

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver/pom.xml
@@ -72,6 +72,18 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-csv</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseStatement.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+
+/** Base statement in flink driver. */
+public abstract class BaseStatement implements Statement {
+    @Override
+    public int executeUpdate(String sql) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#executeUpdate is not supported yet.");
+    }
+
+    @Override
+    public int getMaxFieldSize() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getMaxFieldSize is not supported yet.");
+    }
+
+    @Override
+    public void setMaxFieldSize(int max) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setMaxFieldSize is not supported yet.");
+    }
+
+    @Override
+    public int getMaxRows() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getMaxRows is not supported yet.");
+    }
+
+    @Override
+    public void setMaxRows(int max) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setMaxRows is not supported yet.");
+    }
+
+    @Override
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setEscapeProcessing is not supported yet.");
+    }
+
+    @Override
+    public int getQueryTimeout() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getQueryTimeout is not supported yet.");
+    }
+
+    @Override
+    public void setQueryTimeout(int seconds) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setQueryTimeout is not supported yet.");
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getWarnings is not supported yet.");
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#clearWarnings is not supported yet.");
+    }
+
+    @Override
+    public void setCursorName(String name) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setCursorName is not supported yet.");
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setFetchDirection is not supported yet.");
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getFetchDirection is not supported yet.");
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setFetchSize is not supported yet.");
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getFetchSize is not supported yet.");
+    }
+
+    @Override
+    public int getResultSetConcurrency() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getResultSetConcurrency is not supported yet.");
+    }
+
+    @Override
+    public int getResultSetType() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getResultSetType is not supported yet.");
+    }
+
+    @Override
+    public void addBatch(String sql) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#addBatch is not supported yet.");
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#clearBatch is not supported yet.");
+    }
+
+    @Override
+    public int[] executeBatch() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#executeBatch is not supported yet.");
+    }
+
+    @Override
+    public boolean getMoreResults(int current) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getMoreResults is not supported yet.");
+    }
+
+    @Override
+    public ResultSet getGeneratedKeys() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getGeneratedKeys is not supported yet.");
+    }
+
+    @Override
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#executeUpdate is not supported yet.");
+    }
+
+    @Override
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#executeUpdate is not supported yet.");
+    }
+
+    @Override
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#executeUpdate is not supported yet.");
+    }
+
+    @Override
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#execute is not supported yet.");
+    }
+
+    @Override
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#execute is not supported yet.");
+    }
+
+    @Override
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#execute is not supported yet.");
+    }
+
+    @Override
+    public int getResultSetHoldability() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#getResultSetHoldability is not supported yet.");
+    }
+
+    @Override
+    public void setPoolable(boolean poolable) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#setPoolable is not supported yet.");
+    }
+
+    @Override
+    public boolean isPoolable() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#isPoolable is not supported yet.");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#unwrap is not supported yet.");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#isWrapperFor is not supported yet.");
+    }
+
+    @Override
+    public int getUpdateCount() throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkStatement#getUpdateCount is not supported");
+    }
+
+    @Override
+    public void closeOnCompletion() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#closeOnCompletion is not supported");
+    }
+
+    @Override
+    public boolean isCloseOnCompletion() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkStatement#isCloseOnCompletion is not supported");
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
@@ -56,7 +56,7 @@ public class FlinkConnection extends BaseConnection {
 
     @Override
     public Statement createStatement() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return new FlinkStatement(this);
     }
 
     @VisibleForTesting

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.jdbc;
 
-import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.gateway.StatementResult;
 import org.apache.flink.table.data.RowData;
@@ -52,7 +51,6 @@ public class FlinkResultSet extends BaseResultSet {
     private final Statement statement;
     private final StatementResult result;
     private final DataConverter dataConverter;
-    private final boolean query;
     private final FlinkResultSetMetaData resultSetMetaData;
     private RowData currentRow;
     private boolean wasNull;
@@ -63,8 +61,6 @@ public class FlinkResultSet extends BaseResultSet {
             Statement statement, StatementResult result, DataConverter dataConverter) {
         this.statement = checkNotNull(statement, "Statement cannot be null");
         this.result = checkNotNull(result, "Statement result cannot be null");
-        this.query =
-                result.isQueryResult() || result.getResultKind() == ResultKind.SUCCESS_WITH_CONTENT;
         this.dataConverter = checkNotNull(dataConverter, "Data converter cannot be null");
         this.currentRow = null;
         this.wasNull = false;
@@ -449,9 +445,5 @@ public class FlinkResultSet extends BaseResultSet {
     @Override
     public boolean isClosed() throws SQLException {
         return this.closed;
-    }
-
-    boolean isQuery() {
-        return query;
     }
 }

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSetMetaData.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.jdbc;
 
-import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
 
 import java.math.BigDecimal;
 import java.sql.Array;
@@ -31,22 +31,21 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /** Implementation of {@link ResultSetMetaData} for flink jdbc driver. */
 public class FlinkResultSetMetaData implements ResultSetMetaData {
     private final List<ColumnInfo> columnList;
 
-    public FlinkResultSetMetaData(ResolvedSchema schema) {
-        this.columnList =
-                schema.getColumns().stream()
-                        .map(
-                                c ->
-                                        ColumnInfo.fromLogicalType(
-                                                c.getName(), c.getDataType().getLogicalType()))
-                        .collect(Collectors.toList());
+    public FlinkResultSetMetaData(List<String> columnNameList, List<DataType> columnTypeList) {
+        this.columnList = new ArrayList<>(columnNameList.size());
+        for (int i = 0; i < columnNameList.size(); i++) {
+            this.columnList.add(
+                    ColumnInfo.fromLogicalType(
+                            columnNameList.get(i), columnTypeList.get(i).getLogicalType()));
+        }
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.StatementResult;
+import org.apache.flink.table.jdbc.utils.StringDataConverter;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/* Statement in flink jdbc driver. */
+public class FlinkStatement extends BaseStatement {
+    private final Connection connection;
+    private final Executor executor;
+    private final AtomicReference<FlinkResultSet> currentResults;
+    private volatile boolean closed;
+
+    public FlinkStatement(FlinkConnection connection) {
+        this.connection = connection;
+        this.executor = connection.getExecutor();
+        this.currentResults = new AtomicReference<>();
+    }
+
+    @Override
+    public ResultSet executeQuery(String sql) throws SQLException {
+        if (!execute(sql)) {
+            throw new SQLException(String.format("Statement[%s] is not a query.", sql));
+        }
+
+        return currentResults.get();
+    }
+
+    private void clearCurrentResults() throws SQLException {
+        FlinkResultSet resultSet = currentResults.get();
+        if (resultSet == null) {
+            return;
+        }
+        resultSet.close();
+        currentResults.set(null);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        if (closed) {
+            return;
+        }
+
+        cancel();
+        closed = true;
+    }
+
+    @Override
+    public void cancel() throws SQLException {
+        checkClosed();
+        clearCurrentResults();
+    }
+
+    private void checkClosed() throws SQLException {
+        if (closed) {
+            throw new SQLException("This result set is already closed");
+        }
+    }
+
+    @Override
+    public boolean execute(String sql) throws SQLException {
+        checkClosed();
+        clearCurrentResults();
+
+        StatementResult result = executor.executeStatement(sql);
+        FlinkResultSet resultSet = new FlinkResultSet(this, result, StringDataConverter.CONVERTER);
+        currentResults.set(resultSet);
+
+        return resultSet.isQuery() || result.getResultKind() == ResultKind.SUCCESS_WITH_CONTENT;
+    }
+
+    @Override
+    public ResultSet getResultSet() throws SQLException {
+        checkClosed();
+
+        FlinkResultSet resultSet = currentResults.get();
+        if (resultSet == null) {
+            throw new SQLException("No result set in the current statement.");
+        }
+        if (!resultSet.isQuery()) {
+            throw new SQLException("Result set is not query");
+        }
+        if (resultSet.isClosed()) {
+            throw new SQLException("Result set has been closed");
+        }
+
+        return resultSet;
+    }
+
+    @Override
+    public boolean getMoreResults() throws SQLException {
+        checkClosed();
+
+        FlinkResultSet resultSet = currentResults.get();
+        if (resultSet != null) {
+            cancel();
+            return false;
+        }
+
+        throw new SQLFeatureNotSupportedException("Multiple open results not supported");
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return connection;
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return closed;
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
@@ -29,7 +29,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.atomic.AtomicReference;
 
-/* Statement in flink jdbc driver. */
+/** Statement for flink jdbc driver. */
 public class FlinkStatement extends BaseStatement {
     private final Connection connection;
     private final Executor executor;

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
@@ -64,11 +64,10 @@ public class FlinkStatement extends BaseStatement {
     }
 
     private void clearCurrentResults() throws SQLException {
-        FlinkResultSet resultSet = currentResults;
-        if (resultSet == null) {
+        if (currentResults == null) {
             return;
         }
-        resultSet.close();
+        currentResults.close();
         currentResults = null;
     }
 

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkJdbcDriverTestBase.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkJdbcDriverTestBase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.jdbc;
 
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -11,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Properties;
 
+/** Base test for flink jdbc driver which will launch flink cluster and sql gatewa. */
 public class FlinkJdbcDriverTestBase {
     @RegisterExtension
     @Order(1)

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkJdbcDriverTestBase.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkJdbcDriverTestBase.java
@@ -1,0 +1,47 @@
+package org.apache.flink.table.jdbc;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.client.gateway.SingleSessionManager;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointExtension;
+import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Properties;
+
+public class FlinkJdbcDriverTestBase {
+    @RegisterExtension
+    @Order(1)
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .setNumberSlotsPerTaskManager(4)
+                            .build());
+
+    @RegisterExtension
+    @Order(2)
+    private static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension(
+                    MINI_CLUSTER_RESOURCE::getClientConfiguration, SingleSessionManager::new);
+
+    @RegisterExtension
+    @Order(3)
+    private static final SqlGatewayRestEndpointExtension SQL_GATEWAY_REST_ENDPOINT_EXTENSION =
+            new SqlGatewayRestEndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
+
+    protected DriverUri getDriverUri() throws Exception {
+        return getDriverUri("jdbc:flink://%s:%s", new Properties());
+    }
+
+    protected DriverUri getDriverUri(String url, Properties properties) throws Exception {
+        return DriverUri.create(
+                String.format(
+                        url,
+                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort()),
+                properties);
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetMetaDataTest.java
@@ -64,7 +64,8 @@ public class FlinkResultSetMetaDataTest {
                         Column.physical("c17", DataTypes.ROW()),
                         Column.physical(
                                 "c18", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())));
-        FlinkResultSetMetaData metaData = new FlinkResultSetMetaData(schema);
+        FlinkResultSetMetaData metaData =
+                new FlinkResultSetMetaData(schema.getColumnNames(), schema.getColumnDataTypes());
 
         assertEquals(18, metaData.getColumnCount());
         for (int i = 1; i <= 18; i++) {
@@ -118,7 +119,9 @@ public class FlinkResultSetMetaDataTest {
                 ResolvedSchema.of(Column.physical("c1", DataTypes.MULTISET(DataTypes.STRING())));
         assertThrowsExactly(
                 RuntimeException.class,
-                () -> new FlinkResultSetMetaData(schema),
+                () ->
+                        new FlinkResultSetMetaData(
+                                schema.getColumnNames(), schema.getColumnDataTypes()),
                 "Not supported type[MULTISET<STRING>]");
     }
 }

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -1,0 +1,103 @@
+package org.apache.flink.table.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for flink statement. */
+public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
+    @TempDir private Path tempDir;
+
+    @Test
+    @Timeout(value = 60)
+    public void testExecuteQuery() throws Exception {
+        try (FlinkConnection connection = new FlinkConnection(getDriverUri())) {
+            try (Statement statement = connection.createStatement()) {
+                // CREATE TABLE is not a query and has no results
+                assertFalse(
+                        statement.execute(
+                                String.format(
+                                        "CREATE TABLE test_table(id bigint, val int, str string) "
+                                                + "with ("
+                                                + "'connector'='filesystem',\n"
+                                                + "'format'='csv',\n"
+                                                + "'path'='%s')",
+                                        tempDir)));
+
+                // INSERT TABLE returns job id
+                assertTrue(
+                        statement.execute(
+                                "INSERT INTO test_table VALUES "
+                                        + "(1, 11, '111'), "
+                                        + "(3, 33, '333'), "
+                                        + "(2, 22, '222'), "
+                                        + "(4, 44, '444')"));
+                String jobId;
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    assertTrue(resultSet.next());
+                    assertEquals(1, resultSet.getMetaData().getColumnCount());
+                    jobId = resultSet.getString("job id");
+                    assertEquals(jobId, resultSet.getString(1));
+                    assertFalse(resultSet.next());
+                }
+                assertNotNull(jobId);
+                // Wait job finished
+                boolean jobFinished = false;
+                while (!jobFinished) {
+                    try (ResultSet resultSet = statement.executeQuery("SHOW JOBS")) {
+                        while (resultSet.next()) {
+                            if (resultSet.getString(1).equals(jobId)) {
+                                if (resultSet.getString(3).equals("FINISHED")) {
+                                    jobFinished = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // SELECT all data from test_table
+                try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test_table")) {
+                    assertEquals(3, resultSet.getMetaData().getColumnCount());
+                    List<String> resultList = new ArrayList<>();
+                    while (resultSet.next()) {
+                        assertEquals(resultSet.getLong("id"), resultSet.getLong(1));
+                        assertEquals(resultSet.getInt("val"), resultSet.getInt(2));
+                        assertEquals(resultSet.getString("str"), resultSet.getString(3));
+                        resultList.add(
+                                String.format(
+                                        "%s,%s,%s",
+                                        resultSet.getLong("id"),
+                                        resultSet.getInt("val"),
+                                        resultSet.getString("str")));
+                    }
+                    assertThat(resultList)
+                            .containsExactlyInAnyOrder(
+                                    "1,11,111", "2,22,222", "3,33,333", "4,44,444");
+                }
+
+                try (ResultSet resultSet = statement.executeQuery("SHOW JOBS")) {
+                    // Check there are two finished jobs.
+                    int count = 0;
+                    while (resultSet.next()) {
+                        assertEquals("FINISHED", resultSet.getString(3));
+                        count++;
+                    }
+                    assertEquals(2, count);
+                }
+            }
+        }
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -74,7 +74,8 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
                 // Wait job finished
                 boolean jobFinished = false;
                 while (!jobFinished) {
-                    try (ResultSet resultSet = statement.executeQuery("SHOW JOBS")) {
+                    assertTrue(statement.execute("SHOW JOBS"));
+                    try (ResultSet resultSet = statement.getResultSet()) {
                         while (resultSet.next()) {
                             if (resultSet.getString(1).equals(jobId)) {
                                 if (resultSet.getString(3).equals("FINISHED")) {
@@ -106,7 +107,8 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
                                     "1,11,111", "2,22,222", "3,33,333", "4,44,444");
                 }
 
-                try (ResultSet resultSet = statement.executeQuery("SHOW JOBS")) {
+                assertTrue(statement.execute("SHOW JOBS"));
+                try (ResultSet resultSet = statement.getResultSet()) {
                     // Check there are two finished jobs.
                     int count = 0;
                     while (resultSet.next()) {

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.jdbc;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to introduce statement for flink jdbc driver.

## Brief change log

  - Add FlinkStatement for flink jdbc driver
  - Create flink result set in flink result set
  - Create flink statement in flink connection


## Verifying this change

This change added tests and can be verified as follows:

  - Added FlinkStatementTest to execute ddl/insert/sql queries

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
