### PR TITLE
[FLINK-31609][yarn][test] Extend log whitelist for expected AMRM heartbeat interrupt

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -171,6 +171,8 @@ public abstract class YarnTestBase {
         // this can happen during cluster shutdown, if AMRMClient happens to be heartbeating
         Pattern.compile("Exception on heartbeat"),
         Pattern.compile("java\\.io\\.InterruptedIOException: Call interrupted"),
+        Pattern.compile(
+                "java\\.io\\.InterruptedIOException: Interrupted waiting to send RPC request to server"),
         Pattern.compile("java\\.lang\\.InterruptedException"),
 
         // this can happen if the hbase delegation token provider is not available


### PR DESCRIPTION
## What is the purpose of the change

After test execution, during cluster shutdown there is a chance that Yarn AMRM gets an interruption during its heartbeat logic, which generates an exception and when that happens, tests will fail because that exact exception is not whitelisted at the moment.

## Brief change log

Added a new exception to the `YarnTestBase` whitelist.