### PR TITLE
[FLINK-31917][table-planner] Fix the idempotence lost in JsonSerDe round trip for AggregateCall and RexNode

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallJsonDeserializer.java
@@ -24,6 +24,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.JsonNodeType;
 
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.AggregateCall;
@@ -61,7 +62,8 @@ final class AggregateCallJsonDeserializer extends StdDeserializer<AggregateCall>
         final JsonNode jsonNode = jsonParser.readValueAsTree();
         final SerdeContext serdeContext = SerdeContext.get(ctx);
 
-        final String name = jsonNode.required(FIELD_NAME_NAME).asText();
+        JsonNode nameNode = jsonNode.required(FIELD_NAME_NAME);
+        final String name = nameNode.getNodeType() == JsonNodeType.NULL ? null : nameNode.asText();
         final SqlAggFunction aggFunction =
                 (SqlAggFunction)
                         RexNodeJsonDeserializer.deserializeSqlOperator(jsonNode, serdeContext);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallSerdeTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.TableAggregateFunction;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.functions.utils.AggSqlFunction;
+import org.apache.flink.table.planner.utils.Top3;
+import org.apache.flink.table.planner.utils.Top3Accum;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeTestUtil.testJsonRoundTrip;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link org.apache.calcite.rel.core.AggregateCall} serialization and deserialization.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class AggregateCallSerdeTest {
+
+    private static final FlinkTypeFactory FACTORY =
+            new FlinkTypeFactory(
+                    AggregateCallSerdeTest.class.getClassLoader(), FlinkTypeSystem.INSTANCE);
+
+    @MethodSource("aggregateCallSpecs")
+    @ParameterizedTest
+    void testAggregateCallSerde(AggregateCall aggCall) throws IOException {
+        testJsonRoundTrip(aggCall, AggregateCall.class);
+    }
+
+    @Test
+    void testUnsupportedLegacyAggFunc() {
+        assertThatThrownBy(() -> testJsonRoundTrip(getLegacyAggCall(), AggregateCall.class))
+                .hasRootCauseInstanceOf(TableException.class)
+                .hasRootCauseMessage(
+                        "Functions of the deprecated function stack are not supported. Please update 'top3' to the new interfaces.");
+    }
+
+    public static Stream<Arguments> aggregateCallSpecs() {
+        return Stream.of(
+                Arguments.of(
+                        AggregateCall.create(
+                                SqlStdOperatorTable.RANK,
+                                false,
+                                false,
+                                false,
+                                ImmutableList.of(),
+                                -1,
+                                null,
+                                RelCollations.EMPTY,
+                                fromLogicalType(new BigIntType(false)),
+                                "rk")),
+                Arguments.of(
+                        AggregateCall.create(
+                                SqlStdOperatorTable.MAX,
+                                false,
+                                false,
+                                false,
+                                ImmutableList.of(3),
+                                -1,
+                                null,
+                                RelCollations.EMPTY,
+                                fromLogicalType(new DoubleType(false)),
+                                "max_d")),
+                Arguments.of(
+                        AggregateCall.create(
+                                SqlStdOperatorTable.COUNT,
+                                false,
+                                false,
+                                false,
+                                ImmutableList.of(),
+                                -1,
+                                null,
+                                RelCollations.EMPTY,
+                                fromLogicalType(new BigIntType(false)),
+                                null)));
+    }
+
+    private static RelDataType fromLogicalType(LogicalType type) {
+        return FACTORY.createFieldTypeFromLogicalType(type);
+    }
+
+    private static AggregateCall getLegacyAggCall() {
+        TableAggregateFunction<Tuple2<Integer, Integer>, Top3Accum> top3 = new Top3();
+        DataType externalResultType =
+                TypeConversions.fromLegacyInfoToDataType(
+                        UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(top3));
+        DataType externalAccType =
+                TypeConversions.fromLegacyInfoToDataType(
+                        UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(top3));
+        AggSqlFunction aggFunction =
+                AggSqlFunction.apply(
+                        FunctionIdentifier.of("top3"),
+                        "top3",
+                        top3,
+                        externalResultType,
+                        externalAccType,
+                        FACTORY,
+                        false);
+        return AggregateCall.create(
+                aggFunction,
+                false,
+                false,
+                false,
+                ImmutableList.of(3),
+                -1,
+                null,
+                RelCollations.of(),
+                FACTORY.builder()
+                        .add("f0", new BasicSqlType(FACTORY.getTypeSystem(), SqlTypeName.INTEGER))
+                        .add("f1", new BasicSqlType(FACTORY.getTypeSystem(), SqlTypeName.INTEGER))
+                        .build(),
+                "top3");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeTestUtil.java
@@ -98,6 +98,7 @@ class JsonSerdeTestUtil {
         T actual = toObject(serdeContext, actualJson, clazz);
 
         assertThat(actual).isEqualTo(spec);
+        assertThat(actualJson).isEqualTo(toJson(serdeContext, actual));
         return actual;
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerdeTest.java
@@ -205,8 +205,8 @@ public class RexNodeJsonSerdeTest {
                                 TableException.class,
                                 "Could not lookup system function '" + FUNCTION_NAME + "'."));
 
-        // Registered temporary function
-        registerTemporaryFunction(serdeContext);
+        // Registered temporary system function
+        registerTemporarySystemFunction(serdeContext);
         callable.call();
     }
 
@@ -756,6 +756,13 @@ public class RexNodeJsonSerdeTest {
                 .getFunctionCatalog()
                 .registerTemporaryCatalogFunction(
                         UNRESOLVED_FUNCTION_CAT_ID, NON_SER_FUNCTION_DEF_IMPL, false);
+    }
+
+    private static void registerTemporarySystemFunction(SerdeContext serdeContext) {
+        serdeContext
+                .getFlinkContext()
+                .getFunctionCatalog()
+                .registerTemporarySystemFunction(FUNCTION_NAME, NON_SER_FUNCTION_DEF_IMPL, false);
     }
 
     private JsonNode serializePermanentFunction(SerdeContext serdeContext) throws Exception {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.utils;
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
@@ -41,6 +42,10 @@ public final class JsonTestUtils {
 
     public static JsonNode readFromString(String path) throws IOException {
         return OBJECT_MAPPER_INSTANCE.readTree(path);
+    }
+
+    public static String writeToString(JsonNode target) throws JsonProcessingException {
+        return OBJECT_MAPPER_INSTANCE.writeValueAsString(target);
     }
 
     public static JsonNode setFlinkVersion(JsonNode target, FlinkVersion flinkVersion) {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
@@ -101,11 +101,11 @@
           "type" : "VARCHAR(2147483647)"
         }, {
           "kind" : "LITERAL",
-          "value" : "1",
+          "value" : 1,
           "type" : "INT NOT NULL"
         }, {
           "kind" : "LITERAL",
-          "value" : "5",
+          "value" : 5,
           "type" : "INT NOT NULL"
         } ],
         "type" : "VARCHAR(2147483647)"
@@ -121,7 +121,7 @@
         "type" : "TIMESTAMP(3)"
       }, {
         "kind" : "LITERAL",
-        "value" : "1000",
+        "value" : 1000,
         "type" : "INT NOT NULL"
       } ],
       "type" : "TIMESTAMP(3)"
