### PR TITLE
[BP-1.16][FLINK-31418][network][tests] Fix unstable test case SortMergeResultPartitionReadSchedulerTest.testRequestBufferTimeout

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -266,16 +266,16 @@ class SortMergeResultPartitionReadSchedulerTest {
         SortMergeResultPartitionReadScheduler readScheduler =
                 new SortMergeResultPartitionReadScheduler(
                         bufferPool, executorService, this, bufferRequestTimeout);
+        long startTimestamp = System.nanoTime();
         readScheduler.createSubpartitionReader(
                 new NoOpBufferAvailablityListener(), 0, partitionedFile);
         // request and use all buffers of buffer pool.
         readScheduler.run();
 
         assertThat(bufferPool.getAvailableBuffers()).isZero();
-        long startTimestamp = System.nanoTime();
         assertThatThrownBy(readScheduler::allocateBuffers).isInstanceOf(TimeoutException.class);
         long requestDuration = System.nanoTime() - startTimestamp;
-        assertThat(requestDuration > bufferRequestTimeout.toNanos()).isTrue();
+        assertThat(requestDuration >= bufferRequestTimeout.toNanos()).isTrue();
 
         readScheduler.release();
     }


### PR DESCRIPTION
Backport FLINK-31418 to `release-1.16` branch.