### PR TITLE
[FLINK-31835][planner] Fix the array type can't be converted from ext…

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypeTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.inference.TypeTransformations;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 
 import org.junit.jupiter.api.Test;
 
@@ -219,5 +221,17 @@ class DataTypeTest {
                         FIELD("count", INT().notNull().bridgedTo(int.class)));
         assertThat(DataType.getFields(ARRAY(INT()))).isEmpty();
         assertThat(DataType.getFields(INT())).isEmpty();
+    }
+
+    @Test
+    void testArrayConversionClass() {
+        assertThat(DataTypes.ARRAY(INT())).hasConversionClass(Integer[].class);
+        assertThat(DataTypes.ARRAY(INT().notNull())).hasConversionClass(int[].class);
+        DataType type = DataTypes.ARRAY(INT());
+        assertThat(DataTypeUtils.transform(type, TypeTransformations.toNullable()))
+                .hasConversionClass(Integer[].class);
+        type = DataTypes.ARRAY(INT()).bridgedTo(int[].class);
+        assertThat(DataTypeUtils.transform(type, TypeTransformations.toNullable()))
+                .hasConversionClass(int[].class);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1204,7 +1204,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 new Long[] {1L, null, 2L})
                         .build(),
                 CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().notNull()))
-                        .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new Long[] {1L, 2L})
+                        .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new long[] {1L, 2L})
                         .build(),
                 CastTestSpecBuilder.testCastTo(ROW(BIGINT(), BIGINT(), STRING(), ARRAY(STRING())))
                         .fromCase(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -1329,6 +1329,28 @@ public class FunctionITCase extends StreamingTestBase {
                 "drop function lowerUdf");
     }
 
+    @Test
+    public void testArrayWithPrimitiveType() {
+        List<Row> sourceData = Arrays.asList(Row.of(1, 2), Row.of(3, 4));
+        TestCollectionTableFactory.reset();
+        TestCollectionTableFactory.initData(sourceData);
+
+        tEnv().executeSql(
+                        "CREATE TABLE SourceTable(i INT NOT NULL, j INT NOT NULL) WITH ('connector' = 'COLLECTION')");
+        tEnv().executeSql(
+                        "CREATE FUNCTION row_of_array AS '"
+                                + RowOfArrayFunction.class.getName()
+                                + "'");
+        List<Row> rows =
+                CollectionUtil.iteratorToList(
+                        tEnv().executeSql("SELECT row_of_array(i, j) FROM SourceTable").collect());
+        assertThat(rows)
+                .isEqualTo(
+                        Arrays.asList(
+                                Row.of(Row.of(new int[] {1, 2})),
+                                Row.of(Row.of(new int[] {3, 4}))));
+    }
+
     // --------------------------------------------------------------------------------------------
     // Test functions
     // --------------------------------------------------------------------------------------------
@@ -1753,6 +1775,14 @@ public class FunctionITCase extends StreamingTestBase {
     public static class BoolEcho extends ScalarFunction {
         public Boolean eval(@DataTypeHint("BOOLEAN NOT NULL") Boolean b) {
             return b;
+        }
+    }
+
+    /** A function with Row of array with primitive type as return type for test FLINK-31835. */
+    public static class RowOfArrayFunction extends ScalarFunction {
+        @DataTypeHint("Row<t ARRAY<INT NOT NULL>>")
+        public Row eval(int... v) {
+            return Row.of(v);
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
@@ -332,7 +332,23 @@ public class ValuesITCase extends StreamingTestBase {
         mapData.put(1, 1);
         mapData.put(2, 2);
 
-        Row row = Row.of(mapData, Row.of(1, 2, 3), new Integer[] {1, 2});
+        Row row = Row.of(mapData, Row.of(1, 2, 3), new int[] {1, 2});
+        Table values = tEnv().fromValues(Collections.singletonList(row));
+        tEnv().createTemporaryView("values_t", values);
+        List<Row> results =
+                CollectionUtil.iteratorToList(
+                        tEnv().executeSql("select * from values_t").collect());
+
+        assertThat(results).containsExactly(row);
+    }
+
+    @Test
+    public void testArrayWithNullablePrimitiveType() {
+        Map<Integer, Integer> mapData = new HashMap<>();
+        mapData.put(1, 1);
+        mapData.put(2, 2);
+
+        Row row = Row.of(mapData, Row.of(1, 2, 3), new Integer[] {1, 2, null});
         Table values = tEnv().fromValues(Collections.singletonList(row));
         tEnv().createTemporaryView("values_t", values);
         List<Row> results =

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/test/TableAssertionTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/test/TableAssertionTest.java
@@ -57,7 +57,7 @@ class TableAssertionTest {
         BinaryRowData binaryRowData =
                 new RowDataSerializer((RowType) dataType.getLogicalType())
                         .toBinaryRow(genericRowData);
-        Row row = Row.of(10, "my string", new Boolean[] {true, false});
+        Row row = Row.of(10, "my string", new boolean[] {true, false});
 
         // Test equality with RowData
         assertThat(binaryRowData)


### PR DESCRIPTION
…ernal primitive array


## What is the purpose of the change

In the below UDF, the return type of the function is CollectionDataType with `Array<INT NOT NULL>`, but it's conversion class is `Integer[]`. So the external int[] array can not be converted to internal type with exception

```
    public static class RowFunction extends ScalarFunction {
        @DataTypeHint("Row<t ARRAY<INT NOT NULL>>")
        public Row eval() {
            int[] i = new int[3];
            return Row.of(i)
        }
    }
```

```
Caused by: java.lang.ClassCastException: class [I cannot be cast to class [Ljava.lang.Object; ([I and [Ljava.lang.Object; are in module java.base of loader 'bootstrap')
org.apache.flink.table.data.conversion.ArrayObjectArrayConverter.toInternal(ArrayObjectArrayConverter.java:40)
org.apache.flink.table.data.conversion.DataStructureConverter.toInternalOrNull(DataStructureConverter.java:61)
org.apache.flink.table.data.conversion.RowRowConverter.toInternal(RowRowConverter.java:75)
org.apache.flink.table.data.conversion.RowRowConverter.toInternal(RowRowConverter.java:37)
org.apache.flink.table.data.conversion.DataStructureConverter.toInternalOrNull(DataStructureConverter.java:61)
StreamExecCalc$251.processElement_split9(Unknown Source)
StreamExecCalc$251.processElement(Unknown Source)
org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:82) 
```


## Brief change log

- change the primitive types default conversion class to respect to the nullability
- change the conversion class when datatype is transform the nullability.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
