### PR TITLE
[FLINK-31723] Fix DispatcherTest#testCancellationDuringInitialization to not make assumptions about an underlying scheduler implementation.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
@@ -274,7 +274,7 @@ class DefaultJobMasterServiceProcessTest {
         return new DefaultJobMasterServiceProcess(
                 jobId,
                 UUID.randomUUID(),
-                new TestingJobMasterServiceFactory(() -> jobMasterServiceFuture),
+                new TestingJobMasterServiceFactory(ignored -> jobMasterServiceFuture),
                 failedArchivedExecutionGraphFactory);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
@@ -24,24 +24,26 @@ import org.apache.flink.runtime.jobmaster.TestingJobMasterService;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /** Testing implementation of the {@link JobMasterServiceFactory}. */
 public class TestingJobMasterServiceFactory implements JobMasterServiceFactory {
-    private final Supplier<CompletableFuture<JobMasterService>> jobMasterServiceSupplier;
+    private final Function<OnCompletionActions, CompletableFuture<JobMasterService>>
+            jobMasterServiceFunction;
 
     public TestingJobMasterServiceFactory(
-            Supplier<CompletableFuture<JobMasterService>> jobMasterServiceSupplier) {
-        this.jobMasterServiceSupplier = jobMasterServiceSupplier;
+            Function<OnCompletionActions, CompletableFuture<JobMasterService>>
+                    jobMasterServiceFunction) {
+        this.jobMasterServiceFunction = jobMasterServiceFunction;
     }
 
     public TestingJobMasterServiceFactory() {
-        this(() -> CompletableFuture.completedFuture(new TestingJobMasterService()));
+        this(ignored -> CompletableFuture.completedFuture(new TestingJobMasterService()));
     }
 
     @Override
     public CompletableFuture<JobMasterService> createJobMasterService(
             UUID leaderSessionId, OnCompletionActions onCompletionActions) {
-        return jobMasterServiceSupplier.get();
+        return jobMasterServiceFunction.apply(onCompletionActions);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31723

This test has never worked with the AdaptiveScheduler, because `initializeOnMaster` is run during a different job state.

This test's purpose is to test the behavior of `JobMasterServiceLeadershipRunner,` not of the underlying scheduler implementation, so the fix is to make the test scheduler independent.