### PR TITLE
[FLINK-18808][runtime] Include side outputs in numRecordsOut metric

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OutputWithChainingCheck;
 import org.apache.flink.streaming.runtime.tasks.WatermarkGaugeExposingOutput;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.OutputTag;
@@ -43,7 +44,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Implementation of {@link Output} that sends data using a {@link RecordWriter}. */
 @Internal
-public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<StreamRecord<OUT>> {
+public class RecordWriterOutput<OUT>
+        implements WatermarkGaugeExposingOutput<StreamRecord<OUT>>,
+                OutputWithChainingCheck<StreamRecord<OUT>> {
 
     private RecordWriter<SerializationDelegate<StreamElement>> recordWriter;
 
@@ -83,19 +86,35 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
     @Override
     public void collect(StreamRecord<OUT> record) {
-        if (this.outputTag != null) {
-            // we are not responsible for emitting to the main output.
-            return;
-        }
-
-        pushToRecordWriter(record);
+        collectAndCheckIfChained(record);
     }
 
     @Override
     public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
-        if (OutputTag.isResponsibleFor(this.outputTag, outputTag)) {
-            pushToRecordWriter(record);
+        collectAndCheckIfChained(outputTag, record);
+    }
+
+    @Override
+    public boolean collectAndCheckIfChained(StreamRecord<OUT> record) {
+        if (this.outputTag != null) {
+            // we are not responsible for emitting to the main output.
+            return false;
         }
+
+        pushToRecordWriter(record);
+        return true;
+    }
+
+    @Override
+    public <X> boolean collectAndCheckIfChained(OutputTag<X> outputTag, StreamRecord<X> record) {
+        if (!OutputTag.isResponsibleFor(this.outputTag, outputTag)) {
+            // we are not responsible for emitting to the side-output specified by this
+            // OutputTag.
+            return false;
+        }
+
+        pushToRecordWriter(record);
+        return true;
     }
 
     private <X> void pushToRecordWriter(StreamRecord<X> record) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ChainingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ChainingOutput.java
@@ -36,7 +36,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-class ChainingOutput<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>> {
+class ChainingOutput<T>
+        implements WatermarkGaugeExposingOutput<StreamRecord<T>>,
+                OutputWithChainingCheck<StreamRecord<T>> {
     private static final Logger LOG = LoggerFactory.getLogger(ChainingOutput.class);
 
     protected final Input<T> input;
@@ -80,6 +82,18 @@ class ChainingOutput<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>>
         if (OutputTag.isResponsibleFor(this.outputTag, outputTag)) {
             pushToOperator(record);
         }
+    }
+
+    @Override
+    public boolean collectAndCheckIfChained(StreamRecord<T> record) {
+        collect(record);
+        return false;
+    }
+
+    @Override
+    public <X> boolean collectAndCheckIfChained(OutputTag<X> outputTag, StreamRecord<X> record) {
+        collect(outputTag, record);
+        return false;
     }
 
     protected <X> void pushToOperator(StreamRecord<X> record) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -38,6 +39,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.AcknowledgeCheckpointEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
@@ -658,9 +660,6 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         .getMetricGroup()
                         .getOrAddOperator(
                                 operatorConfig.getOperatorID(), operatorConfig.getOperatorName());
-        if (operatorConfig.isChainEnd()) {
-            operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
-        }
 
         return operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
     }
@@ -703,7 +702,7 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
             MailboxExecutorFactory mailboxExecutorFactory,
             boolean shouldAddMetric) {
-        List<WatermarkGaugeExposingOutput<StreamRecord<T>>> allOutputs = new ArrayList<>(4);
+        List<OutputWithChainingCheck<StreamRecord<T>>> allOutputs = new ArrayList<>(4);
 
         // create collectors for the network outputs
         for (NonChainedOutput streamOutput :
@@ -732,7 +731,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             outputEdge.getOutputTag(),
                             mailboxExecutorFactory,
                             shouldAddMetric);
-            allOutputs.add(output);
+            checkState(output instanceof OutputWithChainingCheck);
+            allOutputs.add((OutputWithChainingCheck) output);
             // If the operator has multiple downstream chained operators, only one of them should
             // increment the recordsOutCounter for this operator. Set shouldAddMetric to false
             // so that we would skip adding the counter to other downstream operators.
@@ -743,22 +743,35 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
 
         if (allOutputs.size() == 1) {
             result = allOutputs.get(0);
+            // only if this is a single RecordWriterOutput, reuse its numRecordOut for task.
+            if (result instanceof RecordWriterOutput) {
+                Counter numRecordsOutCounter = createNumRecordsOutCounter(containingTask);
+                ((RecordWriterOutput<T>) result).setNumRecordsOut(numRecordsOutCounter);
+            }
         } else {
             // send to N outputs. Note that this includes the special case
             // of sending to zero outputs
             @SuppressWarnings({"unchecked"})
-            Output<StreamRecord<T>>[] asArray = new Output[allOutputs.size()];
+            OutputWithChainingCheck<StreamRecord<T>>[] allOutputsArray =
+                    new OutputWithChainingCheck[allOutputs.size()];
             for (int i = 0; i < allOutputs.size(); i++) {
-                asArray[i] = allOutputs.get(i);
+                allOutputsArray[i] = allOutputs.get(i);
             }
 
             // This is the inverse of creating the normal ChainingOutput.
             // If the chaining output does not copy we need to copy in the broadcast output,
             // otherwise multi-chaining would not work correctly.
+            Counter numRecordsOutForTask = createNumRecordsOutCounter(containingTask);
             if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-                result = closer.register(new CopyingBroadcastingOutputCollector<>(asArray));
+                result =
+                        closer.register(
+                                new CopyingBroadcastingOutputCollector<>(
+                                        allOutputsArray, numRecordsOutForTask));
             } else {
-                result = closer.register(new BroadcastingOutputCollector<>(asArray));
+                result =
+                        closer.register(
+                                new BroadcastingOutputCollector<>(
+                                        allOutputsArray, numRecordsOutForTask));
             }
         }
 
@@ -772,6 +785,14 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             }
         }
         return result;
