### PR TITLE
[hotfix]Use wrapper classes like other parameters

### DIFF
--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/StreamSQLExample.java
@@ -100,13 +100,13 @@ public final class StreamSQLExample {
     public static class Order {
         public Long user;
         public String product;
-        public int amount;
+        public Integer amount;
 
         // for POJO detection in DataStream API
         public Order() {}
 
         // for structured type detection in Table API
-        public Order(Long user, String product, int amount) {
+        public Order(Long user, String product, Integer amount) {
             this.user = user;
             this.product = product;
             this.amount = amount;


### PR DESCRIPTION
This modification aims to unify the parameter format