### PR TITLE
[FLINK-32013][runtime] Moves the implicit ownership of the lifecycle management from LeaderContender to the HighAvailabilityServices

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -125,14 +125,14 @@ public interface HighAvailabilityServices
      *
      * @return Leader election service for the resource manager leader election
      */
-    LeaderElectionService getResourceManagerLeaderElectionService();
+    LeaderElectionService getResourceManagerLeaderElectionService() throws Exception;
 
     /**
      * Gets the leader election service for the cluster's dispatcher.
      *
      * @return Leader election service for the dispatcher leader election
      */
-    LeaderElectionService getDispatcherLeaderElectionService();
+    LeaderElectionService getDispatcherLeaderElectionService() throws Exception;
 
     /**
      * Gets the leader election service for the given job.
@@ -140,7 +140,7 @@ public interface HighAvailabilityServices
      * @param jobID The identifier of the job running the election.
      * @return Leader election service for the job manager leader election
      */
-    LeaderElectionService getJobManagerLeaderElectionService(JobID jobID);
+    LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) throws Exception;
 
     /**
      * Gets the leader election service for the cluster's rest endpoint.
@@ -194,7 +194,7 @@ public interface HighAvailabilityServices
      *
      * @return the leader election service used by the cluster's rest endpoint
      */
-    default LeaderElectionService getClusterRestEndpointLeaderElectionService() {
+    default LeaderElectionService getClusterRestEndpointLeaderElectionService() throws Exception {
         // for backwards compatibility we delegate to getWebMonitorLeaderElectionService
         // all implementations of this interface should override
         // getClusterRestEndpointLeaderElectionService, though

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -65,7 +65,7 @@ public class DefaultLeaderElectionService
      * in a supporting IDE.
      */
     @GuardedBy("lock")
-    private volatile LeaderContender leaderContender;
+    private LeaderContender leaderContender;
 
     /**
      * Saves the session ID which was issued by the {@link LeaderElectionDriver} if and only if the
@@ -76,14 +76,14 @@ public class DefaultLeaderElectionService
      */
     @GuardedBy("lock")
     @Nullable
-    private volatile UUID issuedLeaderSessionID;
+    private UUID issuedLeaderSessionID;
 
     /**
      * Saves the leader information for a registered {@link LeaderContender} after this contender
      * confirmed the leadership.
      */
     @GuardedBy("lock")
-    private volatile LeaderInformation confirmedLeaderInformation;
+    private LeaderInformation confirmedLeaderInformation;
 
     /**
      * {@code leaderElectionDriver} being {@code null} indicates that the connection to the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -37,16 +37,17 @@ import java.util.UUID;
 public interface LeaderElectionService {
 
     /**
-     * Starts the leader election service. This method can only be called once.
+     * Registers the passed {@link LeaderContender} with this {@code LeaderElectionService}. This
+     * method can only be called once.
      *
      * @param contender LeaderContender which applies for the leadership
-     * @throws Exception
      */
     void start(LeaderContender contender) throws Exception;
 
     /**
-     * Stops the leader election service. Stopping the {@code LeaderElectionService} will trigger
-     * {@link LeaderContender#revokeLeadership()} if the service still holds the leadership.
+     * Ends the participation of the registered {@link LeaderContender} in the leader election
+     * process. This will trigger {@link LeaderContender#revokeLeadership()} if the service still
+     * holds the leadership.
      *
      * @throws Exception if an error occurs while stopping the {@code LeaderElectionService}.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.UUID;
+
+/** {@code LeaderElectionUtils} collects helper methods to handle LeaderElection-related issues. */
+public class LeaderElectionUtils {
+
+    /**
+     * Converts the passed {@link LeaderInformation} into a human-readable representation that can
+     * be used in log messages.
+     */
+    public static String convertToString(LeaderInformation leaderInformation) {
+        return leaderInformation.isEmpty()
+                ? "<no leader>"
+                : convertToString(
+                        leaderInformation.getLeaderSessionID(),
+                        leaderInformation.getLeaderAddress());
+    }
+
+    public static String convertToString(UUID sessionId, String address) {
+        return String.format(
+                "%s@%s",
+                Preconditions.checkNotNull(sessionId), Preconditions.checkNotNull(address));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -82,7 +81,8 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
 
     private ResourceManagerServiceImpl(
             ResourceManagerFactory<?> resourceManagerFactory,
-            ResourceManagerProcessContext rmProcessContext) {
+            ResourceManagerProcessContext rmProcessContext)
+            throws Exception {
         this.resourceManagerFactory = checkNotNull(resourceManagerFactory);
         this.rmProcessContext = checkNotNull(rmProcessContext);
 
@@ -354,7 +354,7 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
             MetricRegistry metricRegistry,
             String hostname,
             Executor ioExecutor)
-            throws ConfigurationException {
+            throws Exception {
 
         return new ResourceManagerServiceImpl(
                 resourceManagerFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -399,8 +399,8 @@ public class ZooKeeperUtils {
      * @param client The {@link CuratorFramework} ZooKeeper client to use
      * @return {@link DefaultLeaderElectionService} instance.
      */
-    public static DefaultLeaderElectionService createLeaderElectionService(
-            CuratorFramework client) {
+    public static DefaultLeaderElectionService createLeaderElectionService(CuratorFramework client)
+            throws Exception {
 
         return createLeaderElectionService(client, "");
     }
@@ -414,8 +414,12 @@ public class ZooKeeperUtils {
      * @return {@link DefaultLeaderElectionService} instance.
      */
     public static DefaultLeaderElectionService createLeaderElectionService(
-            final CuratorFramework client, final String path) {
-        return new DefaultLeaderElectionService(createLeaderElectionDriverFactory(client, path));
+            final CuratorFramework client, final String path) throws Exception {
+        final DefaultLeaderElectionService leaderElectionService =
+                new DefaultLeaderElectionService(createLeaderElectionDriverFactory(client, path));
+        leaderElectionService.startLeaderElectionBackend();
+
+        return leaderElectionService;
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -680,8 +680,9 @@ class JobMasterServiceLeadershipRunnerTest {
 
         // we need to use DefaultLeaderElectionService here because JobMasterServiceLeadershipRunner
         // in connection with the DefaultLeaderElectionService generates the nested locking
-        final LeaderElectionService defaultLeaderElectionService =
+        final DefaultLeaderElectionService defaultLeaderElectionService =
                 new DefaultLeaderElectionService(testingLeaderElectionDriverFactory);
+        defaultLeaderElectionService.startLeaderElectionBackend();
 
         // latch to detect when we reached the first synchronized section having a lock on the
         // JobMasterServiceProcess#stop side

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -773,7 +773,15 @@ class JobMasterServiceLeadershipRunnerTest {
             closeAsyncCalledTrigger.await();
 
             final CheckedThread grantLeadershipThread =
-                    createCheckedThread(currentLeaderDriver::isLeader);
+                    createCheckedThread(
+                            () -> {
+                                // DefaultLeaderElectionService enforces a proper event handling
+                                // order (i.e. no two grant or revoke events should appear after
+                                // each other). This requires the leadership to be revoked before
+                                // regaining leadership in this test.
+                                currentLeaderDriver.notLeader();
+                                currentLeaderDriver.isLeader();
+                            });
             grantLeadershipThread.start();
 
             // finalize ClassloaderLease release to trigger DefaultLeaderElectionService#stop

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -385,7 +385,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testOldConfirmLeaderInformation() throws Exception {
+    void testOldConfirmLeaderInformationWhileHavingNewLeadership() throws Exception {
         new Context() {
             {
                 runTestWithSynchronousEventHandling(
@@ -399,6 +399,29 @@ class DefaultLeaderElectionServiceTest {
                             leaderElectionService.confirmLeadership(UUID.randomUUID(), TEST_URL);
                             assertThat(leaderElectionService.getLeaderSessionID())
                                     .isEqualTo(currentLeaderSessionId);
+                        });
+            }
+        };
+    }
+
+    @Test
+    void testOldConfirmationWhileHavingLeadershipLost() throws Exception {
+        new Context() {
+            {
+                runTestWithSynchronousEventHandling(
+                        () -> {
+                            testingLeaderElectionDriver.isLeader();
+                            final UUID currentLeaderSessionId =
+                                    leaderElectionService.getLeaderSessionID();
+                            assertThat(currentLeaderSessionId).isNotNull();
+
+                            testingLeaderElectionDriver.notLeader();
+
+                            // Old confirm call should be ignored.
+                            leaderElectionService.confirmLeadership(
+                                    currentLeaderSessionId, TEST_URL);
+
+                            assertThat(leaderElectionService.getLeaderSessionID()).isNull();
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -138,6 +138,26 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
+    void testStopWhileHavingLeadership() throws Exception {
+        final TestingLeaderElectionDriver.TestingLeaderElectionDriverFactory driverFactory =
+                new TestingLeaderElectionDriver.TestingLeaderElectionDriverFactory();
+
+        try (final DefaultLeaderElectionService testInstance =
+                new DefaultLeaderElectionService(driverFactory)) {
+            testInstance.startLeaderElectionBackend();
+
+            final TestingLeaderElectionDriver driver = driverFactory.getCurrentLeaderDriver();
+            assertThat(driver).isNotNull();
+
+            driver.isLeader();
+
+            testInstance.start(TestingGenericLeaderContender.newBuilder().build());
+
+            testInstance.stop();
+        }
+    }
+
+    @Test
     void testContenderRegistrationWithoutDriverBeingInstantiatedFails() throws Exception {
         try (final DefaultLeaderElectionService leaderElectionService =
                 new DefaultLeaderElectionService(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -192,7 +192,7 @@ public class LeaderElectionTest {
         }
 
         @Override
-        public LeaderElectionService createLeaderElectionService() {
+        public LeaderElectionService createLeaderElectionService() throws Exception {
             return ZooKeeperUtils.createLeaderElectionService(
                     curatorFrameworkWrapper.asCuratorFramework());
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -139,6 +139,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
                 new ZooKeeperLeaderElectionDriverFactory(client, PATH);
         DefaultLeaderElectionService leaderElectionService =
                 new DefaultLeaderElectionService(leaderElectionDriverFactory);
+        leaderElectionService.startLeaderElectionBackend();
 
         try {
             final TestingConnectionStateListener connectionStateListener =
@@ -165,6 +166,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
             validationLogic.accept(connectionStateListener, contender);
         } finally {
             leaderElectionService.stop();
+            leaderElectionService.close();
             curatorFrameworkWrapper.close();
 
             if (problem == Problem.LOST_CONNECTION) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -220,6 +220,7 @@ class ZooKeeperLeaderElectionTest {
                                 "Stop leader election service of contender #{}.",
                                 numberSeenLeaders);
                         leaderElectionService[index].stop();
+                        leaderElectionService[index].close();
                         leaderElectionService[index] = null;
 
                         numberSeenLeaders++;
@@ -303,6 +304,8 @@ class ZooKeeperLeaderElectionTest {
 
                     // stop leader election service = revoke leadership
                     leaderElectionService[index].stop();
+                    leaderElectionService[index].close();
+
                     // create new leader election service which takes part in the leader election
                     leaderElectionService[index] =
                             ZooKeeperUtils.createLeaderElectionService(createZooKeeperClient());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -241,6 +241,7 @@ class ZooKeeperLeaderElectionTest {
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
                     electionService.stop();
+                    electionService.close();
                 }
             }
         }
@@ -324,6 +325,7 @@ class ZooKeeperLeaderElectionTest {
             for (DefaultLeaderElectionService electionService : leaderElectionService) {
                 if (electionService != null) {
                     electionService.stop();
+                    electionService.close();
                 }
             }
         }


### PR DESCRIPTION
PR order:
- https://github.com/apache/flink/pull/21742)
- https://github.com/apache/flink/pull/22379)
- https://github.com/apache/flink/pull/22422
- https://github.com/apache/flink/pull/22380
- === THIS PR === FLINK-32013
- https://github.com/apache/flink/pull/22384)
- https://github.com/apache/flink/pull/22390 (FLINK-31785/FLINK-31786)
- https://github.com/apache/flink/pull/22404

## What is the purpose of the change

This change is based on FLINK-31773 (which introduced {{DefaultLeaderElectionService#startLeaderElectionBackend}} separating the {{LeaderElectionService}} from the {{LeaderElectionDriver}} lifecycle). The PR moves the (implicit) ownership of the {{LeaderElectionDriver}} from the {{LeaderContender}} into the {{HighAvailabilityServices}}.

## Brief change log

* Moves the driver initialization and close functionality into `HighAvailabilityServices`

## Verifying this change

* Existing tests should succeed or should be updated if necessary.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable