### PR TITLE
[FLINK-31933][core][tests] Remove reflective access

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Keys.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Keys.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -495,7 +496,8 @@ public abstract class Keys<T> {
         return keyFields;
     }
 
-    private static void rangeCheckFields(int[] fields, int maxAllowedField) {
+    @VisibleForTesting
+    static void rangeCheckFields(int[] fields, int maxAllowedField) {
 
         for (int f : fields) {
             if (f < 0 || f > maxAllowedField) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ExpressionKeysTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ExpressionKeysTest.java
@@ -35,16 +35,10 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 
 @SuppressWarnings("unused")
-@RunWith(PowerMockRunner.class)
 public class ExpressionKeysTest {
 
     @Test
@@ -74,23 +68,18 @@ public class ExpressionKeysTest {
     }
 
     @Test
-    public void testTupleRangeCheck()
-            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-
-        // test private static final int[] rangeCheckFields(int[] fields, int maxAllowedField)
-        Method rangeCheckFieldsMethod =
-                Whitebox.getMethod(Keys.class, "rangeCheckFields", int[].class, int.class);
+    public void testTupleRangeCheck() throws IllegalArgumentException {
 
         // valid indexes
-        rangeCheckFieldsMethod.invoke(null, new int[] {1, 2, 3, 4}, 4);
+        Keys.rangeCheckFields(new int[] {1, 2, 3, 4}, 4);
 
         // corner case tests
-        rangeCheckFieldsMethod.invoke(null, new int[] {0}, 0);
+        Keys.rangeCheckFields(new int[] {0}, 0);
 
         Throwable ex = null;
         try {
             // throws illegal argument.
-            rangeCheckFieldsMethod.invoke(null, new int[] {5}, 0);
+            Keys.rangeCheckFields(new int[] {5}, 0);
         } catch (Throwable iae) {
             ex = iae;
         }


### PR DESCRIPTION
Remove an unnecessary powermock/reflection usage that would fail out-of-the-box on Java 17.