### PR TITLE
[FLINK-32180][runtime] Moves error handling from DefaultMultipleComponentLeaderElectionService into the MultipleComponentLeaderElectionDriver implementations

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverFactory.java
@@ -39,25 +39,22 @@ public class KubernetesMultipleComponentLeaderElectionDriverFactory
 
     private final Executor watchExecutor;
 
-    private final FatalErrorHandler fatalErrorHandler;
-
     public KubernetesMultipleComponentLeaderElectionDriverFactory(
             FlinkKubeClient kubeClient,
             KubernetesLeaderElectionConfiguration kubernetesLeaderElectionConfiguration,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
-            Executor watchExecutor,
-            FatalErrorHandler fatalErrorHandler) {
+            Executor watchExecutor) {
         this.kubeClient = Preconditions.checkNotNull(kubeClient);
         this.kubernetesLeaderElectionConfiguration =
                 Preconditions.checkNotNull(kubernetesLeaderElectionConfiguration);
         this.configMapSharedWatcher = Preconditions.checkNotNull(configMapSharedWatcher);
         this.watchExecutor = Preconditions.checkNotNull(watchExecutor);
-        this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
     }
 
     @Override
     public KubernetesMultipleComponentLeaderElectionDriver create(
-            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener,
+            FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new KubernetesMultipleComponentLeaderElectionDriver(
                 kubernetesLeaderElectionConfiguration,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -128,8 +128,7 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
                                             kubeClient,
                                             leaderElectionConfiguration,
                                             configMapSharedWatcher,
-                                            watchExecutorService,
-                                            fatalErrorHandler));
+                                            watchExecutorService));
                 } catch (Exception e) {
                     throw new FlinkRuntimeException(
                             "Could not initialize the default single leader election service.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
@@ -42,18 +42,15 @@ public interface MultipleComponentLeaderElectionDriver {
      *
      * @param componentId identifying the component for which to publish the leader information
      * @param leaderInformation leader information of the respective component
-     * @throws Exception if publishing fails
      */
-    void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
-            throws Exception;
+    void publishLeaderInformation(String componentId, LeaderInformation leaderInformation);
 
     /**
      * Deletes the leader information for the given component.
      *
      * @param componentId identifying the component for which to delete the leader information
-     * @throws Exception if deleting fails
      */
-    void deleteLeaderInformation(String componentId) throws Exception;
+    void deleteLeaderInformation(String componentId);
 
     /**
      * Listener interface for state changes of the {@link MultipleComponentLeaderElectionDriver}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriverFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
 /** Factory for {@link MultipleComponentLeaderElectionDriver}. */
 public interface MultipleComponentLeaderElectionDriverFactory {
 
@@ -27,9 +29,12 @@ public interface MultipleComponentLeaderElectionDriverFactory {
      *
      * @param leaderElectionListener listener for the callbacks of the {@link
      *     MultipleComponentLeaderElectionDriver}
+     * @param fatalErrorHandler component for handling fatal errors.
      * @return created {@link MultipleComponentLeaderElectionDriver} instance
      * @throws Exception if the creation fails
      */
     MultipleComponentLeaderElectionDriver create(
-            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener) throws Exception;
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener,
+            FatalErrorHandler fatalErrorHandler)
+            throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
@@ -35,9 +36,10 @@ public class ZooKeeperMultipleComponentLeaderElectionDriverFactory
 
     @Override
     public ZooKeeperMultipleComponentLeaderElectionDriver create(
-            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener,
+            FatalErrorHandler fatalErrorHandler)
             throws Exception {
         return new ZooKeeperMultipleComponentLeaderElectionDriver(
-                curatorFramework, leaderElectionListener);
+                curatorFramework, leaderElectionListener, fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingMultipleComponentLeaderElectionDriverFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
 /**
  * Testing implementation of {@link MultipleComponentLeaderElectionDriverFactory} that returns a
  * given {@link MultipleComponentLeaderElectionDriver}.
@@ -36,9 +38,11 @@ public class TestingMultipleComponentLeaderElectionDriverFactory
 
     @Override
     public MultipleComponentLeaderElectionDriver create(
-            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener)
+            MultipleComponentLeaderElectionDriver.Listener leaderElectionListener,
+            FatalErrorHandler fatalErrorHandler)
             throws Exception {
-        testingMultipleComponentLeaderElectionDriver.setListener(leaderElectionListener);
+        testingMultipleComponentLeaderElectionDriver.initializeDriver(
+                leaderElectionListener, fatalErrorHandler);
 
         return testingMultipleComponentLeaderElectionDriver;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -162,7 +162,8 @@ class ZooKeeperLeaderRetrievalTest {
                                                 testingFatalErrorHandlerResource
                                                         .getTestingFatalErrorHandler()),
                                         ZooKeeperUtils.generateLeaderLatchPath("")),
-                                new TestingLeaderElectionListener());
+                                new TestingLeaderElectionListener(),
+                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
                 externalProcessDriver.isLeader();
 
                 externalProcessDriver.publishLeaderInformation(


### PR DESCRIPTION
* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* https://github.com/apache/flink/pull/22390
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* === THIS PR === FLINK-32180
  * https://github.com/apache/flink/pull/22829
  * https://github.com/apache/flink/pull/22830
  * https://github.com/apache/flink/pull/22828
* https://github.com/apache/flink/pull/22661

## What is the purpose of the change

The error handling needs to be moved into the driver to allow errors that were reported to the 
k8s watcher to be forwarded to the `LeaderContender`'s error handling. This aligns with how the `LeaderElectionDriver` was used.

This step is necessary so that we can replace the `LeaderElectionDriver` within `DefaultLeaderElectionService` with the `MultipleComponentLeaderElectionDriver`.

## Brief change log

* Makes the `fatalErrorHandler` being a parameter of `MultipleComponentLeaderElectionDriverFactory.create`
* Moves `fatalErrorHandler` from `DefaultMultipleComponentLeaderElectionService` into the `MultipleComponentLeaderElectionDriver` implementations

## Verifying this change

* added a test in `handleFatalError` in `DefaultMultipleComponentLeaderElectionService`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable