### PR TITLE
[FLINK-32186][runtime-web] Support subtask stack auto-search when red…

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -95,6 +95,10 @@
                 mapOfSubtask.get(subtask['subtask'])['taskmanager-id'],
                 'thread-dump'
               ]"
+              [queryParams]="{
+                vertexName: selectedVertex.detail.name + ' (' + (subtask['subtask'] + 1) + '/'
+              }"
+              target="_blank"
             >
               Dump
             </a>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/thread-dump/task-manager-thread-dump.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/thread-dump/task-manager-thread-dump.component.html
@@ -21,6 +21,7 @@
   [nzLoading]="loading"
   [ngModel]="dump"
   [nzEditorOption]="editorOptions"
+  (nzEditorInitialized)="nzEditorInitialized($event)"
 ></nz-code-editor>
 <flink-addon-compact
   [downloadHref]="downloadUrl"

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/thread-dump/task-manager-thread-dump.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/thread-dump/task-manager-thread-dump.component.ts
@@ -30,8 +30,11 @@ import {
   TASK_MANAGER_MODULE_DEFAULT_CONFIG
 } from '@flink-runtime-web/pages/task-manager/task-manager.config';
 import { ConfigService, TaskManagerService } from '@flink-runtime-web/services';
+import { editor } from 'monaco-editor';
 import { NzCodeEditorModule } from 'ng-zorro-antd/code-editor';
 import { EditorOptions } from 'ng-zorro-antd/code-editor/typings';
+
+import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
 @Component({
   selector: 'flink-task-manager-thread-dump',
@@ -45,6 +48,7 @@ export class TaskManagerThreadDumpComponent implements OnInit, OnDestroy {
   public editorOptions: EditorOptions;
 
   public dump = '';
+  public vertexName = '';
   public loading = true;
   public taskManagerId: string;
   public downloadUrl = '';
@@ -66,12 +70,34 @@ export class TaskManagerThreadDumpComponent implements OnInit, OnDestroy {
     this.taskManagerId = this.activatedRoute.parent!.snapshot.params.taskManagerId;
     this.downloadUrl = `${this.configService.BASE_URL}/taskmanagers/${this.taskManagerId}/thread-dump`;
     this.downloadName = `taskmanager_${this.taskManagerId}_thread_dump`;
-    this.reload();
+    this.activatedRoute.queryParams.subscribe(params => {
+      this.vertexName = decodeURIComponent(params.vertexName);
+    });
   }
 
   public ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  public nzEditorInitialized(editor: IStandaloneCodeEditor): void {
+    if (this.vertexName !== undefined) {
+      editor.onDidChangeModelContent(_ => {
+        const model = editor.getModel();
+        // Note that legacy source will prefix with `Legacy Source Thread - `, we search it first.
+        let results = model!.findMatches(`"Legacy Source Thread - ${this.vertexName}`, false, false, true, null, false);
+        if (results.length == 0) {
+          results = model!.findMatches(`"${this.vertexName}`, false, false, true, null, false);
+        }
+        if (results.length > 0) {
+          editor.setSelection(results[0].range);
+          editor.getAction('actions.find').run();
+          editor.getAction('editor.action.nextMatchFindAction').run();
+        }
+      });
+    }
+    // loading thread dump after editor view ready
+    this.reload();
   }
 
   public reload(): void {


### PR DESCRIPTION
…irecting from subtask backpressure tab

## What is the purpose of the change

To further optimize the scenario of troubleshooting sub-task backpressure, when the user clicks the `Dump` button from the backpressure panel of the operator, it carries the operator name and **automatically** scrolls to the thread stack of the corresponding subtask.


## Brief change log

- Carrying the operator name in the URL when clicking the Dump button in the backpressure panel of the operator.
- Triggers the search automatically when the editor in the ThreadDump page is initialized.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
