### PR TITLE
[FLINK-32169][ui] Show slot allocations on TM page

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -33,6 +33,12 @@ export interface TaskManagerDetail {
   blocked?: boolean;
   freeResource: Resources;
   totalResource: Resources;
+  allocatedSlots: AllocatedSlot[];
+}
+
+export interface AllocatedSlot {
+  jobId: string;
+  resource: Resources;
 }
 
 export interface Resources {

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
@@ -318,7 +318,7 @@
   </tr>
 </ng-template>
 
-<nz-card nzTitle="Resources" nzSize="small">
+<nz-card nzTitle="Resources" nzSize="small" class="flink-memory-model">
   <nz-table
     nzBordered
     nzTitle="Unassigned resources"
@@ -381,6 +381,40 @@
           unit: 'MB'
         }"
       ></ng-container>
+    </tbody>
+  </nz-table>
+  <nz-table
+    nzBordered
+    nzTitle="Allocated slots"
+    [nzTemplateMode]="true"
+    [nzFrontPagination]="false"
+    [nzShowPagination]="false"
+    [nzSize]="'small'"
+    class="no-border top-margin"
+  >
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Job ID</th>
+        <th>CPU (cores)</th>
+        <th>Task Heap memory (MB)</th>
+        <th>Task Off-Heap memory (MB)</th>
+        <th>Managed memory (MB)</th>
+        <th>Network memory (MB)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let slot of taskManagerDetail?.allocatedSlots; let i = index">
+        <td>
+          <strong>{{ i | number }}</strong>
+        </td>
+        <td>{{ slot.jobId }}</td>
+        <td>{{ slot.resource.cpuCores | number }}</td>
+        <td>{{ slot.resource.taskHeapMemory | number }}</td>
+        <td>{{ slot.resource.taskOffHeapMemory | number }}</td>
+        <td>{{ slot.resource.managedMemory | number }}</td>
+        <td>{{ slot.resource.networkMemory | number }}</td>
+      </tr>
     </tbody>
   </nz-table>
 </nz-card>


### PR DESCRIPTION
Adds an overview over allocated slots to the TM metrics page.

![image](https://github.com/apache/flink/assets/5725237/650441bb-664d-4e1a-99c9-a53fde4b55b4)

Now that I'm looking at the screenshot I wonder if the row could be misinterpreted as "job X has 0 slots allocated" :thinking: 

One problem we have is that the order of slots isn't deterministic, so slots may jump around in the table when more are dynamically allocated.
The REST API isn't exposing something right now based on which we could _easily_ sort slots to remedy this (like the allocation id).