### PR TITLE
[FLINK-31118][table] Add ARRAY_UNION function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -16,64 +16,64 @@
 # under the License
 
 comparison:
-    - sql: value1 = value2
-      table: value1 === value2
-      description: Returns TRUE if value1 is equal to value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value1 <> value2
-      table: value1 !== value2
-      description: Returns TRUE if value1 is not equal to value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value1 > value2
-      table: value1 > value2
-      description: Returns TRUE if value1 is greater than value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value1 >= value2
-      table: value1 >= value2
-      description: Returns TRUE if value1 is greater than or equal to value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value1 < value2
-      table: value1 < value2
-      description: Returns TRUE if value1 is less than value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value1 <= value2
-      table: value1 <= value2
-      description: Returns TRUE if value1 is less than or equal to value2; returns UNKNOWN if value1 or value2 is NULL.
-    - sql: value IS NULL
-      table: value.isNull
-      description: Returns TRUE if value is NULL.
-    - sql: value IS NOT NULL
-      table: value.isNotNull
-      description: Returns TRUE if value is not NULL.
-    - sql: value1 IS DISTINCT FROM value2
-      description: Returns TRUE if two values are different. NULL values are treated as identical here. E.g., 1 IS DISTINCT FROM NULL returns TRUE; NULL IS DISTINCT FROM NULL returns FALSE.
-    - sql: value1 IS NOT DISTINCT FROM value2
-      description: Returns TRUE if two values are equal. NULL values are treated as identical here. E.g., 1 IS NOT DISTINCT FROM NULL returns FALSE; NULL IS NOT DISTINCT FROM NULL returns TRUE.
-    - sql: value1 BETWEEN [ ASYMMETRIC | SYMMETRIC ] value2 AND value3
-      description: By default (or with the ASYMMETRIC keyword), returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. With the SYMMETRIC keyword, returns TRUE if value1 is inclusively between value2 and value3. When either value2 or value3 is NULL, returns FALSE or UNKNOWN. E.g., 12 BETWEEN 15 AND 12 returns FALSE; 12 BETWEEN SYMMETRIC 15 AND 12 returns TRUE; 12 BETWEEN 10 AND NULL returns UNKNOWN; 12 BETWEEN NULL AND 10 returns FALSE; 12 BETWEEN SYMMETRIC NULL AND 12 returns UNKNOWN.
-    - sql: value1 NOT BETWEEN [ ASYMMETRIC | SYMMETRIC ] value2 AND value3
-      description: By default (or with the ASYMMETRIC keyword), returns TRUE if value1 is less than value2 or greater than value3. With the SYMMETRIC keyword, returns TRUE if value1 is not inclusively between value2 and value3. When either value2 or value3 is NULL, returns TRUE or UNKNOWN. E.g., 12 NOT BETWEEN 15 AND 12 returns TRUE; 12 NOT BETWEEN SYMMETRIC 15 AND 12 returns FALSE; 12 NOT BETWEEN NULL AND 15 returns UNKNOWN; 12 NOT BETWEEN 15 AND NULL returns TRUE; 12 NOT BETWEEN SYMMETRIC 12 AND NULL returns UNKNOWN.
-    - sql: string1 LIKE string2 [ ESCAPE char ]
-      table: string1.like(string2)
-      description: Returns TRUE if string1 matches pattern string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
-    - sql: string1 NOT LIKE string2 [ ESCAPE char ]
-      description: Returns TRUE if string1 does not match pattern string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
-    - sql: string1 SIMILAR TO string2 [ ESCAPE char ]
-      table: string1.similar(string2)
-      description: Returns TRUE if string1 matches SQL regular expression string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
-    - sql: string1 NOT SIMILAR TO string2 [ ESCAPE char ]
-      description: Returns TRUE if string1 does not match SQL regular expression string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
-    - sql: value1 IN (value2 [, value3]* )
-      table: value1.in(valu2) 
-      description: Returns TRUE if value1 exists in the given list (value2, value3, ...). When (value2, value3, ...). contains NULL, returns TRUE if the element can be found and UNKNOWN otherwise. Always returns UNKNOWN if value1 is NULL. E.g., 4 IN (1, 2, 3) returns FALSE; 1 IN (1, 2, NULL) returns TRUE; 4 IN (1, 2, NULL) returns UNKNOWN.
-    - sql: value1 NOT IN (value2 [, value3]* )
-      description: Returns TRUE if value1 does not exist in the given list (value2, value3, ...). When (value2, value3, ...). contains NULL, returns FALSE if value1 can be found and UNKNOWN otherwise. Always returns UNKNOWN if value1 is NULL. E.g., 4 NOT IN (1, 2, 3) returns TRUE; 1 NOT IN (1, 2, NULL) returns FALSE; 4 NOT IN (1, 2, NULL) returns UNKNOWN.
-    - sql: EXISTS (sub-query)
-      description: Returns TRUE if sub-query returns at least one row. Only supported if the operation can be rewritten in a join and group operation. For streaming queries the operation is rewritten in a join and group operation. The required state to compute the query result might grow infinitely depending on the number of distinct input rows. Please provide a query configuration with valid retention interval to prevent excessive state size.
-    - sql: value IN (sub-query)
-      table: value1.in(TABLE)
-      description: Returns TRUE if value is equal to a row returned by sub-query.
-    - sql: value NOT IN (sub-query)
-      description: Returns TRUE if value is not equal to a row returned by sub-query.
-    - table: value1.between(value2, value3)
-      description: Returns TRUE if value is greater than or equal to value2 and less than or equal to value3. When either value2 or value3 is NULL, returns FALSE or UNKNOWN.
-    - table: value1.notBetween(value2, value3)
-      description: Returns FALSE if value is greater than or equal to value2 and less than or equal to value3. When either value2 or value3 is NULL, returns TRUE or UNKNOWN.
+  - sql: value1 = value2
+    table: value1 === value2
+    description: Returns TRUE if value1 is equal to value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value1 <> value2
+    table: value1 !== value2
+    description: Returns TRUE if value1 is not equal to value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value1 > value2
+    table: value1 > value2
+    description: Returns TRUE if value1 is greater than value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value1 >= value2
+    table: value1 >= value2
+    description: Returns TRUE if value1 is greater than or equal to value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value1 < value2
+    table: value1 < value2
+    description: Returns TRUE if value1 is less than value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value1 <= value2
+    table: value1 <= value2
+    description: Returns TRUE if value1 is less than or equal to value2; returns UNKNOWN if value1 or value2 is NULL.
+  - sql: value IS NULL
+    table: value.isNull
+    description: Returns TRUE if value is NULL.
+  - sql: value IS NOT NULL
+    table: value.isNotNull
+    description: Returns TRUE if value is not NULL.
+  - sql: value1 IS DISTINCT FROM value2
+    description: Returns TRUE if two values are different. NULL values are treated as identical here. E.g., 1 IS DISTINCT FROM NULL returns TRUE; NULL IS DISTINCT FROM NULL returns FALSE.
+  - sql: value1 IS NOT DISTINCT FROM value2
+    description: Returns TRUE if two values are equal. NULL values are treated as identical here. E.g., 1 IS NOT DISTINCT FROM NULL returns FALSE; NULL IS NOT DISTINCT FROM NULL returns TRUE.
+  - sql: value1 BETWEEN [ ASYMMETRIC | SYMMETRIC ] value2 AND value3
+    description: By default (or with the ASYMMETRIC keyword), returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. With the SYMMETRIC keyword, returns TRUE if value1 is inclusively between value2 and value3. When either value2 or value3 is NULL, returns FALSE or UNKNOWN. E.g., 12 BETWEEN 15 AND 12 returns FALSE; 12 BETWEEN SYMMETRIC 15 AND 12 returns TRUE; 12 BETWEEN 10 AND NULL returns UNKNOWN; 12 BETWEEN NULL AND 10 returns FALSE; 12 BETWEEN SYMMETRIC NULL AND 12 returns UNKNOWN.
+  - sql: value1 NOT BETWEEN [ ASYMMETRIC | SYMMETRIC ] value2 AND value3
+    description: By default (or with the ASYMMETRIC keyword), returns TRUE if value1 is less than value2 or greater than value3. With the SYMMETRIC keyword, returns TRUE if value1 is not inclusively between value2 and value3. When either value2 or value3 is NULL, returns TRUE or UNKNOWN. E.g., 12 NOT BETWEEN 15 AND 12 returns TRUE; 12 NOT BETWEEN SYMMETRIC 15 AND 12 returns FALSE; 12 NOT BETWEEN NULL AND 15 returns UNKNOWN; 12 NOT BETWEEN 15 AND NULL returns TRUE; 12 NOT BETWEEN SYMMETRIC 12 AND NULL returns UNKNOWN.
+  - sql: string1 LIKE string2 [ ESCAPE char ]
+    table: string1.like(string2)
+    description: Returns TRUE if string1 matches pattern string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
+  - sql: string1 NOT LIKE string2 [ ESCAPE char ]
+    description: Returns TRUE if string1 does not match pattern string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
+  - sql: string1 SIMILAR TO string2 [ ESCAPE char ]
+    table: string1.similar(string2)
+    description: Returns TRUE if string1 matches SQL regular expression string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
+  - sql: string1 NOT SIMILAR TO string2 [ ESCAPE char ]
+    description: Returns TRUE if string1 does not match SQL regular expression string2; returns UNKNOWN if string1 or string2 is NULL. An escape character can be defined if necessary. The escape character has not been supported yet.
+  - sql: value1 IN (value2 [, value3]* )
+    table: value1.in(valu2)
+    description: Returns TRUE if value1 exists in the given list (value2, value3, ...). When (value2, value3, ...). contains NULL, returns TRUE if the element can be found and UNKNOWN otherwise. Always returns UNKNOWN if value1 is NULL. E.g., 4 IN (1, 2, 3) returns FALSE; 1 IN (1, 2, NULL) returns TRUE; 4 IN (1, 2, NULL) returns UNKNOWN.
+  - sql: value1 NOT IN (value2 [, value3]* )
+    description: Returns TRUE if value1 does not exist in the given list (value2, value3, ...). When (value2, value3, ...). contains NULL, returns FALSE if value1 can be found and UNKNOWN otherwise. Always returns UNKNOWN if value1 is NULL. E.g., 4 NOT IN (1, 2, 3) returns TRUE; 1 NOT IN (1, 2, NULL) returns FALSE; 4 NOT IN (1, 2, NULL) returns UNKNOWN.
+  - sql: EXISTS (sub-query)
+    description: Returns TRUE if sub-query returns at least one row. Only supported if the operation can be rewritten in a join and group operation. For streaming queries the operation is rewritten in a join and group operation. The required state to compute the query result might grow infinitely depending on the number of distinct input rows. Please provide a query configuration with valid retention interval to prevent excessive state size.
+  - sql: value IN (sub-query)
+    table: value1.in(TABLE)
+    description: Returns TRUE if value is equal to a row returned by sub-query.
+  - sql: value NOT IN (sub-query)
+    description: Returns TRUE if value is not equal to a row returned by sub-query.
+  - table: value1.between(value2, value3)
+    description: Returns TRUE if value is greater than or equal to value2 and less than or equal to value3. When either value2 or value3 is NULL, returns FALSE or UNKNOWN.
+  - table: value1.notBetween(value2, value3)
+    description: Returns FALSE if value is greater than or equal to value2 and less than or equal to value3. When either value2 or value3 is NULL, returns TRUE or UNKNOWN.
 
 logical:
   - sql: boolean1 OR boolean2
