### PR TITLE
[FLINK-31546][jdbc-driver] Close all statements when connection is closed

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
@@ -30,10 +30,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 
-/** Statement for flink jdbc driver. */
+/** Statement for flink jdbc driver. Notice that the statement is not thread safe. */
 @NotThreadSafe
 public class FlinkStatement extends BaseStatement {
-    private final Connection connection;
+    private final FlinkConnection connection;
     private final Executor executor;
     private FlinkResultSet currentResults;
     private boolean closed;
@@ -78,6 +78,7 @@ public class FlinkStatement extends BaseStatement {
         }
 
         cancel();
+        connection.removeStatement(this);
         closed = true;
     }
 

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -120,4 +120,19 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
             }
         }
     }
+
+    @Test
+    public void testCloseAllStatements() throws Exception {
+        FlinkConnection connection = new FlinkConnection(getDriverUri());
+        Statement statement1 = connection.createStatement();
+        Statement statement2 = connection.createStatement();
+        Statement statement3 = connection.createStatement();
+
+        statement1.close();
+        connection.close();
+
+        assertTrue(statement1.isClosed());
+        assertTrue(statement2.isClosed());
+        assertTrue(statement3.isClosed());
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to close all statements when a specified connection is closed in jdbc driver.

## Brief change log
  - Add statement list in flink connection
  - Remove the statement from connection when it is closed
  - Close all statements when the connection is closed

## Verifying this change

This change added tests and can be verified as follows:

  - Added test case FlinkStatementTest.testCloseAllStatements

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
