### PR TITLE
[FLINK-31828][planner] Use the inner serializer for RawType when doin…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.codegen.CodeGenUtils;
 import org.apache.flink.table.runtime.generated.CompileUtils;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.runtime.typeutils.RawValueDataSerializer;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -217,10 +218,15 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
                     .computeIfAbsent(
                             type,
                             t -> {
+                                TypeSerializer<?> serializer = InternalSerializers.create(t);
+                                if (serializer instanceof RawValueDataSerializer) {
+                                    serializer =
+                                            ((RawValueDataSerializer<?>) serializer)
+                                                    .getInnerSerializer();
+                                }
                                 Map.Entry<String, TypeSerializer<?>> e =
                                         new SimpleImmutableEntry<>(
-                                                "typeSerializer$" + variableIndex,
-                                                InternalSerializers.create(t));
+                                                "typeSerializer$" + variableIndex, serializer);
                                 variableIndex++;
                                 return e;
                             })


### PR DESCRIPTION
…g casting

## What is the purpose of the change

Fix wrong serializer used when calling `toObject` for RawType.

Before it will fails the cast with 

![image](https://user-images.githubusercontent.com/9486140/233818503-dea44202-3424-405f-91f8-8cb5e436dbed.png)


## Brief change log

Return the inner serializer for `RawValueDataSerializer` when doing cast.


## Verifying this change

CastRulesTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
