### PR TITLE
[FLINK-31831][test] Use random ports as rest bind port and jobmanager rpc port to avoid port binding failure

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -52,6 +52,7 @@ import org.apache.flink.test.util.TestProcessBuilder;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.TestLoggerExtension;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
@@ -67,7 +68,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 /** This test ensures the TaskManager disconnects from the ResourceManager on shutdown. */
 @ExtendWith(TestLoggerExtension.class)
@@ -97,7 +97,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
         // is available on this machine
         String javaCommand = getJavaCommandPath();
         if (javaCommand == null) {
-            fail("cannot find java executable");
+            Assertions.fail("cannot find java executable");
         }
 
         final TaskManagerConnectionTracker tracker = new TaskManagerConnectionTracker();
@@ -133,7 +133,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
             assertThat(tracker.getNumberOfConnectedTaskManager()).isEqualTo(1);
         } catch (Throwable t) {
             printProcessLog(taskManagerProcess);
-            fail(t.getMessage());
+            Assertions.fail(t.getMessage());
         } finally {
             if (taskManagerProcess != null && taskManagerProcess.getProcess().isAlive()) {
                 LOG.error("TaskManager did not shutdown in time.");

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -80,6 +81,8 @@ public class TaskManagerDisconnectOnShutdownITCase {
     public void testTaskManagerProcessFailure() {
         Configuration config = new Configuration();
         config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.PORT, 0);
+        config.set(RestOptions.BIND_PORT, "0");
 
         // disable heartbeats
         config.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, -1);
@@ -116,9 +119,11 @@ public class TaskManagerDisconnectOnShutdownITCase {
                 }) {
             clusterEntrypoint.startCluster();
 
+            final Configuration taskManagerConfig = new Configuration(config);
+            taskManagerConfig.set(JobManagerOptions.PORT, clusterEntrypoint.getRpcPort());
             TestProcessBuilder taskManagerProcessBuilder =
                     new TestProcessBuilder(TaskExecutorProcessEntryPoint.class.getName());
-            taskManagerProcessBuilder.addConfigAsMainClassArgs(config);
+            taskManagerProcessBuilder.addConfigAsMainClassArgs(taskManagerConfig);
 
             // start the TaskManager processes
             taskManagerProcess = taskManagerProcessBuilder.start();


### PR DESCRIPTION
## What is the purpose of the change

Use random ports as rest bind port and jobmanager rpc port to avoid port binding failure

## Verifying this change
This PR trys to fix the unstable test `TaskManagerDisconnectOnShutdownITCase`,  so it is covered by `TaskManagerDisconnectOnShutdownITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