@@ -97,9 +97,9 @@ logical:
   - sql: boolean IS NOT TRUE
     table: BOOLEAN.isNotTrue
     description: Returns TRUE if boolean is FALSE or UNKNOWN; returns FALSE if boolean is TRUE.
-  - sql: boolean IS UNKNOWN 
+  - sql: boolean IS UNKNOWN
     description: Returns TRUE if boolean is UNKNOWN; returns FALSE if boolean is TRUE or FALSE.
-  - sql: boolean IS NOT UNKNOWN 
+  - sql: boolean IS NOT UNKNOWN
     description: Returns TRUE if boolean is TRUE or FALSE; returns FALSE if boolean is UNKNOWN.
 
 arithmetic:
@@ -142,13 +142,13 @@ arithmetic:
   - sql: LOG2(numeric)
     table: numeric.log2()
     description: Returns the base 2 logarithm of numeric.
-  - sql: | 
-        LOG(numeric2)
-        LOG(numeric1, numeric2)
+  - sql: |
+      LOG(numeric2)
+      LOG(numeric1, numeric2)
     table: |
-        NUMERIC1.log()
-        NUMERIC1.log(NUMERIC2)
-    description: When called with one argument, returns the natural logarithm of numeric2. When called with two arguments, this function returns the logarithm of numeric2 to the base numeric1. Currently, numeric2 must be greater than 0 and numeric1 must be greater than 1. 
+      NUMERIC1.log()
+      NUMERIC1.log(NUMERIC2)
+    description: When called with one argument, returns the natural logarithm of numeric2. When called with two arguments, this function returns the logarithm of numeric2 to the base numeric1. Currently, numeric2 must be greater than 0 and numeric1 must be greater than 1.
   - sql: EXP(numeric)
     table: NUMERIC.exp()
     description: Returns e raised to the power of numeric.
