### PR TITLE
[FLINK-32056][Python][Connector/Pulsar] Upgrade flink-connector-pulsar in flink-python to v4.0.0

### DIFF
--- a/flink-python/docs/reference/pyflink.datastream/connectors.rst
+++ b/flink-python/docs/reference/pyflink.datastream/connectors.rst
@@ -149,7 +149,6 @@ Pulsar Source
 .. autosummary::
     :toctree: api/
 
-    PulsarDeserializationSchema
     SubscriptionType
     StartCursor
     StopCursor

--- a/flink-python/docs/reference/pyflink.datastream/connectors.rst
+++ b/flink-python/docs/reference/pyflink.datastream/connectors.rst
@@ -149,7 +149,6 @@ Pulsar Source
 .. autosummary::
     :toctree: api/
 
-    SubscriptionType
     StartCursor
     StopCursor
     PulsarSource

--- a/flink-python/docs/reference/pyflink.datastream/connectors.rst
+++ b/flink-python/docs/reference/pyflink.datastream/connectors.rst
@@ -165,7 +165,6 @@ Pulsar Sink
 .. autosummary::
     :toctree: api/
 
-    PulsarSerializationSchema
     TopicRoutingMode
     MessageDelayer
     PulsarSink

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -298,7 +298,7 @@ under the License.
 			<!-- Indirectly accessed in pyflink_gateway_server -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-pulsar</artifactId>
-			<version>3.0.0-1.16</version>
+			<version>4.0.0-1.17</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -49,7 +49,6 @@ def _install():
     from pyflink.datastream.connectors import pulsar
     setattr(connectors, 'PulsarSource', pulsar.PulsarSource)
     setattr(connectors, 'PulsarSourceBuilder', pulsar.PulsarSourceBuilder)
-    setattr(connectors, 'PulsarDeserializationSchema', pulsar.PulsarDeserializationSchema)
     setattr(connectors, 'SubscriptionType', pulsar.SubscriptionType)
     setattr(connectors, 'StartCursor', pulsar.StartCursor)
     setattr(connectors, 'StopCursor', pulsar.StopCursor)

--- a/flink-python/pyflink/datastream/connectors/__init__.py
+++ b/flink-python/pyflink/datastream/connectors/__init__.py
@@ -49,7 +49,6 @@ def _install():
     from pyflink.datastream.connectors import pulsar
     setattr(connectors, 'PulsarSource', pulsar.PulsarSource)
     setattr(connectors, 'PulsarSourceBuilder', pulsar.PulsarSourceBuilder)
-    setattr(connectors, 'SubscriptionType', pulsar.SubscriptionType)
     setattr(connectors, 'StartCursor', pulsar.StartCursor)
     setattr(connectors, 'StopCursor', pulsar.StopCursor)
 

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -359,16 +359,6 @@ class PulsarSourceBuilder(object):
         self._j_pulsar_source_builder.setSubscriptionName(subscription_name)
         return self
 
-    def set_subscription_type(self, subscription_type: SubscriptionType) -> 'PulsarSourceBuilder':
-        """
-        SubscriptionType is the consuming behavior for pulsar, we would generator different split
-        by the given subscription type. Please take some time to consider which subscription type
-        matches your application best. Default is SubscriptionType.Shared.
-        """
-        self._j_pulsar_source_builder.setSubscriptionType(
-            subscription_type._to_j_subscription_type())
-        return self
-
     def set_topics(self, topics: Union[str, List[str]]) -> 'PulsarSourceBuilder':
         """
         Set a pulsar topic list for flink source. Some topic may not exist currently, consuming this

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -438,7 +438,7 @@ class PulsarSourceBuilder(object):
         self._j_pulsar_source_builder.setBoundedStopCursor(stop_cursor._j_stop_cursor)
         return self
 
-    def set_value_only_deserializer(self, deserialization_schema: DeserializationSchema) \
+    def set_deserialization_schema(self, deserialization_schema: DeserializationSchema) \
             -> 'PulsarSourceBuilder':
         """
         Sets the :class:`~pyflink.common.serialization.DeserializationSchema` for deserializing the