@@ -149,7 +149,7 @@
             "type" : "BIGINT NOT NULL"
           }, {
             "kind" : "LITERAL",
-            "value" : "0",
+            "value" : 0,
             "type" : "INT NOT NULL"
           } ],
           "type" : "BOOLEAN NOT NULL"
@@ -173,7 +173,7 @@
             "type" : "BIGINT"
           }, {
             "kind" : "LITERAL",
-            "value" : "100",
+            "value" : 100,
             "type" : "INT NOT NULL"
           } ],
           "type" : "BOOLEAN"
@@ -189,7 +189,7 @@
           "type" : "INT NOT NULL"
         }, {
           "kind" : "LITERAL",
-          "value" : "10",
+          "value" : 10,
           "type" : "INT NOT NULL"
         } ],
         "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
@@ -68,7 +68,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "0",
+        "value" : 0,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ExpandJsonPlanTest_jsonplan/testExpand.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ExpandJsonPlanTest_jsonplan/testExpand.out
@@ -60,7 +60,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1024",
+        "value" : 1024,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"
@@ -78,7 +78,7 @@
         "type" : "INT"
       }, {
         "kind" : "LITERAL",
-        "value" : "1024",
+        "value" : 1024,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT"
@@ -118,7 +118,7 @@
       "type" : "INT"
     }, {
       "kind" : "LITERAL",
-      "value" : "1",
+      "value" : 1,
       "type" : "BIGINT NOT NULL"
     } ], [ {
       "kind" : "INPUT_REF",
@@ -142,7 +142,7 @@
       "type" : "INT"
     }, {
       "kind" : "LITERAL",
-      "value" : "2",
+      "value" : 2,
       "type" : "BIGINT NOT NULL"
     } ] ],
     "inputProperties" : [ {
@@ -187,7 +187,7 @@
         "type" : "BIGINT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"
@@ -201,7 +201,7 @@
         "type" : "BIGINT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "2",
+        "value" : 2,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
@@ -55,7 +55,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "10",
+        "value" : 10,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
@@ -71,7 +71,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "10",
+        "value" : 10,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
@@ -64,7 +64,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
@@ -80,7 +80,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=false].out
@@ -72,7 +72,7 @@
           "type" : "BIGINT"
         }, {
           "kind" : "LITERAL",
-          "value" : "1",
+          "value" : 1,
           "type" : "INT NOT NULL"
         } ],
         "type" : "BOOLEAN"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=true].out