@@ -234,7 +234,7 @@ arithmetic:
   - sql: |
       HEX(numeric)
       HEX(string)
-    table: | 
+    table: |
       NUMERIC.hex()
       STRING.hex()
     description: Returns a string representation of an integer NUMERIC value or a STRING in hex format. Returns NULL if the argument is NULL. E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".
@@ -340,7 +340,7 @@ string:
     description: Encodes the string1 into a BINARY using the provided string2 character set (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'). If either argument is null, the result will also be null.
   - sql: INSTR(string1, string2)
     table: STRING1.instr(STRING2)
-    description:  Returns the position of the first occurrence of string2 in string1. Returns NULL if any of arguments is NULL.
+    description: Returns the position of the first occurrence of string2 in string1. Returns NULL if any of arguments is NULL.
   - sql: LEFT(string, integer)
     table: STRING.LEFT(INT)
     description: Returns the leftmost integer characters from the string. Returns EMPTY String if integer is negative. Returns NULL if any argument is NULL.
@@ -414,7 +414,7 @@ temporal:
       NUMERIC.day
       NUMERIC.days
     description: Creates an interval of milliseconds for NUMERIC days.
-  - table: | 
+  - table: |
       NUMERIC.hour
       NUMERIC.hours
     description: Creates an interval of milliseconds for NUMERIC hours.
@@ -422,11 +422,11 @@ temporal:
       NUMERIC.minute
       NUMERIC.minutes
     description: Creates an interval of milliseconds for NUMERIC minutes.
-  - table: | 
+  - table: |
       NUMERIC.second
       NUMERIC.seconds
     description: Creates an interval of milliseconds for NUMERIC seconds.
-  - table: | 
+  - table: |
       NUMERIC.milli
       NUMERIC.millis
     description: Creates an interval of NUMERIC milliseconds.
@@ -472,7 +472,7 @@ temporal:
     description: Returns the minute of an hour (an integer between 0 and 59) from SQL timestamp timestamp. Equivalent to EXTRACT(MINUTE FROM timestamp). E.g., MINUTE(TIMESTAMP '1994-09-27 13:14:15') returns 14.
   - sql: SECOND(timestamp)
     description: Returns the second of a minute (an integer between 0 and 59) from SQL timestamp. Equivalent to EXTRACT(SECOND FROM timestamp). E.g., SECOND(TIMESTAMP '1994-09-27 13:14:15') returns 15.
-  - sql: FLOOR(timepoint TO timeintervalunit) 
+  - sql: FLOOR(timepoint TO timeintervalunit)
     table: TIMEPOINT.floor(TIMEINTERVALUNIT)
     description: Returns a value that rounds timepoint down to the time unit timeintervalunit. E.g., FLOOR(TIME '12:44:31' TO MINUTE) returns 12:44:00.
   - sql: CEIL(timepoint TO timeintervaluntit)
@@ -605,8 +605,8 @@ conversion:
     table: ANY.tryCast(TYPE)
     description: Like CAST, but in case of error, returns NULL rather than failing the job. E.g., TRY_CAST('42' AS INT) returns 42; TRY_CAST(NULL AS STRING) returns NULL of type STRING; TRY_CAST('non-number' AS INT) returns NULL of type INT; COALESCE(TRY_CAST('non-number' AS INT), 0) returns 0 of type INT.
   - sql: |
-     TYPEOF(input)
-     TYPEOF(input, force_serializable)
+      TYPEOF(input)
+      TYPEOF(input, force_serializable)
     table: |
       call("TYPEOF", input)
       call("TYPEOF", input, force_serializable)
@@ -643,6 +643,9 @@ collection:
   - sql: ARRAY_REVERSE(haystack)
     table: haystack.arrayReverse()
     description: Returns an array in reverse order. If the array itself is null, the function will return null.
+  - sql: ARRAY_UNION(array1, array2)
+    table: haystack.arrayUnion(array)
+    description: Returns an array of the elements in the union of array1 and array2, without duplicates. If any of the array is null, the function will return null.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.
@@ -991,7 +994,7 @@ hashfunctions:
     description: Returns the SHA-512 hash of string as a string of 128 hexadecimal digits; returns NULL if string is NULL.
   - sql: SHA2(string, hashLength)
     table: STRING.sha2(INT)
-    description: Returns the hash using the SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384, or SHA-512). The first argument string is the string to be hashed and the second argument hashLength is the bit length of the result (224, 256, 384, or 512). Returns NULL if string or hashLength is NULL. 
+    description: Returns the hash using the SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384, or SHA-512). The first argument string is the string to be hashed and the second argument hashLength is the bit length of the result (224, 256, 384, or 512). Returns NULL if string or hashLength is NULL.
 
 auxilary:
   - table: callSql(STRING)
