### PR TITLE
[BP-1.16][FLINK-30844][runtime] Increased TASK_CANCELLATION_TIMEOUT for testInterruptibleSharedLockInInvokeAndCancel

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -938,7 +938,7 @@ public class TaskTest extends TestLogger {
 
         final Configuration config = new Configuration();
         config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
+        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 1000);
 
         final Task task =
                 createTaskBuilder()


### PR DESCRIPTION
This is a cherry-pick backport of https://github.com/apache/flink/pull/22354