@@ -88,7 +88,7 @@
           "type" : "BIGINT"
         }, {
           "kind" : "LITERAL",
-          "value" : "1",
+          "value" : 1,
           "type" : "INT NOT NULL"
         } ],
         "type" : "BOOLEAN"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
@@ -43,11 +43,11 @@
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "10",
+      "value" : 10,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "5",
+      "value" : 5,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "INPUT_REF",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
@@ -59,11 +59,11 @@
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "10",
+      "value" : 10,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "5",
+      "value" : 5,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "INPUT_REF",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
@@ -84,7 +84,7 @@
         "type" : "INT"
       }, {
         "kind" : "LITERAL",
-        "value" : "1024",
+        "value" : 1024,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
@@ -177,7 +177,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1024",
+        "value" : 1024,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
@@ -167,7 +167,7 @@
               "type" : "VARCHAR(2147483647)"
             }, {
               "kind" : "LITERAL",
-              "value" : "0",
+              "value" : 0,
               "type" : "INT NOT NULL"
             } ],
             "type" : "VARCHAR(2147483647)"
@@ -192,7 +192,7 @@
               "type" : "VARCHAR(2147483647)"
             }, {
               "kind" : "LITERAL",
-              "value" : "0",
+              "value" : 0,
               "type" : "INT NOT NULL"
             } ],
             "type" : "VARCHAR(2147483647)"
@@ -217,7 +217,7 @@
               "type" : "VARCHAR(2147483647)"
             }, {
               "kind" : "LITERAL",
-              "value" : "0",
+              "value" : 0,
               "type" : "INT NOT NULL"
             } ],
             "type" : "VARCHAR(2147483647)"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRangeOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRangeOver.out
@@ -386,7 +386,7 @@
               "type" : "BIGINT NOT NULL"
             }, {
               "kind" : "LITERAL",
-              "value" : "0",
+              "value" : 0,
               "type" : "BIGINT NOT NULL"
             } ],
             "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime.out
