### PR TITLE
[FLINK-32039][test] Adds graceful shutdown to TestExecutorExtension and TestExecutorResource

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -49,8 +49,18 @@ public class TestingUtils {
         return new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
     }
 
+    public static TestExecutorExtension<ScheduledExecutorService>
+            defaultExecutorExtensionWithOutstandingTaskAssertion() {
+        return defaultExecutorExtension().withOutstandingTasksAssert();
+    }
+
     public static TestExecutorResource<ScheduledExecutorService> defaultExecutorResource() {
         return new TestExecutorResource<>(Executors::newSingleThreadScheduledExecutor);
+    }
+
+    public static TestExecutorResource<ScheduledExecutorService>
+            defaultExecutorResourceWithOutstandingTaskAssertion() {
+        return defaultExecutorResource().withOutstandingTasksAssert();
     }
 
     public static UUID zeroUUID() {

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
@@ -56,7 +56,7 @@ class FutureUtilsTest {
 
     @RegisterExtension
     static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorExtension();
+            TestingUtils.defaultExecutorExtensionWithOutstandingTaskAssertion();
 
     /** Tests that we can retry an operation. */
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -53,7 +53,7 @@ public class LeaderElectionTest {
 
     @RegisterExtension
     private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorExtension();
+            TestingUtils.defaultExecutorExtensionWithOutstandingTaskAssertion();
 
     @RegisterExtension
     private final TestingFatalErrorHandlerExtension testingFatalErrorHandlerResource =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -160,7 +160,7 @@ public class AdaptiveSchedulerTest {
 
     @RegisterExtension
     public static final TestExecutorExtension<ScheduledExecutorService> TEST_EXECUTOR_RESOURCE =
-            new TestExecutorExtension<>(Executors::newSingleThreadScheduledExecutor);
+            TestingUtils.defaultExecutorExtensionWithOutstandingTaskAssertion();
 
     private final ManuallyTriggeredComponentMainThreadExecutor mainThreadExecutor =
             new ManuallyTriggeredComponentMainThreadExecutor(Thread.currentThread());


### PR DESCRIPTION
Follow-up task that was extraced from PR https://github.com/apache/flink/pull/22544

## What is the purpose of the change

The shutdown of the `executorService` is triggered but no check for hanging threads is done. This PR adds the graceful shutdown and forces threads to be cancelled if necessary (see [ExecutorUtils.gracefulShutdown(..)](https://github.com/apache/flink/blob/c6997c97c575d334679915c328792b8a3067cfb5/flink-core/src/main/java/org/apache/flink/util/ExecutorUtils.java#L42) for reference).

## Brief change log

* Adds graceful shutdown to `TestExecutorExtension` and `TestExecutorResource`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
