### PR TITLE
[FLINK-31900] Fix some typo in java doc, comments and assertion message

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputOperator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SingleInputOperator.java
@@ -28,7 +28,7 @@ import org.apache.flink.util.Visitor;
 import java.util.List;
 
 /**
- * Abstract superclass for for all operators that have one input like "map" or "reduce".
+ * Abstract superclass for all operators that have one input like "map" or "reduce".
  *
  * @param <IN> Input type of the user function
  * @param <OUT> Output type of the user function

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -404,7 +404,7 @@ public class ContinuousFileProcessingTest {
             tester.close();
         }
 
-        // the lines received must be the elements in the files +1 for for the longMax watermark
+        // the lines received must be the elements in the files +1 for the longMax watermark
         // we are in event time, which emits no watermarks, so the last watermark will mark the
         // of the input stream.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -113,7 +113,7 @@ public class CheckpointCoordinator {
     /** The job whose checkpoint this coordinator coordinates. */
     private final JobID job;
 
-    /** Default checkpoint properties. * */
+    /** Default checkpoint properties. */
     private final CheckpointProperties checkpointProperties;
 
     /** The executor used for asynchronous calls, like potentially blocking I/O. */
@@ -800,7 +800,7 @@ public class CheckpointCoordinator {
     }
 
     /**
-     * Initialize the checkpoint location asynchronously. It will expected to be executed in io
+     * Initialize the checkpoint location asynchronously. It will be expected to be executed in io
      * thread due to it might be time-consuming.
      *
      * @param checkpointID checkpoint id

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractThreadsafeJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractThreadsafeJobResultStore.java
@@ -47,7 +47,7 @@ public abstract class AbstractThreadsafeJobResultStore implements JobResultStore
     public void createDirtyResult(JobResultEntry jobResultEntry) throws IOException {
         Preconditions.checkState(
                 !hasJobResultEntry(jobResultEntry.getJobId()),
-                "Job result store already contains an entry for for job %s",
+                "Job result store already contains an entry for job %s",
                 jobResultEntry.getJobId());
 
         withWriteLock(() -> createDirtyResultInternal(jobResultEntry));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
@@ -26,7 +26,7 @@ public final class KeyGroupRangeAssignment {
 
     /**
      * The default lower bound for max parallelism if nothing was configured by the user. We have
-     * this so allow users some degree of scale-up in case they forgot to configure maximum
+     * this to allow users some degree of scale-up in case they forgot to configure maximum
      * parallelism explicitly.
      */
     public static final int DEFAULT_LOWER_BOUND_MAX_PARALLELISM = 1 << 7;
@@ -87,7 +87,7 @@ public final class KeyGroupRangeAssignment {
      * @param maxParallelism Maximal parallelism that the job was initially created with.
      * @param parallelism The current parallelism under which the job runs. Must be <=
      *     maxParallelism.
-     * @param operatorIndex Id of a key-group. 0 <= keyGroupID < maxParallelism.
+     * @param operatorIndex index of a operatorIndex. 0 <= operatorIndex < parallelism.
      * @return the computed key-group range for the operator.
      */
     public static KeyGroupRange computeKeyGroupRangeForOperatorIndex(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -50,8 +50,7 @@ import java.util.Collection;
  *
  * <h2>Raw Bytes Storage and Backends</h2>
  *
- * <p>The {@code StateBackend} creates services for for <i>keyed state</i> and <i>operator
- * state</i>.
+ * <p>The {@code StateBackend} creates services for <i>keyed state</i> and <i>operator state</i>.
  *
  * <p>The {@link CheckpointableKeyedStateBackend} and {@link OperatorStateBackend} created by this
  * state backend define how to hold the working state for keys and operators. They also define how


### PR DESCRIPTION
## What is the purpose of the change

Fix some typo in java doc, comments and assertion message

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)