### PR TITLE
[FLINK-32167] Improved TM-side logging for fine-grained resource management

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
@@ -20,6 +20,9 @@ package org.apache.flink.runtime.clusterframework.types;
 
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Budget manager for {@link ResourceProfile}.
  *
@@ -29,6 +32,8 @@ import org.apache.flink.util.Preconditions;
  * <p>Both the total budget and the reservations are in the form of {@link ResourceProfile}.
  */
 public class ResourceBudgetManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceBudgetManager.class);
 
     private final ResourceProfile totalBudget;
 
@@ -55,6 +60,7 @@ public class ResourceBudgetManager {
         }
 
         availableBudget = availableBudget.subtract(reservation);
+        LOG.debug("Resource budget reduced to {}.", availableBudget);
         return true;
     }
 
@@ -66,6 +72,7 @@ public class ResourceBudgetManager {
         }
 
         availableBudget = newAvailableBudget;
+        LOG.debug("Resource budget increased to {}.", availableBudget);
         return true;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1199,14 +1199,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             SlotID slotId, JobID jobId, AllocationID allocationId, ResourceProfile resourceProfile)
             throws SlotAllocationException {
         if (taskSlotTable.isSlotFree(slotId.getSlotNumber())) {
-            if (taskSlotTable.allocateSlot(
+            if (!taskSlotTable.allocateSlot(
                     slotId.getSlotNumber(),
                     jobId,
                     allocationId,
                     resourceProfile,
                     taskManagerConfiguration.getSlotTimeout())) {
-                log.info("Allocated slot for {}.", allocationId);
-            } else {
                 log.info("Could not allocate slot for {}.", allocationId);
                 throw new SlotAllocationException("Could not allocate slot.");
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -317,6 +317,8 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
                     budgetManager.getTotalBudget());
             return false;
         }
+        LOG.info(
+                "Allocated slot for {} with resources {}.", allocationId, effectiveResourceProfile);
 
         taskSlot =
                 new TaskSlot<>(


### PR DESCRIPTION
The logs currently don't contain any information about the used/free resource budget of a TM.