### PR TITLE
[FLINK-31911][sql][tests] Fix address construction

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -40,7 +40,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -148,10 +147,10 @@ class SqlClientTest {
                 new String[] {
                     "gateway",
                     "-e",
-                    InetSocketAddress.createUnresolved(
-                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
-                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort())
-                            .toString()
+                    String.format(
+                            "%s:%d",
+                            SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                            SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort())
                 };
         String actual = runSqlClient(args, String.join("\n", "SET;", "QUIT;"), false);
         assertThat(actual).contains("execution.target", "yarn-session");


### PR DESCRIPTION
Simplifies the construction of the rest address. On Java 17 this fails because the InetSocketAddress toString representation contained "\<host>/unresolved:\<port>" .