@@ -263,7 +263,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "4",
+        "value" : 4,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 4
@@ -327,7 +327,7 @@
           "type" : "BIGINT NOT NULL"
         }, {
           "kind" : "LITERAL",
-          "value" : "0",
+          "value" : 0,
           "type" : "BIGINT NOT NULL"
         } ],
         "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeUnboundedPartitionedRangeOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProcTimeUnboundedPartitionedRangeOver.out
@@ -363,7 +363,7 @@
             "type" : "BIGINT NOT NULL"
           }, {
             "kind" : "LITERAL",
-            "value" : "0",
+            "value" : 0,
             "type" : "BIGINT NOT NULL"
           } ],
           "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProctimeBoundedDistinctPartitionedRowOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProctimeBoundedDistinctPartitionedRowOver.out
@@ -301,7 +301,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "2",
+        "value" : 2,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 3
@@ -373,7 +373,7 @@
             "type" : "BIGINT NOT NULL"
           }, {
             "kind" : "LITERAL",
-            "value" : "0",
+            "value" : 0,
             "type" : "BIGINT NOT NULL"
           } ],
           "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProctimeBoundedDistinctWithNonDistinctPartitionedRowOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testProctimeBoundedDistinctWithNonDistinctPartitionedRowOver.out
@@ -341,7 +341,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "2",
+        "value" : 2,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 4
@@ -425,7 +425,7 @@
             "type" : "BIGINT NOT NULL"
           }, {
             "kind" : "LITERAL",
-            "value" : "0",
+            "value" : 0,
             "type" : "BIGINT NOT NULL"
           } ],
           "type" : "BOOLEAN NOT NULL"
@@ -465,7 +465,7 @@
           "type" : "BIGINT NOT NULL"
         }, {
           "kind" : "LITERAL",
-          "value" : "0",
+          "value" : 0,
           "type" : "BIGINT NOT NULL"
         } ],
         "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testRowTimeBoundedPartitionedRowsOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/OverAggregateJsonPlanTest_jsonplan/testRowTimeBoundedPartitionedRowsOver.out
@@ -179,7 +179,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "5",
+        "value" : 5,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 3

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCalcJsonPlanTest_jsonplan/testPythonFunctionInWhereClause.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCalcJsonPlanTest_jsonplan/testPythonFunctionInWhereClause.out
@@ -67,7 +67,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCorrelateJsonPlanTest_jsonplan/testJoinWithFilter.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCorrelateJsonPlanTest_jsonplan/testJoinWithFilter.out
@@ -144,7 +144,7 @@
             "type" : "INT"
           }, {
             "kind" : "LITERAL",
-            "value" : "1",
+            "value" : 1,
             "type" : "INT NOT NULL"
           } ],
           "type" : "INT"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupAggregateJsonPlanTest_jsonplan/tesPythonAggCallsWithGroupBy.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupAggregateJsonPlanTest_jsonplan/tesPythonAggCallsWithGroupBy.out
@@ -68,7 +68,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
@@ -187,7 +187,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeSessionWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeSessionWindow.out
@@ -187,7 +187,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -187,7 +187,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
@@ -236,7 +236,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeSessionWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeSessionWindow.out
@@ -236,7 +236,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonGroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
@@ -236,7 +236,7 @@
         "type" : "INT NOT NULL"
       }, {
         "kind" : "LITERAL",
-        "value" : "1",
+        "value" : 1,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT NOT NULL"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonOverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonOverAggregateJsonPlanTest_jsonplan/testProcTimeBoundedPartitionedRowsOverWithBuiltinProctime.out
@@ -244,7 +244,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "4",
+        "value" : 4,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 4

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonOverAggregateJsonPlanTest_jsonplan/testRowTimeBoundedPartitionedRowsOver.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonOverAggregateJsonPlanTest_jsonplan/testRowTimeBoundedPartitionedRowsOver.out
@@ -240,7 +240,7 @@
       } ],
       "constants" : [ {
         "kind" : "LITERAL",
-        "value" : "5",
+        "value" : 5,
         "type" : "INT NOT NULL"
       } ],
       "originalInputFields" : 4

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
@@ -40,7 +40,7 @@
             "type" : "BIGINT"
           }, {
             "kind" : "LITERAL",
-            "value" : "0",
+            "value" : 0,
             "type" : "INT NOT NULL"
           } ],
           "type" : "BOOLEAN"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
