### PR TITLE
[FLINK-32201][runtime]Automatically determine if the shuffle descriptor needs to be offloaded by the blob server based on the number of ShuffleDescriptor edges.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
@@ -53,10 +53,14 @@ public class CachedShuffleDescriptors {
     /** Stores the mapping of resultPartitionId to index subscripts in consumed partition group. */
     private final Map<IntermediateResultPartitionID, Integer> resultPartitionIdToIndex;
 
+    /** The number of consumers for {@link ConsumedPartitionGroup}. */
+    private final int numConsumers;
+
     public CachedShuffleDescriptors(
             ConsumedPartitionGroup consumedPartitionGroup,
             ShuffleDescriptorAndIndex[] shuffleDescriptors) {
         this.resultPartitionIdToIndex = new HashMap<>();
+        this.numConsumers = consumedPartitionGroup.getNumConsumers();
         int index = 0;
         for (IntermediateResultPartitionID resultPartitionID : consumedPartitionGroup) {
             resultPartitionIdToIndex.put(resultPartitionID, index++);
@@ -80,7 +84,7 @@ public class CachedShuffleDescriptors {
         if (!toBeSerialized.isEmpty()) {
             MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptor =
                     shuffleDescriptorSerializer.serializeAndTryOffloadShuffleDescriptor(
-                            toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]));
+                            toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]), numConsumers);
             toBeSerialized.clear();
             serializedShuffleDescriptors.add(serializedShuffleDescriptor);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
