### PR TITLE
[FLINK-31896][runtime] Extend web interface to support failure labels

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-exception.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-exception.ts
@@ -43,6 +43,7 @@ export interface ExceptionInfo {
   exceptionName: string;
   stacktrace: string;
   timestamp: number;
+  failureLabels: Map<string, string>;
   taskName: string;
   endpoint: string;
   taskManagerId: string;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
@@ -52,6 +52,12 @@
               <td>{{ item.selected.timestamp | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
               <td>
                 <div class="name">{{ item.selected.exceptionName }}</div>
+                <nz-tag
+                  *ngFor="let label of item.selected.failureLabels | keyvalue"
+                  [nzColor]="'#ff0000'"
+                >
+                  {{ label.key }}:{{ label.value }}
+                </nz-tag>
               </td>
               <td class="select-td">
                 <nz-select

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
@@ -49,6 +49,10 @@
     margin-top: -@margin-md;
   }
 
+  nz-tag {
+    margin-bottom: 5px;
+  }
+
   .expand-td {
     display: block;
     padding: 0 !important;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { DatePipe, formatDate, NgForOf, NgIf } from '@angular/common';
+import { DatePipe, formatDate, KeyValuePipe, NgForOf, NgIf } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -34,6 +34,7 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzTabsModule } from 'ng-zorro-antd/tabs';
+import { NzTagModule } from 'ng-zorro-antd/tag';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 import { JobLocalService } from '../job-local.service';
@@ -84,7 +85,9 @@ const markGlobalFailure = function (exception: ExceptionInfo): ExceptionInfo {
     NgIf,
     FormsModule,
     NzIconModule,
-    NzButtonModule
+    NzButtonModule,
+    NzTagModule,
+    KeyValuePipe
   ],
   standalone: true
 })


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31896

* ExceptionInfo now includes failureLabels
* Exception History tab on JobExceptions page now exposes failure labels
![Screen Shot 2023-11-30 at 8 35 43 PM](https://github.com/apache/flink/assets/2953485/02139cc5-38bb-4021-986d-f7501a06e7d7)
![Screen Shot 2023-11-30 at 8 35 24 PM](https://github.com/apache/flink/assets/2953485/c1d89b20-fa05-467b-8fba-749c5da3480b)

