### PR TITLE
[FLINK-32152][tests] Consolidate mocking library usage

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -55,9 +55,9 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.doAnswer;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for checking whether {@link FlinkKafkaConsumerBase} can restore from snapshots that were

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /** Tests for the {@link PendingCheckpoint}. */
 class PendingCheckpointTest {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -74,9 +74,9 @@ import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtil
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 /** Various tests for the {@link NettyShuffleEnvironment} class. */
 class NettyShuffleEnvironmentTest {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 public class IncrementalRemoteKeyedStateHandleTest {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -92,9 +92,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 /** Tests for the partitioned state part of {@link EmbeddedRocksDBStateBackend}. */
 @RunWith(Parameterized.class)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
@@ -47,11 +47,11 @@ import java.util.List;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.verifyZeroInteractions;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link BackendRestorerProcedure}. */
 public class BackendRestorerProcedureTest extends TestLogger {
@@ -127,7 +127,7 @@ public class BackendRestorerProcedureTest extends TestLogger {
         try {
             verify(firstFailHandle).openInputStream();
             verify(secondSuccessHandle).openInputStream();
-            verifyZeroInteractions(thirdNotUsedHandle);
+            verify(thirdNotUsedHandle, times(0)).openInputStream();
 
             ListState<Integer> listState = restoredBackend.getListState(stateDescriptor);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
@@ -40,8 +40,8 @@ import java.util.concurrent.RunnableFuture;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.spy;
 
 /** Tests for {@link OperatorSnapshotFutures}. */
 public class OperatorSnapshotFuturesTest extends TestLogger {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateSnapshotContextSynchronousImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateSnapshotContextSynchronousImplTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link StateSnapshotContextSynchronousImpl}. */
 public class StateSnapshotContextSynchronousImplTest extends TestLogger {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
@@ -42,7 +42,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.spy;
 
 /**
  * This class wraps an {@link AbstractStateBackend} and enriches all the created objects as spies.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReaderTest.java
@@ -48,7 +48,7 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /** Test for FlinkCalciteCatalogReader. */
 public class FlinkCalciteCatalogReaderTest {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
@@ -35,7 +35,7 @@ import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataTy
 
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.tools.RelBuilder
-import org.powermock.api.mockito.PowerMockito.{mock, when}
+import org.mockito.Mockito.{mock, when}
 
 /** Agg test base to mock agg information and etc. */
 abstract class AggTestBase(isBatchMode: Boolean) {
@@ -67,28 +67,28 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val aggInfo1: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
-    when(aggInfo, "agg").thenReturn(call)
-    when(call, "getName").thenReturn("avg1")
-    when(aggInfo, "function").thenReturn(new LongAvgAggFunction)
-    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.BIGINT))
-    when(aggInfo, "externalAccTypes").thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
-    when(aggInfo, "argIndexes").thenReturn(Array(1))
-    when(aggInfo, "aggIndex").thenReturn(0)
-    when(aggInfo, "externalResultType").thenReturn(DataTypes.BIGINT)
+    when(aggInfo.agg).thenReturn(call)
+    when(call.getName).thenReturn("avg1")
+    when(aggInfo.function).thenReturn(new LongAvgAggFunction)
+    when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.BIGINT))
+    when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
+    when(aggInfo.argIndexes).thenReturn(Array(1))
+    when(aggInfo.aggIndex).thenReturn(0)
+    when(aggInfo.externalResultType).thenReturn(DataTypes.BIGINT)
     aggInfo
   }
 
   val aggInfo2: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
-    when(aggInfo, "agg").thenReturn(call)
-    when(call, "getName").thenReturn("avg2")
-    when(aggInfo, "function").thenReturn(new DoubleAvgAggFunction)
-    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.DOUBLE()))
-    when(aggInfo, "externalAccTypes").thenReturn(Array(DataTypes.DOUBLE, DataTypes.BIGINT))
-    when(aggInfo, "argIndexes").thenReturn(Array(2))
-    when(aggInfo, "aggIndex").thenReturn(1)
-    when(aggInfo, "externalResultType").thenReturn(DataTypes.DOUBLE)
+    when(aggInfo.agg).thenReturn(call)
+    when(call.getName).thenReturn("avg2")
+    when(aggInfo.function).thenReturn(new DoubleAvgAggFunction)
+    when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.DOUBLE()))
+    when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.DOUBLE, DataTypes.BIGINT))
+    when(aggInfo.argIndexes).thenReturn(Array(2))
+    when(aggInfo.aggIndex).thenReturn(1)
+    when(aggInfo.externalResultType).thenReturn(DataTypes.DOUBLE)
     aggInfo
   }
 
