### PR TITLE
[FLINK-31673][jdbc-driver] Add e2e test for flink jdbc driver

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.18-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-end-to-end-tests-jdbc-driver</artifactId>
+	<name>Flink : E2E Tests : JDBC Driver</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-jdbc-driver-bundle</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-jdbc-driver</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>JdbcDriverExample</finalName>
+							<artifactSet>
+								<excludes>
+									<exclude>com.google.code.findbugs:jsr305</exclude>
+								</excludes>
+								<includes combine.children="append">
+									<include>org.apache.flink:flink-sql-jdbc-driver-bundle</include>
+									<include>org.slf4j:slf4j-api</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/driver/tests/FlinkDriverExample.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/driver/tests/FlinkDriverExample.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.driver.tests;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** E2E tests for flink jdbc driver. */
+public class FlinkDriverExample {
+
+    public static void main(String[] args) throws Exception {
+        final String driver = "org.apache.flink.table.jdbc.FlinkDriver";
+        final String url = "jdbc:flink://localhost:8083";
+        try {
+            Class.forName(driver);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        String tableDir = args[0];
+        String tableOutput = String.format("%s/output.dat", tableDir);
+        try (Connection connection = DriverManager.getConnection(url)) {
+            try (Statement statement = connection.createStatement()) {
+                checkState(
+                        !statement.execute(
+                                String.format(
+                                        "CREATE TABLE test_table(id bigint, val int, str string) "
+                                                + "with ("
+                                                + "'connector'='filesystem',\n"
+                                                + "'format'='csv',\n"
+                                                + "'path'='%s/test_table')",
+                                        tableDir)));
+                // INSERT TABLE returns job id
+                checkState(
+                        statement.execute(
+                                "INSERT INTO test_table VALUES "
+                                        + "(1, 11, '111'), "
+                                        + "(3, 33, '333'), "
+                                        + "(2, 22, '222'), "
+                                        + "(4, 44, '444')"));
+                String jobId;
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    checkState(resultSet.next());
+                    checkState(resultSet.getMetaData().getColumnCount() == 1);
+                    jobId = resultSet.getString("job id");
+                    checkState(!resultSet.next());
+                }
+                boolean jobFinished = false;
+                while (!jobFinished) {
+                    checkState(statement.execute("SHOW JOBS"));
+                    try (ResultSet resultSet = statement.getResultSet()) {
+                        while (resultSet.next()) {
+                            if (resultSet.getString(1).equals(jobId)) {
+                                if (resultSet.getString(3).equals("FINISHED")) {
+                                    jobFinished = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // SELECT all data from test_table
+                List<String> resultList = new ArrayList<>();
+                try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test_table")) {
+                    while (resultSet.next()) {
+                        resultList.add(
+                                String.format(
+                                        "%s,%s,%s",
+                                        resultSet.getLong("id"),
+                                        resultSet.getInt("val"),
+                                        resultSet.getString("str")));
+                    }
+                }
+                Collections.sort(resultList);
+                BufferedWriter bw = new BufferedWriter(new FileWriter(tableOutput));
+                for (String result : resultList) {
+                    bw.write(result);
+                    bw.newLine();
+                }
+                bw.flush();
+                bw.close();
+            }
+        }
+    }
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -76,6 +76,7 @@ under the License.
 		<module>flink-end-to-end-tests-hbase</module>
 		<module>flink-end-to-end-tests-scala</module>
 		<module>flink-end-to-end-tests-sql</module>
+		<module>flink-end-to-end-tests-jdbc-driver</module>
 		<module>flink-end-to-end-tests-hive</module>
     </modules>
 

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -185,6 +185,7 @@ function run_group_2 {
     run_test "Batch SQL end-to-end test using hybrid selective shuffle" "$END_TO_END_DIR/test-scripts/test_batch_sql.sh hybrid_selective"
     run_test "Streaming SQL end-to-end test using planner loader" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh" "skip_check_exceptions"
     run_test "Streaming SQL end-to-end test using planner with Scala version" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh scala-planner" "skip_check_exceptions"
+    run_test "Sql Jdbc Driver end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_jdbc_driver.sh"
 
     if [[ ${PROFILE} != *"enable-adaptive-scheduler"* ]]; then # FLINK-21400
       run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local StreamingFileSink" "skip_check_exceptions"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -299,6 +299,20 @@ function start_cluster {
   wait_dispatcher_running
 }
 
+function wait_sql_gateway_running {
+  local query_url="${REST_PROTOCOL}://${NODENAME}:8083/info"
+  wait_rest_endpoint_up "${query_url}" "SqlGateway" "Apache Flink"
+}
+
+function start_sql_gateway() {
+  "$FLINK_DIR"/bin/sql-gateway.sh start
+  wait_sql_gateway_running
+}
+
+function stop_sql_gateway() {
+  "$FLINK_DIR"/bin/sql-gateway.sh stop
+}
+
 function start_taskmanagers {
     local tmnum=$1
     local c

--- a/flink-end-to-end-tests/test-scripts/test_sql_jdbc_driver.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_jdbc_driver.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+TABLE_DATA_DIR="${TEST_DATA_DIR}/table"
+
+start_cluster
+
+# Set address for sql gateway.
+set_config_key "sql-gateway.endpoint.rest.address" "localhost"
+export FLINK_CONF_DIR="${FLINK_DIR}/conf"
+start_sql_gateway
+
+TEST_JDBC_DRIVER_JAR=${END_TO_END_DIR}/flink-end-to-end-tests-jdbc-driver/target/JdbcDriverExample.jar
+TEST_JDBC_DRIVER_CLASS="org.apache.flink.table.jdbc.driver.tests.FlinkDriverExample"
+
+java -cp ${TEST_JDBC_DRIVER_JAR} ${TEST_JDBC_DRIVER_CLASS} ${TABLE_DATA_DIR}
+
+# check result:
+#1,11,111
+#2,22,222
+#3,33,333
+#4,44,444
+check_result_hash "SqlJdbcDriver" "${TABLE_DATA_DIR}/output.dat" "a5843c415e87aa01202001e3f06b9298"
+
+stop_sql_gateway
+stop_cluster

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/SqlGateway.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/SqlGateway.java
@@ -168,7 +168,6 @@ public class SqlGateway {
         @Override
         public void run() {
             // Shutdown the gateway
-            System.out.println("\nShutting down the Flink SqlGateway...");
             LOG.info("Shutting down the Flink SqlGateway...");
 
             try {
@@ -179,7 +178,6 @@ public class SqlGateway {
             }
 
             LOG.info("Flink SqlGateway has been shutdown.");
-            System.out.println("Flink SqlGateway has been shutdown.");
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add e2e test for flink jdbc driver

## Brief change log
  - Add FlinkDriverE2eTest

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
