### PR TITLE
[FLINK-31951][format] Mix schema record source creates corrupt record

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -139,7 +139,12 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 
         datumReader.setSchema(readerSchema);
 
-        return datumReader.read(null, decoder);
+        try {
+            return datumReader.read(null, decoder);
+        } catch (IOException e) {
+            setupDecoder();
+            throw e;
+        }
     }
 
     void checkAvroInitialized() {
@@ -160,7 +165,10 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             GenericData genericData = new GenericData(cl);
             this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
         }
+        setupDecoder();
+    }
 
+    private void setupDecoder() {
         this.inputStream = new MutableByteArrayInputStream();
         this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.generated.Coordinate;
 import org.apache.flink.formats.avro.generated.UnionLogicalType;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
 
@@ -36,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AvroDeserializationSchemaTest {
 
     private static final Address address = TestDataGenerator.generateRandomAddress(new Random());
+    private static final Coordinate coordinate =
+            TestDataGenerator.generateRandomCoordinate(new Random());
 
     @Test
     void testNullRecord() throws Exception {
@@ -78,5 +81,20 @@ class AvroDeserializationSchemaTest {
         byte[] encodedData = writeRecord(data);
         UnionLogicalType deserializedData = deserializer.deserialize(encodedData);
         assertThat(deserializedData).isEqualTo(data);
+    }
+
+    @Test
+    void testMixSchemaUsage() throws Exception {
+        DeserializationSchema<Address> deserializer =
+                AvroDeserializationSchema.forSpecific(Address.class);
+        byte[] encodedAddressData = writeRecord(address);
+        byte[] encodedCoordinate = writeRecord(coordinate);
+        try {
+            deserializer.deserialize(encodedCoordinate);
+        } catch (Exception e) {
+            // expected exception
+        }
+        Address deserializedData = deserializer.deserialize(encodedAddressData);
+        assertThat(deserializedData).isEqualTo(address);
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro.utils;
 
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
+import org.apache.flink.formats.avro.generated.Coordinate;
 import org.apache.flink.formats.avro.generated.Fixed16;
 import org.apache.flink.formats.avro.generated.Fixed2;
 import org.apache.flink.formats.avro.generated.SimpleUser;
@@ -156,5 +157,9 @@ public class TestDataGenerator {
                 return rnd.nextDouble();
             }
         }
+    }
+
+    public static Coordinate generateRandomCoordinate(Random rnd) {
+        return new Coordinate(rnd.nextDouble(), rnd.nextDouble());
     }
 }

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -19,6 +19,14 @@
 },
 {"namespace": "org.apache.flink.formats.avro.generated",
  "type": "record",
+ "name": "Coordinate",
+ "fields": [
+     {"name": "longitude", "type": "double"},
+     {"name": "latitude", "type": "double"}
+  ]
+},
+{"namespace": "org.apache.flink.formats.avro.generated",
+ "type": "record",
  "name": "User",
  "fields": [
      {"name": "name", "type": "string"},


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem wherer AvroDeserializationSchema class will produce corrupt record after a parsing error was thrown.


## Brief change log
 - refactored the Decoder initialization portion to `setupDecoder()` method
 - capture the datumreader read error and reinitialize decoder when captured, to avoid future corruption
 - added Coordinate as second Avro schema class to test mix schema usage (scenario that encounters unexpected schema record)
 - added `generateRandomCoordinate()` method in TestDataGenerator to support unit test
 - added `testMixSchemaUsage()` method in AvroDeserializationSchemaTest class as an unit test case for the change


## Verifying this change

This change added `testMixSchemaUsage()` unit test case in AvroDeserializationSchemaTest.java for flink-avro test verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

