### PR TITLE
[FLINK-30081][runtime] Reset unused options like jvm-overhead.min/max for local executor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -49,7 +49,8 @@ public class TaskExecutorResourceUtils {
                     TaskManagerOptions.NETWORK_MEMORY_MAX,
                     TaskManagerOptions.MANAGED_MEMORY_SIZE);
 
-    private static final List<ConfigOption<?>> UNUSED_CONFIG_OPTIONS =
+    @VisibleForTesting
+    static final List<ConfigOption<?>> UNUSED_CONFIG_OPTIONS =
             Arrays.asList(
                     TaskManagerOptions.TOTAL_PROCESS_MEMORY,
                     TaskManagerOptions.TOTAL_FLINK_MEMORY,
@@ -189,7 +190,8 @@ public class TaskExecutorResourceUtils {
     }
 
     public static Configuration adjustForLocalExecution(Configuration config) {
-        UNUSED_CONFIG_OPTIONS.forEach(option -> warnOptionHasNoEffectIfSet(config, option));
+        UNUSED_CONFIG_OPTIONS.forEach(
+                option -> warnAndRemoveOptionHasNoEffectIfSet(config, option));
 
         setConfigOptionToPassedMaxIfNotSet(
                 config, TaskManagerOptions.CPU_CORES, LOCAL_EXECUTION_CPU_CORES);
@@ -201,24 +203,20 @@ public class TaskExecutorResourceUtils {
         adjustNetworkMemoryForLocalExecution(config);
         setConfigOptionToDefaultIfNotSet(
                 config, TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
-        silentlySetConfigOptionIfNotSet(
-                config,
+
+        // Set valid default values for unused config options which should have been removed.
+        config.set(
                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY,
                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.defaultValue());
-        silentlySetConfigOptionIfNotSet(
-                config,
+        config.set(
                 TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY,
                 TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.defaultValue());
-        silentlySetConfigOptionIfNotSet(
-                config,
-                TaskManagerOptions.JVM_METASPACE,
-                TaskManagerOptions.JVM_METASPACE.defaultValue());
-        silentlySetConfigOptionIfNotSet(
-                config,
+        config.set(
+                TaskManagerOptions.JVM_METASPACE, TaskManagerOptions.JVM_METASPACE.defaultValue());
+        config.set(
                 TaskManagerOptions.JVM_OVERHEAD_MAX,
                 TaskManagerOptions.JVM_OVERHEAD_MAX.defaultValue());
-        silentlySetConfigOptionIfNotSet(
-                config,
+        config.set(
                 TaskManagerOptions.JVM_OVERHEAD_MIN,
                 TaskManagerOptions.JVM_OVERHEAD_MAX.defaultValue());
 
@@ -244,20 +242,15 @@ public class TaskExecutorResourceUtils {
                 config, TaskManagerOptions.NETWORK_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
     }
 
-    private static void warnOptionHasNoEffectIfSet(Configuration config, ConfigOption<?> option) {
+    private static void warnAndRemoveOptionHasNoEffectIfSet(
+            Configuration config, ConfigOption<?> option) {
         if (config.contains(option)) {
             LOG.warn(
                     "The resource configuration option {} is set but it will have no effect for local execution, "
                             + "only the following options matter for the resource configuration: {}",
                     option,
-                    UNUSED_CONFIG_OPTIONS);
-        }
-    }
-
-    private static <T> void silentlySetConfigOptionIfNotSet(
-            Configuration config, ConfigOption<T> option, T value) {
-        if (!config.contains(option)) {
-            config.set(option, value);
+                    CONFIG_OPTIONS);
+            config.removeConfig(option);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
@@ -124,6 +124,25 @@ class TaskExecutorResourceUtilsTest {
     }
 
     @Test
+    void testUnusedOptionsAreIgnoredForLocalExecution() {
+        Configuration configuration = new Configuration();
+        configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ofMebiBytes(2024));
+        configuration.set(
+                TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.JVM_METASPACE, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.JVM_OVERHEAD_MIN, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.JVM_OVERHEAD_MAX, MemorySize.ofMebiBytes(2024));
+        configuration.set(TaskManagerOptions.JVM_OVERHEAD_FRACTION, 2024.0f);
+
+        TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
+
+        assertThat(configuration)
+                .isEqualTo(TaskExecutorResourceUtils.adjustForLocalExecution(new Configuration()));
+    }
+
+    @Test
     void testCalculateTotalFlinkMemoryWithAllFactorsBeingSet() {
         Configuration config = new Configuration();
 


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-30081

In local executor, it's not possible to set different values for `taskmanager.memory.jvm-overhead.max` and `taskmanager.memory.jvm-overhead.min`. When setting them differently, local executor reports `Exception in thread "main" java.lang.IllegalArgumentException` error.

The problem was that we expect the max and min to equal, but they are not resolved to the same value for local executor. Actually the two values are not effective for local, we should reset them to the same value.

## Brief change log

- reset the two JVM overhead config to the same value for local executor
- fix a bug in l


## Verifying this change

This change is already covered by existing tests, such as `TaskExecutorResourceUtilsTest`. It also adds a new test case in this class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
