### PR TITLE
Remove savepoint and checkpoint mount instructions from flink playground.

### DIFF
--- a/docs/content/docs/try-flink/flink-operations-playground.md
+++ b/docs/content/docs/try-flink/flink-operations-playground.md
@@ -101,13 +101,6 @@ cd flink-playgrounds/operations-playground
 docker-compose build
 ```
 
-Then before starting the playground, create the checkpoint and savepoint directories on the Docker host machine (these volumes are mounted by the jobmanager and taskmanager, as specified in docker-compose.yaml):
-
-```bash
-mkdir -p /tmp/flink-checkpoints-directory
-mkdir -p /tmp/flink-savepoints-directory
-```
-
 Then start the playground:
 
 ```bash


### PR DESCRIPTION
## What is the purpose of the change

With the addition of a docker volume, this step is no long needed.
https://github.com/apache/flink-playgrounds/pull/42

re:
mkdir -p /tmp/flink-checkpoints-directory
mkdir -p /tmp/flink-savepoints-directory

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
