### PR TITLE
[FLINK-32060][test] Migrate subclasses of BatchAbstractTestBase in table and other modules to JUnit5

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFilesystemITCase.java
@@ -19,9 +19,11 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,18 +33,14 @@ import java.util.List;
 import static org.apache.avro.file.DataFileConstants.NULL_CODEC;
 
 /** ITCase to test avro format for {@link AvroFileFormatFactory} in batch mode. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class AvroFilesystemITCase extends BatchFileSystemITCaseBase {
 
-    private final boolean configure;
+    @Parameter public boolean configure;
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameters(name = "configure={0}")
     public static Collection<Boolean> parameters() {
         return Arrays.asList(false, true);
-    }
-
-    public AvroFilesystemITCase(boolean configure) {
-        this.configure = configure;
     }
 
     @Override

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
@@ -19,12 +19,13 @@
 package org.apache.flink.formats.csv;
 
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+import org.apache.flink.testutils.junit.extensions.parameterized.NoOpTestExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FileUtils;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.net.URI;
@@ -33,11 +34,12 @@ import java.util.Arrays;
 import java.util.List;
 
 /** ITCase to test csv format for {@link CsvFileFormatFactory} in batch mode. */
-@RunWith(Enclosed.class)
-public class CsvFilesystemBatchITCase {
+@ExtendWith(NoOpTestExtension.class)
+class CsvFilesystemBatchITCase {
 
     /** General IT cases for CsvRowDataFilesystem in batch mode. */
-    public static class GeneralCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
+    @Nested
+    class GeneralCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
 
         @Override
         public boolean supportsReadingMetadata() {
@@ -58,7 +60,8 @@ public class CsvFilesystemBatchITCase {
      * Enriched IT cases that including testParseError and testEscapeChar for CsvRowDataFilesystem
      * in batch mode.
      */
-    public static class EnrichedCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
+    @Nested
+    class EnrichedCsvFilesystemBatchITCase extends BatchFileSystemITCaseBase {
 
         @Override
         public boolean supportsReadingMetadata() {
@@ -75,7 +78,7 @@ public class CsvFilesystemBatchITCase {
         }
 
         @Test
-        public void testParseError() throws Exception {
+        void testParseError() throws Exception {
             String path = new URI(resultPath()).getPath();
             new File(path).mkdirs();
             File file = new File(path, "test_file");
@@ -89,7 +92,7 @@ public class CsvFilesystemBatchITCase {
         }
 
         @Test
-        public void testParseErrorLast() throws Exception {
+        void testParseErrorLast() throws Exception {
             String path = new URI(resultPath()).getPath();
             new File(path).mkdirs();
             File file = new File(path, "test_file");
@@ -103,7 +106,7 @@ public class CsvFilesystemBatchITCase {
         }
 
         @Test
-        public void testEscapeChar() throws Exception {
+        void testEscapeChar() throws Exception {
             String path = new URI(resultPath()).getPath();
             new File(path).mkdirs();
             File file = new File(path, "test_file");

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** ITCase to test csv format for {@link CsvFileFormatFactory} in stream mode. */
-public class CsvFilesystemStreamITCase extends StreamFileSystemITCaseBase {
+class CsvFilesystemStreamITCase extends StreamFileSystemITCaseBase {
 
     @Override
     public boolean supportsReadingMetadata() {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
@@ -18,14 +18,17 @@
 
 package org.apache.flink.formats.json;
 
+import org.apache.flink.core.testutils.EachCallbackWrapper;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
-import org.apache.flink.table.utils.LegacyRowResource;
+import org.apache.flink.table.utils.LegacyRowExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.NoOpTestExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FileUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,9 +41,12 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase to test json format for {@link JsonFormatFactory}. */
-public class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
+@ExtendWith(NoOpTestExtension.class)
+class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
 
-    @Rule public final LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
+    @RegisterExtension
+    private final EachCallbackWrapper<LegacyRowExtension> legacyRowExtension =
+            new EachCallbackWrapper<>(new LegacyRowExtension());
 
     @Override
     public String[] formatProperties() {
@@ -51,7 +57,7 @@ public class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
     }
 
     @Test
-    public void testParseError() throws Exception {
+    void testParseError() throws Exception {
         String path = new URI(resultPath()).getPath();
         new File(path).mkdirs();
         File file = new File(path, "temp_file");
@@ -68,7 +74,7 @@ public class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
     }
 
     @Test
-    public void bigDataTest() throws IOException {
+    void bigDataTest() throws IOException {
         int numRecords = 1000;
         File dir = generateTestData(numRecords);
 

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
@@ -20,15 +20,18 @@ package org.apache.flink.formats.parquet;
 
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,21 +47,18 @@ import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase for {@link ParquetFileFormatFactory}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
 
-    private final boolean configure;
+    @Parameter public boolean configure;
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameters(name = "configure={0}")
     public static Collection<Boolean> parameters() {
         return Arrays.asList(false, true);
     }
 
-    public ParquetFileSystemITCase(boolean configure) {
-        this.configure = configure;
-    }
-
     @Override
+    @BeforeEach
     public void before() {
         super.before();
         super.tableEnv()
@@ -87,6 +87,7 @@ public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
     }
 
     @Override
+    @TestTemplate
     public void testNonPartition() {
         super.testNonPartition();
 
@@ -112,8 +113,8 @@ public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
         }
     }
 
-    @Test
-    public void testLimitableBulkFormat() throws ExecutionException, InterruptedException {
+    @TestTemplate
+    void testLimitableBulkFormat() throws ExecutionException, InterruptedException {
         super.tableEnv()
                 .executeSql(
                         "insert into parquetLimitTable select x, y, "

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowExtension.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/LegacyRowExtension.java
@@ -15,32 +15,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.planner.runtime.batch.table
 
-import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
+package org.apache.flink.table.utils;
 
-import org.junit.jupiter.api.BeforeEach
+import org.apache.flink.core.testutils.CustomExtension;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowUtils;
 
-class LimitITCase extends LegacyLimitITCase {
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-  @BeforeEach
-  override def before(): Unit = {
-    BatchTestBase.configForMiniCluster(tableConfig)
+/**
+ * Enables the old behavior of {@link Row#toString()} for legacy tests.
+ *
+ * <p>It ignores the changes applied in FLINK-16998 and FLINK-19981.
+ */
+public class LegacyRowExtension implements CustomExtension {
+    @Override
+    public void before(ExtensionContext context) throws Exception {
+        RowUtils.USE_LEGACY_TO_STRING = true;
+    }
 
-    val myTableDataId = TestValuesTableFactory.registerData(TestData.data3)
-    val ddl =
-      s"""
-         |CREATE TABLE LimitTable (
-         |  a int,
-         |  b bigint,
-         |  c string
-         |) WITH (
-         |  'connector' = 'values',
-         |  'data-id' = '$myTableDataId',
-         |  'bounded' = 'true'
-         |)
-       """.stripMargin
-    tEnv.executeSql(ddl)
-  }
+    @Override
+    public void after(ExtensionContext context) throws Exception {
+        RowUtils.USE_LEGACY_TO_STRING = false;
+    }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -19,21 +19,21 @@ package org.apache.flink.table.planner.runtime
 
 import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.core.fs.Path
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase._
 import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.testutils.junit.utils.TempDirUtils
 import org.apache.flink.types.Row
 
-import org.junit.{Rule, Test}
-import org.junit.Assert.{assertEquals, assertNotNull, assertTrue}
-import org.junit.rules.TemporaryFolder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.io.TempDir
 
 import java.io.File
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import java.time.Instant
 
 import scala.collection.{JavaConverters, Seq}
@@ -41,11 +41,10 @@ import scala.collection.{JavaConverters, Seq}
 /** Test File system table factory. */
 trait FileSystemITCaseBase {
 
-  val fileTmpFolder = new TemporaryFolder
   protected var resultPath: String = _
 
-  @Rule
-  def fileTempFolder: TemporaryFolder = fileTmpFolder
+  @TempDir
+  protected var fileTempFolder: Path = _
 
   def formatProperties(): Array[String] = Array()
 
@@ -66,7 +65,7 @@ trait FileSystemITCaseBase {
   def supportsReadingMetadata: Boolean = true
 
   def open(): Unit = {
-    resultPath = fileTmpFolder.newFolder().toURI.getPath
+    resultPath = TempDirUtils.newFolder(fileTempFolder).toURI.getPath
     BatchTableEnvUtil.registerCollection(
       tableEnv,
       "originalT",
@@ -163,7 +162,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testSelectDecimalWithPrecisionTenAndZeroFromFileSystem(): Unit = {
     tableEnv
       .executeSql(
@@ -180,7 +179,7 @@ trait FileSystemITCaseBase {
       ))
   }
 
-  @Test
+  @TestTemplate
   def testSelectDecimalWithPrecisionThreeAndTwoFromFileSystem(): Unit = {
     tableEnv
       .executeSql(
@@ -197,7 +196,7 @@ trait FileSystemITCaseBase {
       ))
   }
 
-  @Test
+  @TestTemplate
   def testAllStaticPartitions1(): Unit = {
     tableEnv
       .executeSql(
@@ -216,7 +215,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testAllStaticPartitions2(): Unit = {
     tableEnv
       .executeSql(
@@ -235,7 +234,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testAllStaticPartitionsWithMetadata(): Unit = {
     if (!supportsReadingMetadata) {
       return
@@ -250,29 +249,26 @@ trait FileSystemITCaseBase {
     checkPredicate(
       "select x, f, y from partitionedTableWithMetadata where a=1 and b=1",
       row => {
-        assertEquals(3, row.getArity)
-        assertNotNull(row.getField("f"))
-        assertNotNull(row.getField(1))
-        assertTrue(
-          "The filepath value should begin with the temporary test path",
-          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+        assertThat(row.getArity).isEqualTo(3)
+        assertThat(row.getField("f")).isNotNull
+        assertThat(row.getField(1)).isNotNull
+
+        assertThat(row.getFieldAs[String](1).contains(fileTempFolder.getParent.toString)).isTrue
       }
     )
 
     checkPredicate(
       "select x, f, y from partitionedTableWithMetadata",
       row => {
-        assertEquals(3, row.getArity)
-        assertNotNull(row.getField("f"))
-        assertNotNull(row.getField(1))
-        assertTrue(
-          "The filepath value should begin with the temporary test path",
-          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+        assertThat(row.getArity).isEqualTo(3)
+        assertThat(row.getField("f")).isNotNull
+        assertThat(row.getField(1)).isNotNull
+        assertThat(row.getFieldAs[String](1).contains(fileTempFolder.getRoot.toString)).isTrue
       }
     )
   }
 
-  @Test
+  @TestTemplate
   def testPartialDynamicPartition(): Unit = {
     tableEnv
       .executeSql(
@@ -316,7 +312,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testDynamicPartition(): Unit = {
     tableEnv
       .executeSql(
@@ -345,7 +341,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testPartitionWithHiddenFile(): Unit = {
     tableEnv
       .executeSql(
@@ -354,7 +350,9 @@ trait FileSystemITCaseBase {
       .await()
 
     // create hidden partition dir
-    assertTrue(new File(new Path("file:" + resultPath + "/a=1/.b=2").toUri).mkdir())
+    assertThat(
+      new File(new org.apache.flink.core.fs.Path("file:" + resultPath + "/a=1/.b=2").toUri)
+        .mkdir()).isTrue
 
     check(
       "select x, y from partitionedTable",
@@ -362,7 +360,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testNonPartition(): Unit = {
     tableEnv
       .executeSql(
@@ -376,7 +374,7 @@ trait FileSystemITCaseBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testNonPartitionWithMetadata(): Unit = {
     if (!supportsReadingMetadata) {
       return
@@ -391,17 +389,15 @@ trait FileSystemITCaseBase {
     checkPredicate(
       "select x, f, y from nonPartitionedTableWithMetadata where a=1 and b=1",
       row => {
-        assertEquals(3, row.getArity)
-        assertNotNull(row.getField("f"))
-        assertNotNull(row.getField(1))
-        assertTrue(
-          "The filepath value should begin with the temporary test path",
-          row.getFieldAs[String](1).contains(fileTmpFolder.getRoot.getPath))
+        assertThat(row.getArity).isEqualTo(3)
+        assertThat(row.getField("f")).isNotNull
+        assertThat(row.getField(1)).isNotNull
+        assertThat(row.getFieldAs[String](1).contains(fileTempFolder.getRoot.toString)).isTrue
       }
     )
   }
 
-  @Test
+  @TestTemplate
   def testReadAllMetadata(): Unit = {
     if (!supportsReadingMetadata) {
       return
@@ -430,34 +426,24 @@ trait FileSystemITCaseBase {
     checkPredicate(
       "SELECT * FROM metadataTable",
       row => {
-        assertEquals(5, row.getArity)
+        assertThat(row.getArity).isEqualTo(5)
 
         // Only one file, because we don't have partitions
         val file = new File(URI.create(resultPath).getPath).listFiles()(0)
         val filename = Paths.get(file.toURI).getFileName.toString
 
-        assertTrue(
-          row.getFieldAs[String](1).contains(filename)
-        )
-        assertEquals(
-          filename,
-          row.getFieldAs[String](2)
-        )
-        assertEquals(
-          file.length(),
-          row.getFieldAs[Long](3)
-        )
-        assertEquals(
+        assertThat(row.getFieldAs[String](1).contains(filename)).isTrue
+        assertThat(row.getFieldAs[String](2)).isEqualTo(filename)
+        assertThat(row.getFieldAs[Long](3)).isEqualTo(file.length())
+        assertThat(row.getFieldAs[Instant](4)).isEqualTo(
           // Note: It's TIMESTAMP_LTZ
-          Instant.ofEpochMilli(file.lastModified()),
-          row.getFieldAs[Instant](4)
-        )
+          Instant.ofEpochMilli(file.lastModified()))
       }
     )
 
   }
 
-  @Test
+  @TestTemplate
   def testLimitPushDown(): Unit = {
     tableEnv.getConfig
       .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, Int.box(1))
@@ -468,14 +454,14 @@ trait FileSystemITCaseBase {
       Seq(row("x1", 1), row("x2", 2), row("x3", 3)))
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDown(): Unit = {
     tableEnv.executeSql("insert into nonPartitionedTable select x, y, a, b from originalT").await()
 
     check("select x, y from nonPartitionedTable where a=10086", Seq())
   }
 
-  @Test
+  @TestTemplate
   def testProjectPushDown(): Unit = {
     tableEnv.executeSql("insert into partitionedTable select x, y, a, b from originalT").await()
 
@@ -488,7 +474,7 @@ trait FileSystemITCaseBase {
       ))
   }
 
-  @Test
+  @TestTemplate
   def testInsertAppend(): Unit = {
     tableEnv
       .executeSql("insert into partitionedTable select x, y, a, b from originalT")
@@ -510,7 +496,7 @@ trait FileSystemITCaseBase {
       ))
   }
 
-  @Test
+  @TestTemplate
   def testInsertOverwrite(): Unit = {
     tableEnv
       .executeSql("insert overwrite partitionedTable select x, y, a, b from originalT")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
@@ -22,13 +22,11 @@ import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.types.Row
 
-import org.junit.Before
-
-import scala.collection.Seq
+import org.junit.jupiter.api.BeforeEach
 
 /** Batch [[FileSystemITCaseBase]]. */
 abstract class BatchFileSystemITCaseBase extends BatchTestBase with FileSystemITCaseBase {
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     super.open()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -19,11 +19,14 @@ package org.apache.flink.table.planner.runtime.batch.sql
 
 import org.apache.flink.core.fs.Path
 import org.apache.flink.testutils.TestFileSystem
+import org.apache.flink.testutils.junit.extensions.parameterized.NoOpTestExtension
 
-import org.junit.After
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.extension.ExtendWith
 
 /** Test for file system table factory with testcsv format. */
+@ExtendWith(Array(classOf[NoOpTestExtension]))
 class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
 
   override def formatProperties(): Array[String] = {
@@ -32,12 +35,11 @@ class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
 
   override def getScheme: String = "test"
 
-  @After
+  @AfterEach
   def close(): Unit = {
     val path = new Path(resultPath)
-    assertEquals(
-      s"File $resultPath is not closed",
-      0,
-      TestFileSystem.getNumberOfUnclosedOutputStream(path))
+    if (TestFileSystem.getNumberOfUnclosedOutputStream(path) != 0) {
+      Assertions.fail(s"File $resultPath is not closed");
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
@@ -20,15 +20,17 @@ package org.apache.flink.table.planner.runtime.batch.table
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala._
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.{CountDistinctWithMergeAndReset, WeightedAvgWithMergeAndReset}
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, CollectionBatchExecTable}
 import org.apache.flink.table.planner.utils.{CountAggFunction, NonMergableCount}
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.{LegacyRowExtension, LegacyRowResource}
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.junit._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import java.lang.{Float => JFloat, Integer => JInt}
 import java.math.BigDecimal
@@ -38,8 +40,8 @@ import scala.collection.mutable
 
 class AggregationITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   @Test
   def testAggregationWithCaseClass(): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CalcITCase.scala
@@ -18,8 +18,8 @@
 package org.apache.flink.table.planner.runtime.batch.table
 
 import org.apache.flink.api.scala._
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
-import org.apache.flink.table.api.DataTypes._
 import org.apache.flink.table.catalog.CatalogDatabaseImpl
 import org.apache.flink.table.data.DecimalDataUtils
 import org.apache.flink.table.functions.ScalarFunction
@@ -27,13 +27,14 @@ import org.apache.flink.table.planner.expressions.utils._
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, CollectionBatchExecTable, UserDefinedFunctionTestUtils}
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.test.util.TestBaseUtils.compareResultAsText
 import org.apache.flink.types.Row
 
-import org.junit.{Before, Rule, Test}
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import java.sql.{Date, Time, Timestamp}
 import java.time.LocalDateTime
@@ -44,10 +45,10 @@ import scala.collection.JavaConverters._
 
 class CalcITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("Table3", data3, type3, "a, b, c", nullablesOfData3)
@@ -455,9 +456,9 @@ class CalcITCase extends BatchTestBase {
     executeQuery(result1).foreach {
       record =>
         val row = record.getField(0).asInstanceOf[Row]
-        assertEquals(1, row.getField(0))
-        assertEquals("Hi", row.getField(1))
-        assertEquals(true, row.getField(2))
+        assertThat(row.getField(0)).isEqualTo(1)
+        assertThat(row.getField(1)).isEqualTo("Hi")
+        assertThat(row.getField(2)).isEqualTo(true)
     }
 
     // primitive type
@@ -465,9 +466,9 @@ class CalcITCase extends BatchTestBase {
     executeQuery(result2).zipWithIndex.foreach {
       case (record, idx) =>
         val row = record.getField(0).asInstanceOf[Row]
-        assertEquals(1, row.getField(0))
-        assertEquals(data(idx)._1, row.getField(1))
-        assertEquals(data(idx)._2, row.getField(2))
+        assertThat(row.getField(0)).isEqualTo(1)
+        assertThat(row.getField(1)).isEqualTo(data(idx)._1)
+        assertThat(row.getField(2)).isEqualTo(data(idx)._2)
     }
 
     // non-primitive type
@@ -476,9 +477,9 @@ class CalcITCase extends BatchTestBase {
     executeQuery(result3).zipWithIndex.foreach {
       case (record, idx) =>
         val row = record.getField(0).asInstanceOf[Row]
-        assertEquals(d.toBigDecimal, row.getField(0))
-        assertEquals(data(idx)._1, row.getField(1))
-        assertEquals(data(idx)._3, row.getField(2))
+        assertThat(row.getField(0)).isEqualTo(d.toBigDecimal)
+        assertThat(row.getField(1)).isEqualTo(data(idx)._1)
+        assertThat(row.getField(2)).isEqualTo(data(idx)._3)
     }
   }
 
@@ -564,16 +565,16 @@ class CalcITCase extends BatchTestBase {
     val result = executeQuery(t)
 
     val nestedRow = result.head.getField(0).asInstanceOf[Row]
-    assertEquals(data.head._1, nestedRow.getField(0))
-    assertEquals(data.head._2, nestedRow.getField(1))
-    assertEquals(data.head._3, nestedRow.getField(2))
+    assertThat(nestedRow.getField(0)).isEqualTo(data.head._1)
+    assertThat(nestedRow.getField(1)).isEqualTo(data.head._2)
+    assertThat(nestedRow.getField(2)).isEqualTo(data.head._3)
 
     val arr = result.head.getField(1).asInstanceOf[Array[Integer]]
-    assertEquals(12, arr(0))
-    assertEquals(data.head._2, arr(1))
+    assertThat(arr(0)).isEqualTo(12)
+    assertThat(arr(1)).isEqualTo(data.head._2)
 
     val hashMap = result.head.getField(2).asInstanceOf[util.HashMap[String, Timestamp]]
-    assertEquals(data.head._3, hashMap.get(data.head._1.asInstanceOf[String]))
+    assertThat(data.head._3).isEqualTo(hashMap.get(data.head._1.asInstanceOf[String]))
   }
 
   @Test
@@ -593,9 +594,9 @@ class CalcITCase extends BatchTestBase {
     results.zipWithIndex.foreach {
       case (row, i) =>
         val nestedRow = row.getField(0).asInstanceOf[(Int, Int)]
-        assertEquals(i, nestedRow._1)
-        assertEquals(i, nestedRow._2)
-        assertEquals(i.toString, row.getField(1))
+        assertThat(nestedRow._1).isEqualTo(i)
+        assertThat(nestedRow._2).isEqualTo(i)
+        assertThat(row.getField(1)).isEqualTo(i.toString)
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/JoinITCase.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.runtime.batch.table
 
 import org.apache.flink.api.scala._
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.expressions.utils.FuncWithOpen
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinITCaseHelper.disableOtherJoinOpForJoin
@@ -25,21 +26,22 @@ import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType.JoinType
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, CollectionBatchExecTable}
 import org.apache.flink.table.planner.utils.TableFunc2
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.junit._
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import scala.collection.JavaConverters._
 
 class JoinITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   val expectedJoinType: JoinType = JoinType.SortMergeJoin
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     disableOtherJoinOpForJoin(tEnv, expectedJoinType)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyLimitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyLimitITCase.scala
@@ -22,12 +22,12 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.TestLegacyLimitableTableSource
 
-import org.junit._
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 class LegacyLimitITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
 
@@ -40,16 +40,16 @@ class LegacyLimitITCase extends BatchTestBase {
 
   @Test
   def testFetch(): Unit = {
-    assertEquals(executeQuery(tEnv.from("LimitTable").fetch(5)).size, 5)
+    assertThat(executeQuery(tEnv.from("LimitTable").fetch(5)).size).isEqualTo(5)
   }
 
   @Test
   def testOffset(): Unit = {
-    assertEquals(executeQuery(tEnv.from("LimitTable").offset(5)).size, 16)
+    assertThat(executeQuery(tEnv.from("LimitTable").offset(5)).size).isEqualTo(16)
   }
 
   @Test
   def testOffsetAndFetch(): Unit = {
-    assertEquals(executeQuery(tEnv.from("LimitTable").limit(5, 5)).size, 5)
+    assertThat(executeQuery(tEnv.from("LimitTable").limit(5, 5)).size).isEqualTo(5)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyTableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/LegacyTableSinkITCase.scala
@@ -17,16 +17,18 @@
  */
 package org.apache.flink.table.planner.runtime.batch.table
 
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestingRetractTableSink, TestingUpsertTableSink}
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.junit._
-import org.junit.Assert._
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{Disabled, Test}
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import java.util.TimeZone
 
@@ -34,8 +36,8 @@ import scala.collection.JavaConverters._
 
 class LegacyTableSinkITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   @Test
   def testDecimalOutputFormatTableSink(): Unit = {
@@ -90,7 +92,7 @@ class LegacyTableSinkITCase extends BatchTestBase {
     TestBaseUtils.compareResultAsText(results, expected)
   }
 
-  @Ignore
+  @Disabled
   @Test
   def testDecimalForLegacyTypeTableSink(): Unit = {
     MemoryTableSourceSinkUtil.clear()
@@ -159,7 +161,7 @@ class LegacyTableSinkITCase extends BatchTestBase {
 
     val result = sink.getUpsertResults.sorted
     val expected = List("1,0.1", "2,0.4", "3,1.0", "4,2.2", "5,3.9").sorted
-    assertEquals(expected, result)
+    assertThat(result).isEqualTo(expected)
   }
 
   @Test
@@ -176,7 +178,7 @@ class LegacyTableSinkITCase extends BatchTestBase {
 
     val result = sink.getRawResults.sorted
     val expected = List("(true,1,0.1)", "(true,2,0.2)", "(true,2,0.2)").sorted
-    assertEquals(expected, result)
+    assertThat(result).isEqualTo(expected)
   }
 
   private def prepareForRetractSink(): TestingRetractTableSink = {
@@ -208,6 +210,6 @@ class LegacyTableSinkITCase extends BatchTestBase {
     val result = sink.getRawResults.sorted
     val expected =
       List("(true,1,0.1)", "(true,2,0.4)", "(true,3,1.0)", "(true,4,2.2)", "(true,5,3.9)").sorted
-    assertEquals(expected, result)
+    assertThat(result).isEqualTo(expected)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/OverAggregateITCase.scala
@@ -23,13 +23,13 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 
-import org.junit.{Before, Ignore, Test}
+import org.junit.jupiter.api.{BeforeEach, Disabled, Test}
 
 // TODO OverWindow on Batch should support to order by non-time attribute
-@Ignore
+@Disabled
 class OverAggregateITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("Table1", data1, type1, "month, area, product", nullablesOfData1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SetOperatorsITCase.scala
@@ -18,18 +18,19 @@
 package org.apache.flink.table.planner.runtime.batch.table
 
 import org.apache.flink.api.scala._
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.JBigDecimal
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinITCaseHelper.disableOtherJoinOpForJoin
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType
 import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType.JoinType
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, CollectionBatchExecTable}
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit._
-import org.junit.Assert.assertThat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -37,12 +38,12 @@ import scala.util.Random
 
 class SetOperatorsITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   val expectedJoinType: JoinType = JoinType.SortMergeJoin
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     disableOtherJoinOpForJoin(tEnv, expectedJoinType)
@@ -68,8 +69,8 @@ class SetOperatorsITCase extends BatchTestBase {
     val unionTable = table1.unionAll(table2)
 
     val schema = unionTable.getResolvedSchema.getColumnDataTypes
-    assertThat(schema.get(0), equalTo(DataTypes.DECIMAL(13, 3).notNull()))
-    assertThat(schema.get(1), equalTo(DataTypes.VARCHAR(3).notNull()))
+    assertThat(schema.get(0)).isEqualTo(DataTypes.DECIMAL(13, 3).notNull())
+    assertThat(schema.get(1)).isEqualTo(DataTypes.VARCHAR(3).notNull())
 
     val results = executeQuery(unionTable)
     val expected = "12.000,\n" + "1234.123,ABC\n"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SortITCase.scala
@@ -17,20 +17,22 @@
  */
 package org.apache.flink.table.planner.runtime.batch.table
 
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, CollectionBatchExecTable}
 import org.apache.flink.table.planner.runtime.utils.SortTestUtils.{sortExpectedly, tupleDataSetStrings}
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.util.TestBaseUtils
 
-import org.junit._
+import org.junit.jupiter.api.{Disabled, Test}
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import scala.collection.JavaConverters._
 
 class SortITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   def compare(t: Table, expected: String): Unit = {
     TestBaseUtils.compareOrderedResultAsText(executeQuery(t).asJava, expected)
@@ -63,7 +65,7 @@ class SortITCase extends BatchTestBase {
     compare(t, sortExpectedly(tupleDataSetStrings))
   }
 
-  @Ignore // TODO something not support?
+  @Disabled // TODO something not support?
   @Test
   def testOrderByOffset(): Unit = {
     val ds = CollectionBatchExecTable.get3TupleDataSet(tEnv)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -17,27 +17,24 @@
  */
 package org.apache.flink.table.planner.runtime.batch.table
 
+import org.apache.flink.core.testutils.EachCallbackWrapper
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData._
-import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.table.utils.LegacyRowExtension
 
-import org.junit.{Rule, Test}
-import org.junit.Assert.assertEquals
-import org.junit.rules.ExpectedException
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import scala.collection.JavaConversions._
 
 class TableSinkITCase extends BatchTestBase {
 
-  @Rule
-  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
-
-  var _expectedEx: ExpectedException = ExpectedException.none
-
-  @Rule
-  def expectedEx: ExpectedException = _expectedEx
+  @RegisterExtension private val _: EachCallbackWrapper[LegacyRowExtension] =
+    new EachCallbackWrapper[LegacyRowExtension](new LegacyRowExtension)
 
   @Test
   def testDecimalOnOutputFormatTableSink(): Unit = {
@@ -63,7 +60,7 @@ class TableSinkITCase extends BatchTestBase {
 
     val result = TestValuesTableFactory.getResults("sink")
     val expected = Seq("12345,55,12345")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -89,7 +86,7 @@ class TableSinkITCase extends BatchTestBase {
 
     val result = TestValuesTableFactory.getResults("sink")
     val expected = Seq("12345,55,12345")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -115,7 +112,7 @@ class TableSinkITCase extends BatchTestBase {
 
     val result = TestValuesTableFactory.getResults("testSink")
     val expected = List("1,0.1", "2,0.4", "3,1.0", "4,2.2", "5,3.9")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -140,7 +137,7 @@ class TableSinkITCase extends BatchTestBase {
 
     val result = TestValuesTableFactory.getResults("testSink")
     val expected = List("1,0.1", "2,0.4", "3,1.0", "4,2.2", "5,3.9")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -171,7 +168,7 @@ class TableSinkITCase extends BatchTestBase {
     val expected =
       List("1,2021,1,0.1", "2,2021,1,0.4", "3,2021,1,1.0", "4,2021,1,2.2", "5,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -197,7 +194,7 @@ class TableSinkITCase extends BatchTestBase {
       .await()
     val expected = List("null,0.1", "null,0.4", "null,1.0", "null,2.2", "null,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -232,7 +229,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,2.2",
       "null,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -263,7 +260,7 @@ class TableSinkITCase extends BatchTestBase {
     val expected =
       List("1,2021,1,0.1", "2,2021,1,0.4", "3,2021,1,1.0", "4,2021,1,2.2", "5,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -298,7 +295,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,null,null,2.2",
       "null,null,null,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -333,7 +330,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,2.2",
       "null,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -368,7 +365,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,2.2",
       "null,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -403,7 +400,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,2.2",
       "null,2021,1,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -438,7 +435,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,null,2.2",
       "null,2021,null,3.9")
     val result = TestValuesTableFactory.getResults("testSink")
-    assertEquals(expected.sorted, result.sorted)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
   @Test
@@ -460,14 +457,16 @@ class TableSinkITCase extends BatchTestBase {
 
     registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
 
-    expectedEx.expect(classOf[ValidationException])
-    expectedEx.expectMessage("Target column 'e' is assigned more than once")
-
-    tEnv
-      .executeSql(s"""
-                     |INSERT INTO testSink PARTITION(`c`='2021') (e, e)
-                     |SELECT 1, sum(y) FROM MyTable GROUP BY x
-                     |""".stripMargin)
-      .await()
+    Assertions
+      .assertThatThrownBy(
+        () => {
+          tEnv
+            .executeSql(s"""
+                           |INSERT INTO testSink PARTITION(`c`='2021') (e, e)
+                           |SELECT 1, sum(y) FROM MyTable GROUP BY x
+                           |""".stripMargin)
+            .await()
+        })
+      .hasMessageContaining("Target column 'e' is assigned more than once")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -23,17 +23,20 @@ import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
 import org.apache.flink.table.planner.runtime.utils.{AbstractExactlyOnceSink, StreamingTestBase, TestingAppendSink, TestSinkUtil}
+import org.apache.flink.testutils.junit.extensions.parameterized.NoOpTestExtension
 import org.apache.flink.types.Row
 
-import org.junit.{Assert, Before, Test}
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.extension.ExtendWith
 
 import scala.collection.{mutable, Seq}
 
 /** Streaming [[FileSystemITCaseBase]]. */
+@ExtendWith(Array(classOf[NoOpTestExtension]))
 abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSystemITCaseBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     super.open()
@@ -49,9 +52,8 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
     result.addSink(sink)
     env.execute()
 
-    assertEquals(
-      expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
-      sink.getAppendResults.sorted)
+    assertThat(expectedResult.map(TestSinkUtil.rowToString(_)).sorted)
+      .isEqualTo(sink.getAppendResults.sorted)
   }
 
   override def checkPredicate(sqlQuery: String, checkFunc: Row => Unit): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
@@ -20,10 +20,8 @@ package org.apache.flink.table.planner.runtime.stream.sql
 import org.apache.flink.core.fs.Path
 import org.apache.flink.testutils.TestFileSystem
 
-import org.junit.After
-import org.junit.Assert.assertEquals
-
-import scala.collection.Seq
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.AfterEach
 
 /** Test csv [[StreamFileSystemITCaseBase]]. */
 class StreamFileSystemTestCsvITCase extends StreamFileSystemITCaseBase {
@@ -34,12 +32,11 @@ class StreamFileSystemTestCsvITCase extends StreamFileSystemITCaseBase {
 
   override def getScheme: String = "test"
 
-  @After
+  @AfterEach
   def close(): Unit = {
     val path = new Path(resultPath)
-    assertEquals(
-      s"File $resultPath is not closed",
-      0,
-      TestFileSystem.getNumberOfUnclosedOutputStream(path))
+    if (TestFileSystem.getNumberOfUnclosedOutputStream(path) != 0) {
+      fail(s"File $resultPath is not closed")
+    }
   }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/NoOpTestExtension.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/NoOpTestExtension.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit.extensions.parameterized;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * A special {@link TestTemplateInvocationContextProvider} that return default {@link
+ * TestTemplateInvocationContext}.
+ *
+ * <p>When use this extension, all tests must be annotated by {@link TestTemplate}.
+ */
+public class NoOpTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext extensionContext) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext extensionContext) {
+        return Stream.of(DefaultTestTemplateInvocationContext.INSTANCE);
+    }
+
+    private static class DefaultTestTemplateInvocationContext
+            implements TestTemplateInvocationContext {
+        public static final DefaultTestTemplateInvocationContext INSTANCE =
+                new DefaultTestTemplateInvocationContext();
+
+        private DefaultTestTemplateInvocationContext() {}
+
+        // no-op as base class has default implementation.
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Migrate subclasses of BatchAbstractTestBase in table and other modules to JUnit5*


## Brief change log

  - *Migrate subclasses of BatchAbstractTestBase in table and other modules to JUnit5*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
