### PR TITLE
[FLINK-32142][build][flink-runtime-web] Upgrade frontend-maven-plugin...

### DIFF
--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -250,7 +250,7 @@ under the License.
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>1.11.0</version>
+				<version>1.12.1</version>
 				<executions>
 					<execution>
 						<id>install node and npm</id>


### PR DESCRIPTION
… to 1.12.1


## What is the purpose of the change

This pull request fixes the build for Apple Silicon which breaks while attempting to run nodejs for flink-runtime-web. The issue is explained in https://issues.apache.org/jira/browse/FLINK-32142


## Brief change log

  - Upgrades frontend-maven-plugin from version 1.11.0 to the latest version, 1.12.1.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