@@ -1007,7 +1010,7 @@ auxilary:
   - table: ANY.as(NAME1, NAME2, ...)
     description: Specifies a name for ANY (a field). Additional names can be specified if the expression expands to multiple fields.
 
-aggregate: 
+aggregate:
   - sql: COUNT([ ALL ] expression | DISTINCT expression1 [, expression2]*)
     description: By default or with ALL, returns the number of input rows for which expression is not NULL. Use DISTINCT for one unique instance of each value.
   - sql: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -230,6 +230,7 @@ advanced type helper functions
     Expression.array_position
     Expression.array_remove
     Expression.array_reverse
+    Expression.array_union
     Expression.map_keys
     Expression.map_values
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1512,6 +1512,13 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayReverse")(self)
 
+    def array_union(self, array) -> 'Expression':
+        """
+        Returns an array of the elements in the union of array1 and array2, without duplicates.
+        If any of the array is null, the function will return null.
+        """
+        return _binary_op("arrayUnion")(self, array)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -59,6 +59,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REMOVE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REVERSE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_UNION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASCII;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AT;
@@ -1394,6 +1395,16 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayReverse() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_REVERSE, toExpr()));
+    }
+
+    /**
+     * Returns an array of the elements in the union of array1 and array2, without duplicates.
+     *
+     * <p>If any of the array is null, the function will return null.
+     */
+    public OutType arrayUnion(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_UNION, toExpr(), objectToExpression(array)));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -69,6 +69,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.NO_ARGS
 import static org.apache.flink.table.types.inference.InputTypeStrategies.OUTPUT_IF_NULL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.TYPE_LITERAL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.commonArrayType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.comparable;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.compositeSequence;
