### PR TITLE
[FLINK-29913] fix shared state be discarded by mistake when maxConcurrentCheckpoint>1

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -342,8 +343,8 @@ public abstract class MetadataV2V3SerializerBase {
 
             serializeStreamStateHandle(incrementalKeyedStateHandle.getMetaStateHandle(), dos);
 
-            serializeStreamStateHandleMap(incrementalKeyedStateHandle.getSharedState(), dos);
-            serializeStreamStateHandleMap(incrementalKeyedStateHandle.getPrivateState(), dos);
+            serializeHandleAndLocalPathList(incrementalKeyedStateHandle.getSharedState(), dos);
+            serializeHandleAndLocalPathList(incrementalKeyedStateHandle.getPrivateState(), dos);
 
             writeStateHandleId(incrementalKeyedStateHandle, dos);
         } else if (stateHandle instanceof ChangelogStateBackendHandle) {
@@ -553,10 +554,8 @@ public abstract class MetadataV2V3SerializerBase {
                 KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
 
         StreamStateHandle metaDataStateHandle = deserializeStreamStateHandle(dis, context);
-        Map<StateHandleID, StreamStateHandle> sharedStates =
-                deserializeStreamStateHandleMap(dis, context);
-        Map<StateHandleID, StreamStateHandle> privateStates =
-                deserializeStreamStateHandleMap(dis, context);
+        List<HandleAndLocalPath> sharedStates = deserializeHandleAndLocalPathList(dis, context);
+        List<HandleAndLocalPath> privateStates = deserializeHandleAndLocalPathList(dis, context);
 
         UUID uuid;
 
@@ -810,27 +809,26 @@ public abstract class MetadataV2V3SerializerBase {
         return new StateObjectCollection<>(result);
     }
 
-    private static void serializeStreamStateHandleMap(
-            Map<StateHandleID, StreamStateHandle> map, DataOutputStream dos) throws IOException {
+    private static void serializeHandleAndLocalPathList(
+            List<HandleAndLocalPath> list, DataOutputStream dos) throws IOException {
 
-        dos.writeInt(map.size());
-        for (Map.Entry<StateHandleID, StreamStateHandle> entry : map.entrySet()) {
-            dos.writeUTF(entry.getKey().toString());
-            serializeStreamStateHandle(entry.getValue(), dos);
+        dos.writeInt(list.size());
+        for (HandleAndLocalPath handleAndLocalPath : list) {
+            dos.writeUTF(handleAndLocalPath.getLocalPath());
+            serializeStreamStateHandle(handleAndLocalPath.getHandle(), dos);
         }
     }
 
-    private static Map<StateHandleID, StreamStateHandle> deserializeStreamStateHandleMap(
+    private static List<HandleAndLocalPath> deserializeHandleAndLocalPathList(
             DataInputStream dis, @Nullable DeserializationContext context) throws IOException {
 
         final int size = dis.readInt();
-        Map<StateHandleID, StreamStateHandle> result =
-                CollectionUtil.newHashMapWithExpectedSize(size);
+        List<HandleAndLocalPath> result = new ArrayList<>(size);
 
         for (int i = 0; i < size; ++i) {
-            StateHandleID stateHandleID = new StateHandleID(dis.readUTF());
+            String localPath = dis.readUTF();
             StreamStateHandle stateHandle = deserializeStreamStateHandle(dis, context);
-            result.put(stateHandleID, stateHandle);
+            result.add(HandleAndLocalPath.of(stateHandle, localPath));
         }
 
         return result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalKeyedStateHandle.java
@@ -20,8 +20,12 @@ package org.apache.flink.runtime.state;
 
 import javax.annotation.Nonnull;
 
-import java.util.Map;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Common interface to all incremental {@link KeyedStateHandle}. */
 public interface IncrementalKeyedStateHandle
@@ -32,9 +36,66 @@ public interface IncrementalKeyedStateHandle
     UUID getBackendIdentifier();
 
     /**
-     * Returns a set of ids of all registered shared states in the backend at the time this was
-     * created.
+     * Returns a list of all shared states and the corresponding localPath in the backend at the
+     * time this was created.
      */
     @Nonnull
-    Map<StateHandleID, StreamStateHandle> getSharedStateHandles();
+    List<HandleAndLocalPath> getSharedStateHandles();
+
+    /** A Holder of StreamStateHandle and the corresponding localPath. */
+    final class HandleAndLocalPath implements Serializable {
+
+        private static final long serialVersionUID = 7711754687567545052L;
+
+        StreamStateHandle handle;
+        final String localPath;
+
+        public static HandleAndLocalPath of(StreamStateHandle handle, String localPath) {
+            checkNotNull(handle, "streamStateHandle cannot be null");
+            checkNotNull(localPath, "localPath cannot be null");
+            return new HandleAndLocalPath(handle, localPath);
+        }
+
+        private HandleAndLocalPath(StreamStateHandle handle, String localPath) {
+            this.handle = handle;
+            this.localPath = localPath;
+        }
+
+        public StreamStateHandle getHandle() {
+            return this.handle;
+        }
+
+        public String getLocalPath() {
+            return this.localPath;
+        }
+
+        public long getStateSize() {
+            return this.handle.getStateSize();
+        }
+
+        /** Replace the StreamStateHandle with the registry returned one. */
+        public void replaceHandle(StreamStateHandle registryReturned) {
+            checkNotNull(registryReturned);
+            this.handle = registryReturned;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (!(o instanceof HandleAndLocalPath)) {
+                return false;
+            }
+
+            HandleAndLocalPath that = (HandleAndLocalPath) o;
+            return this.handle.equals(that.handle) && this.localPath.equals(that.localPath);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(handle, localPath);
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
@@ -23,8 +23,8 @@ import org.apache.flink.util.ExceptionUtils;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -46,8 +46,8 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle
     /** Handle to Flink's state meta data. */
     @Nonnull private final StreamStateHandle metaDataState;
 
-    /** Set with the ids of all shared state handles created by the checkpoint. */
-    @Nonnull private final Map<StateHandleID, StreamStateHandle> sharedStateHandleIDs;
+    /** All shared state handles and the corresponding localPath used by the checkpoint. */
+    @Nonnull private final List<HandleAndLocalPath> sharedState;
 
     public IncrementalLocalKeyedStateHandle(
             @Nonnull UUID backendIdentifier,
@@ -55,13 +55,13 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle
             @Nonnull DirectoryStateHandle directoryStateHandle,
             @Nonnull KeyGroupRange keyGroupRange,
             @Nonnull StreamStateHandle metaDataState,
-            @Nonnull Map<StateHandleID, StreamStateHandle> sharedStateHandleIDs) {
+            @Nonnull List<HandleAndLocalPath> sharedState) {
 
         super(directoryStateHandle, keyGroupRange);
         this.backendIdentifier = backendIdentifier;
         this.checkpointId = checkpointId;
         this.metaDataState = metaDataState;
-        this.sharedStateHandleIDs = new HashMap<>(sharedStateHandleIDs);
+        this.sharedState = new ArrayList<>(sharedState);
     }
 
     @Nonnull
@@ -93,8 +93,8 @@ public class IncrementalLocalKeyedStateHandle extends DirectoryKeyedStateHandle
 
     @Override
     @Nonnull
-    public Map<StateHandleID, StreamStateHandle> getSharedStateHandles() {
-        return sharedStateHandleIDs;
+    public List<HandleAndLocalPath> getSharedStateHandles() {
+        return sharedState;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
@@ -33,9 +33,11 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
 
     private static final long serialVersionUID = 1L;
 
+    private final PhysicalStateHandleID physicalID;
     private final long stateSize;
 
-    public PlaceholderStreamStateHandle(long stateSize) {
+    public PlaceholderStreamStateHandle(PhysicalStateHandleID physicalID, long stateSize) {
+        this.physicalID = physicalID;
         this.stateSize = stateSize;
     }
 
@@ -53,8 +55,7 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
 
     @Override
     public PhysicalStateHandleID getStreamStateHandleID() {
-        throw new UnsupportedOperationException(
-                "This is only a placeholder to be replaced by a real StreamStateHandle in the checkpoint coordinator.");
+        return physicalID;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.CheckpointBoundKeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupsSavepointStateHandle;
@@ -37,7 +38,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -175,18 +175,23 @@ public interface ChangelogStateBackendHandle
                 StreamStateHandle castMetaStateHandle =
                         restoreFileStateHandle(
                                 incrementalRemoteKeyedStateHandle.getMetaStateHandle());
-                Map<StateHandleID, StreamStateHandle> castSharedStates =
-                        incrementalRemoteKeyedStateHandle.getSharedState().entrySet().stream()
-                                .collect(
-                                        Collectors.toMap(
-                                                Map.Entry::getKey,
-                                                e -> restoreFileStateHandle(e.getValue())));
-                Map<StateHandleID, StreamStateHandle> castPrivateStates =
-                        incrementalRemoteKeyedStateHandle.getPrivateState().entrySet().stream()
-                                .collect(
-                                        Collectors.toMap(
-                                                Map.Entry::getKey,
-                                                e -> restoreFileStateHandle(e.getValue())));
+                List<HandleAndLocalPath> castSharedStates =
+                        incrementalRemoteKeyedStateHandle.getSharedState().stream()
+                                .map(
+                                        e ->
+                                                HandleAndLocalPath.of(
+                                                        restoreFileStateHandle(e.getHandle()),
+                                                        e.getLocalPath()))
+                                .collect(Collectors.toList());
+
+                List<HandleAndLocalPath> castPrivateStates =
+                        incrementalRemoteKeyedStateHandle.getPrivateState().stream()
+                                .map(
+                                        e ->
+                                                HandleAndLocalPath.of(
+                                                        restoreFileStateHandle(e.getHandle()),
+                                                        e.getLocalPath()))
+                                .collect(Collectors.toList());
 
                 return IncrementalRemoteKeyedStateHandle.restore(
                         incrementalRemoteKeyedStateHandle.getBackendIdentifier(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
+import org.apache.flink.runtime.state.DiscardRecordedStateObject;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -75,6 +76,7 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
@@ -137,7 +139,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -2942,13 +2943,15 @@ class CheckpointCoordinatorTest extends TestLogger {
                                                 streamStateHandle
                                                         instanceof PlaceholderStreamStateHandle)
                                         .isFalse();
-                                verify(streamStateHandle, never()).discardState();
+                                DiscardRecordedStateObject.verifyDiscard(
+                                        streamStateHandle, TernaryBoolean.FALSE);
                                 ++sharedHandleCount;
                             }
 
                             for (HandleAndLocalPath handleAndLocalPath :
                                     incrementalKeyedStateHandle.getPrivateState()) {
-                                verify(handleAndLocalPath.getHandle(), never()).discardState();
+                                DiscardRecordedStateObject.verifyDiscard(
+                                        handleAndLocalPath.getHandle(), TernaryBoolean.FALSE);
                             }
 
                             verify(incrementalKeyedStateHandle.getMetaStateHandle(), never())
@@ -2971,7 +2974,8 @@ class CheckpointCoordinatorTest extends TestLogger {
             // by CP1
             for (List<HandleAndLocalPath> cpList : sharedHandlesByCheckpoint) {
                 for (HandleAndLocalPath handleAndLocalPath : cpList) {
-                    verify(handleAndLocalPath.getHandle(), never()).discardState();
+                    DiscardRecordedStateObject.verifyDiscard(
+                            handleAndLocalPath.getHandle(), TernaryBoolean.FALSE);
                 }
             }
 
@@ -3030,14 +3034,19 @@ class CheckpointCoordinatorTest extends TestLogger {
             // references the state from CP1, so we expect they are not discarded.
             verifyDiscard(
                     sharedHandlesByCheckpoint,
-                    cpId -> restoreMode == RestoreMode.CLAIM && cpId == 0 ? times(1) : never());
+                    cpId ->
+                            restoreMode == RestoreMode.CLAIM && cpId == 0
+                                    ? TernaryBoolean.TRUE
+                                    : TernaryBoolean.FALSE);
 
             // discard CP2
             secondStore.removeOldestCheckpoint();
 
             // still expect shared state not to be discarded because it may be used in later
             // checkpoints
-            verifyDiscard(sharedHandlesByCheckpoint, cpId -> cpId == 1 ? never() : atLeast(0));
+            verifyDiscard(
+                    sharedHandlesByCheckpoint,
+                    cpId -> cpId == 1 ? TernaryBoolean.FALSE : TernaryBoolean.UNDEFINED);
         }
     }
 
@@ -4041,7 +4050,7 @@ class CheckpointCoordinatorTest extends TestLogger {
             List<HandleAndLocalPath> privateState = new ArrayList<>();
             privateState.add(
                     HandleAndLocalPath.of(
-                            spy(new ByteStreamStateHandle("private-1", new byte[] {'p'})),
+                            new TestingStreamStateHandle("private-1", new byte[] {'p'}),
                             "private-1"));
 
             List<HandleAndLocalPath> sharedState = new ArrayList<>();
@@ -4050,22 +4059,17 @@ class CheckpointCoordinatorTest extends TestLogger {
             if (cpSequenceNumber > 0) {
                 sharedState.add(
                         HandleAndLocalPath.of(
-                                spy(
-                                        new ByteStreamStateHandle(
-                                                "shared-"
-                                                        + (cpSequenceNumber - 1)
-                                                        + "-"
-                                                        + keyGroupRange,
-                                                new byte[] {'s'})),
+                                new TestingStreamStateHandle(
+                                        "shared-" + (cpSequenceNumber - 1) + "-" + keyGroupRange,
+                                        new byte[] {'s'}),
                                 "shared-" + (cpSequenceNumber - 1)));
             }
 
             sharedState.add(
                     HandleAndLocalPath.of(
-                            spy(
-                                    new ByteStreamStateHandle(
-                                            "shared-" + cpSequenceNumber + "-" + keyGroupRange,
-                                            new byte[] {'s'})),
+                            new TestingStreamStateHandle(
+                                    "shared-" + cpSequenceNumber + "-" + keyGroupRange,
+                                    new byte[] {'s'}),
                             "shared-" + cpSequenceNumber));
 
             IncrementalRemoteKeyedStateHandle managedState =
@@ -4203,14 +4207,13 @@ class CheckpointCoordinatorTest extends TestLogger {
 
     private static void verifyDiscard(
             List<List<HandleAndLocalPath>> sharedHandles,
-            Function<Integer, VerificationMode> checkpointVerify)
-            throws Exception {
+            Function<Integer, TernaryBoolean> checkpointVerify) {
         for (List<HandleAndLocalPath> cpList : sharedHandles) {
             for (HandleAndLocalPath handleAndLocalPath : cpList) {
                 String key = handleAndLocalPath.getLocalPath();
                 int checkpointID = Integer.parseInt(String.valueOf(key.charAt(key.length() - 1)));
-                VerificationMode verificationMode = checkpointVerify.apply(checkpointID);
-                verify(handleAndLocalPath.getHandle(), verificationMode).discardState();
+                DiscardRecordedStateObject.verifyDiscard(
+                        handleAndLocalPath.getHandle(), checkpointVerify.apply(checkpointID));
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -36,12 +36,14 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
+import org.apache.flink.runtime.state.TestingRelativeFileStateHandle;
+import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -293,10 +295,9 @@ public class CheckpointTestUtils {
     public static StreamStateHandle createDummyStreamStateHandle(
             Random rnd, @Nullable String basePath) {
         if (!isSavepoint(basePath)) {
-            return new ByteStreamStateHandle(
-                    String.valueOf(createRandomUUID(rnd)),
-                    String.valueOf(createRandomUUID(rnd))
-                            .getBytes(ConfigConstants.DEFAULT_CHARSET));
+            String stateId = String.valueOf(createRandomUUID(rnd));
+            byte[] stateContent = stateId.getBytes(StandardCharsets.UTF_8);
+            return new TestingStreamStateHandle(stateId, stateContent);
         } else {
             long stateSize = rnd.nextLong();
             if (stateSize <= 0) {
@@ -304,7 +305,7 @@ public class CheckpointTestUtils {
             }
             String relativePath = String.valueOf(createRandomUUID(rnd));
             Path statePath = new Path(basePath, relativePath);
-            return new RelativeFileStateHandle(statePath, relativePath, stateSize);
+            return new TestingRelativeFileStateHandle(statePath, relativePath, stateSize);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
@@ -34,7 +35,6 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -256,18 +256,18 @@ public class CheckpointTestUtils {
                 createRandomUUID(rnd),
                 new KeyGroupRange(1, 1),
                 checkpointId,
-                createRandomStateHandleMap(rnd),
-                createRandomStateHandleMap(rnd),
+                createRandomHandleAndLocalPathList(rnd),
+                createRandomHandleAndLocalPathList(rnd),
                 createDummyStreamStateHandle(rnd, null));
     }
 
-    public static Map<StateHandleID, StreamStateHandle> createRandomStateHandleMap(Random rnd) {
+    public static List<HandleAndLocalPath> createRandomHandleAndLocalPathList(Random rnd) {
         final int size = rnd.nextInt(4);
-        Map<StateHandleID, StreamStateHandle> result = new HashMap<>(size);
+        List<HandleAndLocalPath> result = new ArrayList<>(size);
         for (int i = 0; i < size; ++i) {
-            StateHandleID randomId = new StateHandleID(createRandomUUID(rnd).toString());
+            String localPath = createRandomUUID(rnd).toString();
             StreamStateHandle stateHandle = createDummyStreamStateHandle(rnd, null);
-            result.put(randomId, stateHandle);
+            result.add(HandleAndLocalPath.of(stateHandle, localPath));
         }
 
         return result;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -33,13 +33,13 @@ import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
@@ -48,14 +48,12 @@ import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
@@ -94,11 +92,11 @@ public class SchedulerUtilsTest extends TestLogger {
     @Test
     public void testSharedStateRegistration() throws Exception {
         UUID backendId = UUID.randomUUID();
-        StateHandleID key = new StateHandleID("k0");
+        String localPath = "k0";
         StreamStateHandle handle = new ByteStreamStateHandle("h0", new byte[] {1, 2, 3});
         CheckpointRecoveryFactory recoveryFactory =
                 buildRecoveryFactory(
-                        buildCheckpoint(buildIncrementalHandle(key, handle, backendId)));
+                        buildCheckpoint(buildIncrementalHandle(localPath, handle, backendId)));
 
         CompletedCheckpointStore checkpointStore =
                 SchedulerUtils.createCompletedCheckpointStore(
@@ -112,10 +110,20 @@ public class SchedulerUtilsTest extends TestLogger {
         SharedStateRegistry sharedStateRegistry = checkpointStore.getSharedStateRegistry();
 
         IncrementalRemoteKeyedStateHandle newHandle =
-                buildIncrementalHandle(key, new PlaceholderStreamStateHandle(1L), backendId);
+                buildIncrementalHandle(
+                        localPath,
+                        new PlaceholderStreamStateHandle(
+                                handle.getStreamStateHandleID(), handle.getStateSize()),
+                        backendId);
         newHandle.registerSharedStates(sharedStateRegistry, 1L);
 
-        assertSame(handle, newHandle.getSharedState().get(key));
+        assertSame(
+                handle,
+                newHandle.getSharedState().stream()
+                        .filter(e -> e.getLocalPath().equals(localPath))
+                        .findFirst()
+                        .get()
+                        .getHandle());
     }
 
     private CheckpointRecoveryFactory buildRecoveryFactory(CompletedCheckpoint checkpoint) {
@@ -160,16 +168,16 @@ public class SchedulerUtilsTest extends TestLogger {
     }
 
     private IncrementalRemoteKeyedStateHandle buildIncrementalHandle(
-            StateHandleID key, StreamStateHandle shared, UUID backendIdentifier) {
+            String localPath, StreamStateHandle shared, UUID backendIdentifier) {
         StreamStateHandle meta = new ByteStreamStateHandle("meta", new byte[] {1, 2, 3});
-        Map<StateHandleID, StreamStateHandle> sharedStateMap = new HashMap<>();
-        sharedStateMap.put(key, shared);
+        List<HandleAndLocalPath> sharedState = new ArrayList<>(1);
+        sharedState.add(HandleAndLocalPath.of(shared, localPath));
         return new IncrementalRemoteKeyedStateHandle(
                 backendIdentifier,
                 KeyGroupRange.EMPTY_KEY_GROUP_RANGE,
                 1,
-                sharedStateMap,
-                emptyMap(),
+                sharedState,
+                emptyList(),
                 meta);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/DiscardRecordedStateObject.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/DiscardRecordedStateObject.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.util.TernaryBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** A test mock of {@link StateObject} which need record itself whether been discarded. */
+public interface DiscardRecordedStateObject extends StateObject {
+
+    boolean isDisposed();
+
+    static void verifyDiscard(StateObject stateHandle, TernaryBoolean expected) {
+        if (stateHandle instanceof DiscardRecordedStateObject) {
+            DiscardRecordedStateObject testingHandle = (DiscardRecordedStateObject) stateHandle;
+            if (expected.getAsBoolean() != null) {
+                assertThat(testingHandle.isDisposed()).isEqualTo(expected.getAsBoolean());
+            }
+        } else {
+            throw new IllegalStateException("stateHandle must be DiscardRecordedStateObject !");
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -290,8 +290,8 @@ public class SharedStateRegistryTest {
                         UUID.randomUUID(),
                         KeyGroupRange.EMPTY_KEY_GROUP_RANGE,
                         1L,
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         new ByteStreamStateHandle("meta", new byte[1]),
                         1024L,
                         new StateHandleID(stateId));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingRelativeFileStateHandle.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingRelativeFileStateHandle.java
@@ -18,34 +18,24 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
 
-import java.util.UUID;
-
-/** A simple test mock for a {@link StreamStateHandle}. */
-public class TestingStreamStateHandle extends ByteStreamStateHandle
+public class TestingRelativeFileStateHandle extends RelativeFileStateHandle
         implements DiscardRecordedStateObject {
     private static final long serialVersionUID = 1L;
 
     private boolean disposed;
 
-    public TestingStreamStateHandle() {
-        super(UUID.randomUUID().toString(), new byte[0]);
+    public TestingRelativeFileStateHandle(Path path, String relativePath, long stateSize) {
+        super(path, relativePath, stateSize);
     }
-
-    public TestingStreamStateHandle(String handleName, byte[] data) {
-        super(handleName, data);
-    }
-
-    // ------------------------------------------------------------------------
 
     @Override
-    public void discardState() {
+    public void discardState() throws Exception {
         super.discardState();
-        disposed = true;
+        this.disposed = true;
     }
-
-    // ------------------------------------------------------------------------
 
     @Override
     public boolean isDisposed() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
@@ -38,16 +38,21 @@ import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend;
 import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackend.MockSnapshotSupplier;
 import org.apache.flink.runtime.state.ttl.mock.MockKeyedStateBackendBuilder;
 import org.apache.flink.state.changelog.ChangelogStateBackendTestUtils.DummyCheckpointingStorageAccess;
+import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationRunnable;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.RunnableFuture;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /** {@link ChangelogKeyedStateBackend} test. */
 @RunWith(Parameterized.class)
@@ -83,6 +88,57 @@ public class ChangelogKeyedStateBackendTest {
             changelog.close();
             changelog.dispose();
         }
+    }
+
+    @Test
+    public void testInitMaterialization() throws Exception {
+        MockKeyedStateBackend<Integer> delegatedBackend = createMock();
+        ChangelogKeyedStateBackend<Integer> backend = createChangelog(delegatedBackend);
+
+        try {
+            Optional<MaterializationRunnable> runnable;
+
+            appendMockStateChange(backend); // ensure there is non-materialized changelog
+
+            runnable = backend.initMaterialization();
+            // 1. should trigger first materialization
+            assertTrue("first materialization should be trigger.", runnable.isPresent());
+
+            appendMockStateChange(backend); // ensure there is non-materialized changelog
+
+            // 2. should not trigger new one until the previous one has been confirmed or failed
+            assertFalse(backend.initMaterialization().isPresent());
+
+            backend.handleMaterializationFailureOrCancellation(
+                    runnable.get().getMaterializationID(),
+                    runnable.get().getMaterializedTo(),
+                    null);
+            runnable = backend.initMaterialization();
+            // 3. should trigger new one after previous one failed
+            assertTrue(runnable.isPresent());
+
+            appendMockStateChange(backend); // ensure there is non-materialized changelog
+
+            // 4. should not trigger new one until the previous one has been confirmed or failed
+            assertFalse(backend.initMaterialization().isPresent());
+
+            backend.handleMaterializationResult(
+                    SnapshotResult.empty(),
+                    runnable.get().getMaterializationID(),
+                    runnable.get().getMaterializedTo());
+            checkpoint(backend, checkpointId).get().discardState();
+            backend.notifyCheckpointComplete(checkpointId);
+            // 5. should trigger new one after previous one has been confirmed
+            assertTrue(backend.initMaterialization().isPresent());
+        } finally {
+            backend.close();
+            backend.dispose();
+        }
+    }
+
+    private void appendMockStateChange(ChangelogKeyedStateBackend changelogKeyedBackend)
+            throws IOException {
+        changelogKeyedBackend.getChangelogWriter().append(0, new byte[] {'s'});
     }
 
     private MockKeyedStateBackend<Integer> createMock() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -38,14 +38,13 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.BackendBuildingException;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
@@ -306,8 +305,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
         try {
             // Variables for snapshot strategy when incremental checkpoint is enabled
             UUID backendUID = UUID.randomUUID();
-            SortedMap<Long, Map<StateHandleID, StreamStateHandle>> materializedSstFiles =
-                    new TreeMap<>();
+            SortedMap<Long, Collection<HandleAndLocalPath>> materializedSstFiles = new TreeMap<>();
             long lastCompletedCheckpointId = -1L;
             if (injectedTestDB != null) {
                 db = injectedTestDB;
@@ -525,7 +523,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
             int keyGroupPrefixBytes,
             RocksDB db,
             UUID backendUID,
-            SortedMap<Long, Map<StateHandleID, StreamStateHandle>> materializedSstFiles,
+            SortedMap<Long, Collection<HandleAndLocalPath>> materializedSstFiles,
             long lastCompletedCheckpointId) {
         RocksDBSnapshotStrategyBase<K, ?> checkpointSnapshotStrategy;
         RocksDBStateUploader stateUploader =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
@@ -19,7 +19,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -105,21 +104,19 @@ public class RocksDBStateDownloader extends RocksDBStateDataTransfer {
                                 // Take all files from shared and private state.
                                 Streams.concat(
                                                 downloadRequest.getStateHandle().getSharedState()
-                                                        .entrySet().stream(),
+                                                        .stream(),
                                                 downloadRequest.getStateHandle().getPrivateState()
-                                                        .entrySet().stream())
+                                                        .stream())
                                         .map(
                                                 // Create one runnable for each StreamStateHandle
                                                 entry -> {
-                                                    StateHandleID stateHandleID = entry.getKey();
+                                                    String localPath = entry.getLocalPath();
                                                     StreamStateHandle remoteFileHandle =
-                                                            entry.getValue();
+                                                            entry.getHandle();
                                                     Path downloadDest =
                                                             downloadRequest
                                                                     .getDownloadDestination()
-                                                                    .resolve(
-                                                                            stateHandleID
-                                                                                    .toString());
+                                                                    .resolve(localPath);
                                                     return ThrowingRunnable.unchecked(
                                                             () ->
                                                                     downloadDataForStateHandle(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
@@ -22,10 +22,9 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
-import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -38,11 +37,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /** Help class for uploading RocksDB state files. */
 public class RocksDBStateUploader extends RocksDBStateDataTransfer {
@@ -60,17 +59,15 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
      * @param stateScope
      * @throws Exception Thrown if can not upload all the files.
      */
-    public Map<StateHandleID, StreamStateHandle> uploadFilesToCheckpointFs(
-            @Nonnull Map<StateHandleID, Path> files,
+    public List<HandleAndLocalPath> uploadFilesToCheckpointFs(
+            @Nonnull List<Path> files,
             CheckpointStreamFactory checkpointStreamFactory,
             CheckpointedStateScope stateScope,
             CloseableRegistry closeableRegistry,
             CloseableRegistry tmpResourcesRegistry)
             throws Exception {
 
-        Map<StateHandleID, StreamStateHandle> handles = new HashMap<>();
-
-        Map<StateHandleID, CompletableFuture<StreamStateHandle>> futures =
+        List<CompletableFuture<HandleAndLocalPath>> futures =
                 createUploadFutures(
                         files,
                         checkpointStreamFactory,
@@ -78,12 +75,13 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
                         closeableRegistry,
                         tmpResourcesRegistry);
 
-        try {
-            FutureUtils.waitForAll(futures.values()).get();
+        List<HandleAndLocalPath> handles = new ArrayList<>(files.size());
 
-            for (Map.Entry<StateHandleID, CompletableFuture<StreamStateHandle>> entry :
-                    futures.entrySet()) {
-                handles.put(entry.getKey(), entry.getValue().get());
+        try {
+            FutureUtils.waitForAll(futures).get();
+
+            for (CompletableFuture<HandleAndLocalPath> future : futures) {
+                handles.add(future.get());
             }
         } catch (ExecutionException e) {
             Throwable throwable = ExceptionUtils.stripExecutionException(e);
@@ -98,32 +96,29 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
         return handles;
     }
 
-    private Map<StateHandleID, CompletableFuture<StreamStateHandle>> createUploadFutures(
-            Map<StateHandleID, Path> files,
+    private List<CompletableFuture<HandleAndLocalPath>> createUploadFutures(
+            List<Path> files,
             CheckpointStreamFactory checkpointStreamFactory,
             CheckpointedStateScope stateScope,
             CloseableRegistry closeableRegistry,
             CloseableRegistry tmpResourcesRegistry) {
-        Map<StateHandleID, CompletableFuture<StreamStateHandle>> futures =
-                CollectionUtil.newHashMapWithExpectedSize(files.size());
-
-        for (Map.Entry<StateHandleID, Path> entry : files.entrySet()) {
-            final Supplier<StreamStateHandle> supplier =
-                    CheckedSupplier.unchecked(
-                            () ->
-                                    uploadLocalFileToCheckpointFs(
-                                            entry.getValue(),
-                                            checkpointStreamFactory,
-                                            stateScope,
-                                            closeableRegistry,
-                                            tmpResourcesRegistry));
-            futures.put(entry.getKey(), CompletableFuture.supplyAsync(supplier, executorService));
-        }
-
-        return futures;
+        return files.stream()
+                .map(
+                        e ->
+                                CompletableFuture.supplyAsync(
+                                        CheckedSupplier.unchecked(
+                                                () ->
+                                                        uploadLocalFileToCheckpointFs(
+                                                                e,
+                                                                checkpointStreamFactory,
+                                                                stateScope,
+                                                                closeableRegistry,
+                                                                tmpResourcesRegistry)),
+                                        executorService))
+                .collect(Collectors.toList());
     }
 
-    private StreamStateHandle uploadLocalFileToCheckpointFs(
+    private HandleAndLocalPath uploadLocalFileToCheckpointFs(
             Path filePath,
             CheckpointStreamFactory checkpointStreamFactory,
             CheckpointedStateScope stateScope,
@@ -162,7 +157,7 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
             }
             tmpResourcesRegistry.registerCloseable(
                     () -> StateUtil.discardStateObjectQuietly(result));
-            return result;
+            return HandleAndLocalPath.of(result, filePath.getFileName().toString());
 
         } finally {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.state.BackendBuildingException;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.DirectoryStateHandle;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalLocalKeyedStateHandle;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -90,7 +91,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             LoggerFactory.getLogger(RocksDBIncrementalRestoreOperation.class);
 
     private final String operatorIdentifier;
-    private final SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles;
+    private final SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles;
     private final RocksDBHandle rocksHandle;
     private final Collection<KeyedStateHandle> restoreStateHandles;
     private final CloseableRegistry cancelStreamRegistry;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
@@ -19,13 +19,12 @@
 package org.apache.flink.contrib.streaming.state.restore;
 
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
-import org.apache.flink.runtime.state.StateHandleID;
-import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 
-import java.util.Map;
+import java.util.Collection;
 import java.util.SortedMap;
 import java.util.UUID;
 
@@ -38,7 +37,7 @@ public class RocksDBRestoreResult {
     // fields only for incremental restore
     private final long lastCompletedCheckpointId;
     private final UUID backendUID;
-    private final SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles;
+    private final SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles;
 
     public RocksDBRestoreResult(
             RocksDB db,
@@ -46,7 +45,7 @@ public class RocksDBRestoreResult {
             RocksDBNativeMetricMonitor nativeMetricMonitor,
             long lastCompletedCheckpointId,
             UUID backendUID,
-            SortedMap<Long, Map<StateHandleID, StreamStateHandle>> restoredSstFiles) {
+            SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles) {
         this.db = db;
         this.defaultColumnFamilyHandle = defaultColumnFamilyHandle;
         this.nativeMetricMonitor = nativeMetricMonitor;
@@ -67,7 +66,7 @@ public class RocksDBRestoreResult {
         return backendUID;
     }
 
-    public SortedMap<Long, Map<StateHandleID, StreamStateHandle>> getRestoredSstFiles() {
+    public SortedMap<Long, Collection<HandleAndLocalPath>> getRestoredSstFiles() {
         return restoredSstFiles;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.DirectoryStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalLocalKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
@@ -39,7 +40,6 @@ import org.apache.flink.runtime.state.SnapshotDirectory;
 import org.apache.flink.runtime.state.SnapshotResources;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategy;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
@@ -61,12 +61,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base class for {@link SnapshotStrategy} implementations for RocksDB state backend.
@@ -334,7 +336,7 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
 
         protected Optional<KeyedStateHandle> getLocalSnapshot(
                 @Nullable StreamStateHandle localStreamStateHandle,
-                Map<StateHandleID, StreamStateHandle> sharedStateHandleIDs)
+                List<HandleAndLocalPath> sharedState)
                 throws IOException {
             final DirectoryStateHandle directoryStateHandle =
                     localBackupDirectory.completeSnapshotAndGetHandle();
@@ -346,7 +348,7 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
                                 directoryStateHandle,
                                 keyGroupRange,
                                 localStreamStateHandle,
-                                sharedStateHandleIDs));
+                                sharedState));
             } else {
                 return Optional.empty();
             }
@@ -390,23 +392,33 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
     }
 
     protected static final PreviousSnapshot EMPTY_PREVIOUS_SNAPSHOT =
-            new PreviousSnapshot(Collections.emptyMap());
+            new PreviousSnapshot(Collections.emptyList());
 
     /** Previous snapshot with uploaded sst files. */
     protected static class PreviousSnapshot {
 
-        @Nullable private final Map<StateHandleID, Long> confirmedSstFiles;
+        @Nonnull private final Map<String, StreamStateHandle> confirmedSstFiles;
 
-        protected PreviousSnapshot(@Nullable Map<StateHandleID, Long> confirmedSstFiles) {
-            this.confirmedSstFiles = confirmedSstFiles;
+        protected PreviousSnapshot(@Nullable Collection<HandleAndLocalPath> confirmedSstFiles) {
+            this.confirmedSstFiles =
+                    confirmedSstFiles != null
+                            ? confirmedSstFiles.stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    HandleAndLocalPath::getLocalPath,
+                                                    HandleAndLocalPath::getHandle))
+                            : Collections.emptyMap();
         }
 
-        protected Optional<StreamStateHandle> getUploaded(StateHandleID stateHandleID) {
-            if (confirmedSstFiles != null && confirmedSstFiles.containsKey(stateHandleID)) {
-                // we introduce a placeholder state handle, that is replaced with the
-                // original from the shared state registry (created from a previous checkpoint)
+        protected Optional<StreamStateHandle> getUploaded(String filename) {
+            if (confirmedSstFiles.containsKey(filename)) {
+                StreamStateHandle handle = confirmedSstFiles.get(filename);
+                // We introduce a placeholder state handle to reduce network transfer overhead,
+                // it will be replaced by the original handle from the shared state registry
+                // (created from a previous checkpoint).
                 return Optional.of(
-                        new PlaceholderStreamStateHandle(confirmedSstFiles.get(stateHandleID)));
+                        new PlaceholderStreamStateHandle(
+                                handle.getStreamStateHandleID(), handle.getStateSize()));
             } else {
                 // Don't use any uploaded but not confirmed handles because they might be deleted
                 // (by TM) if the previous checkpoint failed. See FLINK-25395

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -27,14 +27,13 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.SnapshotType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SnapshotDirectory;
 import org.apache.flink.runtime.state.SnapshotResult;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
@@ -49,7 +48,9 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,10 +58,8 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.SST_FILE_SUFFIX;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.getUploadedStateSize;
 
 /**
  * Snapshot strategy for {@link org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend}
@@ -78,11 +77,11 @@ public class RocksIncrementalSnapshotStrategy<K>
     private static final String DESCRIPTION = "Asynchronous incremental RocksDB snapshot";
 
     /**
-     * Stores the {@link StateHandleID IDs} of uploaded SST files that build the incremental
-     * history. Once the checkpoint is confirmed by JM, only the ID paired with {@link
-     * PlaceholderStreamStateHandle} can be sent.
+     * Stores the {@link StreamStateHandle} and corresponding local path of uploaded SST files that
+     * build the incremental history. Once the checkpoint is confirmed by JM, they can be reused for
+     * incremental checkpoint.
      */
-    @Nonnull private final SortedMap<Long, Map<StateHandleID, Long>> uploadedStateIDs;
+    @Nonnull private final SortedMap<Long, Collection<HandleAndLocalPath>> uploadedSstFiles;
 
     /** The identifier of the last completed checkpoint. */
     private long lastCompletedCheckpointId;
@@ -101,7 +100,7 @@ public class RocksIncrementalSnapshotStrategy<K>
             @Nonnull CloseableRegistry cancelStreamRegistry,
             @Nonnull File instanceBasePath,
             @Nonnull UUID backendUID,
-            @Nonnull SortedMap<Long, Map<StateHandleID, StreamStateHandle>> uploadedStateHandles,
+            @Nonnull SortedMap<Long, Collection<HandleAndLocalPath>> uploadedStateHandles,
             @Nonnull RocksDBStateUploader rocksDBStateUploader,
             long lastCompletedCheckpointId) {
 
@@ -116,16 +115,8 @@ public class RocksIncrementalSnapshotStrategy<K>
                 localRecoveryConfig,
                 instanceBasePath,
                 backendUID);
-        this.uploadedStateIDs = new TreeMap<>();
-        for (Map.Entry<Long, Map<StateHandleID, StreamStateHandle>> entry :
-                uploadedStateHandles.entrySet()) {
-            Map<StateHandleID, Long> map = new HashMap<>();
-            for (Map.Entry<StateHandleID, StreamStateHandle> stateHandleEntry :
-                    entry.getValue().entrySet()) {
-                map.put(stateHandleEntry.getKey(), stateHandleEntry.getValue().getStateSize());
-            }
-            this.uploadedStateIDs.put(entry.getKey(), map);
-        }
+
+        this.uploadedSstFiles = new TreeMap<>(uploadedStateHandles);
         this.stateUploader = rocksDBStateUploader;
         this.lastCompletedCheckpointId = lastCompletedCheckpointId;
     }
@@ -174,13 +165,13 @@ public class RocksIncrementalSnapshotStrategy<K>
 
     @Override
     public void notifyCheckpointComplete(long completedCheckpointId) {
-        synchronized (uploadedStateIDs) {
+        synchronized (uploadedSstFiles) {
             // FLINK-23949: materializedSstFiles.keySet().contains(completedCheckpointId) make sure
             // the notified checkpointId is not a savepoint, otherwise next checkpoint will
             // degenerate into a full checkpoint
             if (completedCheckpointId > lastCompletedCheckpointId
-                    && uploadedStateIDs.containsKey(completedCheckpointId)) {
-                uploadedStateIDs
+                    && uploadedSstFiles.containsKey(completedCheckpointId)) {
+                uploadedSstFiles
                         .keySet()
                         .removeIf(checkpointId -> checkpointId < completedCheckpointId);
                 lastCompletedCheckpointId = completedCheckpointId;
@@ -190,8 +181,8 @@ public class RocksIncrementalSnapshotStrategy<K>
 
     @Override
     public void notifyCheckpointAborted(long abortedCheckpointId) {
-        synchronized (uploadedStateIDs) {
-            uploadedStateIDs.keySet().remove(abortedCheckpointId);
+        synchronized (uploadedSstFiles) {
+            uploadedSstFiles.keySet().remove(abortedCheckpointId);
         }
     }
 
@@ -205,13 +196,12 @@ public class RocksIncrementalSnapshotStrategy<K>
             long checkpointId, @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots) {
 
         final long lastCompletedCheckpoint;
-        final Map<StateHandleID, Long> confirmedSstFiles;
-        final Map<StateHandleID, StreamStateHandle> uploadedSstFiles;
+        final Collection<HandleAndLocalPath> confirmedSstFiles;
 
         // use the last completed checkpoint as the comparison base.
-        synchronized (uploadedStateIDs) {
+        synchronized (uploadedSstFiles) {
             lastCompletedCheckpoint = lastCompletedCheckpointId;
-            confirmedSstFiles = uploadedStateIDs.get(lastCompletedCheckpoint);
+            confirmedSstFiles = uploadedSstFiles.get(lastCompletedCheckpoint);
             LOG.trace(
                     "Use confirmed SST files for checkpoint {}: {}",
                     checkpointId,
@@ -268,9 +258,9 @@ public class RocksIncrementalSnapshotStrategy<K>
             // Handle to the meta data file
             SnapshotResult<StreamStateHandle> metaStateHandle = null;
             // Handles to new sst files since the last completed checkpoint will go here
-            final Map<StateHandleID, StreamStateHandle> sstFiles = new HashMap<>();
+            final List<HandleAndLocalPath> sstFiles = new ArrayList<>();
             // Handles to the misc files in the current snapshot will go here
-            final Map<StateHandleID, StreamStateHandle> miscFiles = new HashMap<>();
+            final List<HandleAndLocalPath> miscFiles = new ArrayList<>();
 
             try {
 
@@ -288,11 +278,13 @@ public class RocksIncrementalSnapshotStrategy<K>
                         metaStateHandle.getJobManagerOwnedSnapshot(),
                         "Metadata for job manager was not properly created.");
 
-                uploadSstFiles(
-                        sstFiles, miscFiles, snapshotCloseableRegistry, tmpResourcesRegistry);
                 long checkpointedSize = metaStateHandle.getStateSize();
-                checkpointedSize += getUploadedStateSize(sstFiles.values());
-                checkpointedSize += getUploadedStateSize(miscFiles.values());
+                checkpointedSize +=
+                        uploadSnapshotFiles(
+                                sstFiles,
+                                miscFiles,
+                                snapshotCloseableRegistry,
+                                tmpResourcesRegistry);
 
                 // We make the 'sstFiles' as the 'sharedState' in IncrementalRemoteKeyedStateHandle,
                 // whether they belong to the sharded CheckpointedStateScope or exclusive
@@ -334,9 +326,10 @@ public class RocksIncrementalSnapshotStrategy<K>
             }
         }
 
-        private void uploadSstFiles(
-                @Nonnull Map<StateHandleID, StreamStateHandle> sstFiles,
-                @Nonnull Map<StateHandleID, StreamStateHandle> miscFiles,
+        /** upload files and return total uploaded size. */
+        private long uploadSnapshotFiles(
+                @Nonnull List<HandleAndLocalPath> sstFiles,
+                @Nonnull List<HandleAndLocalPath> miscFiles,
                 @Nonnull CloseableRegistry snapshotCloseableRegistry,
                 @Nonnull CloseableRegistry tmpResourcesRegistry)
                 throws Exception {
@@ -344,43 +337,47 @@ public class RocksIncrementalSnapshotStrategy<K>
             // write state data
             Preconditions.checkState(localBackupDirectory.exists());
 
-            Map<StateHandleID, Path> sstFilePaths = new HashMap<>();
-            Map<StateHandleID, Path> miscFilePaths = new HashMap<>();
-
             Path[] files = localBackupDirectory.listDirectory();
+            long uploadedSize = 0;
             if (files != null) {
+                List<Path> sstFilePaths = new ArrayList<>(files.length);
+                List<Path> miscFilePaths = new ArrayList<>(files.length);
+
                 createUploadFilePaths(files, sstFiles, sstFilePaths, miscFilePaths);
 
                 final CheckpointedStateScope stateScope =
                         sharingFilesStrategy == SnapshotType.SharingFilesStrategy.NO_SHARING
                                 ? CheckpointedStateScope.EXCLUSIVE
                                 : CheckpointedStateScope.SHARED;
-                sstFiles.putAll(
+
+                List<HandleAndLocalPath> sstFilesUploadResult =
                         stateUploader.uploadFilesToCheckpointFs(
                                 sstFilePaths,
                                 checkpointStreamFactory,
                                 stateScope,
                                 snapshotCloseableRegistry,
-                                tmpResourcesRegistry));
-                miscFiles.putAll(
+                                tmpResourcesRegistry);
+                uploadedSize +=
+                        sstFilesUploadResult.stream().mapToLong(e -> e.getStateSize()).sum();
+                sstFiles.addAll(sstFilesUploadResult);
+
+                List<HandleAndLocalPath> miscFilesUploadResult =
                         stateUploader.uploadFilesToCheckpointFs(
                                 miscFilePaths,
                                 checkpointStreamFactory,
                                 stateScope,
                                 snapshotCloseableRegistry,
-                                tmpResourcesRegistry));
+                                tmpResourcesRegistry);
+                uploadedSize +=
+                        miscFilesUploadResult.stream().mapToLong(e -> e.getStateSize()).sum();
+                miscFiles.addAll(miscFilesUploadResult);
 
-                synchronized (uploadedStateIDs) {
+                synchronized (uploadedSstFiles) {
                     switch (sharingFilesStrategy) {
                         case FORWARD_BACKWARD:
                         case FORWARD:
-                            uploadedStateIDs.put(
-                                    checkpointId,
-                                    sstFiles.entrySet().stream()
-                                            .collect(
-                                                    Collectors.toMap(
-                                                            Map.Entry::getKey,
-                                                            t -> t.getValue().getStateSize())));
+                            uploadedSstFiles.put(
+                                    checkpointId, Collections.unmodifiableList(sstFiles));
                             break;
                         case NO_SHARING:
                             break;
@@ -392,27 +389,26 @@ public class RocksIncrementalSnapshotStrategy<K>
                     }
                 }
             }
+            return uploadedSize;
         }
 
         private void createUploadFilePaths(
                 Path[] files,
-                Map<StateHandleID, StreamStateHandle> sstFiles,
-                Map<StateHandleID, Path> sstFilePaths,
-                Map<StateHandleID, Path> miscFilePaths) {
+                List<HandleAndLocalPath> sstFiles,
+                List<Path> sstFilePaths,
+                List<Path> miscFilePaths) {
             for (Path filePath : files) {
                 final String fileName = filePath.getFileName().toString();
-                final StateHandleID stateHandleID = new StateHandleID(fileName);
 
                 if (fileName.endsWith(SST_FILE_SUFFIX)) {
-                    Optional<StreamStateHandle> uploaded =
-                            previousSnapshot.getUploaded(stateHandleID);
+                    Optional<StreamStateHandle> uploaded = previousSnapshot.getUploaded(fileName);
                     if (uploaded.isPresent()) {
-                        sstFiles.put(stateHandleID, uploaded.get());
+                        sstFiles.add(HandleAndLocalPath.of(uploaded.get(), fileName));
                     } else {
-                        sstFilePaths.put(stateHandleID, filePath); // re-upload
+                        sstFilePaths.add(filePath); // re-upload
                     }
                 } else {
-                    miscFilePaths.put(stateHandleID, filePath);
+                    miscFilePaths.add(filePath);
                 }
             }
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksSnapshotUtil.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksSnapshotUtil.java
@@ -18,12 +18,6 @@
 
 package org.apache.flink.contrib.streaming.state.snapshot;
 
-import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
-import org.apache.flink.runtime.state.StateObject;
-import org.apache.flink.runtime.state.StreamStateHandle;
-
-import java.util.Collection;
-
 /**
  * Utility methods and constants around RocksDB creating and restoring snapshots for {@link
  * org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend}.
@@ -35,12 +29,5 @@ public class RocksSnapshotUtil {
 
     private RocksSnapshotUtil() {
         throw new AssertionError();
-    }
-
-    public static long getUploadedStateSize(Collection<StreamStateHandle> streamStateHandles) {
-        return streamStateHandles.stream()
-                .filter(s -> !(s instanceof PlaceholderStreamStateHandle))
-                .mapToLong(StateObject::getStateSize)
-                .sum();
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestStreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -39,9 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -61,8 +59,8 @@ public class RocksDBStateDownloaderTest extends TestLogger {
                 new SpecifiedException("throw exception while multi thread restore.");
         StreamStateHandle stateHandle = new ThrowingStateHandle(expectedException);
 
-        Map<StateHandleID, StreamStateHandle> stateHandles = new HashMap<>(1);
-        stateHandles.put(new StateHandleID("state1"), stateHandle);
+        List<HandleAndLocalPath> stateHandles = new ArrayList<>(1);
+        stateHandles.add(HandleAndLocalPath.of(stateHandle, "state1"));
 
         IncrementalRemoteKeyedStateHandle incrementalKeyedStateHandle =
                 new IncrementalRemoteKeyedStateHandle(
@@ -134,9 +132,10 @@ public class RocksDBStateDownloaderTest extends TestLogger {
         // Add a state handle that induces an exception
         stateHandle
                 .getSharedState()
-                .put(
-                        new StateHandleID("error-handle"),
-                        new ThrowingStateHandle(new IOException("Test exception.")));
+                .add(
+                        HandleAndLocalPath.of(
+                                new ThrowingStateHandle(new IOException("Test exception.")),
+                                "error-handle"));
 
         CloseableRegistry closeableRegistry = new CloseableRegistry();
         try (RocksDBStateDownloader rocksDBStateDownloader = new RocksDBStateDownloader(5)) {
@@ -215,15 +214,16 @@ public class RocksDBStateDownloaderTest extends TestLogger {
                             String.format("state-%d-%d", remoteHandleId, i), content[i]));
         }
 
-        Map<StateHandleID, StreamStateHandle> sharedStates = new HashMap<>(numSubHandles);
-        Map<StateHandleID, StreamStateHandle> privateStates = new HashMap<>(numSubHandles);
+        List<HandleAndLocalPath> sharedStates = new ArrayList<>(numSubHandles);
+        List<HandleAndLocalPath> privateStates = new ArrayList<>(numSubHandles);
         for (int i = 0; i < numSubHandles; ++i) {
-            sharedStates.put(
-                    new StateHandleID(String.format("sharedState-%d-%d", remoteHandleId, i)),
-                    handles.get(i));
-            privateStates.put(
-                    new StateHandleID(String.format("privateState-%d-%d", remoteHandleId, i)),
-                    handles.get(i));
+            sharedStates.add(
+                    HandleAndLocalPath.of(
+                            handles.get(i), String.format("sharedState-%d-%d", remoteHandleId, i)));
+            privateStates.add(
+                    HandleAndLocalPath.of(
+                            handles.get(i),
+                            String.format("privateState-%d-%d", remoteHandleId, i)));
         }
 
         IncrementalRemoteKeyedStateHandle incrementalKeyedStateHandle =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateHandleReuseITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateHandleReuseITCase.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommand.FINISH_SOURCES;
 import static org.apache.flink.runtime.operators.lifecycle.command.TestCommandDispatcher.TestCommandScope.ALL_SUBTASKS;
@@ -89,8 +89,8 @@ public class StateHandleReuseITCase extends AbstractTestBase {
                         randomUUID(),
                         EMPTY_KEY_GROUP_RANGE,
                         1L,
-                        emptyMap(),
-                        emptyMap(),
+                        emptyList(),
+                        emptyList(),
                         new ByteStreamStateHandle("meta", new byte[] {0}),
                         0L);
 


### PR DESCRIPTION
## What is the purpose of the change

Fix shared state be discarded by mistake when maxConcurrentCheckpoint>1, discussed in [FLINK-29913](https://issues.apache.org/jira/browse/FLINK-29913).


## Brief change log
  - *make RocksDBIncrementalSnapshotStrategy not use PlaceholderStreamStateHandle*
  - *IncrementalRemoteKeyedStateHandle register shared state use PhysicalStateHandleID as register key*
  - *remove PlaceholderStreamStateHandle*


## Verifying this change

This change added test *IncrementalRemoteKeyedStateHandleTest#testConcurrentCheckpointSharedStateRegistration()*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, checkpointing 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
