### PR TITLE
[DOC]: Remove duplicate sentence in docker deployment documentation

### DIFF
--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -414,7 +414,6 @@ services:
   ```
   
   and reference it (e.g via the `build`) command in the Dockerfile.
-  and reference it (e.g via the `build`) command in the Dockerfile. 
   SQL Commands like `ADD JAR` will not work for JARs located on the host machine as they only work with the local filesystem, which in this case is Docker's overlay filesystem. 
 
 ## Using Flink Python on Docker


### PR DESCRIPTION
Remove seemingly duplicate sentence in docker deployment page