### PR TITLE
[FLINK-32166][ui] Show unassigned TM resources

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -31,6 +31,16 @@ export interface TaskManagerDetail {
   metrics: Metrics;
   memoryConfiguration: MemoryConfiguration;
   blocked?: boolean;
+  freeResource: Resources;
+  totalResource: Resources;
+}
+
+export interface Resources {
+  cpuCores: number;
+  taskHeapMemory: number;
+  taskOffHeapMemory: number;
+  managedMemory: number;
+  networkMemory: number;
 }
 
 export interface TaskManagerLogItem {

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
@@ -164,7 +164,7 @@
     </tbody>
   </nz-table>
 </nz-card>
-<nz-card nzTitle="Advanced" nzSize="small">
+<nz-card nzTitle="Advanced" nzSize="small" class="flink-memory-model">
   <div nz-row [nzGutter]="16">
     <div nz-col [nzSpan]="12">
       <nz-table
@@ -293,4 +293,76 @@
       </nz-table>
     </div>
   </div>
+</nz-card>
+
+<ng-template #tmResourceRow let-detail="detail" let-name="name" let-property="prop">
+  <tr>
+    <td>{{ name }}</td>
+    <td>
+      <nz-progress
+        nzSize="small"
+        nzStrokeLinecap="square"
+        [nzPercent]="
+          +(
+            (detail?.freeResource[property] / detail?.totalResource[property]) * 100
+            | number: '1.0-2'
+          )
+        "
+        nzStatus="normal"
+      ></nz-progress>
+      {{ detail?.freeResource[property] | number }} / {{ detail?.totalResource[property] | number }}
+    </td>
+  </tr>
+</ng-template>
+
+<nz-card nzTitle="Resources" nzSize="small">
+  <nz-table
+    nzBordered
+    nzTitle="Unassigned resources"
+    [nzTemplateMode]="true"
+    [nzFrontPagination]="false"
+    [nzShowPagination]="false"
+    [nzSize]="'small'"
+    class="no-border"
+    [nzWidthConfig]="['200px', null]"
+  >
+    <tbody>
+      <ng-container
+        [ngTemplateOutlet]="tmResourceRow"
+        [ngTemplateOutletContext]="{ name: 'CPU', detail: taskManagerDetail, prop: 'cpuCores' }"
+      ></ng-container>
+      <ng-container
+        [ngTemplateOutlet]="tmResourceRow"
+        [ngTemplateOutletContext]="{
+          name: 'Task Heap memory',
+          detail: taskManagerDetail,
+          prop: 'taskHeapMemory'
+        }"
+      ></ng-container>
+      <ng-container
+        [ngTemplateOutlet]="tmResourceRow"
+        [ngTemplateOutletContext]="{
+          name: 'Task Off-Heap memory',
+          detail: taskManagerDetail,
+          prop: 'taskOffHeapMemory'
+        }"
+      ></ng-container>
+      <ng-container
+        [ngTemplateOutlet]="tmResourceRow"
+        [ngTemplateOutletContext]="{
+          name: 'Managed memory',
+          detail: taskManagerDetail,
+          prop: 'managedMemory'
+        }"
+      ></ng-container>
+      <ng-container
+        [ngTemplateOutlet]="tmResourceRow"
+        [ngTemplateOutletContext]="{
+          name: 'Network memory',
+          detail: taskManagerDetail,
+          prop: 'networkMemory'
+        }"
+      ></ng-container>
+    </tbody>
+  </nz-table>
 </nz-card>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { DecimalPipe, NgForOf, NgIf } from '@angular/common';
+import { DecimalPipe, NgForOf, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { of, Subject } from 'rxjs';
@@ -47,7 +47,8 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
     NzIconModule,
     NzGridModule,
     NgForOf,
-    NgIf
+    NgIf,
+    NgTemplateOutlet
   ],
   standalone: true
 })


### PR DESCRIPTION
Adds another table to the TaskManager metrics page showing unassigned resources.

The picture below was taken from a TM with 2 slots where 1 slot was in use and no resource profiles were set on the slot sharing groups.

![image](https://github.com/apache/flink/assets/5725237/97e515ed-c7f7-4d6e-a5bd-e7d2c2a81066)
 Ill extend this section in a follow-up with a detailed list of slots and their assigned resources.