### PR TITLE
[BP-1.17][FLINK-31984][fs][checkpoint] Savepoint should be relocatable if entropy injection is not effective

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -103,9 +103,18 @@ public class EntropyInjector {
 
     // ------------------------------------------------------------------------
 
+    /** @deprecated Use {@link #isEntropyInjecting(FileSystem, Path)} instead. */
+    @Deprecated
     public static boolean isEntropyInjecting(FileSystem fs) {
         final EntropyInjectingFileSystem entropyFs = getEntropyFs(fs);
         return entropyFs != null && entropyFs.getEntropyInjectionKey() != null;
+    }
+
+    public static boolean isEntropyInjecting(FileSystem fs, Path target) {
+        final EntropyInjectingFileSystem entropyFs = getEntropyFs(fs);
+        return entropyFs != null
+                && entropyFs.getEntropyInjectionKey() != null
+                && target.getPath().contains(entropyFs.getEntropyInjectionKey());
     }
 
     @Nullable

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -216,17 +216,29 @@ public class EntropyInjectorTest {
     }
 
     @Test
-    public void testIsEntropyFs() {
-        final FileSystem efs = new TestEntropyInjectingFs("test", "ignored");
-
-        assertTrue(EntropyInjector.isEntropyInjecting(efs));
+    public void testIsEntropyFs() throws Exception {
+        final String entropyKey = "_test_";
+        final FileSystem efs = new TestEntropyInjectingFs(entropyKey, "ignored");
+        final File folder = TMP_FOLDER.newFolder();
+        final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
+        assertTrue(EntropyInjector.isEntropyInjecting(efs, path));
     }
 
     @Test
-    public void testIsEntropyFsWithNullEntropyKey() {
+    public void testIsEntropyFsWithNullEntropyKey() throws Exception {
         final FileSystem efs = new TestEntropyInjectingFs(null, "ignored");
 
-        assertFalse(EntropyInjector.isEntropyInjecting(efs));
+        final File folder = TMP_FOLDER.newFolder();
+        assertFalse(EntropyInjector.isEntropyInjecting(efs, Path.fromLocalFile(folder)));
+    }
+
+    @Test
+    public void testIsEntropyFsPathDoesNotIncludeEntropyKey() throws Exception {
+        final String entropyKey = "_test_";
+        final FileSystem efs = new TestEntropyInjectingFs(entropyKey, "ignored");
+        final File folder = TMP_FOLDER.newFolder();
+        final Path path = new Path(Path.fromLocalFile(folder), "path"); // no entropy key
+        assertFalse(EntropyInjector.isEntropyInjecting(efs, path));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -86,9 +86,6 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
     /** Cached handle to the file system for file operations. */
     private final FileSystem filesystem;
 
-    /** Whether the file system dynamically injects entropy into the file paths. */
-    private final boolean entropyInjecting;
-
     private final FsCheckpointStateToolset privateStateToolset;
 
     private final FsCheckpointStateToolset sharedStateToolset;
@@ -135,7 +132,6 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
         this.sharedStateDirectory = checkNotNull(sharedStateDirectory);
         this.fileStateThreshold = fileStateSizeThreshold;
         this.writeBufferSize = writeBufferSize;
-        this.entropyInjecting = EntropyInjector.isEntropyInjecting(fileSystem);
         if (fileSystem instanceof DuplicatingFileSystem) {
             final DuplicatingFileSystem duplicatingFileSystem = (DuplicatingFileSystem) fileSystem;
             this.privateStateToolset =
@@ -156,6 +152,8 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
         Path target = getTargetPath(scope);
         int bufferSize = Math.max(writeBufferSize, fileStateThreshold);
 
+        // Whether the file system dynamically injects entropy into the file paths.
+        final boolean entropyInjecting = EntropyInjector.isEntropyInjecting(filesystem, target);
         final boolean absolutePath = entropyInjecting || scope == CheckpointedStateScope.SHARED;
         return new FsCheckpointStateOutputStream(
                 target, filesystem, bufferSize, fileStateThreshold, !absolutePath);


### PR DESCRIPTION
This is backporting FLINK-31984 aka #22510 to 1.17 branch.

The original backport 5c0a53534ed was reverted by #22518 because API change causes [build failures](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=48655&view=logs&j=52b61abe-a3cc-5bde-cc35-1bbe89bb7df5&t=54421a62-0c80-5aad-3319-094ff69180bb&l=1316).

As discussed in [FLINK-31984](https://issues.apache.org/jira/browse/FLINK-31984) we preserve the old public evolving API and introduce a new one. The old API is unlikely used elsewhere and now is `@Deprecated`.