### PR TITLE
[FLINK-31838][runtime] Moves thread handling for leader event listener calls from DefaultMultipleComponentLeaderElectionService into DefaultLeaderElectionService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import java.util.UUID;
 
 /**
@@ -29,7 +31,11 @@ import java.util.UUID;
  * LeaderElectionDriver#close()}. This means that the implementor of {@link
  * LeaderElectionEventHandler} is responsible for filtering out spurious callbacks(e.g. after close
  * has been called on {@link LeaderElectionDriver}).
+ *
+ * <p>The order of events matters. Therefore, calling event processing functions of this interface
+ * should happen in a single-thread environment.
  */
+@NotThreadSafe
 public interface LeaderElectionEventHandler {
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * {@code TestingGenericLeaderContender} is a more generic testing implementation of the {@link
+ * LeaderContender} interface.
+ */
+public class TestingGenericLeaderContender implements LeaderContender {
+
+    private final Object lock = new Object();
+
+    private final Consumer<UUID> grantLeadershipConsumer;
+    private final Runnable revokeLeadershipRunnable;
+    private final Consumer<Exception> handleErrorConsumer;
+    private final Supplier<String> getDescriptionSupplier;
+
+    private TestingGenericLeaderContender(
+            Consumer<UUID> grantLeadershipConsumer,
+            Runnable revokeLeadershipRunnable,
+            Consumer<Exception> handleErrorConsumer,
+            Supplier<String> getDescriptionSupplier) {
+        this.grantLeadershipConsumer = grantLeadershipConsumer;
+        this.revokeLeadershipRunnable = revokeLeadershipRunnable;
+        this.handleErrorConsumer = handleErrorConsumer;
+        this.getDescriptionSupplier = getDescriptionSupplier;
+    }
+
+    @Override
+    public void grantLeadership(UUID leaderSessionID) {
+        synchronized (lock) {
+            grantLeadershipConsumer.accept(leaderSessionID);
+        }
+    }
+
+    @Override
+    public void revokeLeadership() {
+        synchronized (lock) {
+            revokeLeadershipRunnable.run();
+        }
+    }
+
+    @Override
+    public void handleError(Exception exception) {
+        synchronized (lock) {
+            handleErrorConsumer.accept(exception);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return getDescriptionSupplier.get();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingGenericLeaderContender} instances. */
+    public static class Builder {
+        private Consumer<UUID> grantLeadershipConsumer = ignoredSessionID -> {};
+        private Runnable revokeLeadershipRunnable = () -> {};
+        private Consumer<Exception> handleErrorConsumer = ignoredError -> {};
+        private Supplier<String> getDescriptionSupplier = () -> "testing contender";
+
+        private Builder() {}
+
+        public Builder setGrantLeadershipConsumer(Consumer<UUID> grantLeadershipConsumer) {
+            this.grantLeadershipConsumer = grantLeadershipConsumer;
+            return this;
+        }
+
+        public Builder setRevokeLeadershipRunnable(Runnable revokeLeadershipRunnable) {
+            this.revokeLeadershipRunnable = revokeLeadershipRunnable;
+            return this;
+        }
+
+        public Builder setHandleErrorConsumer(Consumer<Exception> handleErrorConsumer) {
+            this.handleErrorConsumer = handleErrorConsumer;
+            return this;
+        }
+
+        public Builder setGetDescriptionSupplier(Supplier<String> getDescriptionSupplier) {
+            this.getDescriptionSupplier = getDescriptionSupplier;
+            return this;
+        }
+
+        public TestingGenericLeaderContender build() {
+            return new TestingGenericLeaderContender(
+                    grantLeadershipConsumer,
+                    revokeLeadershipRunnable,
+                    handleErrorConsumer,
+                    getDescriptionSupplier);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderElectionDriver.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * {@code TestingGenericLeaderElectionDriver} is test implementation of {@link LeaderElectionDriver}
+ * to support test cases in the most generic way.
+ */
+public class TestingGenericLeaderElectionDriver implements LeaderElectionDriver {
+
+    private final Consumer<LeaderInformation> writeLeaderInformationConsumer;
+    private final Supplier<Boolean> hasLeadershipSupplier;
+    private final ThrowingRunnable<Exception> closeRunnable;
+
+    private TestingGenericLeaderElectionDriver(
+            Consumer<LeaderInformation> writeLeaderInformationConsumer,
+            Supplier<Boolean> hasLeadershipSupplier,
+            ThrowingRunnable<Exception> closeRunnable) {
+        this.writeLeaderInformationConsumer = writeLeaderInformationConsumer;
+        this.hasLeadershipSupplier = hasLeadershipSupplier;
+        this.closeRunnable = closeRunnable;
+    }
+
+    @Override
+    public void writeLeaderInformation(LeaderInformation leaderInformation) {
+        writeLeaderInformationConsumer.accept(leaderInformation);
+    }
+
+    @Override
+    public boolean hasLeadership() {
+        return hasLeadershipSupplier.get();
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeRunnable.run();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** {@code Builder} for creating {@code TestingGenericLeaderContender} instances. */
+    public static class Builder {
+        private Consumer<LeaderInformation> writeLeaderInformationConsumer =
+                ignoredLeaderInformation -> {};
+        private Supplier<Boolean> hasLeadershipSupplier = () -> false;
+        private ThrowingRunnable<Exception> closeRunnable = () -> {};
+
+        private Builder() {}
+
+        public Builder setWriteLeaderInformationConsumer(
+                Consumer<LeaderInformation> writeLeaderInformationConsumer) {
+            this.writeLeaderInformationConsumer = writeLeaderInformationConsumer;
+            return this;
+        }
+
+        public Builder setHasLeadershipSupplier(Supplier<Boolean> hasLeadershipSupplier) {
+            this.hasLeadershipSupplier = hasLeadershipSupplier;
+            return this;
+        }
+
+        public Builder setCloseRunnable(ThrowingRunnable<Exception> closeRunnable) {
+            this.closeRunnable = closeRunnable;
+            return this;
+        }
+
+        public TestingGenericLeaderElectionDriver build() {
+            return new TestingGenericLeaderElectionDriver(
+                    writeLeaderInformationConsumer, hasLeadershipSupplier, closeRunnable);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -69,11 +69,15 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
         return leaderInformation;
     }
 
-    public void isLeader() {
+    public void isLeader(UUID newSessionID) {
         synchronized (lock) {
             isLeader.set(true);
-            leaderElectionEventHandler.onGrantLeadership(UUID.randomUUID());
+            leaderElectionEventHandler.onGrantLeadership(newSessionID);
         }
+    }
+
+    public void isLeader() {
+        isLeader(UUID.randomUUID());
     }
 
     public void notLeader() {

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/OneShotLatch.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/OneShotLatch.java
@@ -67,6 +67,18 @@ public final class OneShotLatch {
     }
 
     /**
+     * Calls {@link #await()} and transforms any {@link InterruptedException} into a {@link
+     * RuntimeException}.
+     */
+    public void awaitQuietly() {
+        try {
+            await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Waits until {@link OneShotLatch#trigger()} is called. Once {@code #trigger()} has been called
      * this call will always return immediately.
      *
@@ -106,6 +118,18 @@ public final class OneShotLatch {
                     throw new TimeoutException();
                 }
             }
+        }
+    }
+
+    /**
+     * Calls {@link #await(long, TimeUnit)} and transforms any {@link InterruptedException} or
+     * {@link TimeoutException} into a {@link RuntimeException}.
+     */
+    public void awaitQuietly(long timeout, TimeUnit timeUnit) {
+        try {
+            await(timeout, timeUnit);
+        } catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
PR order:
- https://github.com/apache/flink/pull/21742
- https://github.com/apache/flink/pull/22379
- === this PR === FLINK-31838
- https://github.com/apache/flink/pull/22380
- https://github.com/apache/flink/pull/22384
- https://github.com/apache/flink/pull/22390 (FLINK-31785/FLINK-31786)
- https://github.com/apache/flink/pull/22404

## What is the purpose of the change

We need to handle the leader event calls in a separate thread in `DefaultLeaderElectionService` to ensure that they are not called in the main thread when registering the `LeaderContender` in the `LeaderElectionService`. The legacy implementations of `LeaderElectionDriver` already do this implicitly because their leader election implementations run in a dedicated thread.

The MultipleComponentLeaderElection framework had to deal with this already. I was implemented in `DefaultMultipleComponentLeaderElectionService` where a singleThread executor service was utilized to ensure the order of grant and revoke calls.

## Brief change log

* Renames `LeaderElectionEventHandler` methods to reflect the async nature
* Introduced additional asynchronous methods in `LeaderElectionEventHandler` that enable the legacy `LeaderElectionDriver` implementations to not run asynchronously. As mentioned before: These implementations have their event calls already being executed in the implementations' dedicated event threads.
* Moved `leadershipOperationExecutor` from `DefaultMultipleComponentLeaderElectionService` into `DefaultLeaderElectionService`

## Verifying this change

* Added tests for non-blocking operations to `DefaultLeaderElectionTest`
* Existing tests were refactored and should still pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable