### PR TITLE
[FLINK-31841][flink-streaming-java] remove the redundant variables in AllWindowedStream#reduce

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -201,10 +201,6 @@ public class AllWindowedStream<T, W extends Window> {
 
         // clean the closure
         function = input.getExecutionEnvironment().clean(function);
-
-        String callLocation = Utils.getCallLocationName();
-        String udfName = "AllWindowedStream." + callLocation;
-
         return reduce(function, new PassThroughAllWindowFunction<W, T>());
     }
 


### PR DESCRIPTION
## Brief change log

  - *Remove the redundant variables in AllWindowedStream#reduce.*
