### PR TITLE
[FLINK-32030][sql-client] Add URLs support for SQL Client gateway mode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -121,6 +121,18 @@ public class NetUtils {
     }
 
     /**
+     * Converts an InetSocketAddress to a URL. This method assigns the "http://" schema to the URL
+     * by default.
+     *
+     * @param socketAddress the InetSocketAddress to be converted
+     * @return a URL object representing the provided socket address with "http://" schema
+     */
+    public static URL socketToUrl(InetSocketAddress socketAddress) {
+        String hostPort = socketAddress.getHostString() + ":" + socketAddress.getPort();
+        return validateHostPortString(hostPort);
+    }
+
+    /**
      * Calls {@link ServerSocket#accept()} on the provided server socket, suppressing any thrown
      * {@link SocketTimeoutException}s. This is a workaround for the underlying JDK-8237858 bug in
      * JDK 11 that can cause errant SocketTimeoutExceptions to be thrown at unexpected times.

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.util;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -32,6 +34,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import static org.apache.flink.util.NetUtils.socketToUrl;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
@@ -342,5 +345,13 @@ public class NetUtilsTest extends TestLogger {
                     host.toLowerCase() + ":" + port,
                     NetUtils.unresolvedHostAndPortToNormalizedString(host, port));
         }
+    }
+
+    @Test
+    public void testSocketToUrl() throws MalformedURLException {
+        InetSocketAddress socketAddress = new InetSocketAddress("foo.com", 8080);
+        URL expectedResult = new URL("http://foo.com:8080");
+
+        Assertions.assertThat(socketToUrl(socketAddress)).isEqualTo(expectedResult);
     }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliOptions.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 
 import javax.annotation.Nullable;
 
-import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +134,7 @@ public class CliOptions {
     /** Command option lines to configure SQL Client in the gateway mode. */
     public static class GatewayCliOptions extends CliOptions {
 
-        private final @Nullable InetSocketAddress gatewayAddress;
+        private final @Nullable URL gatewayAddress;
 
         GatewayCliOptions(
                 boolean isPrintHelp,
@@ -144,7 +143,7 @@ public class CliOptions {
                 URL sqlFile,
                 String updateStatement,
                 String historyFilePath,
-                @Nullable InetSocketAddress gatewayAddress,
+                @Nullable URL gatewayAddress,
                 Properties sessionConfig) {
             super(
                     isPrintHelp,
@@ -157,7 +156,7 @@ public class CliOptions {
             this.gatewayAddress = gatewayAddress;
         }
 
-        public Optional<InetSocketAddress> getGatewayAddress() {
+        public Optional<URL> getGatewayAddress() {
             return Optional.ofNullable(gatewayAddress);
         }
     }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.gateway.service.context.DefaultContext;
 
 import java.io.Closeable;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.List;
 
 /** A gateway for communicating with Flink and other external systems. */
@@ -31,6 +32,10 @@ public interface Executor extends Closeable {
     /** Create an {@link Executor} to execute commands. */
     static Executor create(
             DefaultContext defaultContext, InetSocketAddress address, String sessionId) {
+        return new ExecutorImpl(defaultContext, address, sessionId);
+    }
+
+    static Executor create(DefaultContext defaultContext, URL address, String sessionId) {
         return new ExecutorImpl(defaultContext, address, sessionId);
     }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
@@ -49,6 +49,7 @@ import org.apache.flink.table.gateway.rest.header.statement.CompleteStatementHea
 import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHeaders;
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
+import org.apache.flink.table.gateway.rest.header.util.UrlPrefixDecorator;
 import org.apache.flink.table.gateway.rest.message.operation.OperationMessageParameters;
 import org.apache.flink.table.gateway.rest.message.operation.OperationStatusResponseBody;
 import org.apache.flink.table.gateway.rest.message.session.CloseSessionResponseBody;
@@ -68,6 +69,7 @@ import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointUtils;
 import org.apache.flink.table.gateway.service.context.DefaultContext;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -77,6 +79,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -101,7 +104,8 @@ public class ExecutorImpl implements Executor {
     private static final long HEARTBEAT_INTERVAL_MILLISECONDS = 60_000L;
 
     private final AutoCloseableRegistry registry;
-    private final InetSocketAddress gatewayAddress;
+    private final URL gatewayUrl;
+
     private final ExecutorService executorService;
     private final RestClient restClient;
 
@@ -110,7 +114,15 @@ public class ExecutorImpl implements Executor {
 
     public ExecutorImpl(
             DefaultContext defaultContext, InetSocketAddress gatewayAddress, String sessionId) {
-        this(defaultContext, gatewayAddress, sessionId, HEARTBEAT_INTERVAL_MILLISECONDS);
+        this(
+                defaultContext,
+                NetUtils.socketToUrl(gatewayAddress),
+                sessionId,
+                HEARTBEAT_INTERVAL_MILLISECONDS);
+    }
+
+    public ExecutorImpl(DefaultContext defaultContext, URL gatewayUrl, String sessionId) {
+        this(defaultContext, gatewayUrl, sessionId, HEARTBEAT_INTERVAL_MILLISECONDS);
     }
 
     @VisibleForTesting
@@ -119,9 +131,18 @@ public class ExecutorImpl implements Executor {
             InetSocketAddress gatewayAddress,
             String sessionId,
             long heartbeatInterval) {
+        this(defaultContext, NetUtils.socketToUrl(gatewayAddress), sessionId, heartbeatInterval);
+    }
+
+    @VisibleForTesting
+    ExecutorImpl(
+            DefaultContext defaultContext,
+            URL gatewayUrl,
+            String sessionId,
+            long heartbeatInterval) {
         this.registry = new AutoCloseableRegistry();
+        this.gatewayUrl = gatewayUrl;
         try {
-            this.gatewayAddress = gatewayAddress;
             // register required resource
             this.executorService = Executors.newCachedThreadPool();
             registry.registerCloseable(executorService::shutdownNow);
@@ -134,7 +155,7 @@ public class ExecutorImpl implements Executor {
             // register session
             LOG.info(
                     "Open session to {} with connection version: {}.",
-                    gatewayAddress,
+                    gatewayUrl,
                     connectionVersion);
             OpenSessionResponseBody response =
                     sendRequest(
@@ -180,7 +201,7 @@ public class ExecutorImpl implements Executor {
                     .get();
         } catch (Exception e) {
             throw new SqlExecutionException(
-                    String.format("Failed to open session to %s", gatewayAddress), e);
+                    String.format("Failed to open session to %s", gatewayUrl), e);
         }
     }
 
@@ -342,7 +363,11 @@ public class ExecutorImpl implements Executor {
                     P extends ResponseBody>
             CompletableFuture<P> sendRequest(M messageHeaders, U messageParameters, R request) {
         Preconditions.checkNotNull(connectionVersion, "The connection version should not be null.");
-        return sendRequest(messageHeaders, messageParameters, request, connectionVersion);
+        return sendRequest(
+                new UrlPrefixDecorator<>(messageHeaders, gatewayUrl.getPath()),
+                messageParameters,
+                request,
+                connectionVersion);
     }
 
     private <
@@ -357,8 +382,8 @@ public class ExecutorImpl implements Executor {
                     SqlGatewayRestAPIVersion connectionVersion) {
         try {
             return restClient.sendRequest(
-                    gatewayAddress.getHostName(),
-                    gatewayAddress.getPort(),
+                    gatewayUrl.getHost(),
+                    gatewayUrl.getPort(),
                     messageHeaders,
                     messageParameters,
                     request,
@@ -454,9 +479,11 @@ public class ExecutorImpl implements Executor {
         List<SqlGatewayRestAPIVersion> gatewayVersions =
                 getResponse(
                                 restClient.sendRequest(
-                                        gatewayAddress.getHostName(),
-                                        gatewayAddress.getPort(),
-                                        GetApiVersionHeaders.getInstance(),
+                                        gatewayUrl.getHost(),
+                                        gatewayUrl.getPort(),
+                                        new UrlPrefixDecorator<>(
+                                                GetApiVersionHeaders.getInstance(),
+                                                gatewayUrl.getPath()),
                                         EmptyMessageParameters.getInstance(),
                                         EmptyRequestBody.getInstance(),
                                         Collections.emptyList(),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -162,12 +162,10 @@ class SqlClientTest {
                 new String[] {
                     "gateway",
                     "-e",
-                    new URL(
-                                    "http",
-                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
-                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort(),
-                                    "")
-                            .toString()
+                    String.format(
+                            "http://%s:%d",
+                            SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                            SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort())
                 };
         String actual = runSqlClient(args, String.join("\n", "SET;", "QUIT;"), false);
         assertThat(actual).contains("execution.target", "yarn-session");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -142,7 +142,7 @@ class SqlClientTest {
     }
 
     @Test
-    void testGatewayMode() throws Exception {
+    void testGatewayModeHostnamePort() throws Exception {
         String[] args =
                 new String[] {
                     "gateway",
@@ -151,6 +151,23 @@ class SqlClientTest {
                             "%s:%d",
                             SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
                             SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort())
+                };
+        String actual = runSqlClient(args, String.join("\n", "SET;", "QUIT;"), false);
+        assertThat(actual).contains("execution.target", "yarn-session");
+    }
+
+    @Test
+    void testGatewayModeUrl() throws Exception {
+        String[] args =
+                new String[] {
+                    "gateway",
+                    "-e",
+                    new URL(
+                                    "http",
+                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                                    SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort(),
+                                    "")
+                            .toString()
                 };
         String actual = runSqlClient(args, String.join("\n", "SET;", "QUIT;"), false);
         assertThat(actual).contains("execution.target", "yarn-session");

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/UrlPrefixDecorator.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/util/UrlPrefixDecorator.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.util;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import static org.apache.flink.shaded.guava30.com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This class decorates the URL of the original message headers by adding a prefix. The purpose of
+ * this decorator is to provide a consistent URL prefix for all the REST API endpoints while
+ * preserving the behavior of the original message headers.
+ *
+ * @param <R> the type of the request body
+ * @param <P> the type of the response body
+ * @param <M> the type of the message parameters
+ */
+public class UrlPrefixDecorator<
+                R extends RequestBody, P extends ResponseBody, M extends MessageParameters>
+        implements SqlGatewayMessageHeaders<R, P, M> {
+
+    private final String prefixedUrl;
+    private final MessageHeaders<R, P, M> decorated;
+
+    /**
+     * Constructs an instance of UrlPrefixDecorator.
+     *
+     * @param messageHeaders the original SqlGatewayMessageHeaders to be decorated
+     * @param urlPrefix the URL prefix to be added to the target REST endpoint URL
+     */
+    public UrlPrefixDecorator(MessageHeaders<R, P, M> messageHeaders, String urlPrefix) {
+        checkNotNull(messageHeaders);
+        checkNotNull(urlPrefix);
+        this.decorated = messageHeaders;
+        this.prefixedUrl =
+                constructPrefixedUrlWithVersionPlaceholder(
+                        urlPrefix, messageHeaders.getTargetRestEndpointURL());
+    }
+
+    private static String constructPrefixedUrlWithVersionPlaceholder(
+            String urlPrefix, String targetRestEndpointURL) {
+        return urlPrefix + "/" + RestClient.VERSION_PLACEHOLDER + targetRestEndpointURL;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return decorated.getHttpMethod();
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return prefixedUrl;
+    }
+
+    @Override
+    public Class<P> getResponseClass() {
+        return decorated.getResponseClass();
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return decorated.getResponseStatusCode();
+    }
+
+    @Override
+    public String getDescription() {
+        return decorated.getDescription();
+    }
+
+    @Override
+    public Class<R> getRequestClass() {
+        return decorated.getRequestClass();
+    }
+
+    @Override
+    public M getUnresolvedMessageParameters() {
+        return decorated.getUnresolvedMessageParameters();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for URLs in SQL Client gateway mode. The changes are backwards compatible and still allow to pass `hostname:port` as the `--endpoint` parameter.
https://issues.apache.org/jira/browse/FLINK-32030


## Verifying this change

This change added tests and can be verified as follows:

  - Added integration tests using a URL as the new `--endpoint` parameter
  - Manually verified connectivity and interactions with a SQL Gateway that is exposed using a proxy,  and includes a URL path (`foo.com:8083/some-path/v1/info`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - The documentation will be added upon general PR approval
