### PR TITLE
[FLINK-31839][filesystems] Fix flink-s3-fs-hadoop and flink-s3-fs-presto plugin collision

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
-import org.apache.flink.fs.s3.common.token.S3DelegationTokenReceiver;
+import org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenReceiver;
 import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 import org.apache.flink.runtime.util.HadoopConfigLoader;
 import org.apache.flink.util.Preconditions;
@@ -124,7 +124,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
             // create the Hadoop FileSystem
             org.apache.hadoop.conf.Configuration hadoopConfig =
                     hadoopConfigLoader.getOrLoadHadoopConfig();
-            S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfig);
+            AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfig);
             org.apache.hadoop.fs.FileSystem fs = createHadoopFileSystem();
             fs.initialize(getInitURI(fsUri, hadoopConfig), hadoopConfig);
 

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProvider.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProvider.java
@@ -38,18 +38,14 @@ import java.util.Optional;
 
 /** Delegation token provider for S3 filesystems. */
 @Internal
-public class S3DelegationTokenProvider implements DelegationTokenProvider {
+public abstract class AbstractS3DelegationTokenProvider implements DelegationTokenProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(S3DelegationTokenProvider.class);
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AbstractS3DelegationTokenProvider.class);
 
     private String region;
     private String accessKey;
     private String secretKey;
