### PR TITLE
[FLINK-31996] Chaining operators with different max parallelism prevents rescaling

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -95,5 +95,11 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Boolean</td>
             <td>When it is true, the optimizer will collect and use the statistics from source connectors if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN.Default value is true.</td>
         </tr>
+        <tr>
+            <td><h5>table.optimizer.sql2rel.project-merge.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If set to true, it will merge projects when converting SqlNode to RelNode.<br />Note: it is not recommended to turn on unless you are aware of possible side effects, such as causing the output of certain non-deterministic expressions to not meet expectations(see FLINK-20887).</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -95,11 +95,5 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Boolean</td>
             <td>When it is true, the optimizer will collect and use the statistics from source connectors if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN.Default value is true.</td>
         </tr>
-        <tr>
-            <td><h5>table.optimizer.sql2rel.project-merge.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>If set to true, it will merge projects when converting SqlNode to RelNode.<br />Note: it is not recommended to turn on unless you are aware of possible side effects, such as causing the output of certain non-deterministic expressions to not meet expectations(see FLINK-20887).</td>
-        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -105,7 +105,13 @@
             <td>When enabled objects that Flink internally uses for deserialization and passing data to user-code functions will be reused. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behaviour.</td>
         </tr>
         <tr>
-            <td><h5>pipeline.operator-chaining</h5></td>
+            <td><h5>pipeline.operator-chaining.chain-operators-with-different-max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Operators with different max parallelism can be chained together. Default behavior may prevent rescaling when the AdaptiveScheduler is used.</td>
+        </tr>
+        <tr>
+            <td><h5>pipeline.operator-chaining.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Operator chaining allows non-shuffle operations to be co-located in the same thread fully avoiding serialization and de-serialization.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -243,12 +243,21 @@ public class PipelineOptions {
                                     .build());
 
     public static final ConfigOption<Boolean> OPERATOR_CHAINING =
-            key("pipeline.operator-chaining")
+            key("pipeline.operator-chaining.enabled")
                     .booleanType()
                     .defaultValue(true)
+                    .withDeprecatedKeys("pipeline.operator-chaining")
                     .withDescription(
                             "Operator chaining allows non-shuffle operations to be co-located in the same thread "
                                     + "fully avoiding serialization and de-serialization.");
