### PR TITLE
[FLINK-32172][kafka] KafkaExampleUtils incorrect check of the minimum number of parameters

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
@@ -27,7 +27,7 @@ public class KafkaExampleUtil {
     public static StreamExecutionEnvironment prepareExecutionEnv(ParameterTool parameterTool)
             throws Exception {
 
-        if (parameterTool.getNumberOfParameters() < 5) {
+        if (parameterTool.getNumberOfParameters() < 4) {
             System.out.println(
                     "Missing parameters!\n"
                             + "Usage: Kafka --input-topic <topic> --output-topic <topic> "


### PR DESCRIPTION
## What is the purpose of the change

*`KafkaExampleUtils` incorrect check of the minimum number of parameters.*


## Brief change log

  - *Change the minimum number of parameters from `5` to `4`, aligning with error message.*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
