### PR TITLE
[hotfix] Use https://repo.maven.apache.org in maven-utils.sh

### DIFF
--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -33,7 +33,7 @@ export -f run_mvn
 function setup_maven {
 	set -e # fail if there was an error setting up maven
 	if [ ! -d "${MAVEN_VERSIONED_DIR}" ]; then
-	  wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip
+	  wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.zip
 	  unzip -d "${MAVEN_CACHE_DIR}" -qq "apache-maven-${MAVEN_VERSION}-bin.zip"
 	  rm "apache-maven-${MAVEN_VERSION}-bin.zip"
 	fi


### PR DESCRIPTION

## What is the purpose of the change

The idea is to use `https://repo.maven.apache.org` (same as `maven-wrapper.properties`) to download maven via `maven-utils.sh` since connection to `https://archive.apache.org` seems to be unstable sometimes like e.g. at https://issues.apache.org/jira/browse/FLINK-32106

## Brief change log

`maven-utils.sh`


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