@@ -5,11 +5,11 @@
     "type" : "stream-exec-values_1",
     "tuples" : [ [ {
       "kind" : "LITERAL",
-      "value" : "1",
+      "value" : 1,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "2",
+      "value" : 2,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
@@ -17,11 +17,11 @@
       "type" : "CHAR(2) NOT NULL"
     } ], [ {
       "kind" : "LITERAL",
-      "value" : "3",
+      "value" : 3,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",
-      "value" : "4",
+      "value" : 4,
       "type" : "INT NOT NULL"
     }, {
       "kind" : "LITERAL",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testDistinctSplitEnabled.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testDistinctSplitEnabled.out
@@ -194,7 +194,7 @@
         "type" : "INT"
       }, {
         "kind" : "LITERAL",
-        "value" : "1024",
+        "value" : 1024,
         "type" : "INT NOT NULL"
       } ],
       "type" : "INT"

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowTableFunctionJsonPlanTest_jsonplan/testFollowedByWindowJoin.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowTableFunctionJsonPlanTest_jsonplan/testFollowedByWindowJoin.out
@@ -261,7 +261,7 @@
         "type" : "BIGINT"
       }, {
         "kind" : "LITERAL",
-        "value" : "10",
+        "value" : 10,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN"
@@ -549,7 +549,7 @@
         "type" : "BIGINT"
       }, {
         "kind" : "LITERAL",
-        "value" : "10",
+        "value" : 10,
         "type" : "INT NOT NULL"
       } ],
       "type" : "BOOLEAN"


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix the FLINK-31917. The details can be found in the ticket's description.


## Brief change log

- Fix the issue that `AggregateCallJsonDeserializer` converts `null` to `"null"` for attribute `name`.
- Fix the issue that `RexNodeJsonSerdeTest#testTemporarySystemFunction` registered the temporary catalog function by mistake.
- Correct the behavior for `RexNodeJsonSerializer#serializeLiteral`.
  
  **Before**
  
  `INT`, `BIGINT`, and `DOUBLE` are serialized as `STRING` because the `serializeLiteralValue` receives literal type as`DECIMAL`. This is due to `RexBuilder#makeExactLiteral` using `SqlTypeName.DECIMAL` as the `typeName` (which is "An indication of the broad type of this literal", according to Calcite)
    E.g. 
   ```java
    RexLiteral spec = new RexLiteral(3.14, TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE), SqlTypeName.DECIMAL);
   ```
    is serialized to
   ```json
   {
       "kind" : "LITERAL",
       "value" : "3.14",
       "type" : "DOUBLE NOT NULL"
   }
   ```
  However, the deserialization will recognize the `DOUBLE` as the literal type and convert the JSON to the following object
  ```java
   RexLiteral deserialized = new RexLiteral(3.14, TYPE_FACTORY.createSqlType(SqlTypeName.DOUBLE), 
  // the typeName has changed,  the reason why the current assertion works is that Literal's equals method does not compare typeName
  SqlTypeName.DOUBLE);
   ```
  If the deserialized object is serialized again, the result differs.
   ```json
   {
       "kind" : "LITERAL",
       "value" : 3.14,
       "type" : "DOUBLE NOT NULL"
   }
   ```
  **After**
  `serializeLiteralValue` will use literal's type except for `SARG`. Meanwhile, for the `FLOAT` type, in case the precision loss, serialize it as string type.

## Verifying this change

This change added tests and can be verified as follows:

- Add a second round trip for `JsonSerDeTestUtil#testJsonRoundTrip`.
- Add `AggregateCallSerdeTest` to verify the "null" string issue is fixed.
- Add a SerDe round trip for `TableTestBase#verifyJsonPlan` and adapt the test output file.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)