### PR TITLE
[FLINK-32052][table-runtime] Introduce left and right state retention time to StreamingJoinOperator

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -184,6 +184,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             leftInputSpec,
                             rightInputSpec,
                             joinSpec.getFilterNulls(),
+                            minRetentionTime,
                             minRetentionTime);
         } else {
             boolean leftIsOuter = joinType == FlinkJoinType.LEFT || joinType == FlinkJoinType.FULL;
@@ -199,6 +200,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             leftIsOuter,
                             rightIsOuter,
                             joinSpec.getFilterNulls(),
+                            minRetentionTime,
                             minRetentionTime);
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -60,7 +60,8 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 
     private final boolean[] filterNullKeys;
 
-    protected final long stateRetentionTime;
+    protected final long leftStateRetentionTime;
+    protected final long rightStateRetentionTime;
 
     protected transient JoinConditionWithNullFilters joinCondition;
     protected transient TimestampedCollector<RowData> collector;
@@ -72,13 +73,15 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
             JoinInputSideSpec leftInputSideSpec,
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long leftStateRetentionTime,
+            long rightStateRetentionTime) {
         this.leftType = leftType;
         this.rightType = rightType;
         this.generatedJoinCondition = generatedJoinCondition;
         this.leftInputSideSpec = leftInputSideSpec;
         this.rightInputSideSpec = rightInputSideSpec;
-        this.stateRetentionTime = stateRetentionTime;
+        this.leftStateRetentionTime = leftStateRetentionTime;
+        this.rightStateRetentionTime = rightStateRetentionTime;
         this.filterNullKeys = filterNullKeys;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -60,7 +60,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
             boolean leftIsOuter,
             boolean rightIsOuter,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long leftStateRetentionTime,
+            long rightStateRetentionTime) {
         super(
                 leftType,
                 rightType,
@@ -68,7 +69,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                 leftInputSideSpec,
                 rightInputSideSpec,
                 filterNullKeys,
-                stateRetentionTime);
+                leftStateRetentionTime,
+                rightStateRetentionTime);
         this.leftIsOuter = leftIsOuter;
         this.rightIsOuter = rightIsOuter;
     }
@@ -89,7 +91,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "left-records",
                             leftInputSideSpec,
                             leftType,
-                            stateRetentionTime);
+                            leftStateRetentionTime);
         } else {
             this.leftRecordStateView =
                     JoinRecordStateViews.create(
@@ -97,7 +99,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "left-records",
                             leftInputSideSpec,
                             leftType,
-                            stateRetentionTime);
+                            leftStateRetentionTime);
         }
 
         if (rightIsOuter) {
@@ -107,7 +109,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "right-records",
                             rightInputSideSpec,
                             rightType,
-                            stateRetentionTime);
+                            rightStateRetentionTime);
         } else {
             this.rightRecordStateView =
                     JoinRecordStateViews.create(
@@ -115,7 +117,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
                             "right-records",
                             rightInputSideSpec,
                             rightType,
-                            stateRetentionTime);
+                            rightStateRetentionTime);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -35,7 +35,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 
     private static final long serialVersionUID = -3135772379944924519L;
 
-    // true if it is anti join, otherwise is semi joinp
+    // true if it is anti join, otherwise is semi join
     private final boolean isAntiJoin;
 
     // left join state
@@ -51,7 +51,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
             JoinInputSideSpec leftInputSideSpec,
             JoinInputSideSpec rightInputSideSpec,
             boolean[] filterNullKeys,
-            long stateRetentionTime) {
+            long leftStateRetentionTime,
+            long rightStateRetentionTIme) {
         super(
                 leftType,
                 rightType,
@@ -59,7 +60,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                 leftInputSideSpec,
                 rightInputSideSpec,
                 filterNullKeys,
-                stateRetentionTime);
+                leftStateRetentionTime,
+                rightStateRetentionTIme);
         this.isAntiJoin = isAntiJoin;
     }
 
@@ -73,7 +75,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         LEFT_RECORDS_STATE_NAME,
                         leftInputSideSpec,
                         leftType,
