### PR TITLE
[FLINK-31664][table] Add ARRAY_INTERSECT function

### DIFF
--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -228,6 +228,7 @@ advanced type helper functions
     Expression.array_concat
     Expression.array_contains
     Expression.array_distinct
+    Expression.array_intersect
     Expression.array_join
     Expression.array_position
     Expression.array_remove

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1487,6 +1487,13 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayDistinct")(self)
 
+    def array_intersect(self, array) -> 'Expression':
+        """
+        Returns an array of the elements in the intersection of array1 and array2, without
+        duplicates. If any of the array is null, the function will return null.
+        """
+        return _binary_op("arrayIntersect")(self, array)
+
     def array_position(self, needle) -> 'Expression':
         """
         Returns the position of the first occurrence of element in the given array as int.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -57,6 +57,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_INTERSECT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MAX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REMOVE;
@@ -1367,6 +1368,17 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayDistinct() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_DISTINCT, toExpr()));
+    }
+
+    /**
+     * Returns an array of the elements in the intersection of array1 and array2, without
+     * duplicates.
+     *
+     * <p>If any of the array is null, the function will return null.
+     */
+    public OutType arrayIntersect(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_INTERSECT, toExpr(), objectToExpression(array)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -244,6 +244,16 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayDistinctFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_INTERSECT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_INTERSECT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayIntersectFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition ARRAY_POSITION =
             BuiltInFunctionDefinition.newBuilder()
                     .name("ARRAY_POSITION")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_INTERSECT}. */
+@Internal
+public class ArrayIntersectFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    private final SpecializedFunction.ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle equalityHandle;
+
+    public ArrayIntersectFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_INTERSECT, context);
+
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData array1, ArrayData array2) {
+        try {
+            if (array1 == null || array2 == null) {
+                return null;
+            }
+
+            List list = new ArrayList<>();
+            boolean alreadySeenNull = false;
+            for (int i = 0; i < array1.size(); i++) {
+                boolean found = false;
+                final Object element1 = elementGetter.getElementOrNull(array1, i);
+                if (array1.isNullAt(i)) {
+                    if (!alreadySeenNull) {
+                        for (int j = 0; j < array2.size(); j++) {
+                            found = array2.isNullAt(j);
+                            if (found) {
+                                break;
+                            }
+                        }
+                        alreadySeenNull = true;
+                    }
+                } else {
+                    for (int j = 0; j < array2.size(); j++) {
+                        if (!array2.isNullAt(j)) {
+                            final Object element2 = elementGetter.getElementOrNull(array2, j);
+                            if ((boolean) equalityHandle.invoke(element1, element2)) {
+                                boolean foundArrayBuffer = false;
+                                for (int k = 0; k < list.size(); k++) {
+                                    Object va = list.get(k);
+                                    foundArrayBuffer =
+                                            (va != null)
+                                                    && (boolean)
+                                                            equalityHandle.invoke(va, element1);
+                                    if (foundArrayBuffer) {
+                                        break;
+                                    }
+                                }
+                                found = !foundArrayBuffer;
+                            }
+                        }
+                        if (found) {
+                            break;
+                        }
+                    }
+                }
+                if (found) {
+                    list.add(element1);
+                }
+            }
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityEvaluator.close();
+    }
+}


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of ARRAY_INTERSECT

- Brief change log
ARRAY_INTERSECT for Table API and SQL
    
```
Returns an array of the elements in the intersection of array1 and array2, without duplicates.

Syntax:
array_intersect(array1, array2)

Arguments:
array: An ARRAY to be handled.

Returns:
An ARRAY. If any of the array is null, the function will return null.
Examples:

> SELECT array_intersect(array(1, 2, 3), array(1, 3, 5));
 [1,3]

```


See also
spark https://spark.apache.org/docs/latest/api/sql/index.html#array_intersect
presto https://prestodb.io/docs/current/functions/array.html

- Verifying this change
This change added tests in CollectionFunctionsITCase.

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)