### PR TITLE
[FLINK-31868] Fix DefaultInputSplitAssigner javadoc for class

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DefaultInputSplitAssigner.java
@@ -32,8 +32,7 @@ import java.util.List;
 
 /**
  * This is the default implementation of the {@link InputSplitAssigner} interface. The default input
- * split assigner simply returns all input splits of an input vertex in the order they were
- * originally computed.
+ * split assigner simply returns all input splits of an input vertex in an undefined order.
  */
 @Internal
 public class DefaultInputSplitAssigner implements InputSplitAssigner {


### PR DESCRIPTION
## What is the purpose of the change

Fix the discrepancy between the code and the comment. The comment erroneously states that the return order for the splits is in order.

## Brief change log

The decision was to update the comment

## Verifying this change

No testing is needed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
