### PR TITLE
[BP-1.16][FLINK-32172][kafka] KafkaExampleUtils incorrect check of the minimum number of parameters

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/KafkaExampleUtil.java
@@ -27,7 +27,7 @@ public class KafkaExampleUtil {
     public static StreamExecutionEnvironment prepareExecutionEnv(ParameterTool parameterTool)
             throws Exception {
 
-        if (parameterTool.getNumberOfParameters() < 5) {
+        if (parameterTool.getNumberOfParameters() < 4) {
             System.out.println(
                     "Missing parameters!\n"
                             + "Usage: Kafka --input-topic <topic> --output-topic <topic> "


### PR DESCRIPTION
Backport FLINK-32172 to release-1.16.