### PR TITLE
[FLINK-31873][API / DataStream] Add method setMaxParallelism to DataStreamSink.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.common.operators.util.OperatorValidationUtils;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -177,6 +178,21 @@ public class DataStreamSink<T> {
      */
     public DataStreamSink<T> setParallelism(int parallelism) {
         transformation.setParallelism(parallelism);
+        return this;
+    }
+
+    /**
+     * Sets the max parallelism for this sink.
+     *
+     * <p>The maximum parallelism specifies the upper bound for dynamic scaling. The degree must be
+     * higher than zero and less than the upper bound.
+     *
+     * @param maxParallelism The max parallelism for this sink.
+     * @return The sink with set parallelism.
+     */
+    public DataStreamSink<T> setMaxParallelism(int maxParallelism) {
+        OperatorValidationUtils.validateMaxParallelism(maxParallelism, true);
+        transformation.setMaxParallelism(maxParallelism);
         return this;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -257,7 +257,7 @@ class StreamingJobGraphGeneratorTest {
     }
 
     @Test
-    public void testTransformationSetParallelism() {
+    void testTransformationSetParallelism() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         /* The default parallelism of the environment (that is inherited by the source)
         and the parallelism of the map operator needs to be different for this test */
@@ -284,7 +284,7 @@ class StreamingJobGraphGeneratorTest {
     }
 
     @Test
-    public void testChainNodeSetParallelism() {
+    void testChainNodeSetParallelism() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.fromSequence(1L, 3L).map(value -> value).print().setParallelism(env.getParallelism());
         StreamGraph streamGraph = env.getStreamGraph();
@@ -306,7 +306,7 @@ class StreamingJobGraphGeneratorTest {
     }
 
     @Test
-    public void testChainedSourcesSetParallelism() {
+    void testChainedSourcesSetParallelism() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         MultipleInputTransformation<Long> transform =
                 new MultipleInputTransformation<>(
@@ -350,7 +350,7 @@ class StreamingJobGraphGeneratorTest {
     }
 
     @Test
-    public void testDynamicGraphVertexParallelism() {
+    void testDynamicGraphVertexParallelism() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         int defaultParallelism = 20;
         env.setParallelism(defaultParallelism);


### PR DESCRIPTION
## What is the purpose of the change

When turning on Flink reactive mode, it is suggested to convert all `setParallelism` calls to `setMaxParallelism`, [docs](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/deployment/elastic_scaling/#configuration).

With the current implementation of the `DataStreamSink`, only the [`setParallelism` function](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java#L172-L181) of the [`Transformation` class is exposed - `Transformation` also has the `setMaxParallelism` function which is not exposed](https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java#L248-L285).

This PR exposes the `setMaxParallelism` function on any `DataStreamSink` objects in a Flink pipeline, which would be helpful to not only reactive mode, but also to the [vertex auto scaler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-271%3A+Autoscaling) and non elastic scaling mode.

## Brief change log

* Add `setMaxParallelism` function to `DataStreamSink`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? **(yes)**
  - If yes, how is the feature documented? **(JavaDocs)**
