### PR TITLE
[FLINK-31548][jdbc-driver] Introduce FlinkDataSource

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDataSource.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDataSource.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import javax.sql.DataSource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/** Basic flink data source which create {@link FlinkConnection}. */
+public class FlinkDataSource implements DataSource {
+    private final String url;
+    private final Properties properties;
+
+    public FlinkDataSource(String url, Properties properties) {
+        this.url = url;
+        this.properties = properties;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return new FlinkConnection(DriverUri.create(url, properties));
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return getConnection();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkDataSource#unwrap is not supported");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkDataSource#isWrapperFor is not supported");
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkDataSource#getLogWriter is not supported");
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        throw new SQLFeatureNotSupportedException("FlinkDataSource#setLogWriter is not supported");
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkDataSource#setLoginTimeout is not supported");
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkDataSource#getLoginTimeout is not supported");
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException(
+                "FlinkDataSource#getParentLogger is not supported");
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDataSource.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkDataSource.java
@@ -44,7 +44,8 @@ public class FlinkDataSource implements DataSource {
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
-        return getConnection();
+        throw new SQLFeatureNotSupportedException(
+                "FlinkDataSource#getConnection with username and password is not supported");
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDataSourceTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkDataSourceTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for flink data source. */
+public class FlinkDataSourceTest extends FlinkJdbcDriverTestBase {
+
+    @Test
+    public void testDataSource() throws Exception {
+        FlinkDataSource dataSource = new FlinkDataSource(getDriverUri().getURL(), new Properties());
+        try (Connection connection = dataSource.getConnection()) {
+            assertEquals("default_catalog", connection.getCatalog());
+            assertEquals("default_database", connection.getSchema());
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce data source for flink jdbc driver


## Brief change log
  - Add FlinkDataSource


## Verifying this change
This change added tests and can be verified as follows:
  - Add test FlinkDataSourceTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
