### PR TITLE
[FLINK-31640][network] Write the accumulated buffers to the right storage tier

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
@@ -80,7 +80,12 @@ public class TieredStorageProducerClient {
 
         if (isBroadcast && !isBroadcastOnly) {
             for (int i = 0; i < numSubpartitions; ++i) {
-                bufferAccumulator.receive(record.duplicate(), subpartitionId, dataType);
+                // As the tiered storage subpartition ID is created only for broadcast records,
+                // which are fewer than normal records, the performance impact of generating new
+                // TieredStorageSubpartitionId objects is expected to be manageable. If the
+                // performance is significantly affected, this logic will be optimized accordingly.
+                bufferAccumulator.receive(
+                        record.duplicate(), new TieredStorageSubpartitionId(i), dataType);
             }
         } else {
             bufferAccumulator.receive(record, subpartitionId, dataType);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClient.java
@@ -28,10 +28,17 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Client of the Tiered Storage used by the producer. */
 public class TieredStorageProducerClient {
+
     private final boolean isBroadcastOnly;
 
     private final int numSubpartitions;
@@ -40,7 +47,23 @@ public class TieredStorageProducerClient {
 
     private final BufferCompressor bufferCompressor;
 
+    /**
+     * Note that the {@link TierProducerAgent}s are sorted by priority, with a lower index
+     * indicating a higher priority.
+     */
     private final List<TierProducerAgent> tierProducerAgents;
+
+    /** The current writing segment index for each subpartition. */
+    private final int[] currentSubpartitionSegmentId;
+
+    /** The current writing storage tier for each subpartition. */
+    private final TierProducerAgent[] currentSubpartitionTierAgent;
+
+    /**
+     * The metric statistics for producer client. Note that it is necessary to check whether the
+     * value is null before used.
+     */
+    @Nullable private Consumer<TieredStorageProducerMetricUpdate> metricStatisticsUpdater;
 
     public TieredStorageProducerClient(
             int numSubpartitions,
@@ -53,6 +76,10 @@ public class TieredStorageProducerClient {
         this.bufferAccumulator = bufferAccumulator;
         this.bufferCompressor = bufferCompressor;
         this.tierProducerAgents = tierProducerAgents;
+        this.currentSubpartitionSegmentId = new int[numSubpartitions];
+        this.currentSubpartitionTierAgent = new TierProducerAgent[numSubpartitions];
+
+        Arrays.fill(currentSubpartitionSegmentId, -1);
 
         bufferAccumulator.setup(this::writeAccumulatedBuffers);
     }
@@ -92,6 +119,11 @@ public class TieredStorageProducerClient {
         }
     }
 
+    public void setMetricStatisticsUpdater(
+            Consumer<TieredStorageProducerMetricUpdate> metricStatisticsUpdater) {
+        this.metricStatisticsUpdater = checkNotNull(metricStatisticsUpdater);
+    }
+
     public void close() {
         bufferAccumulator.close();
         tierProducerAgents.forEach(TierProducerAgent::close);
@@ -105,18 +137,33 @@ public class TieredStorageProducerClient {
      */
     private void writeAccumulatedBuffers(
             TieredStorageSubpartitionId subpartitionId, List<Buffer> accumulatedBuffers) {
-        try {
-            for (Buffer finishedBuffer : accumulatedBuffers) {
-                writeAccumulatedBuffer(subpartitionId, finishedBuffer);
+        Iterator<Buffer> bufferIterator = accumulatedBuffers.iterator();
+
+        int numWriteBytes = 0;
+        int numWriteBuffers = 0;
+        while (bufferIterator.hasNext()) {
+            Buffer buffer = bufferIterator.next();
+            numWriteBuffers++;
+            numWriteBytes += buffer.readableBytes();
+            try {
+                writeAccumulatedBuffer(subpartitionId, buffer);
+            } catch (IOException ioe) {
+                buffer.recycleBuffer();
+                while (bufferIterator.hasNext()) {
+                    bufferIterator.next().recycleBuffer();
+                }
+                ExceptionUtils.rethrow(ioe);
             }
-        } catch (IOException e) {
-            ExceptionUtils.rethrow(e);
         }
+        updateMetricStatistics(numWriteBuffers, numWriteBytes);
     }
 
     /**
      * Write the accumulated buffer of this subpartitionId to an appropriate tier. After the tier is
      * decided, the buffer will be written to the selected tier.
+     *
+     * <p>Note that the method only throws an exception when choosing a storage tier, so the caller
+     * should ensure that the buffer is recycled when throwing an exception.
      *
      * @param subpartitionId the subpartition identifier
      * @param accumulatedBuffer one accumulated buffer of this subpartition
@@ -124,7 +171,59 @@ public class TieredStorageProducerClient {
     private void writeAccumulatedBuffer(
             TieredStorageSubpartitionId subpartitionId, Buffer accumulatedBuffer)
             throws IOException {
-        // TODO, Try to write the accumulated buffer to the appropriate tier. After the tier is
-        // decided, then write the accumulated buffer to the tier.
+        Buffer compressedBuffer = compressBufferIfPossible(accumulatedBuffer);
+
+        if (currentSubpartitionTierAgent[subpartitionId.getSubpartitionId()] == null) {
+            chooseStorageTierToStartSegment(subpartitionId);
+        }
+
+        if (!currentSubpartitionTierAgent[subpartitionId.getSubpartitionId()].tryWrite(
+                subpartitionId, compressedBuffer)) {
+            chooseStorageTierToStartSegment(subpartitionId);
+            checkState(
+                    currentSubpartitionTierAgent[subpartitionId.getSubpartitionId()].tryWrite(
+                            subpartitionId, compressedBuffer),
+                    "Failed to write the first buffer to the new segment");
+        }
+    }
+
+    private void chooseStorageTierToStartSegment(TieredStorageSubpartitionId subpartitionId)
+            throws IOException {
+        int subpartitionIndex = subpartitionId.getSubpartitionId();
+        int segmentIndex = currentSubpartitionSegmentId[subpartitionIndex];
+        int nextSegmentIndex = segmentIndex + 1;
+
+        for (TierProducerAgent tierProducerAgent : tierProducerAgents) {
+            if (tierProducerAgent.tryStartNewSegment(subpartitionId, nextSegmentIndex)) {
+                // Update the segment index and the chosen storage tier for the subpartition.
+                currentSubpartitionSegmentId[subpartitionIndex] = nextSegmentIndex;
+                currentSubpartitionTierAgent[subpartitionIndex] = tierProducerAgent;
+                return;
+            }
+        }
+        throw new IOException("Failed to choose a storage tier to start a new segment.");
+    }
+
+    private Buffer compressBufferIfPossible(Buffer buffer) {
+        if (!canBeCompressed(buffer)) {
+            return buffer;
+        }
+
+        return checkNotNull(bufferCompressor).compressToOriginalBuffer(buffer);
+    }
+
+    /**
+     * Whether the buffer can be compressed or not. Note that event is not compressed because it is
+     * usually small and the size can become even larger after compression.
+     */
+    private boolean canBeCompressed(Buffer buffer) {
+        return bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
+    }
+
+    private void updateMetricStatistics(int numWriteBuffersDelta, int numWriteBytesDelta) {
+        checkNotNull(metricStatisticsUpdater)
+                .accept(
+                        new TieredStorageProducerMetricUpdate(
+                                numWriteBuffersDelta, numWriteBytesDelta));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerMetricUpdate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerMetricUpdate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+/** The metric statistics for the tiered storage producer. */
+public class TieredStorageProducerMetricUpdate {
+
+    private final int numWriteBuffersDelta;
+
+    private final int numWriteBytesDelta;
+
+    TieredStorageProducerMetricUpdate(int numWriteBuffersDelta, int numWriteBytesDelta) {
+        this.numWriteBuffersDelta = numWriteBuffersDelta;
+        this.numWriteBytesDelta = numWriteBytesDelta;
+    }
+
+    public int numWriteBuffersDelta() {
+        return numWriteBuffersDelta;
+    }
+
+    public int numWriteBytesDelta() {
+        return numWriteBytesDelta;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingBufferAccumulator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingBufferAccumulator.java
@@ -18,25 +18,44 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered;
 
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.BufferAccumulator;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
 /** Test implementation for {@link BufferAccumulator}. */
 public class TestingBufferAccumulator implements BufferAccumulator {
 
+    private BiConsumer<TieredStorageSubpartitionId, List<Buffer>> bufferFlusher;
+
     @Override
-    public void setup(BiConsumer<TieredStorageSubpartitionId, List<Buffer>> bufferFlusher) {}
+    public void setup(BiConsumer<TieredStorageSubpartitionId, List<Buffer>> bufferFlusher) {
+        this.bufferFlusher = bufferFlusher;
+    }
 
     @Override
     public void receive(
             ByteBuffer record, TieredStorageSubpartitionId subpartitionId, Buffer.DataType dataType)
-            throws IOException {}
+            throws IOException {
+        MemorySegment recordData = MemorySegmentFactory.wrap(record.array());
+        bufferFlusher.accept(
+                subpartitionId,
+                Collections.singletonList(
+                        new NetworkBuffer(
+                                recordData,
+                                FreeingBufferRecycler.INSTANCE,
+                                dataType,
+                                recordData.size())));
+    }
 
     @Override
     public void close() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingTierProducerAgent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TestingTierProducerAgent.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+import java.util.function.BiFunction;
+
+/** Test implementation for {@link TierProducerAgent}. */
+public class TestingTierProducerAgent implements TierProducerAgent {
+
+    private final BiFunction<TieredStorageSubpartitionId, Integer, Boolean>
+            tryStartNewSegmentSupplier;
+
+    private final BiFunction<TieredStorageSubpartitionId, Buffer, Boolean> tryWriterFunction;
+
+    private final Runnable closeRunnable;
+
+    private TestingTierProducerAgent(
+            BiFunction<TieredStorageSubpartitionId, Integer, Boolean> tryStartNewSegmentSupplier,
+            BiFunction<TieredStorageSubpartitionId, Buffer, Boolean> tryWriterFunction,
+            Runnable closeRunnable) {
+        this.tryStartNewSegmentSupplier = tryStartNewSegmentSupplier;
+        this.tryWriterFunction = tryWriterFunction;
+        this.closeRunnable = closeRunnable;
+    }
+
+    public static TestingTierProducerAgent.Builder builder() {
+        return new TestingTierProducerAgent.Builder();
+    }
+
+    @Override
+    public boolean tryStartNewSegment(TieredStorageSubpartitionId subpartitionId, int segmentId) {
+        return tryStartNewSegmentSupplier.apply(subpartitionId, segmentId);
+    }
+
+    @Override
+    public boolean tryWrite(TieredStorageSubpartitionId subpartitionId, Buffer finishedBuffer) {
+        return tryWriterFunction.apply(subpartitionId, finishedBuffer);
+    }
+
+    @Override
+    public void close() {
+        closeRunnable.run();
+    }
+
+    /** Builder for {@link TierProducerAgent}. */
+    public static class Builder {
+        private BiFunction<TieredStorageSubpartitionId, Integer, Boolean> tryStartSegmentSupplier =
+                (subpartitionId, integer) -> true;
+
+        private BiFunction<TieredStorageSubpartitionId, Buffer, Boolean> tryWriterFunction =
+                (subpartitionId, buffer) -> true;
+
+        private Runnable closeRunnable = () -> {};
+
+        public Builder() {}
+
+        public TestingTierProducerAgent.Builder setTryStartSegmentSupplier(
+                BiFunction<TieredStorageSubpartitionId, Integer, Boolean> tryStartSegmentSupplier) {
+            this.tryStartSegmentSupplier = tryStartSegmentSupplier;
+            return this;
+        }
+
+        public TestingTierProducerAgent.Builder setTryWriterFunction(
+                BiFunction<TieredStorageSubpartitionId, Buffer, Boolean> tryWriterFunction) {
+            this.tryWriterFunction = tryWriterFunction;
+            return this;
+        }
+
+        public TestingTierProducerAgent.Builder setCloseRunnable(Runnable closeRunnable) {
+            this.closeRunnable = closeRunnable;
+            return this;
+        }
+
+        public TestingTierProducerAgent build() {
+            return new TestingTierProducerAgent(
+                    tryStartSegmentSupplier, tryWriterFunction, closeRunnable);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TieredStorageTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/TieredStorageTestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+/** Test utils for the tiered storage. */
+public class TieredStorageTestUtils {
+
+    public static ByteBuffer generateRandomData(int dataSize, Random random) {
+        byte[] dataWritten = new byte[dataSize];
+        random.nextBytes(dataWritten);
+        return ByteBuffer.wrap(dataWritten);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingBufferAccumulator;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingTierProducerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageProducerClient;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
@@ -45,7 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -189,6 +190,7 @@ class TieredResultPartitionTest {
     private TieredResultPartition createTieredStoreResultPartition(
             int numSubpartitions, BufferPool bufferPool, boolean isBroadcastOnly)
             throws IOException {
+        TestingTierProducerAgent tierProducerAgent = new TestingTierProducerAgent.Builder().build();
         TieredResultPartition tieredResultPartition =
                 new TieredResultPartition(
                         "TieredStoreResultPartitionTest",
@@ -205,7 +207,7 @@ class TieredResultPartitionTest {
                                 isBroadcastOnly,
                                 new TestingBufferAccumulator(),
                                 null,
-                                new ArrayList<>()),
+                                Collections.singletonList(tierProducerAgent)),
                         new TieredStorageResourceRegistry());
         taskIOMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/HashBufferAccumulatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/HashBufferAccumulatorTest.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.TieredStorageTestUtils.generateRandomData;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -160,11 +161,5 @@ class HashBufferAccumulatorTest {
         storageMemoryManager.setup(
                 bufferPool, Collections.singletonList(new TieredStorageMemorySpec(this, 1)));
         return storageMemoryManager;
-    }
-
-    private static ByteBuffer generateRandomData(int dataSize, Random random) {
-        byte[] dataWritten = new byte[dataSize];
-        random.nextBytes(dataWritten);
-        return ByteBuffer.wrap(dataWritten);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageProducerClientTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingBufferAccumulator;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingTierProducerAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.TieredStorageTestUtils.generateRandomData;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+/** Tests for {@link TieredStorageProducerClient}. */
+@ExtendWith(ParameterizedTestExtension.class)
+public class TieredStorageProducerClientTest {
+
+    private static final int NUM_TOTAL_BUFFERS = 1000;
+
+    private static final int NETWORK_BUFFER_SIZE = 1024;
+
+    @Parameter public boolean isBroadcast;
+
+    private NetworkBufferPool globalPool;
+
+    @Parameters(name = "isBroadcast={0}")
+    public static Collection<Boolean> parameters() {
+        return Arrays.asList(false, true);
+    }
+
+    @BeforeEach
+    void before() {
+        globalPool = new NetworkBufferPool(NUM_TOTAL_BUFFERS, NETWORK_BUFFER_SIZE);
+    }
+
+    @AfterEach
+    void after() {
+        globalPool.destroy();
+    }
+
+    @TestTemplate
+    void testWriteRecordsToEmptyStorageTiers() {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        Random random = new Random();
+
+        TieredStorageProducerClient tieredStorageProducerClient =
+                createTieredStorageProducerClient(numSubpartitions, Collections.emptyList());
+        assertThatThrownBy(
+                        () ->
+                                tieredStorageProducerClient.write(
+                                        generateRandomData(bufferSize, random),
+                                        new TieredStorageSubpartitionId(0),
+                                        Buffer.DataType.DATA_BUFFER,
+                                        isBroadcast))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to choose a storage tier");
+    }
+
+    @TestTemplate
+    void testWriteRecords() throws IOException {
+        int numSubpartitions = 10;
+        int numToWriteRecords = 20;
+        int bufferSize = 1024;
+        Random random = new Random();
+
+        AtomicInteger numReceivedBuffers = new AtomicInteger(0);
+        AtomicInteger numReceivedBytes = new AtomicInteger(0);
+        AtomicInteger numReceivedBuffersInTier1 = new AtomicInteger(0);
+        AtomicInteger numReceivedBuffersInTier2 = new AtomicInteger(0);
+
+        TestingTierProducerAgent tierProducerAgent1 =
+                new TestingTierProducerAgent.Builder()
+                        .setTryStartSegmentSupplier(
+                                ((subpartitionId, integer) -> numReceivedBuffersInTier1.get() < 1))
+                        .setTryWriterFunction(
+                                ((subpartitionId, buffer) -> {
+                                    boolean isSuccess = numReceivedBuffersInTier1.get() % 2 == 0;
+                                    if (isSuccess) {
+                                        numReceivedBuffers.incrementAndGet();
+                                        numReceivedBuffersInTier1.incrementAndGet();
+                                        numReceivedBytes.set(
+                                                numReceivedBytes.get() + buffer.readableBytes());
+                                    }
+                                    return isSuccess;
+                                }))
+                        .build();
+        TestingTierProducerAgent tierProducerAgent2 =
+                new TestingTierProducerAgent.Builder()
+                        .setTryWriterFunction(
+                                ((subpartitionId, buffer) -> {
+                                    numReceivedBuffers.incrementAndGet();
+                                    numReceivedBuffersInTier2.incrementAndGet();
+                                    numReceivedBytes.set(
+                                            numReceivedBytes.get() + buffer.readableBytes());
+                                    return true;
+                                }))
+                        .build();
+        List<TierProducerAgent> tierProducerAgents = new ArrayList<>();
+        tierProducerAgents.add(tierProducerAgent1);
+        tierProducerAgents.add(tierProducerAgent2);
+
+        TieredStorageProducerClient tieredStorageProducerClient =
+                createTieredStorageProducerClient(numSubpartitions, tierProducerAgents);
+        TieredStorageSubpartitionId subpartitionId = new TieredStorageSubpartitionId(0);
+
+        for (int i = 0; i < numToWriteRecords; i++) {
+            tieredStorageProducerClient.write(
+                    generateRandomData(bufferSize, random),
+                    subpartitionId,
+                    Buffer.DataType.DATA_BUFFER,
+                    isBroadcast);
+        }
+
+        int numExpectedBytes =
+                isBroadcast
+                        ? numSubpartitions * numToWriteRecords * bufferSize
+                        : numToWriteRecords * bufferSize;
+        assertThat(numReceivedBuffersInTier1.get()).isEqualTo(1);
+        assertThat(numReceivedBuffers.get())
+                .isEqualTo(numReceivedBuffersInTier1.get() + numReceivedBuffersInTier2.get());
+        assertThat(numReceivedBytes.get()).isEqualTo(numExpectedBytes);
+    }
+
+    @TestTemplate
+    void testTierCanNotStartNewSegment() {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        Random random = new Random();
+
+        TestingTierProducerAgent tierProducerAgent =
+                new TestingTierProducerAgent.Builder()
+                        .setTryStartSegmentSupplier(((subpartitionId, integer) -> false))
+                        .build();
+        TieredStorageProducerClient tieredStorageProducerClient =
+                createTieredStorageProducerClient(
+                        numSubpartitions, Collections.singletonList(tierProducerAgent));
+
+        assertThatThrownBy(
+                        () ->
+                                tieredStorageProducerClient.write(
+                                        generateRandomData(bufferSize, random),
+                                        new TieredStorageSubpartitionId(0),
+                                        Buffer.DataType.DATA_BUFFER,
+                                        isBroadcast))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to choose a storage tier");
+    }
+
+    @TestTemplate
+    void testUpdateMetrics() throws IOException {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        Random random = new Random();
+
+        TestingTierProducerAgent tierProducerAgent = new TestingTierProducerAgent.Builder().build();
+        TieredStorageProducerClient tieredStorageProducerClient =
+                new TieredStorageProducerClient(
+                        numSubpartitions,
+                        false,
+                        new TestingBufferAccumulator(),
+                        null,
+                        Collections.singletonList(tierProducerAgent));
+
+        AtomicInteger numWriteBuffers = new AtomicInteger(0);
+        AtomicInteger numWriteBytes = new AtomicInteger(0);
+        tieredStorageProducerClient.setMetricStatisticsUpdater(
+                metricStatistics -> {
+                    numWriteBuffers.set(
+                            numWriteBuffers.get() + metricStatistics.numWriteBuffersDelta());
+                    numWriteBytes.set(numWriteBytes.get() + metricStatistics.numWriteBytesDelta());
+                });
+
+        tieredStorageProducerClient.write(
+                generateRandomData(bufferSize, random),
+                new TieredStorageSubpartitionId(0),
+                Buffer.DataType.DATA_BUFFER,
+                isBroadcast);
+
+        int numExpectedBuffers = isBroadcast ? numSubpartitions : 1;
+        int numExpectedBytes = isBroadcast ? bufferSize * numSubpartitions : bufferSize;
+        assertThat(numWriteBuffers.get()).isEqualTo(numExpectedBuffers);
+        assertThat(numWriteBytes.get()).isEqualTo(numExpectedBytes);
+    }
+
+    @TestTemplate
+    void testClose() {
+        int numSubpartitions = 10;
+
+        AtomicBoolean isClosed = new AtomicBoolean(false);
+        TestingTierProducerAgent tierProducerAgent =
+                new TestingTierProducerAgent.Builder()
+                        .setCloseRunnable(() -> isClosed.set(true))
+                        .build();
+
+        TieredStorageProducerClient tieredStorageProducerClient =
+                createTieredStorageProducerClient(
+                        numSubpartitions, Collections.singletonList(tierProducerAgent));
+
+        assertThat(isClosed.get()).isFalse();
+        tieredStorageProducerClient.close();
+        assertThat(isClosed.get()).isTrue();
+    }
+
+    private static TieredStorageProducerClient createTieredStorageProducerClient(
+            int numSubpartitions, List<TierProducerAgent> tierProducerAgents) {
+        TieredStorageProducerClient tieredStorageProducerClient =
+                new TieredStorageProducerClient(
+                        numSubpartitions,
+                        false,
+                        new TestingBufferAccumulator(),
+                        null,
+                        tierProducerAgents);
+        tieredStorageProducerClient.setMetricStatisticsUpdater(metricStatistics -> {});
+        return tieredStorageProducerClient;
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

1. Write the accumulated buffers to the right storage tier


## Brief change log

  - * Firstly choose the storage tier, then write the accumulated buffers to the right storage tier.*


## Verifying this change

  - *Added the test of `TieredStorageProducerClientTest` to verify the logic of choosing storage tiers.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
