### PR TITLE
[FLINK-32122] [Documentation] Update the Azure Blob Storage document to assist in configuring the MSI provider with a shaded class name

### DIFF
--- a/docs/content/docs/deployment/filesystems/azure.md
+++ b/docs/content/docs/deployment/filesystems/azure.md
@@ -119,5 +119,15 @@ Azure blob storage key can be configured in `flink-conf.yaml` via:
 ```yaml
 fs.azure.account.key.<account_name>.dfs.core.windows.net: <azure_storage_key>
 ```
+##### Accessing ABFS using MSI (Azure Managed Identity)
+Azure blob storage MSI based configuration can be configured in `flink-conf.yaml` via:
+
+```yaml
+fs.azure.account.auth.type.<storage_account_name>.dfs.core.windows.net: OAuth
+fs.azure.account.oauth.provider.type.<storage_account_name>.dfs.core.windows.net: org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider
+fs.azure.account.oauth2.msi.tenant.<storage_account_name>.dfs.core.windows.net: <azure_tenant_id>
+fs.azure.account.oauth2.client.id.<storage_account_name>.dfs.core.windows.net: <managed_service_identity_client_id>
+fs.azure.account.oauth2.client.endpoint.<storage_account_name>.dfs.core.windows.net: https://login.microsoftonline.com/<azure_tenant_id>/oauth2/token
+```
 
 {{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

Many users have reported on the mailing list that they are unable to configure the ABFS filesystem as a checkpoint directory. This is often due to ClassNotFoundException errors for Hadoop classes that are configured in the configuration value. For instance, when using MsiTokenProvider for ABFS storage in Flink, it should be configured with the shaded class name. However, many users mistakenly use the Hadoop class name or package instead.

fs.azure.account.oauth.provider.type: org.apache.flink.fs.shaded.hadoop3.org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider


## Brief change log

This is just document changes.


## Verifying this change

NA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? NA