-                        stateRetentionTime);
+                        leftStateRetentionTime);
 
         this.rightRecordStateView =
                 JoinRecordStateViews.create(
@@ -81,7 +83,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
                         RIGHT_RECORDS_STATE_NAME,
                         rightInputSideSpec,
                         rightType,
-                        stateRetentionTime);
+                        rightStateRetentionTime);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+
+/** Harness tests for {@link StreamingJoinOperator}. */
+public class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
+
+    @Override
+    protected StreamingJoinOperator createJoinOperator(TestInfo testInfo) {
+        Boolean[] joinTypeSpec = JOIN_TYPE_EXTRACTOR.apply(testInfo.getDisplayName());
+        return new StreamingJoinOperator(
+                leftTypeInfo,
+                rightTypeInfo,
+                joinCondition,
+                leftInputSpec,
+                rightInputSpec,
+                joinTypeSpec[0],
+                joinTypeSpec[1],
+                new boolean[] {true},
+                leftStateRetentionTime,
+                rightStateRetentionTime);
+    }
+
+    @Override
+    protected RowType getOutputType() {
+        return RowType.of(
+                Stream.concat(
+                                leftTypeInfo.toRowType().getChildren().stream(),
+                                rightTypeInfo.toRowType().getChildren().stream())
+                        .toArray(LogicalType[]::new),
+                Stream.concat(
+                                leftTypeInfo.toRowType().getFieldNames().stream(),
+                                rightTypeInfo.toRowType().getFieldNames().stream())
+                        .toArray(String[]::new));
+    }
+
+    /**
+     * The equivalent SQL as follows.
+     *
+     * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address, b.line_order_id,
+     * b.line_order_ship_mode FROM orders a JOIN line_orders b ON a.line_order_id = b.line_order_id}
+     */
+    @Test
+    public void testInnerJoinWithDifferentStateRetentionTime() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "LineOrd#2",
+                        "AIR"));
+
+        // the right side state of LineOrd#2 has expired
+        testHarness.setStateTtlProcessingTime(3000);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#2", "68 Manor Station Street, Honolulu, HI 96815"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#2", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        "LineOrd#2",
+                        "SHIP"));
+
+        // the left side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(deleteRecord("LineOrd#2", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        "LineOrd#2",
+                        "SHIP"));
+
+        // the left side state of LineOrd#2 has expired
+        testHarness.setStateTtlProcessingTime(7000);
+        testHarness.processElement2(insertRecord("LineOrd#2", "RAIL"));
+        assertor.shouldEmitNothing(testHarness);
+    }
+
+    /**
+     * The equivalent SQL as follows.
+     *
+     * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address, b.line_order_id,
+     * b.line_order_ship_mode FROM orders a LEFT JOIN line_orders b ON a.line_order_id =
+     * b.line_order_id}
+     */
+    @Test
+    public void testLeftOuterJoinWithDifferentStateRetentionTime() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        null,
+                        null));
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        null,
+                        null));
+
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        null,
+                        null),
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "LineOrd#2",
+                        "AIR"));
+
+        // the right side state of LineOrd#2 has expired
+        testHarness.setStateTtlProcessingTime(3000);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#2", "68 Manor Station Street, Honolulu, HI 96815"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        null,
+                        null));
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#2", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        null,
+                        null),
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        "LineOrd#2",
+                        "SHIP"));
+
+        // the left side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(deleteRecord("LineOrd#2", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        "LineOrd#2",
+                        "SHIP"),
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        null,
+                        null));
+
+        // the left side state of LineOrd#2 has expired
+        testHarness.setStateTtlProcessingTime(8001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "RAIL"));
+        assertor.shouldEmitNothing(testHarness);
+    }
+
+    /**
+     * The equivalent SQL as follows.
+     *
+     * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address, b.line_order_id,
+     * b.line_order_ship_mode FROM orders a RIGHT JOIN line_orders b ON a.line_order_id =
+     * b.line_order_id}
+     */
+    @Test
+    public void testRightOuterJoinWithDifferentStateRetentionTime() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        // left side state is expired
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness, rowOfKind(RowKind.INSERT, null, null, null, "LineOrd#2", "AIR"));
+
+        testHarness.processElement2(insertRecord("LineOrd#1", "TRUCK"));
+        assertor.shouldEmit(
+                testHarness, rowOfKind(RowKind.INSERT, null, null, null, "LineOrd#1", "TRUCK"));
+
+        // the right side state has expired
+        testHarness.setStateTtlProcessingTime(5001);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#2", "68 Manor Station Street, Honolulu, HI 96815"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#2", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "68 Manor Station Street, Honolulu, HI 96815",
+                        "LineOrd#2",
+                        "SHIP"));
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#1", "RAIL"));
+        assertor.shouldEmit(
+                testHarness, rowOfKind(RowKind.INSERT, null, null, null, "LineOrd#1", "RAIL"));
+
+        testHarness.setStateTtlProcessingTime(6000);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#1", "3 North Winchester Drive, Haines City, FL 33844"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(RowKind.DELETE, null, null, null, "LineOrd#1", "RAIL"),
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 North Winchester Drive, Haines City, FL 33844",
+                        "LineOrd#1",
+                        "RAIL"));
+
+        // right side state has expired
+        testHarness.setStateTtlProcessingTime(7000);
+        testHarness.processElement1(
+                deleteRecord(
+                        "Ord#1", "LineOrd#1", "3 North Winchester Drive, Haines City, FL 33844"));
+        assertor.shouldEmitNothing(testHarness);
+    }
+
+    private static final Function<String, Boolean[]> JOIN_TYPE_EXTRACTOR =
+            (testDisplayName) -> {
+                if (testDisplayName.contains("InnerJoin")) {
+                    return new Boolean[] {false, false};
+                } else if (testDisplayName.contains("LeftOuterJoin")) {
+                    return new Boolean[] {true, false};
+                } else {
+                    return new Boolean[] {false, true};
+                }
+            };
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream;
+
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+/** Base test class for {@link AbstractStreamingJoinOperator}. */
+public abstract class StreamingJoinOperatorTestBase {
+
+    protected final InternalTypeInfo<RowData> leftTypeInfo =
+            InternalTypeInfo.of(
+                    RowType.of(
+                            new LogicalType[] {
+                                new CharType(false, 20),
+                                new CharType(false, 20),
+                                VarCharType.STRING_TYPE
+                            },
+                            new String[] {"order_id", "line_order_id", "shipping_address"}));
+
+    protected final InternalTypeInfo<RowData> rightTypeInfo =
+            InternalTypeInfo.of(
+                    RowType.of(
+                            new LogicalType[] {new CharType(false, 20), new CharType(true, 10)},
+                            new String[] {"line_order_id0", "line_order_ship_mode"}));
+
+    protected final RowDataKeySelector leftKeySelector =
+            HandwrittenSelectorUtil.getRowDataSelector(
+                    new int[] {1},
+                    leftTypeInfo.toRowType().getChildren().toArray(new LogicalType[0]));
+    protected final RowDataKeySelector rightKeySelector =
+            HandwrittenSelectorUtil.getRowDataSelector(
+                    new int[] {0},
+                    rightTypeInfo.toRowType().getChildren().toArray(new LogicalType[0]));
+
+    protected final JoinInputSideSpec leftInputSpec =
+            JoinInputSideSpec.withUniqueKeyContainedByJoinKey(leftTypeInfo, leftKeySelector);
+    protected final JoinInputSideSpec rightInputSpec =
+            JoinInputSideSpec.withUniqueKeyContainedByJoinKey(rightTypeInfo, rightKeySelector);
+
+    protected final InternalTypeInfo<RowData> joinKeyTypeInfo =
+            InternalTypeInfo.of(new CharType(false, 20));
+
+    protected final String funcCode =
+            "public class ConditionFunction extends org.apache.flink.api.common.functions.AbstractRichFunction "
+                    + "implements org.apache.flink.table.runtime.generated.JoinCondition {\n"
+                    + "\n"
+                    + "    public ConditionFunction(Object[] reference) {\n"
+                    + "    }\n"
+                    + "\n"
+                    + "    @Override\n"
+                    + "    public boolean apply(org.apache.flink.table.data.RowData in1, org.apache.flink.table.data.RowData in2) {\n"
+                    + "        return true;\n"
+                    + "    }\n"
+                    + "\n"
+                    + "    @Override\n"
+                    + "    public void close() throws Exception {\n"
+                    + "        super.close();\n"
+                    + "    }"
+                    + "}\n";
+    protected final GeneratedJoinCondition joinCondition =
+            new GeneratedJoinCondition("ConditionFunction", funcCode, new Object[0]);
+
+    protected final RowDataHarnessAssertor assertor =
+            new RowDataHarnessAssertor(getOutputType().getChildren().toArray(new LogicalType[0]));
+
+    protected final long leftStateRetentionTime = 4000L;
+    protected final long rightStateRetentionTime = 1000L;
+
+    protected KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData>
+            testHarness;
+
+    @BeforeEach
+    public void beforeEach(TestInfo testInfo) throws Exception {
+        testHarness =
+                new KeyedTwoInputStreamOperatorTestHarness<>(
+                        createJoinOperator(testInfo),
+                        leftKeySelector,
+                        rightKeySelector,
+                        joinKeyTypeInfo);
+        testHarness.open();
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        testHarness.close();
+    }
+
+    /** Create streaming join operator according to {@link TestInfo}. */
+    protected abstract AbstractStreamingJoinOperator createJoinOperator(TestInfo testInfo);
+
+    /** Get the output row type of join operator. */
+    protected abstract RowType getOutputType();
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.join.stream;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -35,6 +36,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterR
 public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Override
     protected StreamingSemiAntiJoinOperator createJoinOperator(TestInfo testInfo) {
+        Long[] ttl = STATE_RETENTION_TIME_EXTRACTOR.apply(testInfo.getTags());
         return new StreamingSemiAntiJoinOperator(
                 ANTI_JOIN_CHECKER.test(testInfo.getDisplayName()),
                 leftTypeInfo,
@@ -43,8 +45,8 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
                 leftInputSpec,
                 rightInputSpec,
                 new boolean[] {true},
-                leftStateRetentionTime,
-                rightStateRetentionTime);
+                ttl[0],
+                ttl[1]);
     }
 
     @Override
