### PR TITLE
[hotfix][doc] Use the flink-connector-jdbc v3.1 branch docs

### DIFF
--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -47,7 +47,7 @@ integrate_connector_docs elasticsearch v3.0
 integrate_connector_docs aws v4.1
 integrate_connector_docs cassandra v3.0
 integrate_connector_docs pulsar v4.0
-integrate_connector_docs jdbc v3.0
+integrate_connector_docs jdbc v3.1
 integrate_connector_docs rabbitmq v3.0
 integrate_connector_docs gcp-pubsub v3.0
 integrate_connector_docs mongodb v1.0


### PR DESCRIPTION
## What is the purpose of the change
Currently, the lastest stable flink-connector-jdbc branch is v3.1, we should use the doc in that branch.

## Verifying this change
Only change docs, no tests needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
