### PR TITLE
[FLINK-31891][runtime] Introduce AdaptiveScheduler per-task failure enrichment/labeling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -143,6 +143,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                 mainThreadExecutor,
                 fatalErrorHandler,
                 jobStatusListener,
+                failureEnrichers,
                 executionGraphFactory);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
-import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -66,6 +65,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -343,9 +343,12 @@ abstract class StateWithExecutionGraph implements State {
      *
      * @param taskExecutionStateTransition taskExecutionStateTransition to update the ExecutionGraph
      *     with
+     * @param failureLabels the failure labels to attach to the task failure cause
      * @return {@code true} if the update was successful; otherwise {@code false}
      */
-    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
+    boolean updateTaskExecutionState(
+            TaskExecutionStateTransition taskExecutionStateTransition,
+            CompletableFuture<Map<String, String>> failureLabels) {
         // collect before updateState, as updateState may deregister the execution
         final Optional<AccessExecution> maybeExecution =
                 executionGraph.findExecution(taskExecutionStateTransition.getID());
@@ -361,8 +364,7 @@ abstract class StateWithExecutionGraph implements State {
             final ExecutionState currentState = execution.getState();
             if (currentState == desiredState) {
                 failureCollection.add(
-                        ExceptionHistoryEntry.create(
-                                execution, taskName, FailureEnricherUtils.EMPTY_FAILURE_LABELS));
+                        ExceptionHistoryEntry.create(execution, taskName, failureLabels));
                 onFailure(
                         ErrorInfo.handleMissingThrowable(
                                 taskExecutionStateTransition.getError(userCodeClassLoader)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -49,6 +50,8 @@ import org.apache.flink.util.FatalExitExceptionHandler;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 
 /** Builder for {@link AdaptiveScheduler}. */
@@ -80,6 +83,7 @@ public class AdaptiveSchedulerBuilder {
                     FatalExitExceptionHandler.INSTANCE.uncaughtException(
                             Thread.currentThread(), error);
     private JobStatusListener jobStatusListener = (ignoredA, ignoredB, ignoredC) -> {};
+    private Collection<FailureEnricher> failureEnrichers = Collections.emptySet();
     private long initializationTimestamp = System.currentTimeMillis();
 
     @Nullable private SlotAllocator slotAllocator;
@@ -176,6 +180,12 @@ public class AdaptiveSchedulerBuilder {
         return this;
     }
 
+    public AdaptiveSchedulerBuilder setFailureEnrichers(
+            Collection<FailureEnricher> failureEnrichers) {
+        this.failureEnrichers = failureEnrichers;
+        return this;
+    }
+
     public AdaptiveSchedulerBuilder setInitializationTimestamp(long initializationTimestamp) {
         this.initializationTimestamp = initializationTimestamp;
         return this;
@@ -221,6 +231,7 @@ public class AdaptiveSchedulerBuilder {
                 mainThreadExecutor,
                 fatalErrorHandler,
                 jobStatusListener,
+                failureEnrichers,
                 executionGraphFactory);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
@@ -109,7 +110,7 @@ public class CancelingTest extends TestLogger {
             meg.registerExecution(execution);
             TaskExecutionStateTransition update =
                     ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
-            canceling.updateTaskExecutionState(update);
+            canceling.updateTaskExecutionState(update, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
             ctx.assertNoStateTransition();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.executiongraph.MarkPartitionFinishedStrategy;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionGroupReleaseStrategy;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -297,7 +298,8 @@ public class ExecutingTest extends TestLogger {
             returnsFailedStateExecutionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     createFailingStateTransition(execution.getAttemptId(), exception);
-            exec.updateTaskExecutionState(taskExecutionStateTransition);
+            exec.updateTaskExecutionState(
+                    taskExecutionStateTransition, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -323,7 +325,8 @@ public class ExecutingTest extends TestLogger {
             returnsFailedStateExecutionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     createFailingStateTransition(execution.getAttemptId(), exception);
-            exec.updateTaskExecutionState(taskExecutionStateTransition);
+            exec.updateTaskExecutionState(
+                    taskExecutionStateTransition, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -346,7 +349,8 @@ public class ExecutingTest extends TestLogger {
             returnsFailedStateExecutionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     createFailingStateTransition(execution.getAttemptId(), exception);
-            exec.updateTaskExecutionState(taskExecutionStateTransition);
+            exec.updateTaskExecutionState(
+                    taskExecutionStateTransition, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
 
             ctx.assertNoStateTransition();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
@@ -116,7 +117,7 @@ public class FailingTest extends TestLogger {
             meg.registerExecution(execution);
             TaskExecutionStateTransition update =
                     ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
-            failing.updateTaskExecutionState(update);
+            failing.updateTaskExecutionState(update, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
             ctx.assertNoStateTransition();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.Matchers.is;
@@ -229,7 +230,8 @@ public class StateWithExecutionGraphTest extends TestLogger {
 
         @Override
         boolean updateTaskExecutionState(
-                TaskExecutionStateTransition taskExecutionStateTransition) {
+                TaskExecutionStateTransition taskExecutionStateTransition,
+                CompletableFuture<Map<String, String>> failureLabels) {
             return false;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
@@ -245,7 +246,11 @@ class StopWithSavepointTest {
             executionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
-            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition)).isTrue();
+            assertThat(
+                            sws.updateTaskExecutionState(
+                                    taskExecutionStateTransition,
+                                    FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                    .isTrue();
         }
     }
 
@@ -269,7 +274,11 @@ class StopWithSavepointTest {
             executionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
-            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition)).isTrue();
+            assertThat(
+                            sws.updateTaskExecutionState(
+                                    taskExecutionStateTransition,
+                                    FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                    .isTrue();
         }
     }
 
@@ -349,7 +358,11 @@ class StopWithSavepointTest {
             executionGraph.registerExecution(execution);
             TaskExecutionStateTransition taskExecutionStateTransition =
                     ExecutingTest.createFailingStateTransition(execution.getAttemptId(), exception);
-            assertThat(sws.updateTaskExecutionState(taskExecutionStateTransition)).isTrue();
+            assertThat(
+                            sws.updateTaskExecutionState(
+                                    taskExecutionStateTransition,
+                                    FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                    .isTrue();
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31891

* Introduce async task failure as part of AdaptiveScheduler#updateTaskExecutionState
* Propagate labels as part of ExceptionHistoryEntry
* Extend AdaptiveSchedulerTests to validate functionality

