### PR TITLE
[FLINK-23190][runtime] Make schedulers allocate slots more evenly

### DIFF
--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -165,6 +165,12 @@
             <td>Determines which scheduler implementation is used to schedule tasks. Accepted values are:<ul><li>'Default': Default scheduler</li><li>'Adaptive': Adaptive scheduler. More details can be found <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/deployment/elastic_scaling#adaptive-scheduler">here</a>.</li><li>'AdaptiveBatch': Adaptive batch scheduler. More details can be found <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/deployment/elastic_scaling#adaptive-batch-scheduler">here</a>.</li></ul><br /><br />Possible values:<ul><li>"Default"</li><li>"Adaptive"</li><li>"AdaptiveBatch"</li></ul></td>
         </tr>
         <tr>
+            <td><h5>jobmanager.scheduler.slot-allocation-optimization.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether to enable the slot allocation optimization for DefaultScheduler and AdaptiveScheduler. It will distribute subtasks across as many TaskManagers as possible.</td>
+        </tr>
+        <tr>
             <td><h5>jobstore.cache-size</h5></td>
             <td style="word-wrap: break-word;">52428800</td>
             <td>Long</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -63,6 +63,12 @@
             <td>The desired context from your Kubernetes config file used to configure the Kubernetes client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different Kubernetes clusters/contexts.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.decorator.exclude</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>A semicolon-separated list of the Kubernetes step decorator class names to be excluded from the JM/TM factories</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.decorator.hadoop-conf-mount.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -717,6 +717,14 @@ public class JobManagerOptions {
                                                             code(UNFINISHED_PRODUCERS.name())))
                                             .build());
 
+    public static final ConfigOption<Boolean> SLOT_ALLOCATE_ORDER_OPTIMIZATION =
+            key("jobmanager.scheduler.slot-allocation-optimization.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Flag indicating whether to enable the slot allocation optimization for DefaultScheduler and AdaptiveScheduler. "
+                                    + "It will distribute subtasks across as many TaskManagers as possible.");
+
     // ---------------------------------------------------------------------------------------------
 
     private JobManagerOptions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
@@ -98,12 +99,16 @@ public class DefaultSchedulerComponents {
                         slotPool, SystemClock.getInstance());
         final PhysicalSlotProvider physicalSlotProvider =
                 new PhysicalSlotProviderImpl(slotSelectionStrategy, slotPool);
