### PR TITLE
[FLINK-32059] Migrate subclasses of BatchAbstractTestBase in batch.sql.agg and batch.sql.join to JUnit5

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -32,14 +32,15 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.types.Row
 
-import org.junit.{Before, Test}
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 /** Aggregate IT case base class. */
 abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
 
   def prepareAggOp(): Unit
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("SmallTable3", smallData3, type3, "a, b, c", nullablesOfSmallData3)
@@ -370,13 +371,16 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testCountCannotByMultiFields(): Unit = {
-    checkQuery(
-      Seq((1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2)),
-      "select count(distinct f0, f1) from TableName",
-      Seq()
-    )
+    assertThatThrownBy(
+      () => {
+        checkQuery(
+          Seq((1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2)),
+          "select count(distinct f0, f1) from TableName",
+          Seq()
+        )
+      }).hasCauseInstanceOf(classOf[TableException])
   }
 
   @Test
@@ -718,36 +722,44 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testMultipleColumnDistinctCount(): Unit = {
+
     val testData = Seq(
       ("a", "b", "c"),
       ("a", "b", "c"),
       ("a", "b", "d"),
       ("x", "y", "z"),
       ("x", "q", null: String))
-
-    checkQuery(
-      testData,
-      "select count(distinct f0, f1) from TableName",
-      Seq(Tuple1(3L))
-    )
+    assertThatThrownBy(
+      () => {
+        checkQuery(
+          testData,
+          "select count(distinct f0, f1) from TableName",
+          Seq(Tuple1(3L))
+        )
+      }).hasCauseInstanceOf(classOf[TableException])
 
     // Note: count distinct on multiple columns
     //       what if, in a row, some columns are null, some are not-null
     //       should the row be counted?
     //       Calcite doc says yes. Spark/MySQL says no.
-
-    checkQuery(
-      testData,
-      "select count(distinct f0, f1, f2) from TableName",
-      Seq(Tuple1(4L)) // NOTE: Spark and MySQL returns 3
-    )
-    checkQuery(
-      testData,
-      "select f0, count(distinct f1, f2) from TableName group by f0",
-      Seq(("a", 2L), ("x", 2L)) // NOTE: Spark and MySQL returns 2
-    )
+    assertThatThrownBy(
+      () => {
+        checkQuery(
+          testData,
+          "select count(distinct f0, f1, f2) from TableName",
+          Seq(Tuple1(4L)) // NOTE: Spark and MySQL returns 3
+        )
+      }).hasCauseInstanceOf(classOf[TableException])
+    assertThatThrownBy(
+      () => {
+        checkQuery(
+          testData,
+          "select f0, count(distinct f1, f2) from TableName group by f0",
+          Seq(("a", 2L), ("x", 2L)) // NOTE: Spark and MySQL returns 2
+        )
+      }).hasCauseInstanceOf(classOf[TableException])
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateJoinTransposeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateJoinTransposeITCase.scala
@@ -32,13 +32,13 @@ import org.apache.flink.table.planner.utils.TableConfigUtils
 import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.tools.RuleSets
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import scala.collection.JavaConverters._
 
 class AggregateJoinTransposeITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     val programs = FlinkBatchProgram.buildProgram(tEnv.getConfig)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
 import org.apache.flink.table.utils.DateTimeUtils.toLocalDateTime
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import java.sql.Date
 import java.time.LocalDateTime
@@ -37,7 +37,7 @@ import scala.collection.Seq
 
 class AggregateReduceGroupingITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateRemoveITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateRemoveITCase.scala
@@ -24,14 +24,13 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import scala.collection.JavaConverters._
-import scala.collection.Seq
 
 class AggregateRemoveITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/DistinctAggregateITCaseBase.scala
@@ -21,7 +21,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import scala.collection.Seq
 
@@ -30,7 +30,7 @@ abstract class DistinctAggregateITCaseBase extends BatchTestBase {
 
   def prepareAggOp(): Unit
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("SmallTable3", smallData3, type3, "a, b, c", nullablesOfSmallData3)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupWindowITCase.scala
@@ -29,13 +29,14 @@ import org.apache.flink.table.planner.utils.{CountAggFunction, IntAvgAggFunction
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
 import org.apache.flink.types.Row
 
-import org.junit.{Before, Test}
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import java.time.LocalDateTime
 
 class GroupWindowITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     // common case
@@ -743,7 +744,7 @@ class GroupWindowITCase extends BatchTestBase {
     )
   }
 
-  @Test(expected = classOf[RuntimeException])
+  @Test
   def testSessionWindowWithProperties(): Unit = {
     registerCollection(
       "T",
@@ -758,8 +759,10 @@ class GroupWindowITCase extends BatchTestBase {
         "SESSION_ROWTIME(ts, INTERVAL '4' SECOND) " +
         "FROM T " +
         "GROUP BY SESSION(ts, INTERVAL '4' SECOND)"
-
-    checkResult(sqlQuery, Seq())
+    assertThatThrownBy(
+      () => {
+        checkResult(sqlQuery, Seq())
+      }).hasCauseInstanceOf(classOf[RuntimeException])
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupingSetsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupingSetsITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import scala.collection.Seq
 
@@ -113,7 +113,7 @@ class GroupingSetsITCase extends BatchTestBase {
     row(7934, "MILLER", "CLERK", 7782, localDate("1982-01-23"), 1300.00, null, 10)
   )
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection(TABLE_NAME, data3, type3, "f0, f1, f2", nullablesOfData3)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
@@ -22,17 +22,18 @@ import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenerator
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
 
 import java.math.BigDecimal
 
 /** AggregateITCase using HashAgg Operator. */
-@RunWith(classOf[Parameterized])
-class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
-  extends AggregateITCaseBase("HashAggregate") {
+@ExtendWith(Array(classOf[ParameterizedTestExtension]))
+class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
+
+  @Parameter var adaptiveLocalHashAggEnable: Boolean = _
 
   override def prepareAggOp(): Unit = {
     tEnv.getConfig.set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "SortAgg")
@@ -48,7 +49,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
     }
   }
 
-  @Test
+  @TestTemplate
   def testAdaptiveLocalHashAggWithHighAggregationDegree(): Unit = {
     checkQuery(
       Seq(
@@ -80,7 +81,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
     )
   }
 
-  @Test
+  @TestTemplate
   def testAdaptiveLocalHashAggWithLowAggregationDegree(): Unit = {
     checkQuery(
       Seq(
@@ -115,7 +116,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
     )
   }
 
-  @Test
+  @TestTemplate
   def testAdaptiveLocalHashAggWithRowLessThanSamplingThreshold(): Unit = {
     checkQuery(
       Seq((1, 1, 1, 1, 1L, 1.1d), (1, 1, 1, 2, 1L, 1.2d), (1, 2, 2, 3, 2L, 2.2d)),
@@ -127,7 +128,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
     )
   }
 
-  @Test
+  @TestTemplate
   def testAdaptiveLocalHashAggWithNullValue(): Unit = {
     val testDataWithNullValue = tEnv.fromValues(
       DataTypes.ROW(
@@ -169,7 +170,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
 
   }
 
-  @Test
+  @TestTemplate
   def testAdaptiveHashAggWithSumAndAvgFunctionForNumericalType(): Unit = {
     val testDataWithAllTypes = tEnv.fromValues(
       DataTypes.ROW(
@@ -333,7 +334,7 @@ class HashAggITCase(adaptiveLocalHashAggEnable: Boolean)
 }
 
 object HashAggITCase {
-  @Parameterized.Parameters(name = "adaptiveLocalHashAggEnable={0}")
+  @Parameters(name = "adaptiveLocalHashAggEnable={0}")
   def parameters(): java.util.Collection[Boolean] = {
     java.util.Arrays.asList(true, false)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/PruneAggregateCallITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/PruneAggregateCallITCase.scala
@@ -22,14 +22,14 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 import scala.collection.JavaConverters._
 import scala.collection.Seq
 
 class PruneAggregateCallITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("MyTable", smallData3, type3, "a, b, c", nullablesOfSmallData3)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.runtime.batch.sql.agg
 
 import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, PrimitiveArrayTypeInfo, TypeInformation}
-import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo, TupleTypeInfo, TypeExtractor}
+import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.config.ExecutionConfigOptions.{TABLE_EXEC_DISABLED_OPERATORS, TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM}
@@ -31,14 +31,13 @@ import org.apache.flink.table.planner.runtime.utils.TestData
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.{MyPojo, MyToPojoFunc}
 import org.apache.flink.table.planner.utils.{CountAccumulator, CountAggFunction, IntSumAggFunction}
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.lang
 import java.lang.{Iterable => JIterable}
 
 import scala.annotation.varargs
 import scala.collection.JavaConverters._
-import scala.collection.Seq
 
 /** AggregateITCase using SortAgg Operator. */
 class SortAggITCase extends AggregateITCaseBase("SortAggregate") {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortDistinctAggregateITCase.scala
@@ -24,9 +24,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvgWithMergeAndReset
 import org.apache.flink.table.planner.utils.{CountAggFunction, IntSumAggFunction}
 
-import org.junit.Test
-
-import scala.collection.Seq
+import org.junit.jupiter.api.Test
 
 /** DistinctAggregateITCase using SortAgg Operator. */
 class SortDistinctAggregateITCase extends DistinctAggregateITCaseBase {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinConditionTypeCoerceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinConditionTypeCoerceITCase.scala
@@ -21,11 +21,11 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 class JoinConditionTypeCoerceITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("t1", numericData, numericType, "a, b, c, d, e", nullablesOfNumericData)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinWithoutKeyITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinWithoutKeyITCase.scala
@@ -21,13 +21,11 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
-
-import scala.collection.Seq
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 class JoinWithoutKeyITCase extends BatchTestBase {
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("SmallTable3", smallData3, type3, "a, b, c", nullablesOfSmallData3)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
@@ -26,23 +26,30 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, InMemoryLookupableTableSource}
 import org.apache.flink.table.runtime.functions.table.fullcache.inputformat.FullCacheTestInputFormat
 import org.apache.flink.table.runtime.functions.table.lookup.LookupCacheManager
+import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assumptions.assumeThat
 import org.assertj.core.api.IterableAssert.assertThatIterable
-import org.junit.{After, Assume, Before, Test}
-import org.junit.Assert.assertEquals
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.api.{AfterEach, BeforeEach, TestTemplate}
+import org.junit.jupiter.api.extension.ExtendWith
 
 import java.lang.{Boolean => JBoolean}
 import java.util
 
 import scala.collection.JavaConversions._
 
-@RunWith(classOf[Parameterized])
-class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheType: LookupCacheType)
-  extends BatchTestBase {
+@ExtendWith(Array(classOf[ParameterizedTestExtension]))
+class LookupJoinITCase extends BatchTestBase {
+
+  @Parameter var legacyTableSource: Boolean = _
+
+  @Parameter(value = 1)
+  var isAsyncMode: Boolean = _
+
+  @Parameter(value = 2)
+  var cacheType: LookupCacheType = _
 
   val data = List(
     rowOf(1L, 12L, "Julian"),
@@ -65,7 +72,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     rowOf(33, 3L, "Fabian"),
     rowOf(44, null, "Hello world"))
 
-  @Before
+  @BeforeEach
   override def before() {
     super.before()
     if (legacyTableSource) {
@@ -85,13 +92,13 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     env.getConfig.disableObjectReuse()
   }
 
-  @After
+  @AfterEach
   override def after(): Unit = {
     if (legacyTableSource) {
-      assertEquals(0, InMemoryLookupableTableSource.RESOURCE_COUNTER.get())
+      assertThat(InMemoryLookupableTableSource.RESOURCE_COUNTER.get()).isEqualTo(0)
     } else {
-      assertEquals(0, TestValuesTableFactory.RESOURCE_COUNTER.get())
-      assertEquals(0, FullCacheTestInputFormat.OPEN_CLOSED_COUNTER.get())
+      assertThat(TestValuesTableFactory.RESOURCE_COUNTER.get()).isEqualTo(0)
+      assertThat(FullCacheTestInputFormat.OPEN_CLOSED_COUNTER.get()).isEqualTo(0)
     }
   }
 
@@ -191,7 +198,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
                        |""".stripMargin)
   }
 
-  @Test
+  @TestTemplate
   def testLeftJoinTemporalTableWithLocalPredicate(): Unit = {
     val sql = s"SELECT T.id, T.len, T.content, D.name, D.age FROM T LEFT JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id " +
@@ -207,7 +214,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTable(): Unit = {
     val sql = s"SELECT T.id, T.len, T.content, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id"
@@ -219,7 +226,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableWithPushDown(): Unit = {
     val sql = s"SELECT T.id, T.len, T.content, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
@@ -229,7 +236,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableWithNonEqualFilter(): Unit = {
     val sql = s"SELECT T.id, T.len, T.content, D.name, D.age FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
@@ -240,7 +247,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnMultiFields(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
@@ -249,7 +256,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnMultiFieldsWithUdf(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON mod(T.id, 4) = D.id AND T.content = D.name"
@@ -258,7 +265,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnMultiKeyFields(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
@@ -267,7 +274,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testLeftJoinTemporalTable(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name, D.age FROM T LEFT JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id"
@@ -282,7 +289,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name FROM nullableT T JOIN userTableWithNull " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
@@ -291,7 +298,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testLeftJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
     val sql = s"SELECT D.id, T.len, D.name FROM nullableT T LEFT JOIN userTableWithNull " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
@@ -303,7 +310,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnNullConstantKey(): Unit = {
     val sql = s"SELECT T.id, T.len, T.content FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON D.id = null"
@@ -311,7 +318,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableOnMultiKeyFieldsWithNullConstantKey(): Unit = {
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND null = D.id"
@@ -319,10 +326,10 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableWithComputedColumn(): Unit = {
     // Computed column do not support in legacyTableSource.
-    Assume.assumeFalse(legacyTableSource)
+    assumeThat(legacyTableSource).isFalse
 
     val sql = s"SELECT T.id, T.len, T.content, D.name, D.age, D.nominal_age " +
       "FROM T JOIN userTableWithComputedColumn " +
@@ -335,10 +342,10 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testJoinTemporalTableWithComputedColumnAndPushDown(): Unit = {
     // Computed column do not support in legacyTableSource.
-    Assume.assumeFalse(legacyTableSource)
+    assumeThat(legacyTableSource).isFalse
 
     val sql = s"SELECT T.id, T.len, T.content, D.name, D.age, D.nominal_age " +
       "FROM T JOIN userTableWithComputedColumn " +
@@ -350,7 +357,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean, cacheTy
     checkResult(sql, expected)
   }
 
-  @Test
+  @TestTemplate
   def testLookupCacheSharingAcrossSubtasks(): Unit = {
     if (cacheType == LookupCacheType.NONE) {
       return
@@ -424,7 +431,7 @@ object LookupJoinITCase {
   val ASYNC_MODE: JBoolean = JBoolean.TRUE;
   val SYNC_MODE: JBoolean = JBoolean.FALSE;
 
-  @Parameterized.Parameters(name = "LegacyTableSource={0}, isAsyncMode = {1}, cacheType = {2}")
+  @Parameters(name = "LegacyTableSource={0}, isAsyncMode = {1}, cacheType = {2}")
   def parameters(): util.Collection[Array[java.lang.Object]] = {
     Seq[Array[AnyRef]](
       Array(LEGACY_TABLE_SOURCE, ASYNC_MODE, LookupCacheType.NONE),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/OuterJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/OuterJoinITCase.scala
@@ -21,17 +21,17 @@ import org.apache.flink.table.planner.runtime.batch.sql.join.JoinType.{Broadcast
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 
-import org.junit.{Before, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.api.{BeforeEach, TestTemplate}
+import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util
 
-import scala.collection.Seq
+@ExtendWith(Array(classOf[ParameterizedTestExtension]))
+class OuterJoinITCase extends BatchTestBase {
 
-@RunWith(classOf[Parameterized])
-class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
+  @Parameter var expectedJoinType: JoinType = _
 
   private lazy val leftT = Seq(
     row(1, 2.0),
@@ -57,7 +57,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     row(null, null)
   )
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("uppercasedata", upperCaseData, INT_STRING, "N, L", nullablesOfUpperCaseData)
@@ -68,7 +68,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     JoinITCaseHelper.disableOtherJoinOpForJoin(tEnv, expectedJoinType)
   }
 
-  @Test
+  @TestTemplate
   def testLeftOuter(): Unit = {
     checkResult(
       "SELECT * FROM leftT LEFT JOIN rightT ON a = c and b < d",
@@ -87,7 +87,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testRightOuter(): Unit = {
     checkResult(
       "SELECT * FROM leftT RIGHT JOIN rightT ON a = c and b < d",
@@ -108,7 +108,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testFullOuter(): Unit = {
     if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
       checkResult(
@@ -136,7 +136,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testLeftEmptyOuter(): Unit = {
     checkResult(
       "SELECT * FROM (SELECT * FROM leftT WHERE FALSE) " +
@@ -144,7 +144,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       Seq())
   }
 
-  @Test
+  @TestTemplate
   def testRightEmptyOuter(): Unit = {
     checkResult(
       "SELECT * FROM (SELECT * FROM leftT WHERE FALSE) " +
@@ -152,7 +152,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       Seq())
   }
 
-  @Test
+  @TestTemplate
   def testFullEmptyOuter(): Unit = {
     if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
       checkResult(
@@ -162,7 +162,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testLeftUpperAndLower(): Unit = {
     checkResult(
       "SELECT * FROM uppercasedata u LEFT JOIN lowercasedata l ON l.n = u.N",
@@ -205,7 +205,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testLeftUpperAndLowerWithAgg(): Unit = {
     checkResult(
       """
@@ -231,7 +231,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testRightUpperAndLower(): Unit = {
     checkResult(
       "SELECT * FROM lowercasedata l RIGHT JOIN uppercasedata u ON l.n = u.N",
@@ -272,7 +272,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
 
   }
 
-  @Test
+  @TestTemplate
   def testRightUpperAndLowerWithAgg(): Unit = {
     checkResult(
       """
@@ -298,7 +298,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testFullUpperAndLower(): Unit = {
     if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
       val leftData = upperCaseData.filter(_.getField(0).asInstanceOf[Int] <= 4)
@@ -343,7 +343,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testFullUpperAndLowerWithAgg(): Unit = {
     if (expectedJoinType != NestedLoopJoin && expectedJoinType != BroadcastHashJoin) {
       checkResult(
@@ -398,7 +398,7 @@ class OuterJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
 }
 
 object OuterJoinITCase {
-  @Parameterized.Parameters(name = "{0}")
+  @Parameters(name = "expectedJoinType={0}")
   def parameters(): util.Collection[Array[_]] = {
     util.Arrays.asList(
       Array(BroadcastHashJoin),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/ScalarQueryITCase.scala
@@ -21,9 +21,8 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 
-import org.junit.{Before, Test}
-
-import scala.collection.Seq
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 class ScalarQueryITCase extends BatchTestBase {
 
@@ -48,7 +47,7 @@ class ScalarQueryITCase extends BatchTestBase {
     row(6, null)
   )
 
-  @Before
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("l", l, INT_DOUBLE, "a, b")
@@ -60,8 +59,11 @@ class ScalarQueryITCase extends BatchTestBase {
     checkResult("SELECT * FROM l WHERE a = (SELECT c FROM r where c = 3)", Seq(row(3, 3.0)))
   }
 
-  @Test(expected = classOf[RuntimeException])
+  @Test
   def testScalarSubQueryException(): Unit = {
-    checkResult("SELECT * FROM l WHERE a = (SELECT c FROM r)", Seq(row(3, 3.0)))
+    assertThatThrownBy(
+      () => {
+        checkResult("SELECT * FROM l WHERE a = (SELECT c FROM r)", Seq(row(3, 3.0)))
+      }).isInstanceOf(classOf[RuntimeException])
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/SemiJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/SemiJoinITCase.scala
@@ -22,19 +22,18 @@ import org.apache.flink.table.planner.runtime.batch.sql.join.SemiJoinITCase.left
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 
-import org.junit.{Before, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.api.{BeforeEach, TestTemplate}
+import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util
 
-import scala.collection.Seq
+@ExtendWith(Array(classOf[ParameterizedTestExtension]))
+class SemiJoinITCase extends BatchTestBase {
 
-@RunWith(classOf[Parameterized])
-class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
-
-  @Before
+  @Parameter var expectedJoinType: JoinType = _
+  @BeforeEach
   override def before(): Unit = {
     super.before()
     registerCollection("leftT", leftT, INT_DOUBLE, "a, b")
@@ -43,28 +42,28 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     JoinITCaseHelper.disableOtherJoinOpForJoin(tEnv, expectedJoinType)
   }
 
-  @Test
+  @TestTemplate
   def testSingleConditionLeftSemi(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE a IN (SELECT c FROM rightT)",
       Seq(row(2, 1.0), row(2, 1.0), row(3, 3.0), row(6, null)))
   }
 
-  @Test
+  @TestTemplate
   def testComposedConditionLeftSemi(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE a IN (SELECT c FROM rightT WHERE b < d)",
       Seq(row(2, 1.0), row(2, 1.0)))
   }
 
-  @Test
+  @TestTemplate
   def testSingleConditionLeftAnti(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE NOT EXISTS (SELECT * FROM rightT WHERE a = c)",
       Seq(row(1, 2.0), row(1, 2.0), row(null, null), row(null, 5.0)))
   }
 
-  @Test
+  @TestTemplate
   def testSingleUniqueConditionLeftAnti(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE NOT EXISTS " +
@@ -73,7 +72,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testComposedConditionLeftAnti(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE NOT EXISTS (SELECT * FROM rightT WHERE a = c AND b < d)",
@@ -81,7 +80,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testComposedUniqueConditionLeftAnti(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE NOT EXISTS (SELECT * FROM rightUniqueKeyT WHERE a = c AND b < d)",
@@ -89,7 +88,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testSemiJoinTranspose(): Unit = {
     checkResult(
       "SELECT a, b FROM " +
@@ -99,14 +98,14 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftSemi1(): Unit = {
     checkResult(
       "SELECT * FROM (SELECT * FROM leftT WHERE a IN (SELECT c FROM rightT)) T WHERE T.b > 2",
       Seq(row(3, 3.0)))
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftSemi2(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -115,7 +114,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftSemi3(): Unit = {
     checkResult(
       "SELECT * FROM " +
@@ -124,14 +123,14 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       Seq(row(3, 3.0)))
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftSemi1(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE a IN (SELECT c FROM rightT WHERE b > 2)",
       Seq(row(3, 3.0)))
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftSemi2(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -140,14 +139,14 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftSemi3(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE EXISTS (SELECT * FROM rightT WHERE a = c AND b > 2)",
       Seq(row(3, 3.0)))
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftAnti1(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -158,7 +157,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftAnti2(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -169,7 +168,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftAnti3(): Unit = {
     checkResult(
       "SELECT * FROM " +
@@ -178,7 +177,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       Seq(row(3, 3.0), row(null, 5.0)))
   }
 
-  @Test
+  @TestTemplate
   def testFilterPushDownLeftAnti4(): Unit = {
     checkResult(
       "SELECT * FROM " +
@@ -187,7 +186,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
       Seq(row(null, 5.0)))
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftAnti1(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -196,7 +195,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftAnti2(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -205,7 +204,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftAnti3(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE a NOT IN (SELECT c FROM rightT WHERE b = d AND b > 1)",
@@ -220,7 +219,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testJoinConditionPushDownLeftAnti4(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE NOT EXISTS (SELECT * FROM rightT WHERE a = c AND b > 2)",
@@ -235,7 +234,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithAggregate1(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT SUM(a) FROM leftT WHERE b = d)",
@@ -243,7 +242,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithAggregate2(): Unit = {
     checkResult(
       "SELECT * FROM leftT t1 WHERE a IN (SELECT DISTINCT a FROM leftT t2 WHERE t1.b = t2.b)",
@@ -251,7 +250,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithAggregate3(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE CAST(c/2 AS BIGINT) IN (SELECT COUNT(*) FROM leftT WHERE b = d)",
@@ -259,7 +258,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithOver1(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT SUM(a) OVER " +
@@ -269,7 +268,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithOver2(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT SUM(a) OVER" +
@@ -279,7 +278,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithOver3(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT SUM(a) OVER " +
@@ -289,7 +288,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithOver4(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT SUM(a) OVER" +
@@ -299,7 +298,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testExistsWithOver1(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE EXISTS (SELECT SUM(a) OVER() FROM leftT WHERE b = d)",
@@ -307,7 +306,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testExistsWithOver2(): Unit = {
     if (expectedJoinType eq NestedLoopJoin) {
       checkResult(
@@ -317,7 +316,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testExistsWithOver3(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE EXISTS (SELECT SUM(a) OVER() FROM leftT WHERE b = d GROUP BY a)",
@@ -325,7 +324,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testExistsWithOver4(): Unit = {
     if (expectedJoinType eq NestedLoopJoin) {
       checkResult(
@@ -335,7 +334,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testInWithNonEqualityCorrelationCondition1(): Unit = {
     checkResult(
       "SELECT * FROM rightT WHERE c IN (SELECT a FROM leftT WHERE b > d)",
@@ -343,7 +342,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithNonEqualityCorrelationCondition2(): Unit = {
     checkResult(
       "SELECT * FROM leftT WHERE a IN " +
@@ -352,7 +351,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     )
   }
 
-  @Test
+  @TestTemplate
   def testInWithNonEqualityCorrelationCondition3(): Unit = {
     if (expectedJoinType eq NestedLoopJoin) {
       checkResult(
@@ -363,7 +362,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testInWithNonEqualityCorrelationCondition4(): Unit = {
     if (expectedJoinType eq NestedLoopJoin) {
       checkResult(
@@ -374,7 +373,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testExistsWithNonEqualityCorrelationCondition(): Unit = {
     if (expectedJoinType eq JoinType.NestedLoopJoin) {
       checkResult(
@@ -384,7 +383,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithoutCorrelation1(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT) > 0",
@@ -398,7 +397,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     ).foreach(checkResult(_, leftT))
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithoutCorrelation2(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT WHERE c > 5) > 0",
@@ -412,7 +411,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     ).foreach(checkResult(_, leftT))
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithoutCorrelation3(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT WHERE c > 15) > 0",
@@ -426,7 +425,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     ).foreach(checkResult(_, Seq.empty))
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithCorrelation1(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT WHERE a = c) > 0",
@@ -440,7 +439,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     ).foreach(checkResult(_, Seq(row(2, 1.0), row(2, 1.0), row(3, 3.0), row(6, null))))
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithCorrelation2(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT WHERE a = c AND c > 5) > 0",
@@ -454,7 +453,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
     ).foreach(checkResult(_, Seq(row(6, null))))
   }
 
-  @Test
+  @TestTemplate
   def testRewriteScalarQueryWithCorrelation3(): Unit = {
     Seq(
       "SELECT * FROM leftT WHERE (SELECT COUNT(*) FROM rightT WHERE a = c AND c > 15) > 0",
@@ -470,7 +469,7 @@ class SemiJoinITCase(expectedJoinType: JoinType) extends BatchTestBase {
 }
 
 object SemiJoinITCase {
-  @Parameterized.Parameters(name = "{0}-{1}")
+  @Parameters(name = "expectedJoinType={0}")
   def parameters(): util.Collection[Any] = {
     util.Arrays.asList(BroadcastHashJoin, HashJoin, SortMergeJoin, NestedLoopJoin)
   }


### PR DESCRIPTION
## What is the purpose of the change

*Migrate subclasses of BatchAbstractTestBase in batch.sql.agg and batch.sql.join to JUnit5*


## Brief change log

  - *Migrate subclasses of BatchAbstractTestBase in batch.sql.agg and batch.sql.join to JUnit5*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
