### PR TITLE
[hotfix][docs] Fix some broken links in docs

### DIFF
--- a/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
@@ -43,7 +43,7 @@ Kubernetes 高可用服务只能在部署到 Kubernetes 时使用。因此，当
 为了启用高可用集群（HA-cluster），你必须设置以下配置项:
 
 - [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (必要的):
-`high-availability.type` 选项必须设置为 `KubernetesHaServicesFactory`.
+`high-availability.type` 选项必须设置为 `kubernetes`.
 
 ```yaml
 high-availability.type: kubernetes

--- a/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content.zh/docs/deployment/ha/kubernetes_ha.md
@@ -42,7 +42,7 @@ Kubernetes 高可用服务只能在部署到 Kubernetes 时使用。因此，当
 
 为了启用高可用集群（HA-cluster），你必须设置以下配置项:
 
-- [high-availability]({{< ref "docs/deployment/config" >}}#high-availability-1) (必要的):
+- [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (必要的):
 `high-availability.type` 选项必须设置为 `KubernetesHaServicesFactory`.
 
 ```yaml

--- a/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content.zh/docs/deployment/ha/zookeeper_ha.md
@@ -34,7 +34,7 @@ Flink 利用 **[ZooKeeper](http://zookeeper.apache.org)** 在所有运行的 Job
 
 为了启用高可用集群（HA-cluster），你必须设置以下配置项:
 
-- [high-availability]({{< ref "docs/deployment/config" >}}#high-availability-1) (必要的):
+- [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (必要的):
   `high-availability.type` 配置项必须设置为 `zookeeper`。
 
   <pre>high-availability.type: zookeeper</pre>

--- a/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
@@ -340,7 +340,7 @@ Please refer to the official Kubernetes documentation on [RBAC Authorization](ht
 
 Flink allows users to define the JobManager and TaskManager pods via template files. This allows to support advanced features
 that are not supported by Flink [Kubernetes config options]({{< ref "docs/deployment/config" >}}#kubernetes) directly.
-Use [`kubernetes.pod-template-file.default`]({{< ref "docs/deployment/config" >}}#kubernetes-pod-template-file)
+Use [`kubernetes.pod-template-file.default`]({{< ref "docs/deployment/config" >}}#kubernetes-pod-template-file-default)
 to specify a local file that contains the pod definition. It will be used to initialize the JobManager and TaskManager.
 The main container should be defined with name `flink-main-container`.
 Please refer to the [pod template example](#example-of-pod-template) for more information.
@@ -481,7 +481,7 @@ All the fields defined in the pod template that are not listed in the tables wil
         <tr>
             <td>image</td>
             <td>Defined by the user</td>
-            <td><a href="{{< ref "docs/deployment/config" >}}#kubernetes-container-image">kubernetes.container.image.ref</a></td>
+            <td><a href="{{< ref "docs/deployment/config" >}}#kubernetes-container-image-ref">kubernetes.container.image.ref</a></td>
             <td>The container image will be resolved with respect to the defined precedence order for user defined values.</td>
         </tr>
         <tr>

--- a/docs/content/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content/docs/deployment/ha/kubernetes_ha.md
@@ -44,7 +44,7 @@ In order to use Flink's Kubernetes HA services you must fulfill the following pr
 
 In order to start an HA-cluster you have to configure the following configuration keys:
 
-- [high-availability]({{< ref "docs/deployment/config" >}}#high-availability-1) (required): 
+- [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (required): 
 The `high-availability.type` option has to be set to `KubernetesHaServicesFactory`.
 
 ```yaml

--- a/docs/content/docs/deployment/ha/kubernetes_ha.md
+++ b/docs/content/docs/deployment/ha/kubernetes_ha.md
@@ -45,7 +45,7 @@ In order to use Flink's Kubernetes HA services you must fulfill the following pr
 In order to start an HA-cluster you have to configure the following configuration keys:
 
 - [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (required): 
-The `high-availability.type` option has to be set to `KubernetesHaServicesFactory`.
+The `high-availability.type` option has to be set to `kubernetes`.
 
 ```yaml
 high-availability.type: kubernetes

--- a/docs/content/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content/docs/deployment/ha/zookeeper_ha.md
@@ -37,7 +37,7 @@ Flink includes scripts to [bootstrap a simple ZooKeeper](#bootstrap-zookeeper) i
 
 In order to start an HA-cluster you have to configure the following configuration keys:
 
-- [high-availability]({{< ref "docs/deployment/config" >}}#high-availability-1) (required): 
+- [high-availability.type]({{< ref "docs/deployment/config" >}}#high-availability-type) (required): 
 The `high-availability.type` option has to be set to `zookeeper`.
 
   <pre>high-availability.type: zookeeper</pre>

--- a/docs/content/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/native_kubernetes.md
@@ -348,7 +348,7 @@ Please refer to the official Kubernetes documentation on [RBAC Authorization](ht
 
 Flink allows users to define the JobManager and TaskManager pods via template files. This allows to support advanced features
 that are not supported by Flink [Kubernetes config options]({{< ref "docs/deployment/config" >}}#kubernetes) directly.
-Use [`kubernetes.pod-template-file.default`]({{< ref "docs/deployment/config" >}}#kubernetes-pod-template-file)
+Use [`kubernetes.pod-template-file.default`]({{< ref "docs/deployment/config" >}}#kubernetes-pod-template-file-default)
 to specify a local file that contains the pod definition. It will be used to initialize the JobManager and TaskManager.
 The main container should be defined with name `flink-main-container`.
 Please refer to the [pod template example](#example-of-pod-template) for more information.
@@ -489,7 +489,7 @@ All the fields defined in the pod template that are not listed in the tables wil
         <tr>
             <td>image</td>
             <td>Defined by the user</td>
-            <td><a href="{{< ref "docs/deployment/config" >}}#kubernetes-container-image">kubernetes.container.image.ref</a></td>
+            <td><a href="{{< ref "docs/deployment/config" >}}#kubernetes-container-image-ref">kubernetes.container.image.ref</a></td>
             <td>The container image will be resolved with respect to the defined precedence order for user defined values.</td>
         </tr>
         <tr>


### PR DESCRIPTION
## What is the purpose of the change

*After FLINK-29372, we add suffix for some config option key, this will cause the link point to configuration doc broken.*


## Brief change log

  - *Fix broken links caused by FLINK-29372.*
  - *Using `kubernetes` instead of `KubernetesHaServicesFactory` as `high-availability.type` for `kubernetes_ha doc`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
