### PR TITLE
[FLINK-32213][core] Add get off heap buffer in segment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -280,17 +280,16 @@ public final class MemorySegment {
     }
 
     /**
-     * Returns the off heap buffer for the segment. It may be used by sink to create writer buffer
-     * for data lake such as iceberg and paimon.
+     * Returns the off-heap buffer of memory segments.
      *
-     * @return underlying byte buffer
+     * @return underlying off-heap buffer
      * @throws IllegalStateException if the memory segment does not represent off-heap buffer
      */
     public ByteBuffer getOffHeapBuffer() {
         if (offHeapBuffer != null) {
             return offHeapBuffer;
         } else {
-            throw new IllegalStateException("Memory segment does not represent off heap buffer");
+            throw new IllegalStateException("Memory segment does not represent off-heap buffer");
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -280,6 +280,21 @@ public final class MemorySegment {
     }
 
     /**
+     * Returns the off heap buffer for the segment. It may be used by sink to create writer buffer
+     * for data lake such as iceberg and paimon.
+     *
+     * @return underlying byte buffer
+     * @throws IllegalStateException if the memory segment does not represent off-heap buffer
+     */
+    public ByteBuffer getOffHeapBuffer() {
+        if (offHeapBuffer != null) {
+            return offHeapBuffer;
+        } else {
+            throw new IllegalStateException("Memory segment does not represent off heap buffer");
+        }
+    }
+
+    /**
      * Returns the memory address of off-heap memory segments.
      *
      * @return absolute memory address outside the heap

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentSimpleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemorySegmentSimpleTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test reading and writing primitive types to {@link MemorySegment}. */
 public class MemorySegmentSimpleTest {
@@ -573,5 +575,23 @@ public class MemorySegmentSimpleTest {
             e.printStackTrace();
             Assert.fail(e.getMessage());
         }
+    }
+
+    @Test
+    public void testGetOffHeapBuffer() {
+        MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(1024);
+        assertThrows(
+                IllegalStateException.class,
+                seg::getOffHeapBuffer,
+                "Memory segment does not represent off-heap buffer");
+        seg.free();
+
+        seg = MemorySegmentFactory.allocateUnpooledOffHeapMemory(1024);
+        assertNotNull(seg.getOffHeapBuffer());
+        seg.free();
+
+        seg = MemorySegmentFactory.allocateOffHeapUnsafeMemory(1024);
+        assertNotNull(seg.getOffHeapBuffer());
+        seg.free();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add `getOffHeapBuffer` in `MemorySegment` and iceberg/paimon sink operator can create writer buffer with managed memory in Flink


## Brief change log
  - Add `getOffHeapBuffer` in `MemorySegment`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