+    }
+
+    private static Counter createNumRecordsOutCounter(StreamTask<?, ?> containingTask) {
+        TaskIOMetricGroup taskIOMetricGroup =
+                containingTask.getEnvironment().getMetricGroup().getIOMetricGroup();
+        Counter counter = new SimpleCounter();
+        taskIOMetricGroup.reuseRecordsOutputCounter(counter);
+        return counter;
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OutputWithChainingCheck.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OutputWithChainingCheck.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * This is a wrapper for outputs to check whether the collected record has been emitted to a
+ * downstream subtask or to a chained operator.
+ */
+@Internal
+public interface OutputWithChainingCheck<OUT> extends WatermarkGaugeExposingOutput<OUT> {
+    /**
+     * @return true if the collected record has been emitted to a downstream subtask. Otherwise,
+     *     false.
+     */
+    boolean collectAndCheckIfChained(OUT record);
+
+    /**
+     * @return true if the collected record has been emitted to a downstream subtask. Otherwise,
+     *     false.
+     */
+    <X> boolean collectAndCheckIfChained(OutputTag<X> outputTag, StreamRecord<X> record);
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -40,6 +40,8 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriterWithAvailabilityHelper;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -48,6 +50,7 @@ import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingTaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -59,13 +62,16 @@ import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
@@ -993,6 +999,101 @@ public class OneInputStreamTaskTest extends TestLogger {
 
             testHarness.processAll();
             assertTrue(canEmitBatchOfRecordsChecker.check());
+        }
+    }
+
+    @Test
+    public void testTaskSideOutputStatistics() throws Exception {
+        TaskMetricGroup taskMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
+
+        ResultPartitionWriter[] partitionWriters = new ResultPartitionWriter[3];
+        for (int i = 0; i < partitionWriters.length; ++i) {
+            partitionWriters[i] =
+                    new RecordOrEventCollectingResultPartitionWriter<>(
+                            new ArrayDeque<>(),
+                            new StreamElementSerializer<>(
+                                    BasicTypeInfo.INT_TYPE_INFO.createSerializer(
+                                            new ExecutionConfig())));
+            partitionWriters[i].setup();
+        }
+
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .addAdditionalOutput(partitionWriters)
+                        .setupOperatorChain(new OperatorID(), new PassThroughOperator<>())
+                        .chain(BasicTypeInfo.INT_TYPE_INFO.createSerializer(new ExecutionConfig()))
+                        .setOperatorFactory(SimpleOperatorFactory.of(new OddEvenOperator()))
+                        .addNonChainedOutputsCount(
+                                new OutputTag<>("odd", BasicTypeInfo.INT_TYPE_INFO), 2)
+                        .addNonChainedOutputsCount(1)
+                        .build()
+                        .chain(BasicTypeInfo.INT_TYPE_INFO.createSerializer(new ExecutionConfig()))
+                        .setOperatorFactory(SimpleOperatorFactory.of(new DuplicatingOperator()))
+                        .addNonChainedOutputsCount(1)
+                        .build()
+                        .finish()
+                        .setTaskMetricGroup(taskMetricGroup)
+                        .build()) {
+            Counter numRecordsInCounter =
+                    taskMetricGroup.getIOMetricGroup().getNumRecordsInCounter();
+            Counter numRecordsOutCounter =
+                    taskMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
+
+            final int numEvenRecords = 5;
+            final int numOddRecords = 3;
+
+            for (int x = 0; x < numEvenRecords; x++) {
+                testHarness.processElement(new StreamRecord<>(2 * x));
+            }
+
+            for (int x = 0; x < numOddRecords; x++) {
+                testHarness.processElement(new StreamRecord<>(2 * x + 1));
+            }
+
+            final int oddEvenOperatorOutputsWithOddTag = numOddRecords;
+            final int oddEvenOperatorOutputsWithoutTag = numOddRecords + numEvenRecords;
+            final int duplicatingOperatorOutput = (numOddRecords + numEvenRecords) * 2;
+            assertEquals(numOddRecords + numEvenRecords, numRecordsInCounter.getCount());
+            assertEquals(
+                    oddEvenOperatorOutputsWithOddTag
+                            + oddEvenOperatorOutputsWithoutTag
+                            + duplicatingOperatorOutput,
+                    numRecordsOutCounter.getCount());
+            testHarness.waitForTaskCompletion();
+        } finally {
+            for (ResultPartitionWriter partitionWriter : partitionWriters) {
+                partitionWriter.close();
+            }
+        }
+    }
+
+    static class PassThroughOperator<T> extends AbstractStreamOperator<T>
+            implements OneInputStreamOperator<T, T> {
+
+        @Override
+        public void processElement(StreamRecord<T> element) throws Exception {
+            output.collect(element);
+        }
+    }
+
+    static class OddEvenOperator extends AbstractStreamOperator<Integer>
+            implements OneInputStreamOperator<Integer, Integer> {
+        private final OutputTag<Integer> oddOutputTag =
+                new OutputTag<>("odd", BasicTypeInfo.INT_TYPE_INFO);
+        private final OutputTag<Integer> evenOutputTag =
+                new OutputTag<>("even", BasicTypeInfo.INT_TYPE_INFO);
+
+        @Override
+        public void processElement(StreamRecord<Integer> element) {
+            if (element.getValue() % 2 == 0) {
+                output.collect(evenOutputTag, element);
+            } else {
+                output.collect(oddOutputTag, element);
+            }
+            output.collect(element);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -20,12 +20,12 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
@@ -89,7 +89,8 @@ public class OperatorChainTest {
             // initial output goes to nowhere
             @SuppressWarnings({"unchecked", "rawtypes"})
             WatermarkGaugeExposingOutput<StreamRecord<T>> lastWriter =
-                    new BroadcastingOutputCollector<>(new Output[0]);
+                    new BroadcastingOutputCollector<>(
+                            new OutputWithChainingCheck[0], new SimpleCounter());
 
             // build the reverse operators array
             for (int i = 0; i < operators.length; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
@@ -36,13 +37,17 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.OutputTag;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -57,6 +62,10 @@ public class StreamConfigChainer<OWNER> {
 
     private StreamConfig tailConfig;
     private int chainIndex = MAIN_NODE_ID;
+
+    private final List<List<NonChainedOutput>> outEdgesInOrder = new LinkedList<>();
+
+    private boolean setTailNonChainedOutputs = true;
 
     StreamConfigChainer(
             OperatorID headOperatorID,
@@ -77,6 +86,11 @@ public class StreamConfigChainer<OWNER> {
         headConfig.setChainIndex(chainIndex);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <T> StreamConfigChainer<OWNER> chain(
             OperatorID operatorID,
             OneInputStreamOperator<T, T> operator,
@@ -85,11 +99,21 @@ public class StreamConfigChainer<OWNER> {
         return chain(operatorID, operator, typeSerializer, typeSerializer, createKeyedStateBackend);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <T> StreamConfigChainer<OWNER> chain(
             OneInputStreamOperator<T, T> operator, TypeSerializer<T> typeSerializer) {
         return chain(new OperatorID(), operator, typeSerializer);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <T> StreamConfigChainer<OWNER> chain(
             OperatorID operatorID,
             OneInputStreamOperator<T, T> operator,
@@ -97,11 +121,21 @@ public class StreamConfigChainer<OWNER> {
         return chain(operatorID, operator, typeSerializer, typeSerializer, false);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <T> StreamConfigChainer<OWNER> chain(
             OneInputStreamOperatorFactory<T, T> operatorFactory, TypeSerializer<T> typeSerializer) {
         return chain(new OperatorID(), operatorFactory, typeSerializer);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <T> StreamConfigChainer<OWNER> chain(
             OperatorID operatorID,
             OneInputStreamOperatorFactory<T, T> operatorFactory,
@@ -109,6 +143,11 @@ public class StreamConfigChainer<OWNER> {
         return chain(operatorID, operatorFactory, typeSerializer, typeSerializer, false);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     private <IN, OUT> StreamConfigChainer<OWNER> chain(
             OperatorID operatorID,
             OneInputStreamOperator<IN, OUT> operator,
@@ -123,6 +162,11 @@ public class StreamConfigChainer<OWNER> {
                 createKeyedStateBackend);
     }
 
+    /**
+     * @deprecated Use {@link #chain(TypeSerializer)} or {@link #chain(TypeSerializer,
+     *     TypeSerializer)} instead.
+     */
+    @Deprecated
     public <IN, OUT> StreamConfigChainer<OWNER> chain(
             OperatorID operatorID,
             StreamOperatorFactory<OUT> operatorFactory,
@@ -168,36 +212,47 @@ public class StreamConfigChainer<OWNER> {
         return this;
     }
 
-    public OWNER finish() {
-        checkState(chainIndex > 0, "Use finishForSingletonOperatorChain");
-        List<NonChainedOutput> outEdgesInOrder = new LinkedList<>();
+    public <T> StreamConfigEdgeChainer<OWNER, T, T> chain(TypeSerializer<T> typeSerializer) {
+        return chain(typeSerializer, typeSerializer);
+    }
 
-        StreamNode sourceVertex =
-                new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null);
-        for (int i = 0; i < numberOfNonChainedOutputs; ++i) {
-            NonChainedOutput streamOutput =
-                    new NonChainedOutput(
-                            true,
-                            sourceVertex.getId(),
-                            1,
-                            1,
-                            100,
-                            false,
-                            new IntermediateDataSetID(),
-                            null,
-                            new BroadcastPartitioner<>(),
-                            ResultPartitionType.PIPELINED_BOUNDED);
-            outEdgesInOrder.add(streamOutput);
+    public <IN, OUT> StreamConfigEdgeChainer<OWNER, IN, OUT> chain(
+            TypeSerializer<IN> inputSerializer, TypeSerializer<OUT> outputSerializer) {
+        return new StreamConfigEdgeChainer<>(this, inputSerializer, outputSerializer);
+    }
+
+    public OWNER finish() {
+        if (setTailNonChainedOutputs) {
+            List<NonChainedOutput> nonChainedOutputs = new ArrayList<>();
+            for (int i = 0; i < numberOfNonChainedOutputs; ++i) {
+                NonChainedOutput streamOutput =
+                        new NonChainedOutput(
+                                true,
+                                chainIndex,
+                                1,
+                                1,
+                                100,
+                                false,
+                                new IntermediateDataSetID(),
+                                null,
+                                new BroadcastPartitioner<>(),
+                                ResultPartitionType.PIPELINED_BOUNDED);
+                nonChainedOutputs.add(streamOutput);
+            }
+            outEdgesInOrder.add(nonChainedOutputs);
+            tailConfig.setNumberOfOutputs(numberOfNonChainedOutputs);
+            tailConfig.setVertexNonChainedOutputs(nonChainedOutputs);
+            tailConfig.setOperatorNonChainedOutputs(nonChainedOutputs);
         }
 
-        tailConfig.setChainEnd();
-        tailConfig.setNumberOfOutputs(numberOfNonChainedOutputs);
-        tailConfig.setVertexNonChainedOutputs(outEdgesInOrder);
-        tailConfig.setOperatorNonChainedOutputs(outEdgesInOrder);
-        chainedConfigs.values().forEach(StreamConfig::serializeAllConfigs);
+        Collections.reverse(outEdgesInOrder);
+        List<NonChainedOutput> allOutEdgesInOrder =
+                outEdgesInOrder.stream().flatMap(List::stream).collect(Collectors.toList());
 
+        tailConfig.setChainEnd();
+        chainedConfigs.values().forEach(StreamConfig::serializeAllConfigs);
         headConfig.setAndSerializeTransitiveChainedTaskConfigs(chainedConfigs);
-        headConfig.setVertexNonChainedOutputs(outEdgesInOrder);
+        headConfig.setVertexNonChainedOutputs(allOutEdgesInOrder);
         headConfig.serializeAllConfigs();
 
         return owner;
@@ -261,5 +316,144 @@ public class StreamConfigChainer<OWNER> {
 
     public void setBufferTimeout(int bufferTimeout) {
         this.bufferTimeout = bufferTimeout;
+    }
+
+    /** Helper class to build operator node. */
+    public static class StreamConfigEdgeChainer<OWNER, IN, OUT> {
+        private final OutputTag<Void> placeHolderTag;
+        private StreamConfigChainer<OWNER> parent;
+        private OperatorID operatorID;
+
+        private final TypeSerializer<IN> inputSerializer;
+        private final TypeSerializer<OUT> outputSerializer;
+
+        private StreamOperatorFactory<OUT> operatorFactory;
+
+        private Map<OutputTag<?>, Integer> nonChainedOutPuts;
+        private boolean createKeyedStateBackend;
+
+        private StreamConfigEdgeChainer(
+                StreamConfigChainer<OWNER> parent,
+                TypeSerializer<IN> inputSerializer,
+                TypeSerializer<OUT> outputSerializer) {
+            this.parent = parent;
+            this.parent.setTailNonChainedOutputs = true;
+
+            this.inputSerializer = inputSerializer;
+            this.outputSerializer = outputSerializer;
+            this.placeHolderTag =
+                    new OutputTag<>("FLINK_PLACEHOLDER", BasicTypeInfo.VOID_TYPE_INFO);
+            this.nonChainedOutPuts = new HashMap<>(4);
+        }
+
+        public StreamConfigEdgeChainer<OWNER, IN, OUT> setOperatorID(OperatorID operatorID) {
+            this.operatorID = operatorID;
+            return this;
+        }
+
+        public StreamConfigEdgeChainer<OWNER, IN, OUT> setOperatorFactory(
+                StreamOperatorFactory operatorFactory) {
+            this.operatorFactory = operatorFactory;
+            return this;
+        }
+
+        public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(
+                int nonChainedOutputsCount) {
+            return addNonChainedOutputsCount(placeHolderTag, nonChainedOutputsCount);
+        }
+
+        public StreamConfigEdgeChainer<OWNER, IN, OUT> addNonChainedOutputsCount(
+                OutputTag<?> outputTag, int nonChainedOutputsCount) {
+            checkArgument(nonChainedOutputsCount >= 0 && outputTag != null);
+            this.nonChainedOutPuts.put(outputTag, nonChainedOutputsCount);
+            return this;
+        }
+
+        public StreamConfigEdgeChainer<OWNER, IN, OUT> setCreateKeyedStateBackend(
+                boolean createKeyedStateBackend) {
+            this.createKeyedStateBackend = createKeyedStateBackend;
+            return this;
+        }
+
+        public StreamConfigChainer<OWNER> build() {
+            parent.chainIndex++;
+
+            StreamEdge streamEdge =
+                    new StreamEdge(
+                            new StreamNode(
+                                    parent.tailConfig.getChainIndex(),
+                                    null,
+                                    null,
+                                    (StreamOperator<?>) null,
+                                    null,
+                                    null),
+                            new StreamNode(
+                                    parent.chainIndex,
+                                    null,
+                                    null,
+                                    (StreamOperator<?>) null,
+                                    null,
+                                    null),
+                            0,
+                            null,
+                            null);
+            streamEdge.setBufferTimeout(parent.bufferTimeout);
+            parent.tailConfig.setChainedOutputs(Collections.singletonList(streamEdge));
+            parent.tailConfig = new StreamConfig(new Configuration());
+            parent.tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
+            parent.tailConfig.setOperatorID(operatorID == null ? new OperatorID() : operatorID);
+            parent.tailConfig.setupNetworkInputs(inputSerializer);
+            parent.tailConfig.setTypeSerializerOut(outputSerializer);
+            if (createKeyedStateBackend) {
+                // used to test multiple stateful operators chained in a single task.
+                parent.tailConfig.setStateKeySerializer(inputSerializer);
+                parent.tailConfig.setStateBackendUsesManagedMemory(true);
+                parent.tailConfig.setManagedMemoryFractionOperatorOfUseCase(
+                        ManagedMemoryUseCase.STATE_BACKEND, 1.0);
+            }
+            if (!nonChainedOutPuts.isEmpty()) {
+                List<NonChainedOutput> nonChainedOutputs =
+                        createNonChainedOutputs(nonChainedOutPuts, streamEdge);
+
+                parent.tailConfig.setVertexNonChainedOutputs(nonChainedOutputs);
+                parent.tailConfig.setOperatorNonChainedOutputs(nonChainedOutputs);
+                parent.chainedConfigs.values().forEach(StreamConfig::serializeAllConfigs);
+                parent.tailConfig.setNumberOfOutputs(nonChainedOutputs.size());
+                parent.outEdgesInOrder.add(nonChainedOutputs);
+                parent.setTailNonChainedOutputs = false;
+            }
+            parent.tailConfig.setChainIndex(parent.chainIndex);
+            parent.tailConfig.serializeAllConfigs();
+
+            parent.chainedConfigs.put(parent.chainIndex, parent.tailConfig);
+            return parent;
+        }
+
+        private List<NonChainedOutput> createNonChainedOutputs(
+                Map<OutputTag<?>, Integer> nonChainedOutputsCount, StreamEdge streamEdge) {
+            List<NonChainedOutput> nonChainedOutputs = new ArrayList<>();
+            nonChainedOutputsCount.forEach(
+                    (outputTag, value) -> {
+                        for (int i = 0; i < value; i++) {
+                            nonChainedOutputs.add(
+                                    new NonChainedOutput(
+                                            true,
+                                            streamEdge.getTargetId(),
+                                            1,
+                                            1,
+                                            100,
+                                            false,
+                                            new IntermediateDataSetID(),
+                                            placeHolderTag.equals(outputTag) ? null : outputTag,
+                                            new BroadcastPartitioner<>(),
+                                            ResultPartitionType.PIPELINED_BOUNDED));
+                            if (!placeHolderTag.equals(outputTag)) {
+                                parent.tailConfig.setTypeSerializerSideOut(
+                                        outputTag, outputSerializer);
+                            }
+                        }
+                    });
+            return nonChainedOutputs;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*If an operator has nonChainedOutputs, then its corresponding output should be counted in the task-level numRecordsOut metric.*

This pull request is borrowed from #13109. The copyright of the original author is reserved as co-author.


## Brief change log

  - *Include side outputs in numRecordsOut metric*

## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
