### PR TITLE
[FLINK-31894][runtime] ExceptionHistory and REST API failure label integration

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1508,7 +1508,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "checkpoint_type" : {
             "type" : "string",
-            "enum" : [ "CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
+            "enum" : [ "CHECKPOINT", "UNALIGNED_CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
           },
           "checkpointed_size" : {
             "type" : "integer"
@@ -1573,7 +1573,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             },
             "checkpoint_type" : {
               "type" : "string",
-              "enum" : [ "CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
+              "enum" : [ "CHECKPOINT", "UNALIGNED_CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
             },
             "checkpointed_size" : {
               "type" : "integer"
@@ -1675,7 +1675,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             },
             "checkpoint_type" : {
               "type" : "string",
-              "enum" : [ "CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
+              "enum" : [ "CHECKPOINT", "UNALIGNED_CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
             },
             "checkpointed_size" : {
               "type" : "integer"
@@ -2028,7 +2028,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "checkpoint_type" : {
       "type" : "string",
-      "enum" : [ "CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
+      "enum" : [ "CHECKPOINT", "UNALIGNED_CHECKPOINT", "SAVEPOINT", "SYNC_SAVEPOINT" ]
     },
     "checkpointed_size" : {
       "type" : "integer"
@@ -2496,6 +2496,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td colspan="2">
         <ul>
 <li><code>maxExceptions</code> (optional): Comma-separated list of integer values that specifies the upper limit of exceptions to return.</li>
+<li><code>failureLabelFilter</code> (optional): Collection of string values working as a filter in the form of `key:value` pairs allowing only exceptions with ALL of the specified failure labels to be returned.</li>
         </ul>
       </td>
     </tr>
@@ -2560,6 +2561,12 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                     "exceptionName" : {
                       "type" : "string"
                     },
+                    "failureLabels" : {
+                      "type" : "object",
+                      "additionalProperties" : {
+                        "type" : "string"
+                      }
+                    },
                     "location" : {
                       "type" : "string"
                     },
@@ -2580,6 +2587,12 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
               },
               "exceptionName" : {
                 "type" : "string"
+              },
+              "failureLabels" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "string"
+                }
               },
               "location" : {
                 "type" : "string"

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -675,6 +675,15 @@ paths:
         schema:
           type: integer
           format: int32
+      - name: failureLabelFilter
+        in: query
+        description: Collection of string values working as a filter in the form of
+          `key:value` pairs allowing only exceptions with ALL of the specified failure
+          labels to be returned.
+        required: false
+        style: form
+        schema:
+          $ref: '#/components/schemas/FailureLabel'
       responses:
         "200":
           description: The request was successful.
@@ -2011,6 +2020,10 @@ components:
       properties:
         exceptionName:
           type: string
+        failureLabels:
+          type: object
+          additionalProperties:
+            type: string
         location:
           type: string
         stacktrace:
@@ -2083,6 +2096,13 @@ components:
             format: int64
           failure_message:
             type: string
+    FailureLabel:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
     Features:
       type: object
       properties:
@@ -2729,6 +2749,7 @@ components:
       type: string
       enum:
       - CHECKPOINT
+      - UNALIGNED_CHECKPOINT
       - SAVEPOINT
       - SYNC_SAVEPOINT
     RestoreMode:
@@ -2759,6 +2780,10 @@ components:
             $ref: '#/components/schemas/ExceptionInfo'
         exceptionName:
           type: string
+        failureLabels:
+          type: object
+          additionalProperties:
+            type: string
         location:
           type: string
         stacktrace:

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1937,6 +1937,9 @@
       "queryParameters" : [ {
         "key" : "maxExceptions",
         "mandatory" : false
+      }, {
+        "key" : "failureLabelFilter",
+        "mandatory" : false
       } ]
     },
     "request" : {
@@ -1999,6 +2002,12 @@
                   "timestamp" : {
                     "type" : "integer"
                   },
+                  "failureLabels" : {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  },
                   "taskName" : {
                     "type" : "string"
                   },
@@ -2022,6 +2031,12 @@
                         },
                         "timestamp" : {
                           "type" : "integer"
+                        },
+                        "failureLabels" : {
+                          "type" : "object",
+                          "additionalProperties" : {
+                            "type" : "string"
+                          }
                         },
                         "taskName" : {
                           "type" : "string"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -177,6 +178,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         public static final String FIELD_NAME_TASK_NAME = "taskName";
         public static final String FIELD_NAME_LOCATION = "location";
         public static final String FIELD_NAME_TASK_MANAGER_ID = "taskManagerId";
+        public static final String FIELD_NAME_FAILURE_LABELS = "failureLabels";
 
         @JsonProperty(FIELD_NAME_EXCEPTION_NAME)
         private final String exceptionName;
@@ -202,8 +204,11 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         @Nullable
         private final String taskManagerId;
 
+        @JsonProperty(FIELD_NAME_FAILURE_LABELS)
+        private final Map<String, String> failureLabels;
+
         public ExceptionInfo(String exceptionName, String stacktrace, long timestamp) {
-            this(exceptionName, stacktrace, timestamp, null, null, null);
+            this(exceptionName, stacktrace, timestamp, Collections.emptyMap(), null, null, null);
         }
 
         @JsonCreator
@@ -211,12 +216,14 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_NAME) String exceptionName,
                 @JsonProperty(FIELD_NAME_EXCEPTION_STACKTRACE) String stacktrace,
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
+                @JsonProperty(FIELD_NAME_FAILURE_LABELS) Map<String, String> failureLabels,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
                 @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
                 @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId) {
             this.exceptionName = checkNotNull(exceptionName);
             this.stacktrace = checkNotNull(stacktrace);
             this.timestamp = timestamp;
+            this.failureLabels = checkNotNull(failureLabels);
             this.taskName = taskName;
             this.location = location;
             this.taskManagerId = taskManagerId;
@@ -255,6 +262,11 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
             return taskManagerId;
         }
 
+        @JsonIgnore
+        public Map<String, String> getFailureLabels() {
+            return failureLabels;
+        }
+
         // hashCode and equals are necessary for the test classes deriving from
         // RestResponseMarshallingTestBase
         @Override
@@ -269,13 +281,15 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
             return exceptionName.equals(that.exceptionName)
                     && stacktrace.equals(that.stacktrace)
                     && Objects.equals(timestamp, that.timestamp)
+                    && Objects.equals(failureLabels, that.failureLabels)
                     && Objects.equals(taskName, that.taskName)
                     && Objects.equals(location, that.location);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(exceptionName, stacktrace, timestamp, taskName, location);
+            return Objects.hash(
+                    exceptionName, stacktrace, timestamp, failureLabels, taskName, location);
         }
 
         @Override
@@ -284,6 +298,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                     .add("exceptionName='" + exceptionName + "'")
                     .add("stacktrace='" + stacktrace + "'")
                     .add("timestamp=" + timestamp)
+                    .add("failureLabels=" + failureLabels)
                     .add("taskName='" + taskName + "'")
                     .add("location='" + location + "'")
                     .toString();
@@ -305,8 +320,17 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 String exceptionName,
                 String stacktrace,
                 long timestamp,
+                Map<String, String> failureLabels,
                 Collection<ExceptionInfo> concurrentExceptions) {
-            this(exceptionName, stacktrace, timestamp, null, null, null, concurrentExceptions);
+            this(
+                    exceptionName,
+                    stacktrace,
+                    timestamp,
+                    failureLabels,
+                    null,
+                    null,
+                    null,
+                    concurrentExceptions);
         }
 
         @JsonCreator
@@ -314,12 +338,20 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_NAME) String exceptionName,
                 @JsonProperty(FIELD_NAME_EXCEPTION_STACKTRACE) String stacktrace,
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
+                @JsonProperty(FIELD_NAME_FAILURE_LABELS) Map<String, String> failureLabels,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
                 @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
                 @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId,
                 @JsonProperty(FIELD_NAME_CONCURRENT_EXCEPTIONS)
                         Collection<ExceptionInfo> concurrentExceptions) {
-            super(exceptionName, stacktrace, timestamp, taskName, location, taskManagerId);
+            super(
+                    exceptionName,
+                    stacktrace,
+                    timestamp,
+                    failureLabels,
+                    taskName,
+                    location,
+                    taskManagerId);
             this.concurrentExceptions = concurrentExceptions;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/FailureLabelFilterParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/FailureLabelFilterParameter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.ConversionException;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Specifies a collections of failure labels, filtering the exceptions returned for
+ * JobExceptionsHandler.
+ *
+ * @see org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler
+ */
+public class FailureLabelFilterParameter
+        extends MessageQueryParameter<FailureLabelFilterParameter.FailureLabel> {
+
+    public static final String KEY = "failureLabelFilter";
+
+    /** Represents a failure label consisting of a KV pair of strings. */
+    public static class FailureLabel {
+
+        private final String key;
+        private final String value;
+
+        public FailureLabel(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public FailureLabelFilterParameter() {
+        super(KEY, MessageParameterRequisiteness.OPTIONAL);
+    }
+
+    @Override
+    public List<FailureLabel> convertFromString(String values) throws ConversionException {
+        String[] splitValues = values.split(",");
+        Set<FailureLabel> result = new HashSet<>();
+        for (String value : splitValues) {
+            result.add(convertStringToValue(value));
+        }
+        return new ArrayList<>(result);
+    }
+
+    @Override
+    public FailureLabel convertStringToValue(String value) throws ConversionException {
+        String[] tokens = value.split(":");
+        if (tokens.length != 2) {
+            throw new ConversionException(
+                    String.format("%s may be a `key:value` entry only (%s)", KEY, value));
+        }
+        return new FailureLabel(tokens[0], tokens[1]);
+    }
+
+    @Override
+    public String convertValueToString(FailureLabel value) {
+        return value.toString();
+    }
+
+    @Override
+    public String getDescription() {
+        return "Collection of string values working as a filter in the form of `key:value` pairs "
+                + "allowing only exceptions with ALL of the specified failure labels to be returned.";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExceptionsMessageParameters.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -32,8 +33,12 @@ public class JobExceptionsMessageParameters extends JobMessageParameters {
     private final UpperLimitExceptionParameter upperLimitExceptionParameter =
             new UpperLimitExceptionParameter();
 
+    private final FailureLabelFilterParameter failureLabelExceptionParameter =
+            new FailureLabelFilterParameter();
+
     @Override
     public Collection<MessageQueryParameter<?>> getQueryParameters() {
-        return Collections.singletonList(upperLimitExceptionParameter);
+        return Collections.unmodifiableList(
+                Arrays.asList(upperLimitExceptionParameter, failureLabelExceptionParameter));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
@@ -63,11 +63,13 @@ public class JobExceptionsInfoWithHistoryNoRootTest
                                         "global failure #0",
                                         "stacktrace #0",
                                         0L,
+                                        Collections.emptyMap(),
                                         Collections.singletonList(
                                                 new JobExceptionsInfoWithHistory.ExceptionInfo(
                                                         "local task failure #2",
                                                         "stacktrace #2",
                                                         2L,
+                                                        Collections.emptyMap(),
                                                         "task name #2",
                                                         "location #2",
                                                         "taskManagerId #2"))),
@@ -75,6 +77,7 @@ public class JobExceptionsInfoWithHistoryNoRootTest
                                         "local task failure #1",
                                         "stacktrace #1",
                                         1L,
+                                        Collections.emptyMap(),
                                         "task name",
                                         "location",
                                         "taskManagerId",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31894

* Introduce FailureLabel class as a KV string container
* Add support for failure labels on JobExceptionsInfoWithHistory
* Extend JobExceptionsHandler to support `failureLabelFilter`
* Extend JobExceptionsHandlerTest to validate functionality