@@ -259,6 +260,16 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(argument(0)))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayReverseFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_UNION =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_UNION")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayUnionFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.strategies.AndArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.AnyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.CommonArrayInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ComparableTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CompositeArgumentTypeStrategy;
@@ -345,6 +346,14 @@ public final class InputTypeStrategies {
      */
     public static InputTypeStrategy commonType(int count) {
         return new CommonInputTypeStrategy(ConstantArgumentCount.of(count));
+    }
+
+    /**
+     * An {@link InputTypeStrategy} that expects {@code count} arguments that have a common array
+     * type.
+     */
+    public static InputTypeStrategy commonArrayType(int count) {
+        return new CommonArrayInputTypeStrategy(ConstantArgumentCount.of(count));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** An {@link InputTypeStrategy} that expects that all arguments have a common array type. */
+@Internal
+public final class CommonArrayInputTypeStrategy implements InputTypeStrategy {
+
+    private static final Argument COMMON_ARGUMENT = Argument.ofGroup("COMMON");
+
+    private final ArgumentCount argumentCount;
+
+    public CommonArrayInputTypeStrategy(ArgumentCount argumentCount) {
+        this.argumentCount = argumentCount;
+    }
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return argumentCount;
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        List<LogicalType> argumentTypes =
+                argumentDataTypes.stream()
+                        .map(DataType::getLogicalType)
+                        .collect(Collectors.toList());
+
+        if (!argumentTypes.stream()
+                .allMatch(logicalType -> logicalType.is(LogicalTypeRoot.ARRAY))) {
+            return callContext.fail(throwOnFailure, "All arguments requires to be a ARRAY type");
+        }
+
+        if (argumentTypes.stream().anyMatch(CommonArrayInputTypeStrategy::isLegacyType)) {
+            return Optional.of(argumentDataTypes);
+        }
+
+        Optional<LogicalType> commonType = LogicalTypeMerging.findCommonType(argumentTypes);
+
+        if (!commonType.isPresent()) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Could not find a common type for arguments: %s",
+                    argumentDataTypes);
+        }
+
+        return commonType.map(
+                type ->
+                        Collections.nCopies(
+                                argumentTypes.size(), TypeConversions.fromLogicalToDataType(type)));
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        Optional<Integer> minCount = argumentCount.getMinCount();
+        Optional<Integer> maxCount = argumentCount.getMaxCount();
+
+        int numberOfMandatoryArguments = minCount.orElse(0);
+
+        if (maxCount.isPresent()) {
+            return IntStream.range(numberOfMandatoryArguments, maxCount.get() + 1)
+                    .mapToObj(count -> Signature.of(Collections.nCopies(count, COMMON_ARGUMENT)))
+                    .collect(Collectors.toList());
+        }
+
+        List<Argument> arguments =
+                new ArrayList<>(Collections.nCopies(numberOfMandatoryArguments, COMMON_ARGUMENT));
+        arguments.add(Argument.ofGroupVarying("COMMON"));
+        return Collections.singletonList(Signature.of(arguments));
+    }
+
+    private static boolean isLegacyType(LogicalType type) {
+        return type instanceof LegacyTypeInformationType;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link CommonArrayInputTypeStrategy}. */
+class CommonArrayInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(InputTypeStrategies.commonArrayType(2))
+                        .expectSignature("f(<COMMON>, <COMMON>)")
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull())
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.DOUBLE()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE())),
+                TestSpec.forStrategy(
+                                "Strategy fails if not all of the argument types are ARRAY",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(DataTypes.INT(), DataTypes.ARRAY(DataTypes.INT()))
+                        .expectErrorMessage("All arguments requires to be a ARRAY type"),
+                TestSpec.forStrategy(
+                                "Strategy fails if can not find a common type",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .expectErrorMessage(
+                                "Could not find a common type for arguments: [ARRAY<INT>, ARRAY<STRING>]"));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayUnionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayUnionFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_UNION}. */
+@Internal
+public class ArrayUnionFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    private final SpecializedFunction.ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle equalityHandle;
+
+    public ArrayUnionFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_UNION, context);
+
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData array1, ArrayData array2) {
+        try {
+            if (array1 == null || array2 == null) {
+                return null;
+            }
+
+            List list = new ArrayList();
+            Boolean[] alreadyIncludeNull = {Boolean.FALSE};
+            distinct(array1, elementGetter, equalityHandle, alreadyIncludeNull, list);
+            distinct(array2, elementGetter, equalityHandle, alreadyIncludeNull, list);
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    List distinct(
+            ArrayData array,
+            ArrayData.ElementGetter elementGetter,
+            MethodHandle equalityHandle,
+            Boolean[] alreadyIncludeNull,
+            List list)
+            throws Throwable {
+
+        for (int i = 0; i < array.size(); i++) {
+            final Object element = elementGetter.getElementOrNull(array, i);
+
+            boolean found = false;
+            if (element == null) {
+                if (alreadyIncludeNull[0]) {
+                    found = true;
+                } else {
+                    alreadyIncludeNull[0] = Boolean.TRUE;
+                }
+            } else {
+                // check elem is already stored in arrayBuffer or not?
+                int j = 0;
+                while (!found && j < list.size()) {
+                    Object va = list.get(j);
+                    if (va != null && (boolean) equalityHandle.invoke(element, va)) {
+                        found = true;
+                    }
+                    j = j + 1;
+                }
+            }
+            if (!found) {
+                list.add(element);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityEvaluator.close();
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of ARRAY_UNION

- Brief change log
ARRAY_UNION for Table API and SQL
    
```
Returns an array of the elements in the union of array1 and array2, without duplicates. 

Syntax:
array_union(array1, array2)

Arguments:
array: An ARRAY to be handled.

Returns:
An ARRAY. If any of the array is null, the function will return null.
Examples:

> SELECT array_union(array(1, 2, 3), array(1, 3, 5));
 [1,2,3,5] 

```


See also
spark https://spark.apache.org/docs/latest/api/sql/index.html#array_union
presto https://prestodb.io/docs/current/functions/array.html

- Verifying this change
This change added tests in CollectionFunctionsITCase.

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)