### PR TITLE
[FLINK-31882][sql-client] Fix sql client can't show result for DELETE statement when delete is pushed down

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -25,9 +25,13 @@ import org.apache.flink.table.client.cli.utils.SqlScriptReader;
 import org.apache.flink.table.client.cli.utils.TestSqlStatement;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SingleSessionManager;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointExtension;
 import org.apache.flink.table.gateway.service.context.DefaultContext;
 import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.test.junit5.InjectClusterClientConfiguration;
 import org.apache.flink.test.junit5.MiniClusterExtension;
@@ -165,6 +169,7 @@ class CliClientITCase {
         replaceVars.put("$VAR_PIPELINE_JARS_URL", udfDependency.toString());
         replaceVars.put("$VAR_REST_PORT", configuration.get(PORT).toString());
         replaceVars.put("$VAR_JOBMANAGER_RPC_ADDRESS", configuration.get(ADDRESS));
+        replaceVars.put("$VAR_DELETE_TABLE_DATA_ID", prepareDataForDeleteStatement());
     }
 
     @BeforeEach
@@ -288,6 +293,14 @@ class CliClientITCase {
             }
             return false;
         }
+    }
+
+    private static String prepareDataForDeleteStatement() {
+        List<RowData> values = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            values.add(GenericRowData.of(i, StringData.fromString("b_" + i), i * 2.0));
+        }
+        return TestUpdateDeleteTableFactory.registerRowData(values);
     }
 
     private static String getInputFromPath(String sqlPath) throws IOException {

--- a/flink-table/flink-sql-client/src/test/resources/sql/delete.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/delete.q
@@ -1,0 +1,80 @@
+# delete.q - test delete statement
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# first set batch mode
+SET 'execution.runtime-mode' = 'batch';
+[INFO] Execute statement succeed.
+!info
+
+SET 'sql-client.execution.result-mode' = 'tableau';
+[INFO] Execute statement succeed.
+!info
+
+SET 'table.dml-sync' = 'true';
+[INFO] Execute statement succeed.
+!info
+
+# create a table first
+CREATE TABLE t (a int, b string, c double)
+WITH (
+  'connector' = 'test-update-delete',
+  'data-id' = '$VAR_DELETE_TABLE_DATA_ID',
+  'mix-delete' = 'true'
+);
+[INFO] Execute statement succeed.
+!info
+
+# query the table first
+SELECT * FROM t;
++---+-----+-----+
+| a |   b |   c |
++---+-----+-----+
+| 0 | b_0 | 0.0 |
+| 1 | b_1 | 2.0 |
+| 2 | b_2 | 4.0 |
+| 3 | b_3 | 6.0 |
+| 4 | b_4 | 8.0 |
++---+-----+-----+
+5 rows in set
+!ok
+
+# delete the table with condition containing subquery which can't be push down, so that it'll submit a job;
+DELETE FROM t WHERE a >= (SELECT COUNT(1) FROM t WHERE c > 2);
+[INFO] Complete execution of the SQL update statement.
+!info
+
+# query the table
+SELECT * FROM t;
++---+-----+-----+
+| a |   b |   c |
++---+-----+-----+
+| 0 | b_0 | 0.0 |
+| 1 | b_1 | 2.0 |
+| 2 | b_2 | 4.0 |
++---+-----+-----+
+3 rows in set
+!ok
+
+# delete the table with filter push down
+DELETE FROM t;
++---------------+
+| rows affected |
++---------------+
+|             3 |
++---------------+
+1 row in set
+!ok

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -67,6 +67,7 @@ import org.apache.flink.table.gateway.service.result.ResultFetcher;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.BeginStatementSetOperation;
+import org.apache.flink.table.operations.DeleteFromFilterOperation;
 import org.apache.flink.table.operations.EndStatementSetOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
 import org.apache.flink.table.operations.ModifyOperation;
@@ -506,6 +507,12 @@ public class OperationExecutor {
             OperationHandle handle,
             List<ModifyOperation> modifyOperations) {
         TableResultInternal result = tableEnv.executeInternal(modifyOperations);
+        // DeleteFromFilterOperation doesn't have a JobClient
+        if (modifyOperations.size() == 1
+                && modifyOperations.get(0) instanceof DeleteFromFilterOperation) {
+            return ResultFetcher.fromTableResult(handle, result, false);
+        }
+
         JobID jobID =
                 result.getJobClient()
                         .orElseThrow(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -824,9 +824,9 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 deleteFromFilterOperation.getSupportsDeletePushDownSink().executeDeletion();
         if (rows.isPresent()) {
             return TableResultImpl.builder()
-                    .resultKind(ResultKind.SUCCESS)
-                    .schema(ResolvedSchema.of(Column.physical("result", DataTypes.STRING())))
-                    .data(Arrays.asList(Row.of(String.valueOf(rows.get())), Row.of("OK")))
+                    .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+                    .schema(ResolvedSchema.of(Column.physical("rows affected", DataTypes.BIGINT())))
+                    .data(Collections.singletonList(Row.of(rows.get())))
                     .build();
         } else {
             return TableResultImpl.TABLE_RESULT_OK;
@@ -1183,6 +1183,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
             SinkModifyOperation sinkModifyOperation = (SinkModifyOperation) operation;
             return sinkModifyOperation.isDelete() || sinkModifyOperation.isUpdate();
         }
-        return true;
+        return false;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/RowLevelDeleteSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/RowLevelDeleteSpec.java
@@ -26,10 +26,9 @@ import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
@@ -74,7 +74,7 @@ public class DeleteTableITCase extends BatchTestBase {
                                 dataId));
         // it only contains equal expression, should be pushed down
         List<Row> rows = toRows(tEnv().executeSql("DELETE FROM t where a = 1"));
-        assertThat(rows.toString()).isEqualTo("[+I[1], +I[OK]]");
+        assertThat(rows.toString()).isEqualTo("[+I[1]]");
         rows = toRows(tEnv().executeSql("SELECT * FROM t"));
         assertThat(rows.toString())
                 .isEqualTo("[+I[0, b_0, 0.0], +I[2, b_2, 4.0], +I[3, b_3, 6.0], +I[4, b_4, 8.0]]");
@@ -130,7 +130,7 @@ public class DeleteTableITCase extends BatchTestBase {
 
         // should fall back to delete push down
         rows = toRows(tEnv().executeSql("DELETE FROM t"));
-        assertThat(rows.toString()).isEqualTo("[+I[3], +I[OK]]");
+        assertThat(rows.toString()).isEqualTo("[+I[3]]");
         rows = toRows(tEnv().executeSql("SELECT * FROM t"));
         assertThat(rows).isEmpty();
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix sql client can't show result for DELETE statement when delete is pushed down


## Brief change log
Check the `ModifyOperation` is `DeleteFromFilterOperation` or not  in `OperationExecutor#callModifyOperations`,
if it's `DeleteFromFilterOperation`, return the result directly without getting the `JobClient`.

## Verifying this change
Added test in `flink-table/flink-sql-client/src/test/resources/sql/delete.q`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