@@ -58,6 +60,8 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
      * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address FROM orders a WHERE
      * a.line_order_id IN (SELECT b.line_order_id FROM line_orders b)}
      */
+    @Tag("leftStateRetentionTime=4000")
+    @Tag("rightStateRetentionTime=1000")
     @Test
     public void testLeftSemiJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
@@ -108,11 +112,77 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
     }
 
     /**
+     * The equivalent SQL is the same as {@link #testLeftSemiJoinWithDifferentStateRetentionTime()}.
+     * The only difference is that the state retention is disabled.
+     */
+    @Test
+    public void testLeftSemiJoinWithStateRetentionDisabled() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.setStateTtlProcessingTime(3001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#2", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(deleteRecord("LineOrd#2", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        // numOfAssociations is reduced to 1, retract the record
+        testHarness.processElement2(deleteRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "SHIP"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        // the right side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(5001);
+        testHarness.processElement1(
+                updateAfterRecord("Ord#1", "LineOrd#1", "7238 Marsh St., Birmingham, AL 35209"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "7238 Marsh St., Birmingham, AL 35209"));
+    }
+
+    /**
      * The equivalent SQL as follows.
      *
      * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address FROM orders a WHERE
      * a.line_order_id NOT IN (SELECT b.line_order_id FROM line_orders b)}
      */
+    @Tag("leftStateRetentionTime=4000")
+    @Tag("rightStateRetentionTime=1000")
     @Test
     public void testLeftAntiJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
@@ -163,6 +233,60 @@ public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTest
                         "Ord#1",
                         "LineOrd#1",
                         "23 W. River Avenue, Port Orange, FL 32127"));
