### PR TITLE
[FLINK-31907][coordination] Remove the unused field inside ExecutionSlotSharingGroupBuilder

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
@@ -133,9 +132,6 @@ class LocalInputPreferredSlotSharingStrategy
         private final Map<CoLocationConstraint, ExecutionSlotSharingGroup>
                 constraintToExecutionSlotSharingGroupMap;
 
-        private final Map<SlotSharingGroupId, List<ExecutionSlotSharingGroup>>
-                executionSlotSharingGroups;
-
         /**
          * A JobVertex only belongs to one {@link SlotSharingGroup}. A SlotSharingGroup is
          * corresponding to a set of {@link ExecutionSlotSharingGroup}s. We can maintain available
@@ -197,7 +193,6 @@ class LocalInputPreferredSlotSharingStrategy
 
             executionSlotSharingGroupMap = new HashMap<>();
             constraintToExecutionSlotSharingGroupMap = new HashMap<>();
-            executionSlotSharingGroups = new HashMap<>();
             availableGroupsForJobVertex = new HashMap<>();
             candidateGroupsForConsumedPartitionGroup = new IdentityHashMap<>();
         }
@@ -398,14 +393,9 @@ class LocalInputPreferredSlotSharingStrategy
                 ExecutionVertexID executionVertexId) {
             final SlotSharingGroup slotSharingGroup =
                     getSlotSharingGroup(executionVertexId.getJobVertexId());
-            final List<ExecutionSlotSharingGroup> correspondingExecutionSlotSharingGroups =
-                    executionSlotSharingGroups.computeIfAbsent(
-                            slotSharingGroup.getSlotSharingGroupId(), k -> new ArrayList<>());
 
             final ExecutionSlotSharingGroup newGroup = new ExecutionSlotSharingGroup();
             newGroup.setResourceProfile(slotSharingGroup.getResourceProfile());
-
-            correspondingExecutionSlotSharingGroups.add(newGroup);
 
             // Once a new ExecutionSlotSharingGroup is created, it's available for all JobVertices
             // in this SlotSharingGroup


### PR DESCRIPTION
## What is the purpose of the change

FLINK-22767 introduced `availableGroupsForJobVertex` to improve the performance during task to slot scheduler.

After FLINK-22767, the `executionSlotSharingGroups`[2] is unused, and it can be removed.


[1] https://github.com/apache/flink/blob/f9b3e0b7bc0432001b4a197539a0712b16e0b33b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java#L153

[2] https://github.com/apache/flink/blob/f9b3e0b7bc0432001b4a197539a0712b16e0b33b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java#L136


## Brief change log

Remove the unused field inside ExecutionSlotSharingGroupBuilder.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
