### PR TITLE
[FLINK-32204][runtime] Separates the DirectExecutorService from the DirectExecutor again.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/DirectExecutorService.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/DirectExecutorService.java
@@ -39,9 +39,24 @@ import java.util.concurrent.TimeoutException;
  * thread.
  */
 class DirectExecutorService implements ExecutorService {
-    static final DirectExecutorService INSTANCE = new DirectExecutorService();
+
+    private final boolean triggerRejectedExecutionException;
 
     private boolean isShutdown = false;
+
+    /**
+     * Creates a new {@link DirectExecutorService} instance.
+     *
+     * @param triggerRejectedExecutionException determines whether proper instance lifecycle
+     *     management is applied. Passing {@code false} enables no-op shutdown functionality.
+     *     Submitting tasks would still work after a shutdown. Passing {@link true} will align the
+     *     instance's behavior with the {@link ExecutorService} contract which states that a {@link
+     *     RejectedExecutionException} is thrown by any task invoking method if the executor service
+     *     is shut down.
+     */
+    DirectExecutorService(boolean triggerRejectedExecutionException) {
+        this.triggerRejectedExecutionException = triggerRejectedExecutionException;
+    }
 
     @Override
     public void shutdown() {
@@ -233,7 +248,7 @@ class DirectExecutorService implements ExecutorService {
     }
 
     private void throwRejectedExecutionExceptionIfShutdown() {
-        if (isShutdown()) {
+        if (isShutdown() && triggerRejectedExecutionException) {
             throw new RejectedExecutionException(
                     "The ExecutorService is shut down already. No Callables can be executed.");
         }

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/Executors.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/Executors.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ExecutorService;
 /** Collection of {@link Executor} and {@link ExecutorService} implementations. */
 public class Executors {
 
+    private Executors() {}
+
     /**
      * Return a direct executor. The direct executor directly executes the runnable in the calling
      * thread.

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/Executors.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/Executors.java
@@ -31,18 +31,31 @@ public class Executors {
      * @return Direct executor
      */
     public static Executor directExecutor() {
-        return DirectExecutorService.INSTANCE;
+        return DirectExecutor.INSTANCE;
+    }
+
+    /** Creates a more {@link ExecutorService} that runs the passed task in the calling thread. */
+    public static ExecutorService newDirectExecutorService() {
+        return new DirectExecutorService(true);
     }
 
     /**
-     * Return a new direct executor service.
+     * Creates a new {@link ExecutorService} that runs the passed tasks in the calling thread but
+     * doesn't implement proper shutdown behavior. Tasks can be still submitted even after {@link
+     * ExecutorService#shutdown()} is called.
      *
-     * <p>The direct executor service directly executes the runnables and the callables in the
-     * calling thread.
-     *
-     * @return New direct executor service
+     * @see #newDirectExecutorService()
      */
-    public static ExecutorService newDirectExecutorService() {
-        return new DirectExecutorService();
+    public static ExecutorService newDirectExecutorServiceWithNoOpShutdown() {
+        return new DirectExecutorService(false);
+    }
+
+    private enum DirectExecutor implements Executor {
+        INSTANCE;
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/DirectExecutorServiceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/DirectExecutorServiceTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.concurrent;
+
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DirectExecutorServiceTest {
+
+    @Test
+    void testExecute() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance ->
+                        testInstance.execute(() -> future.complete(Thread.currentThread())));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitRunnable() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance -> testInstance.submit(() -> future.complete(Thread.currentThread())));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitCallable() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance -> testInstance.submit(callableFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitRunnableWithResult() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance ->
+                        testInstance.submit(() -> future.complete(Thread.currentThread()), null));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAll() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance -> testInstance.invokeAll(callableCollectionFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAllWithTimeout() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance ->
+                        testInstance.invokeAll(
+                                callableCollectionFromFuture(future), 1, TimeUnit.DAYS));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAny() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance -> testInstance.invokeAny(callableCollectionFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAnyWithTimeout() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testTaskSubmissionBeforeShutdown(
+                testInstance ->
+                        testInstance.invokeAny(
+                                callableCollectionFromFuture(future), 1, TimeUnit.DAYS));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    private void testTaskSubmissionBeforeShutdown(
+            ThrowingConsumer<ExecutorService, Throwable> taskSubmission) {
+        final ExecutorService testInstance = new DirectExecutorService(true);
+        testSuccessfulTaskSubmission(testInstance, taskSubmission);
+
+        testInstance.shutdown();
+    }
+
+    @Test
+    void testExecuteWithNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance ->
+                        testInstance.execute(() -> future.complete(Thread.currentThread())));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitRunnableWithNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance -> testInstance.submit(() -> future.complete(Thread.currentThread())));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitCallableWithNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(testInstance -> testInstance.submit(callableFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testSubmitRunnableWithResultAndNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance ->
+                        testInstance.submit(() -> future.complete(Thread.currentThread()), null));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAllWithNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance -> testInstance.invokeAll(callableCollectionFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAllWithTimeoutAndNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance ->
+                        testInstance.invokeAll(
+                                callableCollectionFromFuture(future), 1, TimeUnit.DAYS));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAnyWithNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance -> testInstance.invokeAny(callableCollectionFromFuture(future)));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    @Test
+    void testInvokeAnyWithTimeoutAndNoopShutdown() {
+        final CompletableFuture<Thread> future = new CompletableFuture<>();
+        testWithNoopShutdown(
+                testInstance ->
+                        testInstance.invokeAny(
+                                callableCollectionFromFuture(future), 1, TimeUnit.DAYS));
+
+        assertThat(future).isCompletedWithValue(Thread.currentThread());
+    }
+
+    private void testWithNoopShutdown(ThrowingConsumer<ExecutorService, Throwable> taskSubmission) {
+        final ExecutorService testInstance = new DirectExecutorService(false);
+        testInstance.shutdown();
+
+        testSuccessfulTaskSubmission(testInstance, taskSubmission);
+    }
+
+    private static List<Callable<Void>> callableCollectionFromFuture(
+            CompletableFuture<Thread> future) {
+        return Collections.singletonList(callableFromFuture(future));
+    }
+
+    private static Callable<Void> callableFromFuture(CompletableFuture<Thread> future) {
+        return () -> {
+            future.complete(Thread.currentThread());
+            return null;
+        };
+    }
+
+    private void testSuccessfulTaskSubmission(
+            ExecutorService testInstance,
+            ThrowingConsumer<ExecutorService, Throwable> taskSubmission) {
+        assertThatNoException().isThrownBy(() -> taskSubmission.accept(testInstance));
+    }
+
+    @Test
+    void testRejectedExecute() {
+        testRejectedExecutionException(testInstance -> testInstance.execute(() -> {}));
+    }
+
+    @Test
+    void testRejectedSubmitRunnable() {
+        testRejectedExecutionException(testInstance -> testInstance.submit(() -> {}));
+    }
+
+    @Test
+    void testRejectedSubmitCallable() {
+        testRejectedExecutionException(testInstance -> testInstance.submit(() -> null));
+    }
+
+    @Test
+    void testRejectedSubmitWithResult() {
+        testRejectedExecutionException(testInstance -> testInstance.submit(() -> {}, null));
+    }
+
+    @Test
+    void testRejectedInvokeAll() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAll(Collections.singleton(() -> null)));
+    }
+
+    @Test
+    void testRejectedInvokeAllWithEmptyList() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAll(Collections.emptyList()));
+    }
+
+    @Test
+    void testRejectedInvokeAllWithTimeout() {
+        testRejectedExecutionException(
+                testInstance ->
+                        testInstance.invokeAll(
+                                Collections.singleton(() -> null), 1L, TimeUnit.DAYS));
+    }
+
+    @Test
+    void testRejectedInvokeAllWithEmptyListAndTimeout() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAll(Collections.emptyList(), 1L, TimeUnit.DAYS));
+    }
+
+    @Test
+    void testRejectedInvokeAny() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAny(Collections.singleton(() -> null)));
+    }
+
+    @Test
+    void testRejectedInvokeAnyWithEmptyList() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAny(Collections.emptyList()));
+    }
+
+    @Test
+    void testRejectedInvokeAnyWithTimeout() {
+        testRejectedExecutionException(
+                testInstance ->
+                        testInstance.invokeAll(
+                                Collections.singleton(() -> null), 1L, TimeUnit.DAYS));
+    }
+
+    @Test
+    void testRejectedInvokeAnyWithEmptyListAndTimeout() {
+        testRejectedExecutionException(
+                testInstance -> testInstance.invokeAll(Collections.emptyList(), 1L, TimeUnit.DAYS));
+    }
+
+    private void testRejectedExecutionException(
+            ThrowingConsumer<ExecutorService, Throwable> taskSubmission) {
+        final ExecutorService testInstance = new DirectExecutorService(true);
+        testInstance.shutdown();
+
+        assertThatThrownBy(() -> taskSubmission.accept(testInstance))
+                .isInstanceOf(RejectedExecutionException.class);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriver.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.concurrent.Executors;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.cache.ChildData;
@@ -67,14 +66,12 @@ public class ZooKeeperMultipleComponentLeaderElectionDriver
 
         this.leaderLatch = new LeaderLatch(curatorFramework, ZooKeeperUtils.getLeaderLatchPath());
         this.treeCache =
-                TreeCache.newBuilder(curatorFramework, "/")
-                        .setCacheData(true)
-                        .setCreateParentNodes(false)
-                        .setSelector(
-                                new ZooKeeperMultipleComponentLeaderElectionDriver
-                                        .ConnectionInfoNodeSelector())
-                        .setExecutor(Executors.newDirectExecutorService())
-                        .build();
+                ZooKeeperUtils.createTreeCache(
+                        curatorFramework,
+                        "/",
+                        new ZooKeeperMultipleComponentLeaderElectionDriver
+                                .ConnectionInfoNodeSelector());
+
         treeCache
                 .getListenable()
                 .addListener(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -773,7 +773,9 @@ public class ZooKeeperUtils {
                 .setCacheData(true)
                 .setCreateParentNodes(false)
                 .setSelector(selector)
-                .setExecutor(Executors.newDirectExecutorService())
+                // see FLINK-32204 for further details on why the task rejection shouldn't
+                // be enforced here
+                .setExecutor(Executors.newDirectExecutorServiceWithNoOpShutdown())
                 .build();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -757,16 +757,24 @@ public class ZooKeeperUtils {
             final String pathToNode,
             final RunnableWithException nodeChangeCallback) {
         final TreeCache cache =
-                TreeCache.newBuilder(client, pathToNode)
-                        .setCacheData(true)
-                        .setCreateParentNodes(false)
-                        .setSelector(ZooKeeperUtils.treeCacheSelectorForPath(pathToNode))
-                        .setExecutor(Executors.newDirectExecutorService())
-                        .build();
+                createTreeCache(
+                        client, pathToNode, ZooKeeperUtils.treeCacheSelectorForPath(pathToNode));
 
         cache.getListenable().addListener(createTreeCacheListener(nodeChangeCallback));
 
         return cache;
+    }
+
+    public static TreeCache createTreeCache(
+            final CuratorFramework client,
+            final String pathToNode,
+            final TreeCacheSelector selector) {
+        return TreeCache.newBuilder(client, pathToNode)
+                .setCacheData(true)
+                .setCreateParentNodes(false)
+                .setSelector(selector)
+                .setExecutor(Executors.newDirectExecutorService())
+                .build();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## What is the purpose of the change

The `DirectExecutor` doesn't have to handle the shutdown state and, therefore, can be served as a singleton. The `DirectExecutorService`, instead, cannot be served as a singleton due to the shutdown state.

We still have to provide an `ExecutorService` implementation without proper task rejection after shutdown was called, though, due to a bug in the `TreeCache` implementation as described in FLINK-32204.

## Brief change log

* Merges TreeCache instantiation of `ZooKeeperUtils` and `ZooKeeperMultipleComponentLeaderElectionDriver`
* reintroduced `Executor.DirectExecutor` after it was removed in 17082604
* Introduces new factory methods for the `DirectExecutorService` and made them available through the `Executors` interface

## Verifying this change

* The error couldn't be reproduced locally and is, therefore, hard to verify because it's supposed to be a bug within curator. But the code itself is back to its pre-FLINK-31995 state for the ZooKeeper codebase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable