### PR TITLE
[hotfix][doc]Fix typo in analyze.md

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/analyze.md
+++ b/docs/content.zh/docs/dev/table/sql/analyze.md
@@ -83,8 +83,8 @@ tableEnv.executeSql(
         " `id` BIGINT NOT NULl," +
         " `product` VARCHAR(32)," +
         " `amount` INT," +
-        " `sold_year` BIGINT", +
-        " `sold_month` BIGINT", +
+        " `sold_year` BIGINT," +
+        " `sold_month` BIGINT," +
         " `sold_day` BIGINT" +
         ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
         ") with (...)");
@@ -152,8 +152,8 @@ tableEnv.executeSql(
           " `id` BIGINT NOT NULl," +
           " `product` VARCHAR(32)," +
           " `amount` INT," +
-          " `sold_year` BIGINT", +
-          " `sold_month` BIGINT", +
+          " `sold_year` BIGINT," +
+          " `sold_month` BIGINT," +
           " `sold_day` BIGINT" +
           ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
 ") with (...)");
@@ -221,8 +221,8 @@ table_env.execute_sql(
           " `id` BIGINT NOT NULl," +
           " `product` VARCHAR(32)," +
           " `amount` INT," +
-          " `sold_year` BIGINT", +
-          " `sold_month` BIGINT", +
+          " `sold_year` BIGINT," +
+          " `sold_month` BIGINT," +
           " `sold_day` BIGINT" +
           ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
 ") with (...)");

--- a/docs/content/docs/dev/table/sql/analyze.md
+++ b/docs/content/docs/dev/table/sql/analyze.md
@@ -81,8 +81,8 @@ tableEnv.executeSql(
         " `id` BIGINT NOT NULl," +
         " `product` VARCHAR(32)," +
         " `amount` INT," +
-        " `sold_year` BIGINT", +
-        " `sold_month` BIGINT", +
+        " `sold_year` BIGINT," +
+        " `sold_month` BIGINT," +
         " `sold_day` BIGINT" +
         ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
         ") with (...)");
@@ -150,8 +150,8 @@ tableEnv.executeSql(
           " `id` BIGINT NOT NULl," +
           " `product` VARCHAR(32)," +
           " `amount` INT," +
-          " `sold_year` BIGINT", +
-          " `sold_month` BIGINT", +
+          " `sold_year` BIGINT," +
+          " `sold_month` BIGINT," +
           " `sold_day` BIGINT" +
           ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
 ") with (...)");
@@ -219,8 +219,8 @@ table_env.execute_sql(
           " `id` BIGINT NOT NULl," +
           " `product` VARCHAR(32)," +
           " `amount` INT," +
-          " `sold_year` BIGINT", +
-          " `sold_month` BIGINT", +
+          " `sold_year` BIGINT," +
+          " `sold_month` BIGINT," +
           " `sold_day` BIGINT" +
           ") PARTITIONED BY (`sold_year`, `sold_month`, `sold_day`) "
 ") with (...)");


### PR DESCRIPTION
Fixed the SQL sample syntax error in analyze.md for both English and Chinese documents, the comma in the sample SQL should be inside the double quotes.