### PR TITLE
[FLINK-31984][checkpoint] Savepoint should be relocatable if entropy injection is not effective

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -103,9 +103,11 @@ public class EntropyInjector {
 
     // ------------------------------------------------------------------------
 
-    public static boolean isEntropyInjecting(FileSystem fs) {
+    public static boolean isEntropyInjecting(FileSystem fs, Path target) {
         final EntropyInjectingFileSystem entropyFs = getEntropyFs(fs);
-        return entropyFs != null && entropyFs.getEntropyInjectionKey() != null;
+        return entropyFs != null
+                && entropyFs.getEntropyInjectionKey() != null
+                && target.getPath().contains(entropyFs.getEntropyInjectionKey());
     }
 
     @Nullable

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -216,17 +216,29 @@ public class EntropyInjectorTest {
     }
 
     @Test
-    public void testIsEntropyFs() {
-        final FileSystem efs = new TestEntropyInjectingFs("test", "ignored");
-
-        assertTrue(EntropyInjector.isEntropyInjecting(efs));
+    public void testIsEntropyFs() throws Exception {
+        final String entropyKey = "_test_";
+        final FileSystem efs = new TestEntropyInjectingFs(entropyKey, "ignored");
+        final File folder = TMP_FOLDER.newFolder();
+        final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
+        assertTrue(EntropyInjector.isEntropyInjecting(efs, path));
     }
 
     @Test
-    public void testIsEntropyFsWithNullEntropyKey() {
+    public void testIsEntropyFsWithNullEntropyKey() throws Exception {
         final FileSystem efs = new TestEntropyInjectingFs(null, "ignored");
 
-        assertFalse(EntropyInjector.isEntropyInjecting(efs));
+        final File folder = TMP_FOLDER.newFolder();
+        assertFalse(EntropyInjector.isEntropyInjecting(efs, Path.fromLocalFile(folder)));
+    }
+
+    @Test
+    public void testIsEntropyFsPathDoesNotIncludeEntropyKey() throws Exception {
+        final String entropyKey = "_test_";
+        final FileSystem efs = new TestEntropyInjectingFs(entropyKey, "ignored");
+        final File folder = TMP_FOLDER.newFolder();
+        final Path path = new Path(Path.fromLocalFile(folder), "path"); // no entropy key
+        assertFalse(EntropyInjector.isEntropyInjecting(efs, path));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -86,9 +86,6 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
     /** Cached handle to the file system for file operations. */
     private final FileSystem filesystem;
 
-    /** Whether the file system dynamically injects entropy into the file paths. */
-    private final boolean entropyInjecting;
-
     private final FsCheckpointStateToolset privateStateToolset;
 
     private final FsCheckpointStateToolset sharedStateToolset;
@@ -135,7 +132,6 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
         this.sharedStateDirectory = checkNotNull(sharedStateDirectory);
         this.fileStateThreshold = fileStateSizeThreshold;
         this.writeBufferSize = writeBufferSize;
-        this.entropyInjecting = EntropyInjector.isEntropyInjecting(fileSystem);
         if (fileSystem instanceof DuplicatingFileSystem) {
             final DuplicatingFileSystem duplicatingFileSystem = (DuplicatingFileSystem) fileSystem;
             this.privateStateToolset =
@@ -156,6 +152,8 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
         Path target = getTargetPath(scope);
         int bufferSize = Math.max(writeBufferSize, fileStateThreshold);
 
+        // Whether the file system dynamically injects entropy into the file paths.
+        final boolean entropyInjecting = EntropyInjector.isEntropyInjecting(filesystem, target);
         final boolean absolutePath = entropyInjecting || scope == CheckpointedStateScope.SHARED;
         return new FsCheckpointStateOutputStream(
                 target, filesystem, bufferSize, fileStateThreshold, !absolutePath);


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-31984

We have a limitation that if we create savepoints with an injected entropy, they are not relocatable (https://nightlies.apache.org/flink/flink-docs-master/docs/ops/state/savepoints/#triggering-savepoints).

[FLINK-25952](https://issues.apache.org/jira/browse/FLINK-25952) improves the check by inspecting both the FileSystem extending `EntropyInjectingFileSystem` and `FlinkS3FileSystem#getEntropyInjectionKey` not returning null. We can improve this further by checking the checkpoint path is indeed using the entropy injection key. Without that, the savepoint is not relocatable even if the `state.savepoints.dir` does not contain the entropy.

## Brief change log

- Check the checkpoint path is indeed using the entropy injection key.

## Verifying this change

- Updated existing tests
- Added new test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