+    }
+
+    /**
+     * The equivalent SQL is the same as {@link #testLeftAntiJoinWithDifferentStateRetentionTime()}.
+     * The only difference is that the state retention is disabled.
+     */
+    @Test
+    public void testLeftAntiJoinWithStateRetentionTimeDisabled() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.setStateTtlProcessingTime(3001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "RAIL"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.setStateTtlProcessingTime(5001);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#1", "23 W. River Avenue, Port Orange, FL 32127"));
+        assertor.shouldEmitNothing(testHarness);
     }
 
     private static final Predicate<String> ANTI_JOIN_CHECKER =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperatorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream;
+
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.function.Predicate;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+
+/** Test for {@link StreamingSemiAntiJoinOperator}. */
+public class StreamingSemiAntiJoinOperatorTest extends StreamingJoinOperatorTestBase {
+    @Override
+    protected StreamingSemiAntiJoinOperator createJoinOperator(TestInfo testInfo) {
+        return new StreamingSemiAntiJoinOperator(
+                ANTI_JOIN_CHECKER.test(testInfo.getDisplayName()),
+                leftTypeInfo,
+                rightTypeInfo,
+                joinCondition,
+                leftInputSpec,
+                rightInputSpec,
+                new boolean[] {true},
+                leftStateRetentionTime,
+                rightStateRetentionTime);
+    }
+
+    @Override
+    protected RowType getOutputType() {
+        return leftTypeInfo.toRowType();
+    }
+
+    /**
+     * The equivalent SQL as follows.
+     *
+     * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address FROM orders a WHERE
+     * a.line_order_id IN (SELECT b.line_order_id FROM line_orders b)}
+     */
+    @Test
+    public void testLeftSemiJoinWithDifferentStateRetentionTime() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.setStateTtlProcessingTime(3001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.processElement2(updateAfterRecord("LineOrd#2", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        testHarness.processElement2(deleteRecord("LineOrd#2", "TRUCK"));
+        assertor.shouldEmitNothing(testHarness);
+
+        // numOfAssociations is reduced to 1, retract the record
+        testHarness.processElement2(deleteRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        // the left side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "SHIP"));
+        assertor.shouldEmitNothing(testHarness);
+
+        // the right side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(5001);
+        testHarness.processElement1(
+                updateAfterRecord("Ord#1", "LineOrd#1", "7238 Marsh St., Birmingham, AL 35209"));
+        assertor.shouldEmitNothing(testHarness);
+    }
+
+    /**
+     * The equivalent SQL as follows.
+     *
+     * <p>{@code SELECT a.order_id, a.line_order_id, a.shipping_address FROM orders a WHERE
+     * a.line_order_id NOT IN (SELECT b.line_order_id FROM line_orders b)}
+     */
+    @Test
+    public void testLeftAntiJoinWithDifferentStateRetentionTime() throws Exception {
+        testHarness.setStateTtlProcessingTime(1);
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.processElement1(
+                insertRecord("Ord#1", "LineOrd#2", "3 Bellevue Drive, Pottstown, PA 19464"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        testHarness.setStateTtlProcessingTime(3001);
+        testHarness.processElement2(insertRecord("LineOrd#2", "AIR"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.DELETE,
+                        "Ord#1",
+                        "LineOrd#2",
+                        "3 Bellevue Drive, Pottstown, PA 19464"));
+
+        // left side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(4001);
+        testHarness.processElement2(insertRecord("LineOrd#1", "RAIL"));
+        assertor.shouldEmitNothing(testHarness);
+
+        // right side state of LineOrd#1 has expired
+        testHarness.setStateTtlProcessingTime(5001);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#1", "23 W. River Avenue, Port Orange, FL 32127"));
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "23 W. River Avenue, Port Orange, FL 32127"));
+    }
+
+    private static final Predicate<String> ANTI_JOIN_CHECKER =
+            (testDisplayName) -> testDisplayName.contains("Anti");
+}


### PR DESCRIPTION
## What is the purpose of the change

This is the second subtask for FLIP-292.


## Brief change log

This PR introduces `leftStateRetentionTime` and `rightStateRetentionTime` to `StreamingJoinOperator` and `StreamingSemiAntiJoinOperator`.


## Verifying this change

This change added tests and can be verified as follows:

Add `StreamingJoinOperatorTest` and `StreamingSemiAntiJoinOperatorTest` to verify the different state TTL for join operators work as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduces a new feature? yes
  - If yes, how is the feature documented? [FLINK-31957](https://issues.apache.org/jira/browse/FLINK-31957)
