### PR TITLE
[FLINK-30478] [core] Avoiding dependence on JDK-internal code

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -21,9 +21,10 @@ package org.apache.flink.util;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.IllegalConfigurationException;
 
+import org.apache.flink.shaded.guava30.com.google.common.net.InetAddresses;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.net.util.IPAddressUtil;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -197,17 +198,20 @@ public class NetUtils {
             host = host.trim().toLowerCase();
             if (host.startsWith("[") && host.endsWith("]")) {
                 String address = host.substring(1, host.length() - 1);
-                if (IPAddressUtil.isIPv6LiteralAddress(address)) {
+                if (InetAddresses.isInetAddress(address)) {
                     host = address;
                 }
             }
         }
 
         // normalize and valid address
-        if (IPAddressUtil.isIPv6LiteralAddress(host)) {
-            byte[] ipV6Address = IPAddressUtil.textToNumericFormatV6(host);
-            host = getIPv6UrlRepresentation(ipV6Address);
-        } else if (!IPAddressUtil.isIPv4LiteralAddress(host)) {
+        if (InetAddresses.isInetAddress(host)) {
+            InetAddress inetAddress = InetAddresses.forString(host);
+            if (inetAddress instanceof Inet6Address) {
+                byte[] ipV6Address = inetAddress.getAddress();
+                host = getIPv6UrlRepresentation(ipV6Address);
+            }
+        } else {
             try {
                 // We don't allow these in hostnames
                 Preconditions.checkArgument(!host.startsWith("."));

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -28,7 +28,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -259,7 +258,15 @@ public class NetUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testFormatAddress() throws UnknownHostException {
+    public void testFormatAddress() {
+        {
+            // null
+            String host = null;
+            int port = 42;
+            Assert.assertEquals(
+                    "127.0.0.1" + ":" + port,
+                    NetUtils.unresolvedHostAndPortToNormalizedString(host, port));
+        }
         {
             // IPv4
             String host = "1.2.3.4";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
@@ -39,10 +39,11 @@ import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.concurrent.Executors;
 
+import org.apache.flink.shaded.guava30.com.google.common.net.InetAddresses;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.opentest4j.TestAbortedException;
-import sun.net.util.IPAddressUtil;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -132,11 +133,7 @@ class TaskManagerRunnerConfigurationTest {
             taskManagerRpcService =
                     TaskManagerRunner.createRpcService(
                             config, highAvailabilityServices, RPC_SYSTEM);
-            assertThat(taskManagerRpcService.getAddress())
-                    .matches(
-                            value ->
-                                    (IPAddressUtil.isIPv4LiteralAddress(value)
-                                            || IPAddressUtil.isIPv6LiteralAddress(value)));
+            assertThat(taskManagerRpcService.getAddress()).matches(InetAddresses::isInetAddress);
         } finally {
             maybeCloseRpcService(taskManagerRpcService);
             highAvailabilityServices.closeAndCleanupAllData();


### PR DESCRIPTION
## What is the purpose of the change

Increasing the usability of Flink with JDK 17: sun.net.util.IPAddressUtil is not exported by the JDK, i.e. --add-opens configuration is needed for making use of it.


## Brief change log

  - Replace usage of `sun.net.util.IPAddressUtil` with `com.google.common.net.InetAddresses` in production and testing code.
  - Complement coverage of unit test case when `host` is `null`.


## Verifying this change

This change is already covered by existing tests, such as *NetUtilsTest* and `TaskManagerRunnerConfigurationTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
