### PR TITLE
[FLINK-32044][table-api] Validate catalog name when listFunctions in FunctionCatalog

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -303,7 +303,14 @@ public final class FunctionCatalog {
                         .collect(Collectors.toSet()));
 
         // add catalog functions
-        Catalog catalog = catalogManager.getCatalog(catalogName).get();
+        Catalog catalog =
+                catalogManager
+                        .getCatalog(catalogName)
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                String.format(
+                                                        "Catalog %s not exists.", catalogName)));
         try {
             catalog.listFunctions(databaseName)
                     .forEach(


### PR DESCRIPTION
## What is the purpose of the change

Add catalog name check to make exception log friendly (otherwise it will cause NPE).

## Brief change log

Add catalog name check instead of call Optional class#get().

## Verifying this change

It's a trivial improvement can be covered by current table tests.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable