### PR TITLE
[BP-1.17][FLINK-31764][runtime] Get rid of numberOfRequestedOverdraftMemorySegments in LocalBufferPool.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -85,7 +85,7 @@ class LocalBufferPool implements BufferPool {
      *
      * <p><strong>BEWARE:</strong> Take special care with the interactions between this lock and
      * locks acquired before entering this class vs. locks being acquired during calls to external
-     * code inside this class, e.g. with {@link
+     * code inside this class, e.g. with {@code
      * org.apache.flink.runtime.io.network.partition.consumer.BufferManager#bufferQueue} via the
      * {@link #registeredListeners} callback.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -285,15 +285,24 @@ class LocalBufferPool implements BufferPool {
     }
 
     /**
+     * Estimates the number of requested buffers.
+     *
      * @return the same value as {@link #getMaxNumberOfMemorySegments()} for bounded pools. For
      *     unbounded pools it returns an approximation based upon {@link
      *     #getNumberOfRequiredMemorySegments()}
      */
-    public int getNumberOfRequestedMemorySegments() {
+    public int getEstimatedNumberOfRequestedMemorySegments() {
         if (maxNumberOfMemorySegments < NetworkBufferPool.UNBOUNDED_POOL_SIZE) {
             return maxNumberOfMemorySegments;
         } else {
             return getNumberOfRequiredMemorySegments() * 2;
+        }
+    }
+
+    @VisibleForTesting
+    public int getNumberOfRequestedMemorySegments() {
+        synchronized (availableMemorySegments) {
+            return numberOfRequestedMemorySegments;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -366,36 +366,38 @@ public class NetworkBufferPool
         }
     }
 
-    public long getNumberOfRequestedMemorySegments() {
+    public long getEstimatedNumberOfRequestedMemorySegments() {
         long requestedSegments = 0;
         synchronized (factoryLock) {
             for (LocalBufferPool bufferPool : allBufferPools) {
-                requestedSegments += bufferPool.getNumberOfRequestedMemorySegments();
+                requestedSegments += bufferPool.getEstimatedNumberOfRequestedMemorySegments();
             }
         }
         return requestedSegments;
     }
 
-    public long getRequestedMemory() {
-        return getNumberOfRequestedMemorySegments() * memorySegmentSize;
+    public long getEstimatedRequestedMemory() {
+        return getEstimatedNumberOfRequestedMemorySegments() * memorySegmentSize;
     }
 
-    public int getRequestedSegmentsUsage() {
+    public int getEstimatedRequestedSegmentsUsage() {
         int totalNumberOfMemorySegments = getTotalNumberOfMemorySegments();
         return totalNumberOfMemorySegments == 0
                 ? 0
                 : Math.toIntExact(
-                        100L * getNumberOfRequestedMemorySegments() / totalNumberOfMemorySegments);
+                        100L
+                                * getEstimatedNumberOfRequestedMemorySegments()
+                                / totalNumberOfMemorySegments);
     }
 
     @VisibleForTesting
     Optional<String> getUsageWarning() {
-        int currentUsage = getRequestedSegmentsUsage();
+        int currentUsage = getEstimatedRequestedSegmentsUsage();
         Optional<String> message = Optional.empty();
         // do not log warning if the value hasn't changed to avoid spamming warnings.
         if (currentUsage >= USAGE_WARNING_THRESHOLD && lastCheckedUsage != currentUsage) {
             long totalMemory = getTotalMemory();
-            long requestedMemory = getRequestedMemory();
+            long requestedMemory = getEstimatedRequestedMemory();
             long missingMemory = requestedMemory - totalMemory;
             message =
                     Optional.of(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -244,7 +244,7 @@ public class NettyShuffleMetricFactory {
 
         @Override
         public Integer getValue() {
-            return networkBufferPool.getRequestedSegmentsUsage();
+            return networkBufferPool.getEstimatedRequestedSegmentsUsage();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -309,10 +309,7 @@ class LocalBufferPoolTest {
         assertThat(bufferPool.getNumBuffers()).isEqualTo(smallPoolSize);
         assertThat(bufferPool.getNumberOfRequestedOverdraftMemorySegments())
                 .isEqualTo(numRequestedOverdraftBuffersAfterDecreasing);
-        assertThat(
-                        bufferPool.bestEffortGetNumOfUsedBuffers()
-                                + bufferPool.getNumberOfAvailableMemorySegments()
-                                - bufferPool.getNumberOfRequestedOverdraftMemorySegments())
+        assertThat(bufferPool.getNumberOfRequestedMemorySegments())
                 .isEqualTo(numRequestedOrdinaryBuffersAfterDecreasing);
         assertThat(bufferPool.getNumberOfAvailableMemorySegments())
                 .isEqualTo(numAvailableBuffersAfterDecreasing);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -307,9 +307,9 @@ class LocalBufferPoolTest {
         // set a small pool size.
         bufferPool.setNumBuffers(smallPoolSize);
         assertThat(bufferPool.getNumBuffers()).isEqualTo(smallPoolSize);
-        assertThat(bufferPool.getNumberOfRequestedOverdraftMemorySegments())
+        assertThat(getNumberRequestedOverdraftBuffers(bufferPool))
                 .isEqualTo(numRequestedOverdraftBuffersAfterDecreasing);
-        assertThat(bufferPool.getNumberOfRequestedMemorySegments())
+        assertThat(getNumberRequestedOrdinaryBuffers(bufferPool))
                 .isEqualTo(numRequestedOrdinaryBuffersAfterDecreasing);
         assertThat(bufferPool.getNumberOfAvailableMemorySegments())
                 .isEqualTo(numAvailableBuffersAfterDecreasing);
@@ -396,8 +396,7 @@ class LocalBufferPoolTest {
             buffers.add(bufferPool.requestMemorySegmentBlocking());
         }
         assertThat(bufferPool.requestMemorySegment()).isNull();
-        assertThat(bufferPool.getNumberOfRequestedOverdraftMemorySegments())
-                .isEqualTo(maxOverdraftBuffers);
+        assertThat(getNumberRequestedOverdraftBuffers(bufferPool)).isEqualTo(maxOverdraftBuffers);
         assertThat(bufferPool.isAvailable()).isFalse();
 
         // set a large pool size.
@@ -405,7 +404,7 @@ class LocalBufferPoolTest {
         assertThat(bufferPool.getNumBuffers()).isEqualTo(largePoolSize);
         assertThat(bufferPool.getNumberOfAvailableMemorySegments())
                 .isEqualTo(numAvailableBuffersAfterIncreasePoolSize);
-        assertThat(bufferPool.getNumberOfRequestedOverdraftMemorySegments())
+        assertThat(getNumberRequestedOverdraftBuffers(bufferPool))
                 .isEqualTo(numOverdraftBuffersAfterIncreasePoolSize);
         assertThat(bufferPool.isAvailable()).isEqualTo(isAvailableAfterIncreasePoolSize);
 
@@ -864,7 +863,7 @@ class LocalBufferPoolTest {
         if (numberOfRequestedOverdraftBuffer > 0) {
             checkArgument(!isAvailable);
         }
-        assertThat(bufferPool.getNumberOfRequestedOverdraftMemorySegments())
+        assertThat(getNumberRequestedOverdraftBuffers(bufferPool))
                 .isEqualTo(numberOfRequestedOverdraftBuffer);
 
         assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(numberOfRequestedBuffer);
@@ -874,6 +873,16 @@ class LocalBufferPoolTest {
     // ------------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------------
+
+    private static int getNumberRequestedOverdraftBuffers(LocalBufferPool bufferPool) {
+        return Math.max(
+                bufferPool.getNumberOfRequestedMemorySegments() - bufferPool.getNumBuffers(), 0);
+    }
+
+    private static int getNumberRequestedOrdinaryBuffers(LocalBufferPool bufferPool) {
+        return Math.min(
+                bufferPool.getNumBuffers(), bufferPool.getNumberOfRequestedMemorySegments());
+    }
 
     private int getNumRequestedFromMemorySegmentPool() {
         return networkBufferPool.getTotalNumberOfMemorySegments()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -330,7 +330,7 @@ public class NetworkBufferPoolTest extends TestLogger {
         try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
             NetworkBufferPool globalPool = new NetworkBufferPool(0, 128);
             closeableRegistry.registerCloseable(globalPool::destroy);
-            assertEquals(0, globalPool.getRequestedSegmentsUsage());
+            assertEquals(0, globalPool.getEstimatedRequestedSegmentsUsage());
         }
     }
 
@@ -342,21 +342,21 @@ public class NetworkBufferPoolTest extends TestLogger {
 
             BufferPool bufferPool1 = globalPool.createBufferPool(10, 20);
 
-            assertEquals(20, globalPool.getNumberOfRequestedMemorySegments());
-            assertEquals(40, globalPool.getRequestedSegmentsUsage());
+            assertEquals(20, globalPool.getEstimatedNumberOfRequestedMemorySegments());
+            assertEquals(40, globalPool.getEstimatedRequestedSegmentsUsage());
             assertThat(globalPool.getUsageWarning(), equalTo(Optional.empty()));
 
             closeableRegistry.registerCloseable(
                     (globalPool.createBufferPool(5, Integer.MAX_VALUE))::lazyDestroy);
 
-            assertEquals(30, globalPool.getNumberOfRequestedMemorySegments());
-            assertEquals(60, globalPool.getRequestedSegmentsUsage());
+            assertEquals(30, globalPool.getEstimatedNumberOfRequestedMemorySegments());
+            assertEquals(60, globalPool.getEstimatedRequestedSegmentsUsage());
             assertThat(globalPool.getUsageWarning(), equalTo(Optional.empty()));
 
             closeableRegistry.registerCloseable((globalPool.createBufferPool(10, 30))::lazyDestroy);
 
-            assertEquals(60, globalPool.getNumberOfRequestedMemorySegments());
-            assertEquals(120, globalPool.getRequestedSegmentsUsage());
+            assertEquals(60, globalPool.getEstimatedNumberOfRequestedMemorySegments());
+            assertEquals(120, globalPool.getEstimatedRequestedSegmentsUsage());
             assertThat(
                     globalPool.getUsageWarning(),
                     equalTo(
@@ -372,8 +372,8 @@ public class NetworkBufferPoolTest extends TestLogger {
 
             BufferPool bufferPool2 = globalPool.createBufferPool(10, 20);
 
-            assertEquals(80, globalPool.getNumberOfRequestedMemorySegments());
-            assertEquals(160, globalPool.getRequestedSegmentsUsage());
+            assertEquals(80, globalPool.getEstimatedNumberOfRequestedMemorySegments());
+            assertEquals(160, globalPool.getEstimatedRequestedSegmentsUsage());
             assertThat(
                     globalPool.getUsageWarning(),
                     equalTo(
@@ -389,9 +389,9 @@ public class NetworkBufferPoolTest extends TestLogger {
             bufferPool2.lazyDestroy();
             bufferPool1.lazyDestroy();
 
-            assertEquals(40, globalPool.getNumberOfRequestedMemorySegments());
-            assertEquals(40 * 128, globalPool.getRequestedMemory());
-            assertEquals(80, globalPool.getRequestedSegmentsUsage());
+            assertEquals(40, globalPool.getEstimatedNumberOfRequestedMemorySegments());
+            assertEquals(40 * 128, globalPool.getEstimatedRequestedMemory());
+            assertEquals(80, globalPool.getEstimatedRequestedSegmentsUsage());
             assertThat(
                     globalPool.getUsageWarning(),
                     equalTo(Optional.of("Memory usage [80%] went back to normal")));


### PR DESCRIPTION
Backport FLINK-31764 to release-1.17.