### PR TITLE
[BP-1.17][FLINK-32010][kubernetes] Properly handle KubernetesLeaderRetrievalDriver.ConfigMapCallbackHandlerImpl#onAdded events in case the leader is already known

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -44,8 +44,8 @@ import java.util.concurrent.ExecutorService;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_SESSION_ID_KEY;
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.getLeaderInformationFromConfigMap;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -216,7 +216,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
             // We should only receive events for the watched ConfigMap
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
 
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 leaderElectionEventHandler.onLeaderInformationChange(
@@ -226,7 +226,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
         @Override
         public void onDeleted(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             // The ConfigMap is deleted externally.
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
@@ -237,7 +237,7 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
 
         @Override
         public void onError(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -49,8 +49,6 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
     private static final Logger LOG =
             LoggerFactory.getLogger(KubernetesLeaderRetrievalDriver.class);
 
-    private final FlinkKubeClient kubeClient;
-
     private final String configMapName;
 
     private final LeaderRetrievalEventHandler leaderRetrievalEventHandler;
@@ -64,14 +62,12 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
     private final Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor;
 
     public KubernetesLeaderRetrievalDriver(
-            FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName,
             LeaderRetrievalEventHandler leaderRetrievalEventHandler,
             Function<KubernetesConfigMap, LeaderInformation> leaderInformationExtractor,
             FatalErrorHandler fatalErrorHandler) {
-        this.kubeClient = checkNotNull(kubeClient, "Kubernetes client");
         this.configMapName = checkNotNull(configMapName, "ConfigMap name");
         this.leaderRetrievalEventHandler =
                 checkNotNull(leaderRetrievalEventHandler, "LeaderRetrievalEventHandler");

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -98,9 +98,14 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
         @Override
         public void onAdded(List<KubernetesConfigMap> configMaps) {
-            // The ConfigMap is created by KubernetesLeaderElectionDriver with empty data. We do not
-            // process this
-            // useless event.
+            // The ConfigMap is created by KubernetesLeaderElectionDriver with empty data. We don't
+            // really need to process anything unless the retriever was started after the leader
+            // election has already succeeded.
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
+            final LeaderInformation leaderInformation = leaderInformationExtractor.apply(configMap);
+            if (!leaderInformation.isEmpty()) {
+                leaderRetrievalEventHandler.notifyLeaderAddress(leaderInformation);
+            }
         }
 
         @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriver.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -105,7 +105,7 @@ public class KubernetesLeaderRetrievalDriver implements LeaderRetrievalDriver {
 
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             leaderRetrievalEventHandler.notifyLeaderAddress(
                     leaderInformationExtractor.apply(configMap));
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.kubernetes.highavailability;
 
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriverFactory;
@@ -35,19 +34,15 @@ import java.util.concurrent.Executor;
 @Deprecated
 public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDriverFactory {
 
-    private final FlinkKubeClient kubeClient;
-
     private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
     private final Executor watchExecutor;
 
     private final String configMapName;
 
     public KubernetesLeaderRetrievalDriverFactory(
-            FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName) {
-        this.kubeClient = kubeClient;
         this.configMapSharedWatcher = configMapSharedWatcher;
         this.watchExecutor = watchExecutor;
         this.configMapName = configMapName;
@@ -57,7 +52,6 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
     public KubernetesLeaderRetrievalDriver createLeaderRetrievalDriver(
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderRetrievalDriver(
-                kubeClient,
                 configMapSharedWatcher,
                 watchExecutor,
                 configMapName,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriver.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
-import static org.apache.flink.kubernetes.utils.KubernetesUtils.checkConfigMaps;
+import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 
 /** {@link MultipleComponentLeaderElectionDriver} for Kubernetes. */
 public class KubernetesMultipleComponentLeaderElectionDriver
@@ -229,7 +229,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onModified(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
 
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 Collection<LeaderInformationWithComponentId> leaderInformationWithLeaderNames =
@@ -242,7 +242,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onDeleted(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(
@@ -254,7 +254,7 @@ public class KubernetesMultipleComponentLeaderElectionDriver
 
         @Override
         public void onError(List<KubernetesConfigMap> configMaps) {
-            final KubernetesConfigMap configMap = checkConfigMaps(configMaps, configMapName);
+            final KubernetesConfigMap configMap = getOnlyConfigMap(configMaps, configMapName);
             if (KubernetesLeaderElector.hasLeadership(configMap, lockIdentity)) {
                 fatalErrorHandler.onFatalError(
                         new LeaderElectionException(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
@@ -66,7 +66,6 @@ public class KubernetesMultipleComponentLeaderRetrievalDriverFactory
     public LeaderRetrievalDriver createLeaderRetrievalDriver(
             LeaderRetrievalEventHandler leaderEventHandler, FatalErrorHandler fatalErrorHandler) {
         return new KubernetesLeaderRetrievalDriver(
-                kubeClient,
                 configMapSharedWatcher,
                 watchExecutor,
                 configMapName,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -209,11 +209,15 @@ public class KubernetesUtils {
      * @param expectedConfigMapName expected ConfigMap Name
      * @return Return the expected ConfigMap
      */
-    public static KubernetesConfigMap checkConfigMaps(
+    public static KubernetesConfigMap getOnlyConfigMap(
             List<KubernetesConfigMap> configMaps, String expectedConfigMapName) {
-        assert (configMaps.size() == 1);
-        assert (configMaps.get(0).getName().equals(expectedConfigMapName));
-        return configMaps.get(0);
+        if (configMaps.size() == 1 && expectedConfigMapName.equals(configMaps.get(0).getName())) {
+            return configMaps.get(0);
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "ConfigMap list should only contain a single ConfigMap [%s].",
+                        expectedConfigMapName));
     }
 
     /**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -162,7 +162,6 @@ class KubernetesHighAvailabilityTestBase {
         private LeaderRetrievalDriver createLeaderRetrievalDriver() {
             final KubernetesLeaderRetrievalDriverFactory factory =
                     new KubernetesLeaderRetrievalDriverFactory(
-                            flinkKubeClient,
                             kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService,
                             LEADER_CONFIGMAP_NAME);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.kubernetes.highavailability;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.KubernetesExtension;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesHighAvailabilityOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
@@ -28,15 +29,18 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionEventHandler;
 import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandler;
-import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,73 +58,99 @@ class KubernetesLeaderElectionAndRetrievalITCase {
             "akka.tcp://flink@172.20.1.21:6123/user/rpc/dispatcher";
 
     @RegisterExtension
-    private static final KubernetesExtension kubernetesExtension = new KubernetesExtension();
+    private static final KubernetesExtension KUBERNETES_EXTENSION = new KubernetesExtension();
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(Executors::newCachedThreadPool);
 
     @Test
     void testLeaderElectionAndRetrieval() throws Exception {
-        final String configMapName = LEADER_CONFIGMAP_NAME + System.currentTimeMillis();
-        KubernetesLeaderElectionDriver leaderElectionDriver = null;
-        KubernetesLeaderRetrievalDriver leaderRetrievalDriver = null;
-
-        final FlinkKubeClient flinkKubeClient = kubernetesExtension.getFlinkKubeClient();
-        final Configuration configuration = kubernetesExtension.getConfiguration();
+        final String configMapName = LEADER_CONFIGMAP_NAME + UUID.randomUUID();
+        final FlinkKubeClient flinkKubeClient = KUBERNETES_EXTENSION.getFlinkKubeClient();
+        final Configuration configuration = KUBERNETES_EXTENSION.getConfiguration();
 
         final String clusterId = configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+
+        // This will make the leader election retrieval time out if we won't process already
+        // existing leader information when starting it up.
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_LEASE_DURATION, Duration.ofHours(1));
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_RETRY_PERIOD, Duration.ofHours(1));
+        configuration.set(
+                KubernetesHighAvailabilityOptions.KUBERNETES_RENEW_DEADLINE, Duration.ofHours(1));
+
+        final List<AutoCloseable> closeables = new ArrayList<>();
+
         final KubernetesConfigMapSharedWatcher configMapSharedWatcher =
                 flinkKubeClient.createConfigMapSharedWatcher(
                         KubernetesUtils.getConfigMapLabels(
                                 clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
-        final ExecutorService watchExecutorService = Executors.newCachedThreadPool();
+        closeables.add(configMapSharedWatcher);
 
         final TestingLeaderElectionEventHandler electionEventHandler =
                 new TestingLeaderElectionEventHandler(LEADER_ADDRESS);
+        closeables.add(electionEventHandler);
 
         try {
-            leaderElectionDriver =
+            final KubernetesLeaderElectionDriver leaderElectionDriver =
                     new KubernetesLeaderElectionDriver(
                             flinkKubeClient,
                             configMapSharedWatcher,
-                            watchExecutorService,
+                            EXECUTOR_EXTENSION.getExecutor(),
                             new KubernetesLeaderElectionConfiguration(
                                     configMapName, UUID.randomUUID().toString(), configuration),
                             electionEventHandler,
                             electionEventHandler::handleError);
+            closeables.add(leaderElectionDriver);
+
             electionEventHandler.init(leaderElectionDriver);
 
-            final TestingLeaderRetrievalEventHandler retrievalEventHandler =
-                    new TestingLeaderRetrievalEventHandler();
-            leaderRetrievalDriver =
-                    new KubernetesLeaderRetrievalDriver(
-                            configMapSharedWatcher,
-                            watchExecutorService,
-                            configMapName,
-                            retrievalEventHandler,
-                            KubernetesUtils::getLeaderInformationFromConfigMap,
-                            retrievalEventHandler::handleError);
+            final Function<TestingLeaderRetrievalEventHandler, AutoCloseable>
+                    leaderRetrievalDriverFactory =
+                            leaderRetrievalEventHandler ->
+                                    new KubernetesLeaderRetrievalDriver(
+                                            configMapSharedWatcher,
+                                            EXECUTOR_EXTENSION.getExecutor(),
+                                            configMapName,
+                                            leaderRetrievalEventHandler,
+                                            KubernetesUtils::getLeaderInformationFromConfigMap,
+                                            leaderRetrievalEventHandler::handleError);
 
+            final TestingLeaderRetrievalEventHandler firstLeaderRetrievalEventHandler =
+                    new TestingLeaderRetrievalEventHandler();
+            closeables.add(leaderRetrievalDriverFactory.apply(firstLeaderRetrievalEventHandler));
+
+            // Wait for the driver to obtain leadership.
             electionEventHandler.waitForLeader();
-            // Check the new leader is confirmed
             final LeaderInformation confirmedLeaderInformation =
                     electionEventHandler.getConfirmedLeaderInformation();
             assertThat(confirmedLeaderInformation.getLeaderAddress()).isEqualTo(LEADER_ADDRESS);
 
-            // Check the leader retrieval driver should be notified the leader address
-            retrievalEventHandler.waitForNewLeader();
-            assertThat(retrievalEventHandler.getLeaderSessionID())
-                    .isEqualByComparingTo(confirmedLeaderInformation.getLeaderSessionID());
-            assertThat(retrievalEventHandler.getAddress())
-                    .isEqualTo(confirmedLeaderInformation.getLeaderAddress());
+            // Check if the leader retrieval driver is notified about the leader address
+            awaitLeadership(firstLeaderRetrievalEventHandler, confirmedLeaderInformation);
+
+            // Start a second leader retrieval that should be notified immediately because we
+            // already know who the leader is.
+            final TestingLeaderRetrievalEventHandler secondRetrievalEventHandler =
+                    new TestingLeaderRetrievalEventHandler();
+            closeables.add(leaderRetrievalDriverFactory.apply(secondRetrievalEventHandler));
+            awaitLeadership(secondRetrievalEventHandler, confirmedLeaderInformation);
         } finally {
-            electionEventHandler.close();
-            if (leaderElectionDriver != null) {
-                leaderElectionDriver.close();
-            }
-            if (leaderRetrievalDriver != null) {
-                leaderRetrievalDriver.close();
+            for (AutoCloseable closeable : closeables) {
+                closeable.close();
             }
             flinkKubeClient.deleteConfigMap(configMapName).get();
-            configMapSharedWatcher.close();
-            ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, watchExecutorService);
         }
+    }
+
+    private static void awaitLeadership(
+            TestingLeaderRetrievalEventHandler handler, LeaderInformation leaderInformation)
+            throws Exception {
+        handler.waitForNewLeader();
+        assertThat(handler.getLeaderSessionID())
+                .isEqualByComparingTo(leaderInformation.getLeaderSessionID());
+        assertThat(handler.getAddress()).isEqualTo(leaderInformation.getLeaderAddress());
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -91,7 +91,6 @@ class KubernetesLeaderElectionAndRetrievalITCase {
                     new TestingLeaderRetrievalEventHandler();
             leaderRetrievalDriver =
                     new KubernetesLeaderRetrievalDriver(
-                            flinkKubeClient,
                             configMapSharedWatcher,
                             watchExecutorService,
                             configMapName,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
@@ -28,7 +28,7 @@ package org.apache.flink.runtime.leaderelection;
  * <p><strong>Important</strong>: The {@link LeaderElectionDriver} could not guarantee that there is
  * no {@link LeaderElectionEventHandler} callbacks happen after {@link #close()}.
  */
-public interface LeaderElectionDriver {
+public interface LeaderElectionDriver extends AutoCloseable {
 
     /**
      * Write the current leader information to external persistent storage(e.g. Zookeeper,
@@ -49,7 +49,4 @@ public interface LeaderElectionDriver {
      * @return Return whether the driver has leadership.
      */
     boolean hasLeadership();
-
-    /** Close the services used for leader election. */
-    void close() throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalDriver.java
@@ -25,8 +25,4 @@ package org.apache.flink.runtime.leaderretrieval;
  * <p><strong>Important</strong>: The {@link LeaderRetrievalDriver} could not guarantee that there
  * is no {@link LeaderRetrievalEventHandler} callbacks happen after {@link #close()}.
  */
-public interface LeaderRetrievalDriver {
-
-    /** Close the services used for leader retrieval. */
-    void close() throws Exception;
-}
+public interface LeaderRetrievalDriver extends AutoCloseable {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
  * testing purposes.
  */
 public class TestingLeaderElectionEventHandler extends TestingLeaderBase
-        implements LeaderElectionEventHandler {
+        implements LeaderElectionEventHandler, AutoCloseable {
 
     private final Object lock = new Object();
 
@@ -135,6 +135,7 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
         }
     }
 
+    @Override
     public void close() {
         synchronized (lock) {
             running = false;


### PR DESCRIPTION
Backport of https://github.com/apache/flink/pull/22524