### PR TITLE
[FLINK-32112][docs] Fix the deprecated state backend sample config in Chinese document

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -177,7 +177,7 @@ env.set_state_backend(HashMapStateBackend())
 ```yaml
 # 用于存储 operator state 快照的 State Backend
 
-state.backend: filesystem
+state.backend: hashmap
 
 
 # 存储快照的目录


### PR DESCRIPTION


## What is the purpose of the change

This pull request fixed State Backend sample config error in zh-doc


## Brief change log

update State Backends configuration in zh-doc:
before  -> state.backend: filesystem
after     -> state.backend: hashmap   


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