+        final boolean enableSlotAllocateOrderOptimization =
+                jobMasterConfiguration.getBoolean(
+                        JobManagerOptions.SLOT_ALLOCATE_ORDER_OPTIMIZATION);
         final ExecutionSlotAllocatorFactory allocatorFactory =
                 new SlotSharingExecutionSlotAllocatorFactory(
                         physicalSlotProvider,
                         jobType == JobType.STREAMING,
                         bulkChecker,
-                        slotRequestTimeout);
+                        slotRequestTimeout,
+                        enableSlotAllocateOrderOptimization);
         return new DefaultSchedulerComponents(
                 new PipelinedRegionSchedulingStrategy.Factory(),
                 bulkChecker::start,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotSharingGroup.java
@@ -19,12 +19,14 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Represents execution vertices that will run the same shared slot. */
 class ExecutionSlotSharingGroup {
@@ -51,6 +53,12 @@ class ExecutionSlotSharingGroup {
 
     Set<ExecutionVertexID> getExecutionVertexIds() {
         return Collections.unmodifiableSet(executionVertexIds);
+    }
+
+    Set<JobVertexID> getJobVertexIds() {
+        return executionVertexIds.stream()
+                .map(ExecutionVertexID::getJobVertexId)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocator.java
@@ -31,12 +31,15 @@ import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequest;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequestBulkChecker;
 import org.apache.flink.runtime.scheduler.SharedSlotProfileRetriever.SharedSlotProfileRetrieverFactory;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.util.CircleIterator;
+import org.apache.flink.runtime.util.SortingFunction;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -79,6 +82,8 @@ class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
 
     private final Function<ExecutionVertexID, ResourceProfile> resourceProfileRetriever;
 
+    private final SortingFunction<ExecutionSlotSharingGroup> slotSharingGroupOrderFunction;
+
     SlotSharingExecutionSlotAllocator(
             PhysicalSlotProvider slotProvider,
             boolean slotWillBeOccupiedIndefinitely,
@@ -86,7 +91,8 @@ class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
             SharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory,
             PhysicalSlotRequestBulkChecker bulkChecker,
             Time allocationTimeout,
-            Function<ExecutionVertexID, ResourceProfile> resourceProfileRetriever) {
+            Function<ExecutionVertexID, ResourceProfile> resourceProfileRetriever,
+            boolean enableSlotAllocateOrderOptimization) {
         this.slotProvider = checkNotNull(slotProvider);
         this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
         this.slotSharingStrategy = checkNotNull(slotSharingStrategy);
@@ -95,8 +101,11 @@ class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
         this.allocationTimeout = checkNotNull(allocationTimeout);
         this.resourceProfileRetriever = checkNotNull(resourceProfileRetriever);
         this.sharedSlots = new IdentityHashMap<>();
-
         this.slotProvider.disableBatchSlotRequestTimeoutCheck();
+        this.slotSharingGroupOrderFunction =
+                enableSlotAllocateOrderOptimization
+                        ? CircleIterator.sortFunction(ExecutionSlotSharingGroup::getJobVertexIds)
+                        : ArrayList::new;
     }
 
     @Override
@@ -160,8 +169,10 @@ class SlotSharingExecutionSlotAllocator implements ExecutionSlotAllocator {
                         .collect(
                                 Collectors.groupingBy(
                                         slotSharingStrategy::getExecutionSlotSharingGroup));
+        List<ExecutionSlotSharingGroup> slotSharingGroups =
+                slotSharingGroupOrderFunction.sort(executionsByGroup.keySet());
         Map<ExecutionSlotSharingGroup, SharedSlot> slots =
-                executionsByGroup.keySet().stream()
+                slotSharingGroups.stream()
                         .map(group -> getOrAllocateSharedSlot(group, sharedSlotProfileRetriever))
                         .collect(
                                 Collectors.toMap(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
@@ -29,6 +29,8 @@ public class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAl
 
     private final boolean slotWillBeOccupiedIndefinitely;
 
+    private final boolean enableSlotAllocateOrderOptimization;
+
     private final PhysicalSlotRequestBulkChecker bulkChecker;
 
     private final Time allocationTimeout;
@@ -39,13 +41,15 @@ public class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAl
             PhysicalSlotProvider slotProvider,
             boolean slotWillBeOccupiedIndefinitely,
             PhysicalSlotRequestBulkChecker bulkChecker,
-            Time allocationTimeout) {
+            Time allocationTimeout,
+            boolean enableSlotAllocateOrderOptimization) {
         this(
                 slotProvider,
                 slotWillBeOccupiedIndefinitely,
                 bulkChecker,
                 allocationTimeout,
-                new LocalInputPreferredSlotSharingStrategy.Factory());
+                new LocalInputPreferredSlotSharingStrategy.Factory(),
+                enableSlotAllocateOrderOptimization);
     }
 
     SlotSharingExecutionSlotAllocatorFactory(
@@ -53,12 +57,14 @@ public class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAl
             boolean slotWillBeOccupiedIndefinitely,
             PhysicalSlotRequestBulkChecker bulkChecker,
             Time allocationTimeout,
-            SlotSharingStrategy.Factory slotSharingStrategyFactory) {
+            SlotSharingStrategy.Factory slotSharingStrategyFactory,
+            boolean enableSlotAllocateOrderOptimization) {
         this.slotProvider = slotProvider;
         this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
         this.bulkChecker = bulkChecker;
         this.slotSharingStrategyFactory = slotSharingStrategyFactory;
         this.allocationTimeout = allocationTimeout;
+        this.enableSlotAllocateOrderOptimization = enableSlotAllocateOrderOptimization;
     }
 
     @Override
@@ -82,6 +88,7 @@ public class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAl
                 sharedSlotProfileRetrieverFactory,
                 bulkChecker,
                 allocationTimeout,
-                context::getResourceProfile);
+                context::getResourceProfile,
+                enableSlotAllocateOrderOptimization);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -107,7 +107,7 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                 jobGraph.getJobID());
 
         final SlotSharingSlotAllocator slotAllocator =
-                createSlotSharingSlotAllocator(declarativeSlotPool);
+                createSlotSharingSlotAllocator(declarativeSlotPool, jobMasterConfiguration);
 
         final ExecutionGraphFactory executionGraphFactory =
                 new DefaultExecutionGraphFactory(
@@ -149,10 +149,15 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
     }
 
     public static SlotSharingSlotAllocator createSlotSharingSlotAllocator(
-            DeclarativeSlotPool declarativeSlotPool) {
+            DeclarativeSlotPool declarativeSlotPool, Configuration jobMasterConfiguration) {
+
+        final boolean enableSlotAllocateOrderOptimization =
+                jobMasterConfiguration.getBoolean(
+                        JobManagerOptions.SLOT_ALLOCATE_ORDER_OPTIMIZATION);
         return SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                 declarativeSlotPool::reserveFreeSlot,
                 declarativeSlotPool::freeReservedSlot,
-                declarativeSlotPool::containsFreeSlot);
+                declarativeSlotPool::containsFreeSlot,
+                enableSlotAllocateOrderOptimization);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/CircleIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/CircleIterator.java
@@ -1,0 +1,119 @@
+package org.apache.flink.runtime.util;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Iterator for merging multiple lists of varying sizes into a single list as uniformly as possible.
+ *
+ * @param <V> Element type
+ */
+public class CircleIterator<V> implements Iterator<V> {
+
+    private final Random rnd = new Random();
+    private final List<Group> groups;
+
+    public CircleIterator(Collection<List<V>> lists) {
+        Preconditions.checkNotNull(lists);
+        double totalValues = lists.stream().mapToInt(List::size).sum();
+        this.groups = new LinkedList<>();
+        lists.stream()
+                .filter(l -> !l.isEmpty())
+                .forEach(l -> groups.add(new Group(new ArrayList<>(l), totalValues / l.size())));
+        Collections.sort(groups, Comparator.comparingDouble(g -> g.total));
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !groups.isEmpty();
+    }
+
+    @Override
+    public V next() {
+        // We get the next element from the group with the smallest total frequency
+        Group nextGroup = groups.remove(0);
+        V nextElement = nextGroup.removeNext();
+
+        // Insert group back to the queue if it still has elements
+        insertGroup(nextGroup);
+        return nextElement;
+    }
+
+    /**
+     * Insert group to the correct position by maintaining sort order on total frequency
+     *
+     * @param group Group to insert
+     */
+    private void insertGroup(Group group) {
+        if (!group.elements.isEmpty()) {
+            int insertIndex = groups.size();
+            for (int i = 0; i < groups.size(); i++) {
+                if (group.total < groups.get(i).total) {
+                    insertIndex = i;
+                    break;
+                }
+            }
+            groups.add(insertIndex, group);
+        }
+    }
+
+    public static <V> SortingFunction<V> sortFunction(Function<V, ?> groupingFunction) {
+        return elements -> sort(elements, groupingFunction);
+    }
+
+    private static <V> List<V> sort(Collection<V> elements, Function<V, ?> groupingFunction) {
+        Collection<List<V>> groups =
+                elements.stream().collect(Collectors.groupingBy(groupingFunction)).values();
+
+        List<V> out = new ArrayList<>(elements.size());
+        new CircleIterator<>(groups).forEachRemaining(out::add);
+        return out;
+    }
+
+    private class Group {
+        private final List<V> elements;
+        private final double frequency;
+        private double total;
+
+        Group(List<V> elements, double frequency) {
+            this.elements = elements;
+            this.frequency = frequency;
+
+            // we initialize the total randomly between (0, frequency) to avoid clustering of
+            // elements with the same initial frequency
+            this.total = rnd.nextDouble() * frequency;
+        }
+
+        V removeNext() {
+            V next = elements.remove(0);
+            total += frequency;
+            return next;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/SortingFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/SortingFunction.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import java.util.Collection;
+import java.util.List;
+
+/** A function for sorting collections. */
+@FunctionalInterface
+public interface SortingFunction<T> {
+
+    List<T> sort(Collection<T> elements);
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -319,7 +319,8 @@ public class SchedulerTestingUtils {
                 true,
                 new TestingPhysicalSlotRequestBulkChecker(),
                 allocationTimeout,
-                new LocalInputPreferredSlotSharingStrategy.Factory());
+                new LocalInputPreferredSlotSharingStrategy.Factory(),
+                false);
     }
 
     public static SchedulerBase createSchedulerAndDeploy(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -207,7 +207,7 @@ public class AdaptiveSchedulerBuilder {
                 declarativeSlotPool,
                 slotAllocator == null
                         ? AdaptiveSchedulerFactory.createSlotSharingSlotAllocator(
-                                declarativeSlotPool)
+                                declarativeSlotPool, jobMasterConfiguration)
                         : slotAllocator,
                 executorService,
                 userCodeLoader,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestSlotInfo.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestSlotInfo.java
@@ -29,6 +29,8 @@ public class TestSlotInfo implements SlotInfo {
     private final AllocationID allocationId;
     private final ResourceProfile resourceProfile;
 
+    private TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
     public TestSlotInfo() {
         this(new AllocationID(), ResourceProfile.ANY);
     }
@@ -53,7 +55,7 @@ public class TestSlotInfo implements SlotInfo {
 
     @Override
     public TaskManagerLocation getTaskManagerLocation() {
-        return new LocalTaskManagerLocation();
+        return taskManagerLocation;
     }
 
     @Override
@@ -69,5 +71,9 @@ public class TestSlotInfo implements SlotInfo {
     @Override
     public boolean willBeOccupiedIndefinitely() {
         return false;
+    }
+
+    public void setTaskManagerLocation(TaskManagerLocation location) {
+        this.taskManagerLocation = location;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Flink does not really do a good job at distributing the tasks uniformly across the taskmanagers of the cluster.
The reason is that there is no strategy for spreading out the tasks, they are simply assigned to the next available slots. This PR improves this by simply sorting the available slots in a way that slots from different TMs are interleaving as evenly as possible.

This works for both the the Default and Adaptive scheduler. The new behaviour can be turned on and off by a new config.

## Verifying this change

New unit tests have been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
