### PR TITLE
[hotfix][doc] mvn 3.8.6 is recommended or higher version could be used

### DIFF
--- a/docs/content/docs/dev/configuration/maven.md
+++ b/docs/content/docs/dev/configuration/maven.md
@@ -30,7 +30,7 @@ publish, and deploy projects. You can use it to manage the entire lifecycle of y
 
 ## Requirements
 
-- Maven 3.0.4 (or higher)
+- Maven 3.8.6 (recommended or higher)
 - Java 8 (deprecated) or Java 11
 
 ## Importing the project into your IDE


### PR DESCRIPTION
## What is the purpose of the change

update the doc to help developer use the feasible maven version. 


## Brief change log

  - pointed out that 3.8.6 is recommended according to https://lists.apache.org/thread/jbw3lzzoq5w16ckco3fc9xokycs3f22x. 
  - Higher version could also be used. I personally tested with 3.9.1


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
