### PR TITLE
[FLINK-32220][table-runtime] Improving the adaptive local hash agg code to avoid get value from RowData repeatedly

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -160,7 +160,7 @@ object ProjectionCodeGenerator {
               sumAggFunction.getResultType.getLogicalType,
               aggInfo.agg.getArgList.get(0))
           case _: MaxAggFunction | _: MinAggFunction =>
-            fieldExprs += getReuseFieldExprForAggFunc(
+            fieldExprs += reuseFieldExprForAggFunc(
               ctx,
               inputType,
               inputTerm,
@@ -230,18 +230,18 @@ object ProjectionCodeGenerator {
       inputTerm: String,
       targetType: LogicalType,
       index: Int): GeneratedExpression = {
-    val fieldExpr = getReuseFieldExprForAggFunc(ctx, inputType, inputTerm, index)
+    val fieldExpr = reuseFieldExprForAggFunc(ctx, inputType, inputTerm, index)
     // Convert the projected value type to sum agg func target type.
-    ScalarOperatorGens.generateCast(ctx, fieldExpr, targetType, true)
+    ScalarOperatorGens.generateCast(ctx, fieldExpr, targetType, nullOnFailure = true)
   }
 
   /** Get reuse field expr if it has been evaluated before for adaptive local hash aggregation. */
-  def getReuseFieldExprForAggFunc(
+  def reuseFieldExprForAggFunc(
       ctx: CodeGeneratorContext,
       inputType: LogicalType,
       inputTerm: String,
-      index: Int) = {
-    // reuse the field access code if it has been evaluated before
+      index: Int): GeneratedExpression = {
+    // Reuse the field access code if it has been evaluated before
     ctx.getReusableInputUnboxingExprs(inputTerm, index) match {
       case None => GenerateUtils.generateFieldAccess(ctx, inputType, inputTerm, index)
       case Some(expr) =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -142,21 +142,6 @@ object HashAggCodeGenerator {
         outRecordWriterTerm = currentKeyWriterTerm)
       .code
 
-    val valueProjectionCode =
-      if (!isFinal && supportAdaptiveLocalHashAgg) {
-        ProjectionCodeGenerator.genAdaptiveLocalHashAggValueProjectionCode(
-          ctx,
-          inputType,
-          classOf[BinaryRowData],
-          inputTerm = inputTerm,
-          aggInfos,
-          outRecordTerm = currentValueTerm,
-          outRecordWriterTerm = currentValueWriterTerm
-        )
-      } else {
-        ""
-      }
-
     // gen code to create groupKey, aggBuffer Type array
     // it will be used in BytesHashMap and BufferedKVExternalSorter if enable fallback
     val groupKeyTypesTerm = CodeGenUtils.newName("groupKeyTypes")
@@ -264,6 +249,21 @@ object HashAggCodeGenerator {
     }
     val localAggSuppressedTerm = CodeGenUtils.newName("localAggSuppressed")
     ctx.addReusableMember(s"private transient boolean $localAggSuppressedTerm = false;")
+    val valueProjectionCode =
+      if (!isFinal && supportAdaptiveLocalHashAgg) {
+        ProjectionCodeGenerator.genAdaptiveLocalHashAggValueProjectionCode(
+          ctx,
+          inputType,
+          classOf[BinaryRowData],
+          inputTerm = inputTerm,
+          aggInfos,
+          outRecordTerm = currentValueTerm,
+          outRecordWriterTerm = currentValueWriterTerm
+        )
+      } else {
+        ""
+      }
+
     val (
       distinctCountIncCode,
       totalCountIncCode,


### PR DESCRIPTION

## What is the purpose of the change

If the adaptive local hash agg is enabled, the generated code for value projection is evaluated repeatedly, the field access code can be reused to avoid accessing RowData twice, this optimization can improve the query performance.  


## Brief change log

  - *Improve the adaptive local hash agg value projection code*


## Verifying this change

This change is a trivial code improvement, already covered by existing tests in HashAggITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
