### PR TITLE
[FLINK-32158] Unify the getMultiInputOperatorDefaultMeta and getOneInputOperatorDefaultMeta methods into the same getInputOperatorDefaultMeta method

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/StateMetadata.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/StateMetadata.java
@@ -33,7 +33,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -106,16 +105,7 @@ public class StateMetadata {
         return stateName;
     }
 
-    public static List<StateMetadata> getOneInputOperatorDefaultMeta(
-            ReadableConfig tableConfig, String stateName) {
-        return Collections.singletonList(
-                new StateMetadata(
-                        0,
-                        tableConfig.get(ExecutionConfigOptions.IDLE_STATE_RETENTION),
-                        stateName));
-    }
-
-    public static List<StateMetadata> getMultiInputOperatorDefaultMeta(
+    public static List<StateMetadata> getInputOperatorDefaultMeta(
             ReadableConfig tableConfig, String... stateNameList) {
         Duration stateRetentionTime = tableConfig.get(ExecutionConfigOptions.IDLE_STATE_RETENTION);
         return IntStream.range(0, stateNameList.length)
@@ -124,12 +114,7 @@ public class StateMetadata {
                 .collect(Collectors.toList());
     }
 
-    public static long getStateTtlForOneInputOperator(
-            ExecNodeConfig config, @Nullable List<StateMetadata> stateMetadataList) {
-        return getStateTtlForMultiInputOperator(config, 1, stateMetadataList).get(0);
-    }
-
-    public static List<Long> getStateTtlForMultiInputOperator(
+    public static List<Long> getStateTtlForInputOperator(
             ExecNodeConfig config,
             int inputNumOfOperator,
             @Nullable List<StateMetadata> stateMetadataList) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/StateMetadataTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/StateMetadataTest.java
@@ -94,7 +94,7 @@ public class StateMetadataTest {
             Consumer<TableConfig> configModifier, String expectedStateName, long expectedStateTtl) {
         configModifier.accept(tableConfig);
         List<StateMetadata> stateMetadataList =
-                StateMetadata.getOneInputOperatorDefaultMeta(tableConfig, expectedStateName);
+                StateMetadata.getInputOperatorDefaultMeta(tableConfig, expectedStateName);
         assertThat(stateMetadataList).hasSize(1);
         assertThat(stateMetadataList.get(0))
                 .matches(
@@ -112,7 +112,7 @@ public class StateMetadataTest {
             List<Long> expectedStateTtlList) {
         configModifier.accept(tableConfig);
         List<StateMetadata> stateMetadataList =
-                StateMetadata.getMultiInputOperatorDefaultMeta(
+                StateMetadata.getInputOperatorDefaultMeta(
                         tableConfig, expectedStateNameList.toArray(new String[0]));
         assertThat(stateMetadataList).hasSameSizeAs(expectedStateNameList);
         IntStream.range(0, stateMetadataList.size())
@@ -139,7 +139,7 @@ public class StateMetadataTest {
             @Nullable List<StateMetadata> stateMetadataList,
             long expectedStateTtl) {
         ExecNodeConfig nodeConfig = configModifier.apply(tableConfig);
-        assertThat(StateMetadata.getStateTtlForOneInputOperator(nodeConfig, stateMetadataList))
+        assertThat(StateMetadata.getStateTtlForInputOperator(nodeConfig, 1, stateMetadataList))
                 .isEqualTo(expectedStateTtl);
     }
 
@@ -151,7 +151,7 @@ public class StateMetadataTest {
             List<Long> expectedStateTtlList) {
         ExecNodeConfig nodeConfig = configModifier.apply(tableConfig);
         assertThat(
-                        StateMetadata.getStateTtlForMultiInputOperator(
+                        StateMetadata.getStateTtlForInputOperator(
                                 nodeConfig, expectedStateTtlList.size(), stateMetadataList))
                 .containsExactlyElementsOf(expectedStateTtlList);
     }
@@ -164,7 +164,7 @@ public class StateMetadataTest {
             String expectedMessage) {
         assertThatThrownBy(
                         () ->
-                                StateMetadata.getStateTtlForMultiInputOperator(
+                                StateMetadata.getStateTtlForInputOperator(
                                         ExecNodeConfig.ofTableConfig(tableConfig, true),
                                         expectedInputNumOfOperator,
                                         malformedStateMetadataList))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/StateMetadataTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/StateMetadataTest.java
@@ -139,7 +139,9 @@ public class StateMetadataTest {
             @Nullable List<StateMetadata> stateMetadataList,
             long expectedStateTtl) {
         ExecNodeConfig nodeConfig = configModifier.apply(tableConfig);
-        assertThat(StateMetadata.getStateTtlForInputOperator(nodeConfig, 1, stateMetadataList))
+        assertThat(
+                        StateMetadata.getStateTtlForInputOperator(nodeConfig, 1, stateMetadataList)
+                                .get(0))
                 .isEqualTo(expectedStateTtl);
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Unify the getMultiInputOperatorDefaultMeta and getOneInputOperatorDefaultMeta methods into the same getInputOperatorDefaultMeta method. Because 1 is a special case of Multi, there is no need to repeat the definition.Same applies to getStateTtlForMultiInputOperator and getStateTtlForOneInputOperator methods


## Brief change log
Unify the getMultiInputOperatorDefaultMeta and getOneInputOperatorDefaultMeta methods into the same getInputOperatorDefaultMeta method
Unify the getStateTtlForMultiInputOperator and getStateTtlForOneInputOperator methods into the same getStateTtlForInputOperator method

## Verifying this change

This change is already covered by existing tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