-import org.apache.flink.util.function.FunctionWithException;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -76,15 +75,11 @@ public class CachedShuffleDescriptors {
     }
 
     public void serializeShuffleDescriptors(
-            FunctionWithException<
-                            ShuffleDescriptorAndIndex[],
-                            MaybeOffloaded<ShuffleDescriptorAndIndex[]>,
-                            IOException>
-                    shuffleDescriptorSerializer)
+            TaskDeploymentDescriptorFactory.ShuffleDescriptorSerializer shuffleDescriptorSerializer)
             throws IOException {
         if (!toBeSerialized.isEmpty()) {
             MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptor =
-                    shuffleDescriptorSerializer.apply(
+                    shuffleDescriptorSerializer.serializeAndTryOffloadShuffleDescriptor(
                             toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]));
             toBeSerialized.clear();
             serializedShuffleDescriptors.add(serializedShuffleDescriptor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -118,6 +118,10 @@ public class DefaultExecutionGraphBuilder {
                 PartitionGroupReleaseStrategyFactoryLoader.loadPartitionGroupReleaseStrategyFactory(
                         jobManagerConfig);
 
+        final int offloadShuffleDescriptorsThreshold =
+                jobManagerConfig.get(
+                        TaskDeploymentDescriptorFactory.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD);
+
         final TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory;
         try {
             taskDeploymentDescriptorFactory =
@@ -126,7 +130,8 @@ public class DefaultExecutionGraphBuilder {
                             jobId,
                             partitionLocationConstraint,
                             blobWriter,
-                            nonFinishedHybridPartitionShouldBeUnknown);
+                            nonFinishedHybridPartitionShouldBeUnknown,
+                            offloadShuffleDescriptorsThreshold);
         } catch (IOException e) {
             throw new JobException("Could not create the TaskDeploymentDescriptorFactory.", e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
@@ -215,7 +215,8 @@ class CachedShuffleDescriptorsTest {
 
         @Override
         public MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializeAndTryOffloadShuffleDescriptor(
-                ShuffleDescriptorAndIndex[] shuffleDescriptors) throws IOException {
+                ShuffleDescriptorAndIndex[] shuffleDescriptors, int numConsumer)
+                throws IOException {
             return new NonOffloaded<>(CompressedSerializedValue.fromObject(shuffleDescriptors));
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -33,9 +33,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.util.SerializedValue;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -45,14 +44,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link TaskDeploymentDescriptor}. */
-public class TaskDeploymentDescriptorTest extends TestLogger {
+class TaskDeploymentDescriptorTest {
 
     private static final JobID jobID = new JobID();
     private static final JobVertexID vertexID = new JobVertexID();
@@ -96,10 +92,10 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
                             invokableClass.getName(),
                             taskConfiguration));
 
-    public TaskDeploymentDescriptorTest() throws IOException {}
+    TaskDeploymentDescriptorTest() throws IOException {}
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final TaskDeploymentDescriptor orig =
                 createTaskDeploymentDescriptor(
                         new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
@@ -108,31 +104,33 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 
         final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 
-        assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
-        assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
-        assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
-        assertFalse(orig.getTaskRestore() == copy.getTaskRestore());
-        assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
-        assertFalse(orig.getInputGates() == copy.getInputGates());
+        assertThat(orig.getSerializedJobInformation())
+                .isNotSameAs(copy.getSerializedJobInformation());
+        assertThat(orig.getSerializedTaskInformation())
+                .isNotSameAs(copy.getSerializedTaskInformation());
+        assertThat(orig.getExecutionAttemptId()).isNotSameAs(copy.getExecutionAttemptId());
+        assertThat(orig.getTaskRestore()).isNotSameAs(copy.getTaskRestore());
+        assertThat(orig.getProducedPartitions()).isNotSameAs(copy.getProducedPartitions());
+        assertThat(orig.getInputGates()).isNotSameAs(copy.getInputGates());
 
-        assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
-        assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
-        assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
-        assertEquals(orig.getAllocationId(), copy.getAllocationId());
-        assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
-        assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
-        assertEquals(
-                orig.getTaskRestore().getRestoreCheckpointId(),
-                copy.getTaskRestore().getRestoreCheckpointId());
-        assertEquals(
-                orig.getTaskRestore().getTaskStateSnapshot(),
-                copy.getTaskRestore().getTaskStateSnapshot());
-        assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
-        assertEquals(orig.getInputGates(), copy.getInputGates());
+        assertThat(orig.getSerializedJobInformation())
+                .isEqualTo(copy.getSerializedJobInformation());
+        assertThat(orig.getSerializedTaskInformation())
+                .isEqualTo(copy.getSerializedTaskInformation());
+        assertThat(orig.getExecutionAttemptId()).isEqualTo(copy.getExecutionAttemptId());
+        assertThat(orig.getAllocationId()).isEqualTo(copy.getAllocationId());
+        assertThat(orig.getSubtaskIndex()).isEqualTo(copy.getSubtaskIndex());
+        assertThat(orig.getAttemptNumber()).isEqualTo(copy.getAttemptNumber());
+        assertThat(orig.getTaskRestore().getRestoreCheckpointId())
+                .isEqualTo(copy.getTaskRestore().getRestoreCheckpointId());
+        assertThat(orig.getTaskRestore().getTaskStateSnapshot())
+                .isEqualTo(copy.getTaskRestore().getTaskStateSnapshot());
+        assertThat(orig.getProducedPartitions()).isEqualTo(copy.getProducedPartitions());
+        assertThat(orig.getInputGates()).isEqualTo(copy.getInputGates());
     }
 
     @Test
-    public void testOffLoadedAndNonOffLoadedPayload() {
+    void testOffLoadedAndNonOffLoadedPayload() {
         final TaskDeploymentDescriptor taskDeploymentDescriptor =
                 createTaskDeploymentDescriptor(
                         new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
@@ -140,14 +138,10 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 
         SerializedValue<JobInformation> actualSerializedJobInformation =
                 taskDeploymentDescriptor.getSerializedJobInformation();
-        assertThat(actualSerializedJobInformation, is(serializedJobInformation));
+        assertThat(actualSerializedJobInformation).isSameAs(serializedJobInformation);
 
-        try {
-            taskDeploymentDescriptor.getSerializedTaskInformation();
-            fail("Expected to fail since the task information should be offloaded.");
-        } catch (IllegalStateException expected) {
-            // expected
-        }
+        assertThatThrownBy(taskDeploymentDescriptor::getSerializedTaskInformation)
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Nonnull

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.TestingBlobWriter;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.util.CompressedSerializedValue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A collection of utility methods for testing the TaskDeploymentDescriptor and its related classes.
+ */
+public class TaskDeploymentDescriptorTestUtils {
+
+    public static ShuffleDescriptor[] deserializeShuffleDescriptors(
+            List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded,
+            JobID jobId,
+            TestingBlobWriter blobWriter)
+            throws IOException, ClassNotFoundException {
+        Map<Integer, ShuffleDescriptor> shuffleDescriptorsMap = new HashMap<>();
+        int maxIndex = 0;
+        for (MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd : maybeOffloaded) {
+            ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices;
+            if (sd instanceof NonOffloaded) {
+                shuffleDescriptorAndIndices =
+                        ((NonOffloaded<ShuffleDescriptorAndIndex[]>) sd)
+                                .serializedValue.deserializeValue(
+                                        ClassLoader.getSystemClassLoader());
+
+            } else {
+                final CompressedSerializedValue<ShuffleDescriptorAndIndex[]>
+                        compressedSerializedValue =
+                                CompressedSerializedValue.fromBytes(
+                                        blobWriter.getBlob(
+                                                jobId,
+                                                ((Offloaded<ShuffleDescriptorAndIndex[]>) sd)
+                                                        .serializedValueKey));
+                shuffleDescriptorAndIndices =
+                        compressedSerializedValue.deserializeValue(
+                                ClassLoader.getSystemClassLoader());
+            }
+            for (ShuffleDescriptorAndIndex shuffleDescriptorAndIndex :
+                    shuffleDescriptorAndIndices) {
+                int index = shuffleDescriptorAndIndex.getIndex();
+                maxIndex = Math.max(maxIndex, shuffleDescriptorAndIndex.getIndex());
+                shuffleDescriptorsMap.put(index, shuffleDescriptorAndIndex.getShuffleDescriptor());
+            }
+        }
+        ShuffleDescriptor[] shuffleDescriptors = new ShuffleDescriptor[maxIndex + 1];
+        shuffleDescriptorsMap.forEach((key, value) -> shuffleDescriptors[key] = value);
+        return shuffleDescriptors;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/BlockingResultPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/BlockingResultPartitionReleaseTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -106,7 +107,8 @@ class BlockingResultPartitionReleaseTest {
                         mainThreadExecutor,
                         ioExecutor,
                         partitionTracker,
-                        EXECUTOR_RESOURCE.getExecutor());
+                        EXECUTOR_RESOURCE.getExecutor(),
+                        new Configuration());
         ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         assertThat(partitionTracker.releasedPartitions).isEmpty();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactoryTest.deserializeShuffleDescriptors;
+import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorTestUtils.deserializeShuffleDescriptors;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishExecutionVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishJobVertex;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -332,7 +333,8 @@ public class SchedulerTestingUtils {
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService ioExecutor,
             JobMasterPartitionTracker partitionTracker,
-            ScheduledExecutorService scheduledExecutor)
+            ScheduledExecutorService scheduledExecutor,
+            Configuration jobMasterConfiguration)
             throws Exception {
         final List<JobVertex> vertices = new ArrayList<>(Collections.singletonList(producer));
         IntermediateDataSetID dataSetId = new IntermediateDataSetID();
@@ -351,7 +353,8 @@ public class SchedulerTestingUtils {
                         mainThreadExecutor,
                         ioExecutor,
                         partitionTracker,
-                        scheduledExecutor);
+                        scheduledExecutor,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
         final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 
@@ -402,7 +405,8 @@ public class SchedulerTestingUtils {
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService ioExecutor,
             JobMasterPartitionTracker partitionTracker,
-            ScheduledExecutorService scheduledExecutor)
+            ScheduledExecutorService scheduledExecutor,
+            Configuration jobMasterConfiguration)
             throws Exception {
         final JobGraph jobGraph =
                 JobGraphBuilder.newBatchJobGraphBuilder()
@@ -415,7 +419,8 @@ public class SchedulerTestingUtils {
                         .setRestartBackoffTimeStrategy(new TestRestartBackoffTimeStrategy(true, 0))
                         .setBlobWriter(blobWriter)
                         .setIoExecutor(ioExecutor)
-                        .setPartitionTracker(partitionTracker);
+                        .setPartitionTracker(partitionTracker)
+                        .setJobMasterConfiguration(jobMasterConfiguration);
         return isAdaptive ? builder.buildAdaptiveBatchJobScheduler() : builder.build();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Flink support distributes shuffle descriptors via the blob server to reduce JobManager overhead. But the default threshold to enable it is 1MB, which never reaches. Users need to set a proper value for this, but it requires advanced knowledge before configuring it.

I would like to enable this feature by the number of connections of a group of shuffle descriptors. For examples, a simple streaming job with two operators, each with 10,000 parallelism and connected via all-to-all distribution. In this job, we only get one set of shuffle descriptors, and this group has 10000 * 10000 connections. This means that JobManager needs to send this set of shuffle descriptors to 10000 tasks.

Since it's difficult for users to configure, I would like to give it a default value. 

## Brief change log
  - *determine if the shuffle descriptor needs to be offloaded by the blob server based on the number of ShuffleDescriptor edges.*

## Verifying this change

This change added tests and can be verified as follows:
  - *Manually verified the change by running a cluster with 1 JobManagers and 2000 TaskManagers (10 slots per TaskManager), a streaming program with 20000 parallelism, and verifying that the task deploy was successful.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  (no)
  - The serializers:  (no)
  - The runtime per-record code paths (performance sensitive):  (no)
  - Anything that affects deployment or recovery: Task Deployment: (yes)
  - The S3 file system connector:  (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