@@ -96,16 +96,16 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val aggInfo3: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
-    when(aggInfo, "agg").thenReturn(call)
-    when(call, "getName").thenReturn("avg3")
-    when(aggInfo, "function").thenReturn(imperativeAggFunc)
-    when(aggInfo, "externalArgTypes").thenReturn(Array(DataTypes.BIGINT()))
-    when(aggInfo, "externalAccTypes").thenReturn(
+    when(aggInfo.agg).thenReturn(call)
+    when(call.getName).thenReturn("avg3")
+    when(aggInfo.function).thenReturn(imperativeAggFunc)
+    when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.BIGINT()))
+    when(aggInfo.externalAccTypes).thenReturn(
       Array(fromLegacyInfoToDataType(imperativeAggFunc.getAccumulatorType)))
-    when(aggInfo, "externalResultType").thenReturn(DataTypes.BIGINT)
-    when(aggInfo, "viewSpecs").thenReturn(Array[DataViewSpec]())
-    when(aggInfo, "argIndexes").thenReturn(Array(3))
-    when(aggInfo, "aggIndex").thenReturn(2)
+    when(aggInfo.externalResultType).thenReturn(DataTypes.BIGINT)
+    when(aggInfo.viewSpecs).thenReturn(Array[DataViewSpec]())
+    when(aggInfo.argIndexes).thenReturn(Array(3))
+    when(aggInfo.aggIndex).thenReturn(2)
     aggInfo
   }
 
@@ -114,5 +114,5 @@ abstract class AggTestBase(isBatchMode: Boolean) {
   val ctx = new CodeGeneratorContext(tEnv.getConfig, Thread.currentThread().getContextClassLoader)
   val classLoader: ClassLoader = Thread.currentThread().getContextClassLoader
   val context: ExecutionContext = mock(classOf[ExecutionContext])
-  when(context, "getRuntimeContext").thenReturn(mock(classOf[RuntimeContext]))
+  when(context.getRuntimeContext).thenReturn(mock(classOf[RuntimeContext]))
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGeneratorTest.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.types.logical._
 
 import org.apache.calcite.rel.core.AggregateCall
 import org.junit.Test
-import org.powermock.api.mockito.PowerMockito.{mock, when}
+import org.mockito.Mockito.{mock, when}
 
 /** Test for [[HashAggCodeGenerator]]. */
 class HashAggCodeGeneratorTest extends BatchAggTestBase {
@@ -57,12 +57,12 @@ class HashAggCodeGeneratorTest extends BatchAggTestBase {
   override val aggInfo3: AggregateInfo = {
     val aggInfo = mock(classOf[AggregateInfo])
     val call = mock(classOf[AggregateCall])
-    when(aggInfo, "agg").thenReturn(call)
-    when(call, "getName").thenReturn("avg3")
-    when(aggInfo, "function").thenReturn(new LongAvgAggFunction)
-    when(aggInfo, "externalAccTypes").thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
-    when(aggInfo, "argIndexes").thenReturn(Array(3))
-    when(aggInfo, "aggIndex").thenReturn(2)
+    when(aggInfo.agg).thenReturn(call)
+    when(call.getName).thenReturn("avg3")
+    when(aggInfo.function).thenReturn(new LongAvgAggFunction)
+    when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
+    when(aggInfo.argIndexes).thenReturn(Array(3))
+    when(aggInfo.aggIndex).thenReturn(2)
     aggInfo
   }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 /**
  * These tests verify that {@link WindowOperator} correctly interacts with the other windowing


### PR DESCRIPTION
Migrates most powermock usages to mockito. We mock a few static things with powermock that couldn't be migrated easily.
The goal is to reduce powermock usages to a minimum, and limit the powermock dependency to flink-core/runtime in a follow-up.

Note: This PR is not touching mocks that are being removed in #22616.