@@ -448,7 +448,8 @@ class PulsarSourceBuilder(object):
             deserialization.
         :return: this PulsarSourceBuilder.
         """
-        self._j_builder.setValueOnlyDeserializer(deserialization_schema._j_deserialization_schema)
+        self._j_pulsar_source_builder.setDeserializationSchema(
+            deserialization_schema._j_deserialization_schema)
         return self
 
     def set_config(self, key: Union[str, ConfigOption], value) -> 'PulsarSourceBuilder':
@@ -623,7 +624,7 @@ class PulsarSinkBuilder(object):
         ...     .set_service_url(PULSAR_BROKER_URL) \\
         ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
         ...     .set_topics([TOPIC1, TOPIC2]) \\
-        ...     .set_value_serialization_schema(SimpleStringSchema()) \\
+        ...     .set_serialization_schema(SimpleStringSchema()) \\
         ...     .build()
 
     The service url, admin url, and the record serializer are required fields that must be set. If

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -574,7 +574,7 @@ class PulsarSink(Sink):
         ...     .set_service_url(PULSAR_BROKER_URL) \\
         ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
         ...     .set_topics(topic) \\
-        ...     .set_value_serialization_schema(SimpleStringSchema()) \\
+        ...     .set_serialization_schema(SimpleStringSchema()) \\
         ...     .build()
 
     The sink supports all delivery guarantees described by DeliveryGuarantee.
@@ -643,7 +643,7 @@ class PulsarSinkBuilder(object):
         ...     .set_service_url(PULSAR_BROKER_URL) \\
         ...     .set_admin_url(PULSAR_BROKER_HTTP_URL) \\
         ...     .set_topics([TOPIC1, TOPIC2]) \\
-        ...     .set_value_serialization_schema(SimpleStringSchema()) \\
+        ...     .set_serialization_schema(SimpleStringSchema()) \\
         ...     .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE)
         ...     .build()
     """

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -29,7 +29,6 @@ from pyflink.util.java_utils import load_java_class
 __all__ = [
     'PulsarSource',
     'PulsarSourceBuilder',
-    'SubscriptionType',
     'StartCursor',
     'StopCursor',
     'PulsarSink',
@@ -40,46 +39,6 @@ __all__ = [
 
 
 # ---- PulsarSource ----
-
-class SubscriptionType(Enum):
-    """
-    Types of subscription supported by Pulsar.
-
-    :data: `Exclusive`:
-
-    There can be only 1 consumer on the same topic with the same subscription name.
-
-    :data: `Shared`:
-
-    Multiple consumer will be able to use the same subscription name and the messages will be
-    dispatched according to a round-robin rotation between the connected consumers. In this mode,
-    the consumption order is not guaranteed.
-
-    :data: `Failover`:
-
-    Multiple consumer will be able to use the same subscription name but only 1 consumer will
-    receive the messages. If that consumer disconnects, one of the other connected consumers will
-    start receiving messages. In failover mode, the consumption ordering is guaranteed. In case of
-    partitioned topics, the ordering is guaranteed on a per-partition basis. The partitions
-    assignments will be split across the available consumers. On each partition, at most one
-    consumer will be active at a given point in time.
-
-    :data: `Key_Shared`:
-
-    Multiple consumer will be able to use the same subscription and all messages with the same key
-    will be dispatched to only one consumer. Use ordering_key to overwrite the message key for
-    message ordering.
-    """
-
-    Exclusive = 0,
-    Shared = 1,
-    Failover = 2,
-    Key_Shared = 3
-
-    def _to_j_subscription_type(self):
-        JSubscriptionType = get_gateway().jvm.org.apache.pulsar.client.api.SubscriptionType
-        return getattr(JSubscriptionType, self.name)
-
 
 class StartCursor(object):
     """

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -35,7 +35,6 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_unbounded_stop_cursor(StopCursor.never()) \
             .set_bounded_stop_cursor(StopCursor.at_publish_time(22)) \
             .set_subscription_name('ff') \
-            .set_subscription_type(SubscriptionType.Exclusive) \
             .set_deserialization_schema(SimpleStringSchema()) \
             .set_config(TEST_OPTION_NAME, True) \
             .set_properties({'pulsar.source.autoCommitCursorInterval': '1000'}) \

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -18,7 +18,7 @@
 from pyflink.common import WatermarkStrategy, SimpleStringSchema, Types, ConfigOptions, Duration
 from pyflink.datastream.connectors import DeliveryGuarantee
 from pyflink.datastream.connectors.pulsar import TopicRoutingMode, MessageDelayer, PulsarSink, \
-    PulsarSource, StartCursor, PulsarDeserializationSchema, StopCursor, SubscriptionType
+    PulsarSource, StartCursor, StopCursor, SubscriptionType
 from pyflink.testing.test_case_utils import PyFlinkUTTestCase
 from pyflink.util.java_utils import get_field_value, is_instance_of
 
@@ -36,10 +36,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_bounded_stop_cursor(StopCursor.at_publish_time(22)) \
             .set_subscription_name('ff') \
             .set_subscription_type(SubscriptionType.Exclusive) \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_type_info(Types.STRING())) \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .set_config(TEST_OPTION_NAME, True) \
             .set_properties({'pulsar.source.autoCommitCursorInterval': '1000'}) \
             .build()
@@ -88,8 +85,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_topics(['ada', 'beta']) \
             .set_subscription_name('ff') \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .build()
 
     def test_source_set_topics_pattern(self):
@@ -98,8 +94,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_topic_pattern('ada.*') \
             .set_subscription_name('ff') \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .build()
 
     def test_source_deprecated_method(self):
@@ -109,8 +104,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
             .set_topic_pattern('ada.*') \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_type_info(Types.STRING())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .set_unbounded_stop_cursor(StopCursor.at_publish_time(4444)) \
             .set_subscription_name('ff') \
             .set_config(test_option, True) \
@@ -132,8 +126,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_topics('ada') \
             .set_subscription_name('ff') \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .set_start_cursor(StartCursor.from_publish_time(2)) \
             .set_bounded_stop_cursor(StopCursor.at_publish_time(14)) \
             .set_bounded_stop_cursor(StopCursor.after_publish_time(24)) \
@@ -145,8 +138,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_topics('ada') \
             .set_subscription_name('ff') \
-            .set_deserialization_schema(
-                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_deserialization_schema(SimpleStringSchema()) \
             .set_bounded_stop_cursor(StopCursor.after_event_time(14)) \
             .set_bounded_stop_cursor(StopCursor.at_event_time(24)) \
             .build()

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -153,7 +153,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_producer_name('fo') \
             .set_topics('ada') \
-            .set_value_serialization_schema(SimpleStringSchema()) \
+            .set_serialization_schema(SimpleStringSchema()) \
             .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
             .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
             .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
@@ -222,5 +222,5 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
             .set_topics(['ada', 'beta']) \
-            .set_value_serialization_schema(SimpleStringSchema()) \
+            .set_serialization_schema(SimpleStringSchema()) \
             .build()

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -17,9 +17,8 @@
 ################################################################################
 from pyflink.common import WatermarkStrategy, SimpleStringSchema, Types, ConfigOptions, Duration
 from pyflink.datastream.connectors import DeliveryGuarantee
-from pyflink.datastream.connectors.pulsar import PulsarSerializationSchema, TopicRoutingMode, \
-    MessageDelayer, PulsarSink, PulsarSource, StartCursor, PulsarDeserializationSchema, \
-    StopCursor, SubscriptionType
+from pyflink.datastream.connectors.pulsar import TopicRoutingMode, MessageDelayer, PulsarSink, \
+    PulsarSource, StartCursor, PulsarDeserializationSchema, StopCursor, SubscriptionType
 from pyflink.testing.test_case_utils import PyFlinkUTTestCase
 from pyflink.util.java_utils import get_field_value, is_instance_of
 
@@ -162,8 +161,7 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_admin_url('http://localhost:8080') \
             .set_producer_name('fo') \
             .set_topics('ada') \
-            .set_serialization_schema(
-                PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_value_serialization_schema(SimpleStringSchema()) \
             .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
             .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
             .delay_sending_message(MessageDelayer.fixed(Duration.of_seconds(12))) \
@@ -232,6 +230,5 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
             .set_service_url('pulsar://localhost:6650') \
             .set_admin_url('http://localhost:8080') \
             .set_topics(['ada', 'beta']) \
-            .set_serialization_schema(
-                PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_value_serialization_schema(SimpleStringSchema()) \
             .build()

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -18,7 +18,7 @@
 from pyflink.common import WatermarkStrategy, SimpleStringSchema, Types, ConfigOptions, Duration
 from pyflink.datastream.connectors import DeliveryGuarantee
 from pyflink.datastream.connectors.pulsar import TopicRoutingMode, MessageDelayer, PulsarSink, \
-    PulsarSource, StartCursor, StopCursor, SubscriptionType
+    PulsarSource, StartCursor, StopCursor
 from pyflink.testing.test_case_utils import PyFlinkUTTestCase
 from pyflink.util.java_utils import get_field_value, is_instance_of
 
@@ -63,11 +63,6 @@ class FlinkPulsarTest(PyFlinkUTTestCase):
                 ConfigOptions.key('pulsar.consumer.subscriptionName')
                 .string_type()
                 .no_default_value()._j_config_option), 'ff')
-        self.assertEqual(
-            configuration.getString(
-                ConfigOptions.key('pulsar.consumer.subscriptionType')
-                .string_type()
-                .no_default_value()._j_config_option), SubscriptionType.Exclusive.name)
         test_option = ConfigOptions.key(TEST_OPTION_NAME).boolean_type().no_default_value()
         self.assertEqual(
             configuration.getBoolean(

--- a/flink-python/pyflink/examples/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/examples/datastream/connectors/pulsar.py
@@ -21,9 +21,8 @@ import sys
 
 from pyflink.common import SimpleStringSchema, WatermarkStrategy
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors.pulsar import PulsarSource, PulsarSink,\
-    PulsarSerializationSchema, StartCursor, StopCursor, SubscriptionType, \
-    PulsarDeserializationSchema, DeliveryGuarantee, TopicRoutingMode
+from pyflink.datastream.connectors.pulsar import PulsarSource, PulsarSink, StartCursor, \
+    StopCursor, SubscriptionType, PulsarDeserializationSchema, DeliveryGuarantee, TopicRoutingMode
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
@@ -59,8 +58,7 @@ if __name__ == '__main__':
         .set_admin_url(ADMIN_URL) \
         .set_producer_name('pyflink_producer') \
         .set_topics('beta') \
-        .set_serialization_schema(
-            PulsarSerializationSchema.flink_schema(SimpleStringSchema())) \
+        .set_value_serialization_schema(SimpleStringSchema()) \
         .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
         .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
         .set_config('pulsar.producer.maxPendingMessages', 1000) \

--- a/flink-python/pyflink/examples/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/examples/datastream/connectors/pulsar.py
@@ -22,7 +22,7 @@ import sys
 from pyflink.common import SimpleStringSchema, WatermarkStrategy
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.connectors.pulsar import PulsarSource, PulsarSink, StartCursor, \
-    StopCursor, SubscriptionType, DeliveryGuarantee, TopicRoutingMode
+    StopCursor, DeliveryGuarantee, TopicRoutingMode
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")

--- a/flink-python/pyflink/examples/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/examples/datastream/connectors/pulsar.py
@@ -22,7 +22,7 @@ import sys
 from pyflink.common import SimpleStringSchema, WatermarkStrategy
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.connectors.pulsar import PulsarSource, PulsarSink, StartCursor, \
-    StopCursor, SubscriptionType, PulsarDeserializationSchema, DeliveryGuarantee, TopicRoutingMode
+    StopCursor, SubscriptionType, DeliveryGuarantee, TopicRoutingMode
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
@@ -43,8 +43,7 @@ if __name__ == '__main__':
         .set_unbounded_stop_cursor(StopCursor.never()) \
         .set_subscription_name('pyflink_subscription') \
         .set_subscription_type(SubscriptionType.Exclusive) \
-        .set_deserialization_schema(
-            PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+        .set_deserialization_schema(SimpleStringSchema()) \
         .set_config('pulsar.source.enableAutoAcknowledgeMessage', True) \
         .set_properties({'pulsar.source.autoCommitCursorInterval': '1000'}) \
         .build()

--- a/flink-python/pyflink/examples/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/examples/datastream/connectors/pulsar.py
@@ -42,7 +42,6 @@ if __name__ == '__main__':
         .set_start_cursor(StartCursor.latest()) \
         .set_unbounded_stop_cursor(StopCursor.never()) \
         .set_subscription_name('pyflink_subscription') \
-        .set_subscription_type(SubscriptionType.Exclusive) \
         .set_deserialization_schema(SimpleStringSchema()) \
         .set_config('pulsar.source.enableAutoAcknowledgeMessage', True) \
         .set_properties({'pulsar.source.autoCommitCursorInterval': '1000'}) \

--- a/flink-python/pyflink/examples/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/examples/datastream/connectors/pulsar.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         .set_admin_url(ADMIN_URL) \
         .set_producer_name('pyflink_producer') \
         .set_topics('beta') \
-        .set_value_serialization_schema(SimpleStringSchema()) \
+        .set_serialization_schema(SimpleStringSchema()) \
         .set_delivery_guarantee(DeliveryGuarantee.AT_LEAST_ONCE) \
         .set_topic_routing_mode(TopicRoutingMode.ROUND_ROBIN) \
         .set_config('pulsar.producer.maxPendingMessages', 1000) \


### PR DESCRIPTION
## What is the purpose of the change

* Upgrade used `flink-connector-pulsar` in `flink-python` to 4.0.0, since that's compatible with Flink 1.17+. Without this upgrade, we can't upgrade `flink-shaded` since the older versions of `flink-connector-pulsar` directly use `flink-shaded` and there's a breaking change in `flink-shaded`.

## Brief change log

* Upgrade to `flink-connector-pulsar` to 4.0.0
* Remove and refactoring all occurrences of `PulsarSerializationSchema`, `SubscriptionType` and `PulsarSerializationSchema`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
