### PR TITLE
[FLINK-31940] DataStreamCsvITCase#CityPojo serialized as POJO

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/DataStreamCsvITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/DataStreamCsvITCase.java
@@ -246,6 +246,7 @@ public class DataStreamCsvITCase {
         return contents;
     }
 
+    /** Test pojo describing a city. */
     @JsonPropertyOrder({
         "city",
         "lat",

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/DataStreamCsvITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/DataStreamCsvITCase.java
@@ -256,7 +256,7 @@ public class DataStreamCsvITCase {
         "capital",
         "population"
     })
-    static class CityPojo implements Serializable {
+    public static class CityPojo implements Serializable {
         public String city;
         public BigDecimal lat;
         public BigDecimal lng;


### PR DESCRIPTION
POJO classes should be public. This currently causes Kryo to be used for the entire pojo, requiring additional --add-opens on Java 17.