-
-    @Override
-    public String serviceName() {
-        return "s3";
-    }
 
     @Override
     public void init(Configuration configuration) {

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiver.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiver.java
@@ -34,11 +34,12 @@ import javax.annotation.Nullable;
 
 /** Delegation token receiver for S3 filesystems. */
 @Internal
-public class S3DelegationTokenReceiver implements DelegationTokenReceiver {
+public abstract class AbstractS3DelegationTokenReceiver implements DelegationTokenReceiver {
 
     public static final String PROVIDER_CONFIG_NAME = "fs.s3a.aws.credentials.provider";
 
-    private static final Logger LOG = LoggerFactory.getLogger(S3DelegationTokenReceiver.class);
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AbstractS3DelegationTokenReceiver.class);
 
     @VisibleForTesting @Nullable static volatile Credentials credentials;
 
@@ -70,11 +71,6 @@ public class S3DelegationTokenReceiver implements DelegationTokenReceiver {
     }
 
     @Override
-    public String serviceName() {
-        return "s3";
-    }
-
-    @Override
     public void init(Configuration configuration) {
         region =
                 configuration.getString(
@@ -92,7 +88,7 @@ public class S3DelegationTokenReceiver implements DelegationTokenReceiver {
         LOG.info("Updating session credentials");
         credentials =
                 InstantiationUtil.deserializeObject(
-                        tokens, S3DelegationTokenReceiver.class.getClassLoader());
+                        tokens, AbstractS3DelegationTokenReceiver.class.getClassLoader());
         LOG.info(
                 "Session credentials updated successfully with access key: {} expiration: {}",
                 credentials.getAccessKeyId(),

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProvider.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProvider.java
@@ -47,7 +47,7 @@ public class DynamicTemporaryAWSCredentialsProvider implements AWSCredentialsPro
 
     @Override
     public AWSCredentials getCredentials() throws SdkBaseException {
-        Credentials credentials = S3DelegationTokenReceiver.getCredentials();
+        Credentials credentials = AbstractS3DelegationTokenReceiver.getCredentials();
         if (credentials == null) {
             throw new NoAwsCredentialsException(COMPONENT);
         }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
@@ -20,30 +20,41 @@ package org.apache.flink.fs.s3.common.token;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFIG_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Tests for {@link S3DelegationTokenProvider}. */
-public class S3DelegationTokenProviderTest {
+/** Tests for {@link AbstractS3DelegationTokenProvider}. */
+public class AbstractS3DelegationTokenProviderTest {
 
     private static final String REGION = "testRegion";
     private static final String ACCESS_KEY_ID = "testAccessKeyId";
     private static final String SECRET_ACCESS_KEY = "testSecretAccessKey";
 
+    private AbstractS3DelegationTokenProvider provider;
+
+    @BeforeEach
+    public void beforeEach() {
+        provider =
+                new AbstractS3DelegationTokenProvider() {
+                    @Override
+                    public String serviceName() {
+                        return "s3";
+                    }
+                };
+    }
+
     @Test
     public void delegationTokensRequiredShouldReturnFalseWithoutCredentials() {
-        S3DelegationTokenProvider provider = new S3DelegationTokenProvider();
         provider.init(new Configuration());
-
         assertFalse(provider.delegationTokensRequired());
     }
 
     @Test
     public void delegationTokensRequiredShouldReturnTrueWithCredentials() {
-        S3DelegationTokenProvider provider = new S3DelegationTokenProvider();
         Configuration configuration = new Configuration();
         configuration.setString(CONFIG_PREFIX + ".s3.region", REGION);
         configuration.setString(CONFIG_PREFIX + ".s3.access-key", ACCESS_KEY_ID);

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
@@ -20,29 +20,29 @@ package org.apache.flink.fs.s3.common.token;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFIG_PREFIX;
-import static org.apache.flink.fs.s3.common.token.S3DelegationTokenReceiver.PROVIDER_CONFIG_NAME;
+import static org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenReceiver.PROVIDER_CONFIG_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-/** Tests for {@link S3DelegationTokenReceiver}. */
-public class S3DelegationTokenReceiverTest {
+/** Tests for {@link AbstractS3DelegationTokenReceiver}. */
+public class AbstractS3DelegationTokenReceiverTest {
 
     private static final String PROVIDER_CLASS_NAME = "TestProvider";
     private static final String REGION = "testRegion";
 
     @BeforeEach
     void beforeEach() {
-        S3DelegationTokenReceiver.region = null;
+        AbstractS3DelegationTokenReceiver.region = null;
     }
 
     @AfterEach
     void afterEach() {
-        S3DelegationTokenReceiver.region = null;
+        AbstractS3DelegationTokenReceiver.region = null;
     }
 
     @Test
@@ -50,7 +50,7 @@ public class S3DelegationTokenReceiverTest {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, "");
-        S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
+        AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         assertEquals(
                 DynamicTemporaryAWSCredentialsProvider.NAME,
                 hadoopConfiguration.get(PROVIDER_CONFIG_NAME));
@@ -61,7 +61,7 @@ public class S3DelegationTokenReceiverTest {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, PROVIDER_CLASS_NAME);
-        S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
+        AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         String[] providers = hadoopConfiguration.get(PROVIDER_CONFIG_NAME).split(",");
         assertEquals(2, providers.length);
         assertEquals(DynamicTemporaryAWSCredentialsProvider.NAME, providers[0]);
@@ -73,7 +73,7 @@ public class S3DelegationTokenReceiverTest {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, DynamicTemporaryAWSCredentialsProvider.NAME);
-        S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
+        AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         assertEquals(
                 DynamicTemporaryAWSCredentialsProvider.NAME,
                 hadoopConfiguration.get(PROVIDER_CONFIG_NAME));
@@ -81,25 +81,34 @@ public class S3DelegationTokenReceiverTest {
 
     @Test
     public void updateHadoopConfigShouldNotUpdateRegionWhenNotConfigured() {
-        S3DelegationTokenReceiver receiver = new S3DelegationTokenReceiver();
+        AbstractS3DelegationTokenReceiver receiver = createReceiver();
         receiver.init(new Configuration());
 
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
-        S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
+        AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         assertNull(hadoopConfiguration.get("fs.s3a.endpoint.region"));
     }
 
     @Test
     public void updateHadoopConfigShouldUpdateRegionWhenConfigured() {
-        S3DelegationTokenReceiver receiver = new S3DelegationTokenReceiver();
+        AbstractS3DelegationTokenReceiver receiver = createReceiver();
         Configuration configuration = new Configuration();
         configuration.setString(CONFIG_PREFIX + ".s3.region", REGION);
         receiver.init(configuration);
 
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
-        S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
+        AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         assertEquals(REGION, hadoopConfiguration.get("fs.s3a.endpoint.region"));
+    }
+
+    private AbstractS3DelegationTokenReceiver createReceiver() {
+        return new AbstractS3DelegationTokenReceiver() {
+            @Override
+            public String serviceName() {
+                return "s3";
+            }
+        };
     }
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
@@ -39,12 +39,12 @@ public class DynamicTemporaryAWSCredentialsProviderTest {
 
     @BeforeEach
     void beforeEach() {
-        S3DelegationTokenReceiver.credentials = null;
+        AbstractS3DelegationTokenReceiver.credentials = null;
     }
 
     @AfterEach
     void afterEach() {
-        S3DelegationTokenReceiver.credentials = null;
+        AbstractS3DelegationTokenReceiver.credentials = null;
     }
 
     @Test
@@ -61,7 +61,13 @@ public class DynamicTemporaryAWSCredentialsProviderTest {
                 new DynamicTemporaryAWSCredentialsProvider();
         Credentials credentials =
                 new Credentials(ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN, null);
-        S3DelegationTokenReceiver receiver = new S3DelegationTokenReceiver();
+        AbstractS3DelegationTokenReceiver receiver =
+                new AbstractS3DelegationTokenReceiver() {
+                    @Override
+                    public String serviceName() {
+                        return "s3";
+                    }
+                };
 
         receiver.onNewTokensObtained(InstantiationUtil.serializeObject(credentials));
         BasicSessionCredentials returnedCredentials =

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/token/S3HadoopDelegationTokenProvider.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/token/S3HadoopDelegationTokenProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenProvider;
+
+/** Delegation token provider for S3 Hadoop filesystems. */
+@Internal
+public class S3HadoopDelegationTokenProvider extends AbstractS3DelegationTokenProvider {
+    @Override
+    public String serviceName() {
+        return "s3-hadoop";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/token/S3HadoopDelegationTokenReceiver.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/token/S3HadoopDelegationTokenReceiver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenReceiver;
+
+/** Delegation token receiver for S3 Hadoop filesystems. */
+@Internal
+public class S3HadoopDelegationTokenReceiver extends AbstractS3DelegationTokenReceiver {
+    @Override
+    public String serviceName() {
+        return "s3-hadoop";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3hadoop.token.S3HadoopDelegationTokenProvider

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.fs.s3.common.token.S3DelegationTokenReceiver
+org.apache.flink.fs.s3hadoop.token.S3HadoopDelegationTokenReceiver

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/token/S3PrestoDelegationTokenProvider.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/token/S3PrestoDelegationTokenProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenProvider;
+
+/** Delegation token provider for S3 Presto filesystems. */
+@Internal
+public class S3PrestoDelegationTokenProvider extends AbstractS3DelegationTokenProvider {
+    @Override
+    public String serviceName() {
+        return "s3-presto";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/token/S3PrestoDelegationTokenReceiver.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/token/S3PrestoDelegationTokenReceiver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenReceiver;
+
+/** Delegation token receiver for S3 Presto filesystems. */
+@Internal
+public class S3PrestoDelegationTokenReceiver extends AbstractS3DelegationTokenReceiver {
+    @Override
+    public String serviceName() {
+        return "s3-presto";
+    }
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3presto.token.S3PrestoDelegationTokenProvider

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.security.token.DelegationTokenReceiver
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.fs.s3.common.token.S3DelegationTokenProvider
+org.apache.flink.fs.s3presto.token.S3PrestoDelegationTokenReceiver


### PR DESCRIPTION
## What is the purpose of the change

At the moment it's not possible to add `flink-s3-fs-hadoop` and `flink-s3-fs-presto` plugins at the same time.

## Brief change log

* Now both the plugins are having a provider with a different name
* Fixed bad error message in the `DefaultDelegationTokenManager`
* Added a warning message when multiple providers are loaded with the same prefix.

## Verifying this change

Existing + additional unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
