### PR TITLE
[FLINK-31842][runtime] Calculate the utilization of the task executor only when it is using

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
@@ -195,21 +195,22 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
             final AllocatedSlot allocatedSlot =
                     Preconditions.checkNotNull(registeredSlots.get(freeSlot.getKey()));
 
-            final ResourceID owner = allocatedSlot.getTaskManagerId();
-            final int numberOfSlotsOnOwner = slotsPerTaskExecutor.get(owner).size();
-            final int numberOfFreeSlotsOnOwner = freeSlots.getFreeSlotsNumberOfTaskExecutor(owner);
-            final double taskExecutorUtilization =
-                    (double) (numberOfSlotsOnOwner - numberOfFreeSlotsOnOwner)
-                            / numberOfSlotsOnOwner;
-
             final SlotInfoWithUtilization slotInfoWithUtilization =
-                    SlotInfoWithUtilization.from(allocatedSlot, taskExecutorUtilization);
+                    SlotInfoWithUtilization.from(allocatedSlot, this::getTaskExecutorUtilization);
 
             freeSlotInfos.add(
                     DefaultFreeSlotInfo.create(slotInfoWithUtilization, freeSlot.getValue()));
         }
 
         return freeSlotInfos;
+    }
+
+    public double getTaskExecutorUtilization(ResourceID resourceId) {
+        Set<AllocationID> slots = slotsPerTaskExecutor.get(resourceId);
+        Preconditions.checkNotNull(slots, "There is no slots on %s", resourceId);
+
+        return (double) (slots.size() - freeSlots.getFreeSlotsNumberOfTaskExecutor(resourceId))
+                / slots.size();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
@@ -44,8 +44,8 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 
     private final Map<AllocationID, AllocatedSlot> registeredSlots;
 
-    /** Map containing all free slots and since when they are free. */
-    private final Map<AllocationID, Long> freeSlotsSince;
+    /** All free slots and since when they are free, index by TaskExecutor. */
+    private final FreeSlots freeSlots;
 
     /** Index containing a mapping between TaskExecutors and their slots. */
     private final Map<ResourceID, Set<AllocationID>> slotsPerTaskExecutor;
@@ -53,7 +53,7 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
     public DefaultAllocatedSlotPool() {
         this.registeredSlots = new HashMap<>();
         this.slotsPerTaskExecutor = new HashMap<>();
-        this.freeSlotsSince = new HashMap<>();
+        this.freeSlots = new FreeSlots();
     }
 
     @Override
@@ -77,7 +77,7 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 
     private void addSlotInternal(AllocatedSlot slot, long currentTime) {
         registeredSlots.put(slot.getAllocationId(), slot);
-        freeSlotsSince.put(slot.getAllocationId(), currentTime);
+        freeSlots.addFreeSlot(slot, currentTime);
     }
 
     @Override
@@ -108,7 +108,9 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
     @Nullable
     private AllocatedSlot removeSlotInternal(AllocationID allocationId) {
         final AllocatedSlot removedSlot = registeredSlots.remove(allocationId);
-        freeSlotsSince.remove(allocationId);
+        if (removedSlot != null) {
+            freeSlots.removeFreeSlot(removedSlot);
+        }
         return removedSlot;
     }
 
@@ -153,14 +155,16 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 
     @Override
     public boolean containsFreeSlot(AllocationID allocationId) {
-        return freeSlotsSince.containsKey(allocationId);
+        return freeSlots.contains(allocationId);
     }
 
     @Override
     public AllocatedSlot reserveFreeSlot(AllocationID allocationId) {
         LOG.debug("Reserve free slot with allocation id {}.", allocationId);
+        AllocatedSlot slot = registeredSlots.get(allocationId);
+        Preconditions.checkNotNull(slot, "The slot with id %s was not exists.", allocationId);
         Preconditions.checkState(
-                freeSlotsSince.remove(allocationId) != null,
+                freeSlots.removeFreeSlot(slot) != null,
                 "The slot with id %s was not free.",
                 allocationId);
         return registeredSlots.get(allocationId);
@@ -170,8 +174,8 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
     public Optional<AllocatedSlot> freeReservedSlot(AllocationID allocationId, long currentTime) {
         final AllocatedSlot allocatedSlot = registeredSlots.get(allocationId);
 
-        if (allocatedSlot != null && !freeSlotsSince.containsKey(allocationId)) {
-            freeSlotsSince.put(allocationId, currentTime);
+        if (allocatedSlot != null && !freeSlots.contains(allocationId)) {
+            freeSlots.addFreeSlot(allocatedSlot, currentTime);
             return Optional.of(allocatedSlot);
         } else {
             return Optional.empty();
@@ -185,25 +189,15 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 
     @Override
     public Collection<FreeSlotInfo> getFreeSlotsInformation() {
-        final Map<ResourceID, Integer> freeSlotsPerTaskExecutor = new HashMap<>();
-
-        for (AllocationID allocationId : freeSlotsSince.keySet()) {
-            final ResourceID owner =
-                    Preconditions.checkNotNull(registeredSlots.get(allocationId))
-                            .getTaskManagerId();
-            final int newCount = freeSlotsPerTaskExecutor.getOrDefault(owner, 0) + 1;
-            freeSlotsPerTaskExecutor.put(owner, newCount);
-        }
-
         final Collection<FreeSlotInfo> freeSlotInfos = new ArrayList<>();
 
-        for (Map.Entry<AllocationID, Long> freeSlot : freeSlotsSince.entrySet()) {
+        for (Map.Entry<AllocationID, Long> freeSlot : freeSlots.getFreeSlotsSince().entrySet()) {
             final AllocatedSlot allocatedSlot =
                     Preconditions.checkNotNull(registeredSlots.get(freeSlot.getKey()));
 
             final ResourceID owner = allocatedSlot.getTaskManagerId();
             final int numberOfSlotsOnOwner = slotsPerTaskExecutor.get(owner).size();
-            final int numberOfFreeSlotsOnOwner = freeSlotsPerTaskExecutor.get(owner);
+            final int numberOfFreeSlotsOnOwner = freeSlots.getFreeSlotsNumberOfTaskExecutor(owner);
             final double taskExecutorUtilization =
                     (double) (numberOfSlotsOnOwner - numberOfFreeSlotsOnOwner)
                             / numberOfSlotsOnOwner;
@@ -221,6 +215,46 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
     @Override
     public Collection<? extends SlotInfo> getAllSlotsInformation() {
         return registeredSlots.values();
+    }
+
+    private static final class FreeSlots {
+        /** Map containing all free slots and since when they are free. */
+        private final Map<AllocationID, Long> freeSlotsSince = new HashMap<>();
+
+        /** Index containing a mapping between TaskExecutors and their free slots number. */
+        private final Map<ResourceID, Integer> freeSlotsNumberPerTaskExecutor = new HashMap<>();
+
+        public void addFreeSlot(AllocatedSlot slot, long currentTime) {
+            Preconditions.checkState(
+                    !freeSlotsSince.containsKey(slot.getAllocationId()),
+                    "Slot with id %s has been freed",
+                    slot.getAllocationId());
+            freeSlotsSince.put(slot.getAllocationId(), currentTime);
+            freeSlotsNumberPerTaskExecutor.put(
+                    slot.getTaskManagerId(),
+                    freeSlotsNumberPerTaskExecutor.getOrDefault(slot.getTaskManagerId(), 0) + 1);
+        }
+
+        public Long removeFreeSlot(AllocatedSlot slot) {
+            if (freeSlotsSince.containsKey(slot.getAllocationId())) {
+                freeSlotsNumberPerTaskExecutor.put(
+                        slot.getTaskManagerId(),
+                        freeSlotsNumberPerTaskExecutor.get(slot.getTaskManagerId()) - 1);
+            }
+            return freeSlotsSince.remove(slot.getAllocationId());
+        }
+
+        public boolean contains(AllocationID allocationId) {
+            return freeSlotsSince.containsKey(allocationId);
+        }
+
+        public int getFreeSlotsNumberOfTaskExecutor(ResourceID resourceId) {
+            return freeSlotsNumberPerTaskExecutor.getOrDefault(resourceId, 0);
+        }
+
+        public Map<AllocationID, Long> getFreeSlotsSince() {
+            return freeSlotsSince;
+        }
     }
 
     private static final class DefaultFreeSlotInfo implements AllocatedSlotPool.FreeSlotInfo {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
@@ -32,12 +32,11 @@ class DefaultLocationPreferenceSlotSelectionStrategy
     @Nonnull
     @Override
     protected Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull ResourceProfile resourceProfile) {
-        for (SlotInfoAndResources candidate : availableSlots) {
-            if (candidate.getRemainingResources().isMatching(resourceProfile)) {
-                return Optional.of(
-                        SlotInfoAndLocality.of(candidate.getSlotInfo(), Locality.UNCONSTRAINED));
+        for (SlotInfoWithUtilization candidate : availableSlots) {
+            if (candidate.getResourceProfile().isMatching(resourceProfile)) {
+                return Optional.of(SlotInfoAndLocality.of(candidate, Locality.UNCONSTRAINED));
             }
         }
         return Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultLocationPreferenceSlotSelectionStrategy.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 class DefaultLocationPreferenceSlotSelectionStrategy
         extends LocationPreferenceSlotSelectionStrategy {
@@ -44,7 +45,7 @@ class DefaultLocationPreferenceSlotSelectionStrategy
 
     @Override
     protected double calculateCandidateScore(
-            int localWeigh, int hostLocalWeigh, double taskExecutorUtilization) {
+            int localWeigh, int hostLocalWeigh, Supplier<Double> taskExecutorUtilizationSupplier) {
         return localWeigh * 10 + hostLocalWeigh;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
@@ -32,20 +32,19 @@ class EvenlySpreadOutLocationPreferenceSlotSelectionStrategy
     @Nonnull
     @Override
     protected Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull ResourceProfile resourceProfile) {
         return availableSlots.stream()
                 .filter(
-                        slotInfoAndResources ->
-                                slotInfoAndResources
-                                        .getRemainingResources()
+                        slotInfoWithUtilization ->
+                                slotInfoWithUtilization
+                                        .getResourceProfile()
                                         .isMatching(resourceProfile))
-                .min(Comparator.comparing(SlotInfoAndResources::getTaskExecutorUtilization))
+                .min(Comparator.comparing(SlotInfoWithUtilization::getTaskExecutorUtilization))
                 .map(
-                        slotInfoAndResources ->
+                        slotInfoWithUtilization ->
                                 SlotInfoAndLocality.of(
-                                        slotInfoAndResources.getSlotInfo(),
-                                        Locality.UNCONSTRAINED));
+                                        slotInfoWithUtilization, Locality.UNCONSTRAINED));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/EvenlySpreadOutLocationPreferenceSlotSelectionStrategy.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 class EvenlySpreadOutLocationPreferenceSlotSelectionStrategy
         extends LocationPreferenceSlotSelectionStrategy {
@@ -49,10 +50,10 @@ class EvenlySpreadOutLocationPreferenceSlotSelectionStrategy
 
     @Override
     protected double calculateCandidateScore(
-            int localWeigh, int hostLocalWeigh, double taskExecutorUtilization) {
+            int localWeigh, int hostLocalWeigh, Supplier<Double> taskExecutorUtilizationSupplier) {
         // taskExecutorUtilization in [0, 1] --> only affects choice if localWeigh and
         // hostLocalWeigh
         // between two candidates are equal
-        return localWeigh * 20 + hostLocalWeigh * 2 - taskExecutorUtilization;
+        return localWeigh * 20 + hostLocalWeigh * 2 - taskExecutorUtilizationSupplier.get();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -40,7 +40,7 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
 
     @Override
     public Optional<SlotInfoAndLocality> selectBestSlotForProfile(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull SlotProfile slotProfile) {
 
         Collection<TaskManagerLocation> locationPreferences = slotProfile.getPreferredLocations();
@@ -60,7 +60,7 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
 
     @Nonnull
     private Optional<SlotInfoAndLocality> selectWithLocationPreference(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull Collection<TaskManagerLocation> locationPreferences,
             @Nonnull ResourceProfile resourceProfile) {
 
@@ -75,25 +75,23 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
             preferredFQHostNames.merge(locationPreference.getFQDNHostname(), 1, Integer::sum);
         }
 
-        SlotInfoAndResources bestCandidate = null;
+        SlotInfoWithUtilization bestCandidate = null;
         Locality bestCandidateLocality = Locality.UNKNOWN;
         double bestCandidateScore = Double.NEGATIVE_INFINITY;
 
-        for (SlotInfoAndResources candidate : availableSlots) {
+        for (SlotInfoWithUtilization candidate : availableSlots) {
 
-            if (candidate.getRemainingResources().isMatching(resourceProfile)) {
+            if (candidate.getResourceProfile().isMatching(resourceProfile)) {
 
                 // this gets candidate is local-weigh
                 int localWeigh =
                         preferredResourceIDs.getOrDefault(
-                                candidate.getSlotInfo().getTaskManagerLocation().getResourceID(),
-                                0);
+                                candidate.getTaskManagerLocation().getResourceID(), 0);
 
                 // this gets candidate is host-local-weigh
                 int hostLocalWeigh =
                         preferredFQHostNames.getOrDefault(
-                                candidate.getSlotInfo().getTaskManagerLocation().getFQDNHostname(),
-                                0);
+                                candidate.getTaskManagerLocation().getFQDNHostname(), 0);
 
                 double candidateScore =
                         calculateCandidateScore(
@@ -111,14 +109,13 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
 
         // at the end of the iteration, we return the candidate with best possible locality or null.
         return bestCandidate != null
-                ? Optional.of(
-                        SlotInfoAndLocality.of(bestCandidate.getSlotInfo(), bestCandidateLocality))
+                ? Optional.of(SlotInfoAndLocality.of(bestCandidate, bestCandidateLocality))
                 : Optional.empty();
     }
 
     @Nonnull
     protected abstract Optional<SlotInfoAndLocality> selectWithoutLocationPreference(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull ResourceProfile resourceProfile);
 
     protected abstract double calculateCandidateScore(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * This class implements a {@link SlotSelectionStrategy} that is based on location preference hints.
@@ -95,7 +96,7 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
 
                 double candidateScore =
                         calculateCandidateScore(
-                                localWeigh, hostLocalWeigh, candidate.getTaskExecutorUtilization());
+                                localWeigh, hostLocalWeigh, candidate::getTaskExecutorUtilization);
                 if (candidateScore > bestCandidateScore) {
                     bestCandidateScore = candidateScore;
                     bestCandidate = candidate;
@@ -119,7 +120,7 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
             @Nonnull ResourceProfile resourceProfile);
 
     protected abstract double calculateCandidateScore(
-            int localWeigh, int hostLocalWeigh, double taskExecutorUtilization);
+            int localWeigh, int hostLocalWeigh, Supplier<Double> taskExecutorUtilizationSupplier);
 
     // -------------------------------------------------------------------------------------------
     // Factory methods

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -86,10 +85,7 @@ public class PhysicalSlotProviderImpl implements PhysicalSlotProvider {
 
     private Optional<PhysicalSlot> tryAllocateFromAvailable(
             SlotRequestId slotRequestId, SlotProfile slotProfile) {
-        Collection<SlotSelectionStrategy.SlotInfoAndResources> slotInfoList =
-                slotPool.getAvailableSlotsInformation().stream()
-                        .map(SlotSelectionStrategy.SlotInfoAndResources::fromSingleSlot)
-                        .collect(Collectors.toList());
+        Collection<SlotInfoWithUtilization> slotInfoList = slotPool.getAvailableSlotsInformation();
 
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> selectedAvailableSlot =
                 slotSelectionStrategy.selectBestSlotForProfile(slotInfoList, slotProfile);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSelectionStrategy.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
@@ -42,52 +41,8 @@ public interface SlotSelectionStrategy {
      * @return the selected slot info with the corresponding locality hint.
      */
     Optional<SlotInfoAndLocality> selectBestSlotForProfile(
-            @Nonnull Collection<SlotInfoAndResources> availableSlots,
+            @Nonnull Collection<SlotInfoWithUtilization> availableSlots,
             @Nonnull SlotProfile slotProfile);
-
-    /**
-     * This class is a value type that combines a {@link SlotInfo} with its remaining {@link
-     * ResourceProfile}.
-     */
-    final class SlotInfoAndResources {
-
-        @Nonnull private final SlotInfo slotInfo;
-
-        @Nonnull private final ResourceProfile remainingResources;
-
-        private final double taskExecutorUtilization;
-
-        public SlotInfoAndResources(
-                @Nonnull SlotInfo slotInfo,
-                @Nonnull ResourceProfile remainingResources,
-                double taskExecutorUtilization) {
-            this.slotInfo = slotInfo;
-            this.remainingResources = remainingResources;
-            this.taskExecutorUtilization = taskExecutorUtilization;
-        }
-
-        @Nonnull
-        public SlotInfo getSlotInfo() {
-            return slotInfo;
-        }
-
-        @Nonnull
-        public ResourceProfile getRemainingResources() {
-            return remainingResources;
-        }
-
-        public double getTaskExecutorUtilization() {
-            return taskExecutorUtilization;
-        }
-
-        public static SlotInfoAndResources fromSingleSlot(
-                @Nonnull SlotInfoWithUtilization slotInfoWithUtilization) {
-            return new SlotInfoAndResources(
-                    slotInfoWithUtilization,
-                    slotInfoWithUtilization.getResourceProfile(),
-                    slotInfoWithUtilization.getTaskExecutorUtilization());
-        }
-    }
 
     /** This class is a value type that combines a {@link SlotInfo} with a {@link Locality} hint. */
     final class SlotInfoAndLocality {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -177,15 +177,15 @@ class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionStrategyT
     protected static void assertMatchingSlotLocalityAndInCandidates(
             Optional<SlotSelectionStrategy.SlotInfoAndLocality> matchingSlot,
             Locality locality,
-            Set<SlotSelectionStrategy.SlotInfoAndResources> candidates) {
+            Set<SlotInfoWithUtilization> candidates) {
         assertThat(matchingSlot)
                 .hasValueSatisfying(
                         slotInfoAndLocality -> {
                             assertThat(slotInfoAndLocality.getLocality()).isEqualTo(locality);
                             assertThat(candidates)
                                     .anySatisfy(
-                                            slotInfoAndResources ->
-                                                    assertThat(slotInfoAndResources.getSlotInfo())
+                                            slotInfoWithUtilization ->
+                                                    assertThat(slotInfoWithUtilization)
                                                             .isEqualTo(
                                                                     slotInfoAndLocality
                                                                             .getSlotInfo()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
@@ -21,24 +21,28 @@ package org.apache.flink.runtime.clusterframework.types;
 import org.apache.flink.runtime.jobmaster.slotpool.PreviousAllocationSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for {@link PreviousAllocationSlotSelectionStrategy}. */
-public class PreviousAllocationSlotSelectionStrategyTest
+class PreviousAllocationSlotSelectionStrategyTest
         extends LocationPreferenceSlotSelectionStrategyTest {
 
-    public PreviousAllocationSlotSelectionStrategyTest() {
-        super(PreviousAllocationSlotSelectionStrategy.create());
+    @BeforeEach
+    @Override
+    void setUp() {
+        this.selectionStrategy = PreviousAllocationSlotSelectionStrategy.create();
     }
 
     @Test
-    public void matchPreviousAllocationOverridesPreferredLocation() {
+    void matchPreviousAllocationOverridesPreferredLocation() {
 
         SlotProfile slotProfile =
                 SlotProfile.priorAllocation(
@@ -48,8 +52,7 @@ public class PreviousAllocationSlotSelectionStrategyTest
                         Collections.singleton(aid3),
                         Collections.emptySet());
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
-
-        Assert.assertEquals(slotInfo3, match.get().getSlotInfo());
+        assertMatchingSlotEqualsToSlotInfo(match, slotInfo3);
 
         slotProfile =
                 SlotProfile.priorAllocation(
@@ -59,12 +62,11 @@ public class PreviousAllocationSlotSelectionStrategyTest
                         new HashSet<>(Arrays.asList(aidX, aid2)),
                         Collections.emptySet());
         match = runMatching(slotProfile);
-
-        Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
+        assertMatchingSlotEqualsToSlotInfo(match, slotInfo2);
     }
 
     @Test
-    public void matchPreviousLocationNotAvailableButByLocality() {
+    void matchPreviousLocationNotAvailableButByLocality() {
 
         SlotProfile slotProfile =
                 SlotProfile.priorAllocation(
@@ -74,12 +76,11 @@ public class PreviousAllocationSlotSelectionStrategyTest
                         Collections.singleton(aidX),
                         Collections.emptySet());
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
-
-        Assert.assertEquals(slotInfo4, match.get().getSlotInfo());
+        assertMatchingSlotEqualsToSlotInfo(match, slotInfo4);
     }
 
     @Test
-    public void matchPreviousLocationNotAvailableAndAllOthersBlacklisted() {
+    void matchPreviousLocationNotAvailableAndAllOthersBlacklisted() {
         HashSet<AllocationID> blacklisted = new HashSet<>(4);
         blacklisted.add(aid1);
         blacklisted.add(aid2);
@@ -95,11 +96,11 @@ public class PreviousAllocationSlotSelectionStrategyTest
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         // there should be no valid option left and we expect null as return
-        Assert.assertFalse(match.isPresent());
+        assertThat(match).isNotPresent();
     }
 
     @Test
-    public void matchPreviousLocationNotAvailableAndSomeOthersBlacklisted() {
+    void matchPreviousLocationNotAvailableAndSomeOthersBlacklisted() {
         HashSet<AllocationID> blacklisted = new HashSet<>(3);
         blacklisted.add(aid2);
         blacklisted.add(aid3);
@@ -114,6 +115,6 @@ public class PreviousAllocationSlotSelectionStrategyTest
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         // we expect that the candidate that is not blacklisted is returned
-        Assert.assertEquals(slotInfo1, match.get().getSlotInfo());
+        assertMatchingSlotEqualsToSlotInfo(match, slotInfo1);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -58,17 +58,20 @@ abstract class SlotSelectionStrategyTestBase {
 
     protected final SlotInfoWithUtilization slotInfo1 =
             SlotInfoWithUtilization.from(
-                    new SimpleSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile), 0);
+                    new SimpleSlotContext(aid1, tml1, 1, taskManagerGateway, resourceProfile),
+                    ignored -> 0.0d);
     protected final SlotInfoWithUtilization slotInfo2 =
             SlotInfoWithUtilization.from(
                     new SimpleSlotContext(aid2, tml2, 2, taskManagerGateway, biggerResourceProfile),
-                    0);
+                    ignored -> 0.0d);
     protected final SlotInfoWithUtilization slotInfo3 =
             SlotInfoWithUtilization.from(
-                    new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile), 0);
+                    new SimpleSlotContext(aid3, tml3, 3, taskManagerGateway, resourceProfile),
+                    ignored -> 0.0d);
     protected final SlotInfoWithUtilization slotInfo4 =
             SlotInfoWithUtilization.from(
-                    new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile), 0);
+                    new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile),
+                    ignored -> 0.0d);
 
     protected final Set<SlotInfoWithUtilization> candidates =
             Collections.unmodifiableSet(createCandidates());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -70,17 +70,17 @@ abstract class SlotSelectionStrategyTestBase {
             SlotInfoWithUtilization.from(
                     new SimpleSlotContext(aid4, tml4, 4, taskManagerGateway, resourceProfile), 0);
 
-    protected final Set<SlotSelectionStrategy.SlotInfoAndResources> candidates =
+    protected final Set<SlotInfoWithUtilization> candidates =
             Collections.unmodifiableSet(createCandidates());
 
     protected SlotSelectionStrategy selectionStrategy;
 
-    private Set<SlotSelectionStrategy.SlotInfoAndResources> createCandidates() {
-        Set<SlotSelectionStrategy.SlotInfoAndResources> candidates = new HashSet<>(4);
-        candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo1));
-        candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo2));
-        candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo3));
-        candidates.add(SlotSelectionStrategy.SlotInfoAndResources.fromSingleSlot(slotInfo4));
+    private Set<SlotInfoWithUtilization> createCandidates() {
+        Set<SlotInfoWithUtilization> candidates = new HashSet<>(4);
+        candidates.add(slotInfo1);
+        candidates.add(slotInfo2);
+        candidates.add(slotInfo3);
+        candidates.add(slotInfo4);
         return candidates;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotSelectionStrategyTestBase.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.TestLogger;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -33,7 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /** Test base for {@link SlotSelectionStrategy}. */
-public abstract class SlotSelectionStrategyTestBase extends TestLogger {
+abstract class SlotSelectionStrategyTestBase {
 
     protected final ResourceProfile resourceProfile = ResourceProfile.fromResources(2, 1024);
     protected final ResourceProfile biggerResourceProfile = ResourceProfile.fromResources(3, 1024);
@@ -74,11 +73,7 @@ public abstract class SlotSelectionStrategyTestBase extends TestLogger {
     protected final Set<SlotSelectionStrategy.SlotInfoAndResources> candidates =
             Collections.unmodifiableSet(createCandidates());
 
-    protected final SlotSelectionStrategy selectionStrategy;
-
-    public SlotSelectionStrategyTestBase(SlotSelectionStrategy slotSelectionStrategy) {
-        this.selectionStrategy = slotSelectionStrategy;
-    }
+    protected SlotSelectionStrategy selectionStrategy;
 
     private Set<SlotSelectionStrategy.SlotInfoAndResources> createCandidates() {
         Set<SlotSelectionStrategy.SlotInfoAndResources> candidates = new HashSet<>(4);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -576,7 +576,7 @@ class JobMasterTest {
             final Collection<SlotInfoWithUtilization> allSlotInfos =
                     registeredSlots.values().stream()
                             .flatMap(Collection::stream)
-                            .map(slot -> SlotInfoWithUtilization.from(slot, 0))
+                            .map(slot -> SlotInfoWithUtilization.from(slot, ignored -> 0.0d))
                             .collect(Collectors.toList());
 
             return Collections.unmodifiableCollection(allSlotInfos);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPoolTest.java
@@ -47,9 +47,9 @@ import java.util.stream.Collectors;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.FreeSlotConsumer;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.NewSlotsService;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createResourceRequirements;
-import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.drainNewSlotService;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.increaseRequirementsAndOfferSlotsToSlotPool;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
 import static org.apache.flink.shaded.guava30.com.google.common.collect.Iterables.getOnlyElement;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPoolTest.java
@@ -23,18 +23,13 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
-import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -49,20 +44,15 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.offset;
 
 /** Tests for the {@link DefaultAllocatedSlotPool}. */
-public class DefaultAllocatedSlotPoolTest extends TestLogger {
+class DefaultAllocatedSlotPoolTest {
 
     @Test
-    public void testAddSlots() {
+    void testAddSlots() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
         final Collection<AllocatedSlot> slots = createAllocatedSlots();
@@ -74,7 +64,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
     }
 
     @Test
-    public void testRemoveSlot() {
+    void testRemoveSlot() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
         final Collection<AllocatedSlot> slots = createAllocatedSlots();
@@ -91,7 +81,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
     }
 
     @Test
-    public void testRemoveSlots() {
+    void testRemoveSlots() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
         final ResourceID owner = ResourceID.generate();
@@ -107,7 +97,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
     }
 
     @Test
-    public void testRemoveSlotsReturnValue() {
+    void testRemoveSlotsReturnValue() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
         final ResourceID owner = ResourceID.generate();
@@ -120,36 +110,37 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
         final AllocatedSlotPool.AllocatedSlotsAndReservationStatus
                 allocatedSlotsAndReservationStatus = slotPool.removeSlots(owner);
 
-        assertThat(allocatedSlotsAndReservationStatus.getAllocatedSlots(), hasItems(slot1, slot2));
-        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot1.getAllocationId()), is(false));
-        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot2.getAllocationId()), is(true));
+        assertThat(allocatedSlotsAndReservationStatus.getAllocatedSlots())
+                .containsExactlyInAnyOrder(slot1, slot2);
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot1.getAllocationId())).isFalse();
+        assertThat(allocatedSlotsAndReservationStatus.wasFree(slot2.getAllocationId())).isTrue();
     }
 
     @Test
-    public void testContainsSlots() {
+    void testContainsSlots() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final ResourceID owner = ResourceID.generate();
         final AllocatedSlot allocatedSlot = createAllocatedSlot(owner);
 
         slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
 
-        assertTrue(slotPool.containsSlots(owner));
-        assertFalse(slotPool.containsSlots(ResourceID.generate()));
+        assertThat(slotPool.containsSlots(owner)).isTrue();
+        assertThat(slotPool.containsSlots(ResourceID.generate())).isFalse();
     }
 
     @Test
-    public void testContainsSlot() {
+    void testContainsSlot() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final AllocatedSlot allocatedSlot = createAllocatedSlot(null);
 
         slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
 
-        assertTrue(slotPool.containsSlot(allocatedSlot.getAllocationId()));
-        assertFalse(slotPool.containsSlot(new AllocationID()));
+        assertThat(slotPool.containsSlot(allocatedSlot.getAllocationId())).isTrue();
+        assertThat(slotPool.containsSlot(new AllocationID())).isFalse();
     }
 
     @Test
-    public void testReserveFreeSlot() {
+    void testReserveFreeSlot() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final Collection<AllocatedSlot> allSlots = createAllocatedSlots();
         final Collection<AllocatedSlot> freeSlots = new ArrayList<>(allSlots);
@@ -159,27 +150,27 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
 
         slotPool.addSlots(allSlots, 0);
 
-        assertThat(
-                slotPool.reserveFreeSlot(allocatedSlot.getAllocationId()),
-                sameInstance(allocatedSlot));
+        assertThat(slotPool.reserveFreeSlot(allocatedSlot.getAllocationId()))
+                .isEqualTo(allocatedSlot);
 
         assertSlotPoolContainsFreeSlots(slotPool, freeSlots);
         assertSlotPoolContainsSlots(slotPool, allSlots);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testReserveNonFreeSlotFails() {
+    @Test
+    void testReserveNonFreeSlotFails() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final AllocatedSlot slot = createAllocatedSlot(null);
 
         slotPool.addSlots(Collections.singleton(slot), 0);
 
         slotPool.reserveFreeSlot(slot.getAllocationId());
-        slotPool.reserveFreeSlot(slot.getAllocationId());
+        assertThatThrownBy(() -> slotPool.reserveFreeSlot(slot.getAllocationId()))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void testFreeingOfReservedSlot() {
+    void testFreeingOfReservedSlot() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final Collection<AllocatedSlot> slots = createAllocatedSlots();
 
@@ -191,7 +182,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
         slotPool.reserveFreeSlot(slot.getAllocationId());
 
         final int releaseTime = 1;
-        assertTrue(slotPool.freeReservedSlot(slot.getAllocationId(), releaseTime).isPresent());
+        assertThat(slotPool.freeReservedSlot(slot.getAllocationId(), releaseTime)).isPresent();
         assertSlotPoolContainsFreeSlots(slotPool, slots);
 
         for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
@@ -202,89 +193,90 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
                 time = initialTime;
             }
 
-            assertThat(freeSlotInfo.getFreeSince(), is(time));
+            assertThat(freeSlotInfo.getFreeSince()).isEqualTo(time);
         }
     }
 
     @Test
-    public void testFreeingOfFreeSlotIsIgnored() {
+    void testFreeingOfFreeSlotIsIgnored() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final AllocatedSlot slot = createAllocatedSlot(null);
 
         slotPool.addSlots(Collections.singleton(slot), 0);
 
-        assertFalse(slotPool.freeReservedSlot(slot.getAllocationId(), 1).isPresent());
+        assertThat(slotPool.freeReservedSlot(slot.getAllocationId(), 1)).isNotPresent();
 
         final AllocatedSlotPool.FreeSlotInfo freeSlotInfo =
                 Iterables.getOnlyElement(slotPool.getFreeSlotsInformation());
 
-        assertThat(freeSlotInfo.getFreeSince(), is(0L));
+        assertThat(freeSlotInfo.getFreeSince()).isEqualTo(0L);
     }
 
     @Test
-    public void testSlotUtilizationCalculation() {
+    void testSlotUtilizationCalculation() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final ResourceID owner = ResourceID.generate();
         final Collection<AllocatedSlot> slots = createAllocatedSlotsWithOwner(owner);
 
         slotPool.addSlots(slots, 0);
 
-        for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
-            assertThat(freeSlotInfo.asSlotInfo().getTaskExecutorUtilization(), closeTo(0, 0.1));
-        }
+        assertThat(slotPool.getFreeSlotsInformation())
+                .allSatisfy(
+                        freeSlotInfo ->
+                                assertThat(freeSlotInfo.asSlotInfo().getTaskExecutorUtilization())
+                                        .isCloseTo(0, offset(0.1)));
 
         int numAllocatedSlots = 0;
         for (AllocatedSlot slot : slots) {
-            assertThat(slotPool.reserveFreeSlot(slot.getAllocationId()), sameInstance(slot));
+            assertThat(slotPool.reserveFreeSlot(slot.getAllocationId())).isEqualTo(slot);
             numAllocatedSlots++;
 
             for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : slotPool.getFreeSlotsInformation()) {
                 final double utilization = (double) numAllocatedSlots / slots.size();
-                assertThat(
-                        freeSlotInfo.asSlotInfo().getTaskExecutorUtilization(),
-                        closeTo(utilization, 0.1));
+                assertThat(freeSlotInfo.asSlotInfo().getTaskExecutorUtilization())
+                        .isCloseTo(utilization, offset(0.1));
             }
         }
     }
 
     @Test
-    public void testRemoveSlotsOfUnknownOwnerIsIgnored() {
+    void testRemoveSlotsOfUnknownOwnerIsIgnored() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
         slotPool.removeSlots(ResourceID.generate());
     }
 
     @Test
-    public void testContainsFreeSlotReturnsTrueIfSlotIsFree() {
+    void testContainsFreeSlotReturnsTrueIfSlotIsFree() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final AllocatedSlot allocatedSlot = createAllocatedSlot(ResourceID.generate());
 
         slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
 
-        assertTrue(slotPool.containsFreeSlot(allocatedSlot.getAllocationId()));
+        assertThat(slotPool.containsFreeSlot(allocatedSlot.getAllocationId())).isTrue();
     }
 
     @Test
-    public void testContainsFreeSlotReturnsFalseIfSlotDoesNotExist() {
+    void testContainsFreeSlotReturnsFalseIfSlotDoesNotExist() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
 
-        assertFalse(slotPool.containsFreeSlot(new AllocationID()));
+        assertThat(slotPool.containsFreeSlot(new AllocationID())).isFalse();
     }
 
     @Test
-    public void testContainsFreeSlotReturnsFalseIfSlotIsReserved() {
+    void testContainsFreeSlotReturnsFalseIfSlotIsReserved() {
         final DefaultAllocatedSlotPool slotPool = new DefaultAllocatedSlotPool();
         final AllocatedSlot allocatedSlot = createAllocatedSlot(ResourceID.generate());
 
         slotPool.addSlots(Collections.singleton(allocatedSlot), 0);
         slotPool.reserveFreeSlot(allocatedSlot.getAllocationId());
 
-        assertFalse(slotPool.containsFreeSlot(allocatedSlot.getAllocationId()));
+        assertThat(slotPool.containsFreeSlot(allocatedSlot.getAllocationId())).isFalse();
     }
 
     private void assertSlotPoolContainsSlots(
             DefaultAllocatedSlotPool slotPool, Collection<AllocatedSlot> slots) {
-        assertThat(slotPool.getAllSlotsInformation(), hasSize(slots.size()));
+        assertThat(slotPool.getAllSlotsInformation()).hasSize(slots.size());
 
         final Map<AllocationID, AllocatedSlot> slotsPerAllocationId =
                 slots.stream()
@@ -292,13 +284,11 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
                                 Collectors.toMap(
                                         AllocatedSlot::getAllocationId, Function.identity()));
 
-        for (SlotInfo slotInfo : slotPool.getAllSlotsInformation()) {
-            assertTrue(slotsPerAllocationId.containsKey(slotInfo.getAllocationId()));
-            final AllocatedSlot allocatedSlot =
-                    slotsPerAllocationId.get(slotInfo.getAllocationId());
-
-            assertThat(slotInfo, matchesPhysicalSlot(allocatedSlot));
-        }
+        assertThat(slotPool.getAllSlotsInformation())
+                .allSatisfy(
+                        slotInfo ->
+                                assertThat(slotsPerAllocationId.get(slotInfo.getAllocationId()))
+                                        .isEqualTo(slotInfo));
     }
 
     private void assertSlotPoolContainsFreeSlots(
@@ -306,7 +296,7 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
         final Collection<AllocatedSlotPool.FreeSlotInfo> freeSlotsInformation =
                 slotPool.getFreeSlotsInformation();
 
-        assertThat(freeSlotsInformation, hasSize(allocatedSlots.size()));
+        assertThat(freeSlotsInformation).hasSize(allocatedSlots.size());
 
         final Map<AllocationID, AllocatedSlot> allocatedSlotMap =
                 allocatedSlots.stream()
@@ -314,17 +304,23 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
                                 Collectors.toMap(
                                         AllocatedSlot::getAllocationId, Function.identity()));
 
-        for (AllocatedSlotPool.FreeSlotInfo freeSlotInfo : freeSlotsInformation) {
-            assertTrue(allocatedSlotMap.containsKey(freeSlotInfo.getAllocationId()));
-
-            assertThat(
-                    freeSlotInfo.asSlotInfo(),
-                    matchesPhysicalSlot(allocatedSlotMap.get(freeSlotInfo.getAllocationId())));
-        }
-    }
-
-    static Matcher<SlotInfo> matchesPhysicalSlot(PhysicalSlot allocatedSlot) {
-        return new SlotInfoMatcher(allocatedSlot);
+        assertThat(freeSlotsInformation)
+                .allSatisfy(
+                        freeSlotInfo -> {
+                            AllocatedSlot allocatedSlot =
+                                    allocatedSlotMap.get(freeSlotInfo.getAllocationId());
+                            assertThat(allocatedSlot).isNotNull();
+                            SlotInfoWithUtilization slotInfoWithUtilization =
+                                    freeSlotInfo.asSlotInfo();
+                            assertThat(allocatedSlot.getAllocationId())
+                                    .isEqualTo(slotInfoWithUtilization.getAllocationId());
+                            assertThat(allocatedSlot.getPhysicalSlotNumber())
+                                    .isEqualTo(slotInfoWithUtilization.getPhysicalSlotNumber());
+                            assertThat(allocatedSlot.getResourceProfile())
+                                    .isEqualTo(slotInfoWithUtilization.getResourceProfile());
+                            assertThat(allocatedSlot.getTaskManagerLocation())
+                                    .isEqualTo(slotInfoWithUtilization.getTaskManagerLocation());
+                        });
     }
 
     private Collection<AllocatedSlot> createAllocatedSlots() {
@@ -355,35 +351,5 @@ public class DefaultAllocatedSlotPoolTest extends TestLogger {
                 new RpcTaskManagerGateway(
                         new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(),
                         JobMasterId.generate()));
-    }
-
-    static class SlotInfoMatcher extends TypeSafeMatcher<SlotInfo> {
-
-        private final PhysicalSlot physicalSlot;
-
-        SlotInfoMatcher(PhysicalSlot physicalSlot) {
-            this.physicalSlot = physicalSlot;
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("SlotInfo with values: ");
-            description.appendValueList(
-                    "{",
-                    ",",
-                    "}",
-                    physicalSlot.getAllocationId(),
-                    physicalSlot.getPhysicalSlotNumber(),
-                    physicalSlot.getResourceProfile(),
-                    physicalSlot.getTaskManagerLocation());
-        }
-
-        @Override
-        protected boolean matchesSafely(SlotInfo item) {
-            return item.getAllocationId().equals(physicalSlot.getAllocationId())
-                    && item.getPhysicalSlotNumber() == physicalSlot.getPhysicalSlotNumber()
-                    && item.getResourceProfile().equals(physicalSlot.getResourceProfile())
-                    && item.getTaskManagerLocation().equals(physicalSlot.getTaskManagerLocation());
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -130,7 +130,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.acknowledgePendingCheckpoint;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createFailedTaskExecutionState;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.enableCheckpointing;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -139,7 +139,7 @@ import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.jobgraph.JobGraphTestUtils.streamingJobGraph;
-import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.enableCheckpointing;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## What is the purpose of the change
Currently DefaultAllocatedSlotPool#getFreeSlotsInformation always calculates the taskExecutorUtilization. This causes task schedules to be too slow when there are lots of slots, such as 20000 slots total. But only the EvenlySpreadOutLocationPreferenceSlotSelectionStrategy uses this utilization.

## Brief change log

  - *Maintain free slots per task executor in DefaultAllocatedSlotPool to reduce the cost of task executor utilization calculation.*
  - *Calculate task executor's utilization only when used*

## Verifying this change
This change is already covered by existing tests.

### benchmark results
#### origin version
```
Benchmark                                                        (jobConfiguration)  Mode  Cnt      Score       Error  Units
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover               BATCH    ss    6   7963.471 ?  3040.474  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover           STREAMING    ss    6  41735.536 ? 13175.253  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover        BATCH_EVENLY    ss    6   9461.976 ?  3823.653  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover    STREAMING_EVENLY    ss    6  41957.036 ? 10394.205  ms/op
```
#### Maintain free slots per task executor in DefaultAllocatedSlotPool  
```
Benchmark                                                        (jobConfiguration)  Mode  Cnt      Score      Error  Units
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover               BATCH    ss    6   7039.183 ? 2073.795  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover           STREAMING    ss    6  25766.287 ? 7546.104  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover        BATCH_EVENLY    ss    6   7701.995 ? 1154.260  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover    STREAMING_EVENLY    ss    6  29273.547 ? 7111.815  ms/op

```

#### Calculate task executor's utilization only when used
```
Benchmark                                                        (jobConfiguration)  Mode  Cnt      Score      Error  Units
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover               BATCH    ss    6   5157.789 ?  674.883  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover           STREAMING    ss    6  14386.616 ? 3058.114  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover        BATCH_EVENLY    ss    6   8494.799 ? 1747.083  ms/op
RestartStreamingJobBenchmarkExecutor.startSchedulingAndFailover    STREAMING_EVENLY    ss    6  33175.847 ? 5706.390  ms/op

```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
