### PR TITLE
[FLINK-31892][runtime] Introduce AdaptiveScheduler global failure enrichment/labeling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -520,7 +520,17 @@ public class AdaptiveScheduler
 
     @Override
     public void handleGlobalFailure(Throwable cause) {
-        state.handleGlobalFailure(cause);
+        final FailureEnricher.Context ctx =
+                DefaultFailureEnricherContext.forGlobalFailure(
+                        jobInformation.getJobID(),
+                        jobInformation.getName(),
+                        jobManagerJobMetricGroup,
+                        ioExecutor,
+                        userCodeClassLoader);
+        final CompletableFuture<Map<String, String>> failureLabels =
+                FailureEnricherUtils.labelFailure(
+                        cause, ctx, getMainThreadExecutor(), failureEnrichers);
+        state.handleGlobalFailure(cause, failureLabels);
     }
 
     private CompletableFuture<Map<String, String>> labelFailure(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
@@ -25,6 +25,9 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 /** Initial state of the {@link AdaptiveScheduler}. */
 class Created implements State {
 
@@ -58,7 +61,8 @@ class Created implements State {
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
@@ -171,7 +172,8 @@ public class CreatingExecutionGraph implements State {
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
@@ -23,6 +23,9 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
 import org.slf4j.Logger;
 
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 /** State which describes a finished job execution. */
 class Finished implements State {
 
@@ -54,7 +57,8 @@ class Finished implements State {
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         logger.debug(
                 "Ignore global failure because we already finished the job {}.",
                 archivedExecutionGraph.getJobID(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/LabeledGlobalFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/LabeledGlobalFailureHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.core.failure.FailureEnricher;
+import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An interface for handling and associating global failures with labels from {@link
+ * FailureEnricher}. In context of a scheduler we distinguish between local and global failures.
+ * Global failure is the one that happens in context of the scheduler (in the JobManager process)
+ * and local failure is one that is "local" to an executing task.
+ */
+public interface LabeledGlobalFailureHandler {
+
+    /**
+     * An adapted version of {@link GlobalFailureHandler} that handles and associates global
+     * failures with enricher labels.
+     *
+     * @param cause A cause that describes the global failure.
+     * @param failureLabels Labels providing an additional context about the failure.
+     */
+    void handleGlobalFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
-import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -32,7 +31,7 @@ import java.util.Optional;
  * State abstraction of the {@link AdaptiveScheduler}. This interface contains all methods every
  * state implementation must support.
  */
-interface State extends GlobalFailureHandler {
+interface State extends LabeledGlobalFailureHandler {
 
     /**
      * This method is called whenever one transitions out of this state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -333,8 +333,9 @@ abstract class StateWithExecutionGraph implements State {
     abstract void onGloballyTerminalState(JobStatus globallyTerminalState);
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
-        failureCollection.add(ExceptionHistoryEntry.createGlobal(cause));
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
+        failureCollection.add(ExceptionHistoryEntry.createGlobal(cause, failureLabels));
         onFailure(cause);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointStoppingException;
@@ -251,7 +252,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
                                 return null;
                             }));
         } else {
-            handleGlobalFailure(
+            context.handleGlobalFailure(
                     new FlinkException(
                             "Job did not reach the FINISHED state while performing stop-with-savepoint."));
         }
@@ -271,7 +272,8 @@ class StopWithSavepoint extends StateWithExecutionGraph {
                     StateTransitions.ToCancelling,
                     StateTransitions.ToExecuting,
                     StateTransitions.ToFailing,
-                    StateTransitions.ToRestarting {
+                    StateTransitions.ToRestarting,
+                    GlobalFailureHandler {
 
         /**
          * Asks how to handle the failure.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 /**
@@ -125,7 +127,8 @@ class WaitingForResources implements State, ResourceListener {
     }
 
     @Override
-    public void handleGlobalFailure(Throwable cause) {
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.Execution;
-import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
@@ -81,11 +80,12 @@ public class ExceptionHistoryEntry extends ErrorInfo {
     }
 
     /** Creates an {@code ExceptionHistoryEntry} that is not based on an {@code Execution}. */
-    public static ExceptionHistoryEntry createGlobal(Throwable cause) {
+    public static ExceptionHistoryEntry createGlobal(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         return new ExceptionHistoryEntry(
                 cause,
                 System.currentTimeMillis(),
-                FailureEnricherUtils.EMPTY_FAILURE_LABELS,
+                failureLabels,
                 null,
                 (ArchivedTaskManagerLocation) null);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -89,7 +89,8 @@ public class CancelingTest extends TestLogger {
     public void testGlobalFailuresAreIgnored() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             Canceling canceling = createCancelingState(ctx, new StateTrackingMockExecutionGraph());
-            canceling.handleGlobalFailure(new RuntimeException("test"));
+            canceling.handleGlobalFailure(
+                    new RuntimeException("test"), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
             ctx.assertNoStateTransition();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -83,7 +84,8 @@ public class CreatedTest extends TestLogger {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
                     });
 
-            created.handleGlobalFailure(new RuntimeException("Global"));
+            created.handleGlobalFailure(
+                    new RuntimeException("Global"), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
@@ -112,7 +113,9 @@ public class CreatingExecutionGraphTest extends TestLogger {
                             assertThat(archivedExecutionGraph.getState())
                                     .isEqualTo(JobStatus.FAILED));
 
-            creatingExecutionGraph.handleGlobalFailure(new FlinkException("Test exception"));
+            creatingExecutionGraph.handleGlobalFailure(
+                    new FlinkException("Test exception"),
+                    FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -87,6 +87,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -196,7 +197,8 @@ public class ExecutingTest extends TestLogger {
                         assertThat(failingArguments.getFailureCause().getMessage(), is(failureMsg));
                     }));
             ctx.setHowToHandleFailure(FailureResult::canNotRestart);
-            exec.handleGlobalFailure(new RuntimeException(failureMsg));
+            exec.handleGlobalFailure(
+                    new RuntimeException(failureMsg), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -209,7 +211,9 @@ public class ExecutingTest extends TestLogger {
                     (restartingArguments ->
                             assertThat(restartingArguments.getBackoffTime(), is(duration))));
             ctx.setHowToHandleFailure((f) -> FailureResult.canRestart(f, duration));
-            exec.handleGlobalFailure(new RuntimeException("Recoverable error"));
+            exec.handleGlobalFailure(
+                    new RuntimeException("Recoverable error"),
+                    FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -808,7 +812,8 @@ public class ExecutingTest extends TestLogger {
         }
 
         @Override
-        public void handleGlobalFailure(Throwable cause) {}
+        public void handleGlobalFailure(
+                Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {}
 
         @Override
         public Logger getLogger() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -97,7 +97,8 @@ public class FailingTest extends TestLogger {
         try (MockFailingContext ctx = new MockFailingContext()) {
             StateTrackingMockExecutionGraph meg = new StateTrackingMockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
-            failing.handleGlobalFailure(new RuntimeException());
+            failing.handleGlobalFailure(
+                    new RuntimeException(), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
             ctx.assertNoStateTransition();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FinishedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FinishedTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.util.TestLogger;
 
@@ -57,7 +58,9 @@ public class FinishedTest extends TestLogger {
     @Test
     public void testGlobalFailureIgnored() {
         MockFinishedContext ctx = new MockFinishedContext();
-        createFinishedState(ctx).handleGlobalFailure(new RuntimeException());
+        createFinishedState(ctx)
+                .handleGlobalFailure(
+                        new RuntimeException(), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         assertThat(ctx.getArchivedExecutionGraph().getState(), is(testJobStatus));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.testutils.CompletedScheduledFuture;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
@@ -89,7 +90,8 @@ public class RestartingTest extends TestLogger {
     public void testGlobalFailuresAreIgnored() throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             Restarting restarting = createRestartingState(ctx);
-            restarting.handleGlobalFailure(new RuntimeException());
+            restarting.handleGlobalFailure(
+                    new RuntimeException(), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
             ctx.assertNoStateTransition();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
@@ -226,7 +226,8 @@ public class StateWithExecutionGraphTest extends TestLogger {
         }
 
         @Override
-        public void handleGlobalFailure(Throwable cause) {}
+        public void handleGlobalFailure(
+                Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {}
 
         @Override
         boolean updateTaskExecutionState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -199,7 +199,8 @@ class StopWithSavepointTest {
 
             ctx.setExpectRestarting(assertNonNull());
 
-            sws.handleGlobalFailure(new RuntimeException());
+            sws.handleGlobalFailure(
+                    new RuntimeException(), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -218,7 +219,8 @@ class StopWithSavepointTest {
                                 .satisfies(FlinkAssertions.anyCauseMatches(RuntimeException.class));
                     });
 
-            sws.handleGlobalFailure(new RuntimeException());
+            sws.handleGlobalFailure(
+                    new RuntimeException(), FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 
@@ -650,6 +652,11 @@ class StopWithSavepointTest {
             restartingStateValidator.close();
             cancellingStateValidator.close();
             executingStateTransition.close();
+        }
+
+        @Override
+        public void handleGlobalFailure(Throwable cause) {
+            state.handleGlobalFailure(cause, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.clock.Clock;
@@ -253,7 +254,9 @@ public class WaitingForResourcesTest extends TestLogger {
                                         .contains(testExceptionString));
                     });
 
-            wfr.handleGlobalFailure(new RuntimeException(testExceptionString));
+            wfr.handleGlobalFailure(
+                    new RuntimeException(testExceptionString),
+                    FailureEnricherUtils.EMPTY_FAILURE_LABELS);
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31892

* Introduce LabeledGlobalFailureHandler interface for handling and associating global failures with labels
* Introduce async task failure labeling as part of AdaptiveScheduler#handleGlobalFailure
* Extend AdaptiveSchedulerTest to validate functionality