### PR TITLE
[FLINK-32024][docs] Short code related to externalized connector retrieve version from its own data yaml

### DIFF
--- a/docs/layouts/shortcodes/connector_artifact.html
+++ b/docs/layouts/shortcodes/connector_artifact.html
@@ -22,8 +22,9 @@ under the License.
   rendered documentation. 
 */}}
 {{ $artifactId := .Get 0 }}
-{{ $version := .Get 1 }}
-
+{{ $name := .Get 1 }}
+{{ $connector := index .Site.Data $name }}
+{{ $version := $connector.version  }}
 {{ $path := .Page.Path }}
 
 {{ $hash := md5 now }}

--- a/docs/layouts/shortcodes/py_connector_download_link.html
+++ b/docs/layouts/shortcodes/py_connector_download_link.html
@@ -19,8 +19,8 @@ under the License.
 Generates an XML snippet for the externalized connector python download table.
 */}}
 {{ $name := .Get 0 }}
-{{ $connector_version := .Get 1 }}
 {{ $connector := index .Site.Data $name }}
+{{ $connector_version := $connector.version  }}
 {{ $flink_version := .Site.Params.VersionTitle }}
 {{ $full_version := printf "%s-%s" $connector_version $flink_version }}
 

--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -22,8 +22,8 @@
     rendered documentation. 
   */}}
   {{ $name := .Get 0 }}
-  {{ $connector_version := .Get 1 }}
   {{ $connector := index .Site.Data $name }}
+  {{ $connector_version := $connector.version  }}
   {{ $flink_version := .Site.Params.VersionTitle }}
   {{ $full_version := printf "%s-%s" $connector_version $flink_version }}
   


### PR DESCRIPTION
## What is the purpose of the change

*Currently, we have some shortcodes specifically designed for externalized connector, such as `connectors_artifact`, `sql_connector_download_table`, etc.*

*When using them, we need to pass in a version number, such as `sql_connector_download_table "pulsar" 3.0.0`. It's easy for us to forget to modify the corresponding version in the document when releasing a new version.*

*Of course, we can hard code these into the release process. But perhaps we can introduce a version field to `docs/data/connector_name.yml` and let flink directly reads the corresponding version when rendering shortcode.*


## Brief change log

  - *Let short codes related to externalized connector retrieve version from its own data yaml.*


## Verifying this change

Test manually in my local env.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