+
+    public static final ConfigOption<Boolean>
+            OPERATOR_CHAINING_CHAIN_OPERATORS_WITH_DIFFERENT_MAX_PARALLELISM =
+                    key("pipeline.operator-chaining.chain-operators-with-different-max-parallelism")
+                            .booleanType()
+                            .defaultValue(true)
+                            .withDescription(
+                                    "Operators with different max parallelism can be chained together. Default behavior may prevent rescaling when the AdaptiveScheduler is used.");
 
     public static final ConfigOption<List<String>> CACHED_FILES =
             key("pipeline.cached-files")

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -213,6 +213,15 @@ class StreamExecutionEnvironment(object):
         """
         return self._j_stream_execution_environment.isChainingEnabled()
 
+    def is_chaining_of_operators_with_different_max_parallelism_enabled(self) -> bool:
+        """
+        Returns whether operators that have a different max parallelism can be chained.
+
+        :return: True if chaining is enabled, false otherwise
+        """
+        return self._j_stream_execution_environment\
+            .isChainingOfOperatorsWithDifferentMaxParallelismEnabled()
+
     def get_checkpoint_config(self) -> CheckpointConfig:
         """
         Gets the checkpoint config, which defines values like checkpoint interval, delay between

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -194,7 +194,9 @@ public class StreamExecutionEnvironment implements AutoCloseable {
 
     private long bufferTimeout = ExecutionOptions.BUFFER_TIMEOUT.defaultValue().toMillis();
 
-    protected boolean isChainingEnabled = true;
+    private boolean isChainingEnabled = true;
+
+    private boolean isChainingOfOperatorsWithDifferentMaxParallelismEnabled = true;
 
     /** The state backend used for storing k/v state and state snapshots. */
     private StateBackend defaultStateBackend;
@@ -473,6 +475,11 @@ public class StreamExecutionEnvironment implements AutoCloseable {
     @PublicEvolving
     public boolean isChainingEnabled() {
         return isChainingEnabled;
+    }
+
+    @PublicEvolving
+    public boolean isChainingOfOperatorsWithDifferentMaxParallelismEnabled() {
+        return isChainingOfOperatorsWithDifferentMaxParallelismEnabled;
     }
 
     // ------------------------------------------------------------------------
@@ -990,6 +997,11 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         configuration
                 .getOptional(PipelineOptions.OPERATOR_CHAINING)
                 .ifPresent(c -> this.isChainingEnabled = c);
+        configuration
+                .getOptional(
+                        PipelineOptions
+                                .OPERATOR_CHAINING_CHAIN_OPERATORS_WITH_DIFFERENT_MAX_PARALLELISM)
+                .ifPresent(c -> this.isChainingOfOperatorsWithDifferentMaxParallelismEnabled = c);
         configuration
                 .getOptional(DeploymentOptions.JOB_LISTENERS)
                 .ifPresent(listeners -> registerCustomListeners(classLoader, listeners));
@@ -2299,6 +2311,8 @@ public class StreamExecutionEnvironment implements AutoCloseable {
                 .setChangelogStateBackendEnabled(changelogStateBackendEnabled)
                 .setSavepointDir(defaultSavepointDirectory)
                 .setChaining(isChainingEnabled)
+                .setChainingOfOperatorsWithDifferentMaxParallelism(
+                        isChainingOfOperatorsWithDifferentMaxParallelismEnabled)
                 .setUserArtifacts(cacheFile)
                 .setTimeCharacteristic(timeCharacteristic)
                 .setDefaultBufferTimeout(bufferTimeout)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -103,6 +103,7 @@ public class StreamGraph implements Pipeline {
     private SavepointRestoreSettings savepointRestoreSettings = SavepointRestoreSettings.none();
 
     private boolean chaining;
+    private boolean chainingOfOperatorsWithDifferentMaxParallelism;
 
     private Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts =
             Collections.emptyList();
@@ -194,6 +195,12 @@ public class StreamGraph implements Pipeline {
 
     public void setChaining(boolean chaining) {
         this.chaining = chaining;
+    }
+
+    public void setChainingOfOperatorsWithDifferentMaxParallelism(
+            boolean chainingOfOperatorsWithDifferentMaxParallelism) {
+        this.chainingOfOperatorsWithDifferentMaxParallelism =
+                chainingOfOperatorsWithDifferentMaxParallelism;
     }
 
     public void setStateBackend(StateBackend backend) {
@@ -308,6 +315,10 @@ public class StreamGraph implements Pipeline {
 
     public boolean isChainingEnabled() {
         return chaining;
+    }
+
+    public boolean isChainingOfOperatorsWithDifferentMaxParallelismEnabled() {
+        return chainingOfOperatorsWithDifferentMaxParallelism;
     }
 
     public boolean isIterative() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -170,6 +170,8 @@ public class StreamGraphGenerator {
 
     private boolean chaining = true;
 
+    private boolean chainingOfOperatorsWithDifferentMaxParallelism = true;
+
     private Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts =
             Collections.emptyList();
 
@@ -269,6 +271,13 @@ public class StreamGraphGenerator {
         return this;
     }
 
+    public StreamGraphGenerator setChainingOfOperatorsWithDifferentMaxParallelism(
+            boolean chainingOfOperatorsWithDifferentMaxParallelism) {
+        this.chainingOfOperatorsWithDifferentMaxParallelism =
+                chainingOfOperatorsWithDifferentMaxParallelism;
+        return this;
+    }
+
     public StreamGraphGenerator setUserArtifacts(
             Collection<Tuple2<String, DistributedCache.DistributedCacheEntry>> userArtifacts) {
         this.userArtifacts = checkNotNull(userArtifacts);
@@ -360,6 +369,8 @@ public class StreamGraphGenerator {
         checkNotNull(graph);
 
         graph.setChaining(chaining);
+        graph.setChainingOfOperatorsWithDifferentMaxParallelism(
+                chainingOfOperatorsWithDifferentMaxParallelism);
         graph.setUserArtifacts(userArtifacts);
         graph.setTimeCharacteristic(timeCharacteristic);
         graph.setVertexDescriptionMode(configuration.get(PipelineOptions.VERTEX_DESCRIPTION_MODE));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1180,6 +1180,39 @@ class StreamingJobGraphGeneratorTest {
         assertThat(vertices.get(1).getOperatorIDs()).hasSize(5);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testChainingOfOperatorsWithDifferentMaxParallelism(
+            boolean chainingOfOperatorsWithDifferentMaxParallelismEnabled) throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.set(
+                PipelineOptions.OPERATOR_CHAINING_CHAIN_OPERATORS_WITH_DIFFERENT_MAX_PARALLELISM,
+                chainingOfOperatorsWithDifferentMaxParallelismEnabled);
+        configuration.set(PipelineOptions.MAX_PARALLELISM, 10);
+        try (StreamExecutionEnvironment chainEnv =
+                StreamExecutionEnvironment.createLocalEnvironment(1, configuration)) {
+            chainEnv.fromElements(1)
+                    .map(x -> x)
+                    // should automatically break chain here
+                    .map(x -> x)
+                    .setMaxParallelism(1)
+                    .map(x -> x);
+
+            final JobGraph jobGraph = chainEnv.getStreamGraph().getJobGraph();
+
+            final List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
+            if (chainingOfOperatorsWithDifferentMaxParallelismEnabled) {
+                assertThat(vertices).hasSize(1);
+                assertThat(vertices.get(0).getOperatorIDs()).hasSize(4);
+            } else {
+                assertThat(vertices).hasSize(3);
+                assertThat(vertices.get(0).getOperatorIDs()).hasSize(2);
+                assertThat(vertices.get(1).getOperatorIDs()).hasSize(1);
+                assertThat(vertices.get(1).getOperatorIDs()).hasSize(1);
+            }
+        }
+    }
+
     /**
      * Tests that {@link org.apache.flink.streaming.api.operators.YieldingOperatorFactory} are
      * chained to new sources, see FLINK-20444.

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingScalaAPICompletenessTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingScalaAPICompletenessTest.scala
@@ -54,6 +54,8 @@ class StreamingScalaAPICompletenessTest extends ScalaAPICompletenessTestBase {
       "org.apache.flink.streaming.api.datastream.KeyedStream.getKeySelector",
       "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.isChainingEnabled",
       "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment." +
+        "isChainingOfOperatorsWithDifferentMaxParallelismEnabled",
+      "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment." +
         "getStateHandleProvider",
       "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.getCheckpointInterval",
       "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.addOperator",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31996

Introduce a new opt-in flag that can disable the chaining of operators with different max parallelism, which prevents rescaling in some cases when the AdaptiveScheduler is being used.

- We introduce the new `pipeline.operator-chaining.chain-operators-with-different-max-parallelism` flag to opt-in.
- We deprecate the `pipeline.operator-chaining` flag and surpass it with `pipeline.operator-chaining.enabled` to provide a more consistent configuration experience.
- The StreamingJobGraphGenerator and StreamGraphHasherV2 respect the new flag.