### PR TITLE
[FLINK-32179][tests] Harden FileUtils#findFlinkDist against custom repo names

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -254,7 +254,7 @@ function run_group_2 {
     e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"
 
     PROFILE="$PROFILE -Prun-end-to-end-tests"
-    run_mvn ${MVN_COMMON_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} verify -pl ${e2e_modules} -DdistDir=$(readlink -e build-target) -Dcache-dir=$E2E_CACHE_FOLDER -Dcache-download-attempt-timeout=4min -Dcache-download-global-timeout=10min
+    run_mvn ${MVN_COMMON_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} verify -pl ${e2e_modules} -Dcache-dir=$E2E_CACHE_FOLDER -Dcache-download-attempt-timeout=4min -Dcache-download-global-timeout=10min
 
     EXIT_CODE=$?
 }

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/FileUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/FileUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileUtilsTest {
+    @Test
+    void testFindProjectRootDirectory(@TempDir Path tmp) throws IOException {
+        final Path expectedProjectRoot = tmp.resolve("odd_root");
+        // seeing this as a contained directory is the successful exit condition
+        Files.createDirectories(expectedProjectRoot.resolve("flink-dist"));
+
+        assertThat(FileUtils.findProjectRootDirectory(expectedProjectRoot))
+                .contains(expectedProjectRoot);
+
+        final Path someModule =
+                Files.createDirectories(expectedProjectRoot.resolve("flink-some-module"));
+        assertThat(FileUtils.findProjectRootDirectory(someModule)).contains(expectedProjectRoot);
+    }
+}


### PR DESCRIPTION
We currently assume that Flink is checked out in a directory named "flink" or "flinkAndSomeSuffix", but this doesnt always hold. Focus more on module names because that's the bit we are certain of.