### PR TITLE
disable setting client id prefix if client.id is set

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -451,14 +451,21 @@ public class KafkaSourceBuilder<OUT> {
                 "-1",
                 boundedness == Boundedness.BOUNDED);
 
-        // If the client id prefix is not set, reuse the consumer group id as the client id prefix,
+        // If the client id prefix is not set and client id is not set
+        // reuse the consumer group id as the client id prefix,
         // or generate a random string if consumer group id is not specified.
-        maybeOverride(
-                KafkaSourceOptions.CLIENT_ID_PREFIX.key(),
-                props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)
-                        ? props.getProperty(ConsumerConfig.GROUP_ID_CONFIG)
-                        : "KafkaSource-" + new Random().nextLong(),
-                false);
+        if (!props.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)) {
+            maybeOverride(
+                    KafkaSourceOptions.CLIENT_ID_PREFIX.key(),
+                    props.containsKey(ConsumerConfig.GROUP_ID_CONFIG)
+                            ? props.getProperty(ConsumerConfig.GROUP_ID_CONFIG)
+                            : "KafkaSource-" + new Random().nextLong(),
+                    false);
+        } else {
+            LOG.warn(
+                    "{} is set, {} will not be set which will affect kafka consumer metrics reporting",
+                    ConsumerConfig.CLIENT_ID_CONFIG, KafkaSourceOptions.CLIENT_ID_PREFIX);
+        }
     }
 
     private boolean maybeOverride(String key, String value, boolean override) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -36,6 +36,7 @@ import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
@@ -402,9 +403,19 @@ public class KafkaSourceEnumerator
     private AdminClient getKafkaAdminClient() {
         Properties adminClientProps = new Properties();
         deepCopyProperties(properties, adminClientProps);
+
         // set client id prefix
-        String clientIdPrefix =
-                adminClientProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
+        String clientIdPrefix;
+        if (adminClientProps.containsKey(KafkaSourceOptions.CLIENT_ID_PREFIX.key())) {
+            clientIdPrefix = adminClientProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
+        } else if (adminClientProps.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)) {
+            clientIdPrefix = adminClientProps.getProperty(ConsumerConfig.CLIENT_ID_CONFIG);
+        } else if (adminClientProps.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
+            clientIdPrefix = adminClientProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+        } else {
+            clientIdPrefix = "KafkaSource";
+        }
+
         adminClientProps.setProperty(
                 ConsumerConfig.CLIENT_ID_CONFIG, clientIdPrefix + "-enumerator-admin-client");
         return AdminClient.create(adminClientProps);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -84,7 +84,9 @@ public class KafkaPartitionSplitReader
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
         Properties consumerProps = new Properties();
         consumerProps.putAll(props);
-        consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+        if (props.containsKey(KafkaSourceOptions.CLIENT_ID_PREFIX.key())) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+        }
         this.consumer = new KafkaConsumer<>(consumerProps);
         this.stoppingOffsets = new HashMap<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);


### PR DESCRIPTION
What is the purpose of the change
Setting different client ids for the consumer makes it difficult to set kafka quotas for that consumer group. Disabling setting consumer id prefix on the expense of kafka consumer metrics won't be reported correctly.

Brief change log
Allows setting client.id on the kafka consumer level which will ignore client.id.prefix being and will print a warning.

Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

Manually verified the change a simple job and verified the client.id being set
Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
The S3 file system connector: (no )
Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not applicable)