### PR TITLE
[FLINK-31934][rocksdb][tests] Remove mocking

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD;
@@ -912,6 +913,13 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
 
     @VisibleForTesting
     static void ensureRocksDBIsLoaded(String tempDirectory) throws IOException {
+        ensureRocksDBIsLoaded(tempDirectory, NativeLibraryLoader::getInstance);
+    }
+
+    @VisibleForTesting
+    static void ensureRocksDBIsLoaded(
+            String tempDirectory, Supplier<NativeLibraryLoader> nativeLibraryLoaderSupplier)
+            throws IOException {
         synchronized (EmbeddedRocksDBStateBackend.class) {
             if (!rocksDbInitialized) {
 
@@ -947,7 +955,8 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                         rocksLibFolder.mkdirs();
 
                         // explicitly load the JNI dependency if it has not been loaded before
-                        NativeLibraryLoader.getInstance()
+                        nativeLibraryLoaderSupplier
+                                .get()
                                 .loadLibrary(rocksLibFolder.getAbsolutePath());
 
                         // this initialization here should validate that the loading succeeded

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitITCase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitITCase.java
@@ -24,13 +24,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.rocksdb.NativeLibraryLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,11 +31,7 @@ import java.io.IOException;
 import static org.junit.Assert.fail;
 
 /** Tests for {@link EmbeddedRocksDBStateBackend} on initialization. */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({NativeLibraryLoader.class})
-public class RocksDBInitTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RocksDBInitTest.class);
+public class RocksDBInitITCase {
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -57,13 +46,13 @@ public class RocksDBInitTest {
 
     @Test
     public void testTempLibFolderDeletedOnFail() throws Exception {
-        PowerMockito.spy(NativeLibraryLoader.class);
-        PowerMockito.when(NativeLibraryLoader.class, "getInstance")
-                .thenThrow(new ExpectedTestException());
-
         File tempFolder = temporaryFolder.newFolder();
         try {
-            EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(tempFolder.getAbsolutePath());
+            EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(
+                    tempFolder.getAbsolutePath(),
+                    () -> {
+                        throw new ExpectedTestException();
+                    });
             fail("Not throwing expected exception.");
         } catch (IOException ignored) {
             // ignored


### PR DESCRIPTION
Remove mocking from the rocksdb tests, that would fail out-of-the-box on Java 17.

RocksDBInitTest was renamed to RocksDBInitITCase so it runs in a separate JVM, which ensures that rocksdb wasn't initialized beforehand by another test.