### PR TITLE
[FLINK-32225][Runtime] Executions in same Job use a shared TaskDeploymentDescriptorFactory.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -118,35 +118,42 @@ public class DefaultExecutionGraphBuilder {
                 PartitionGroupReleaseStrategyFactoryLoader.loadPartitionGroupReleaseStrategyFactory(
                         jobManagerConfig);
 
-        // create a new execution graph, if none exists so far
-        final DefaultExecutionGraph executionGraph;
+        final TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory;
         try {
-            executionGraph =
-                    new DefaultExecutionGraph(
-                            jobInformation,
-                            futureExecutor,
-                            ioExecutor,
-                            rpcTimeout,
-                            executionHistorySizeLimit,
-                            classLoader,
-                            blobWriter,
-                            partitionGroupReleaseStrategyFactory,
-                            shuffleMaster,
-                            partitionTracker,
+            taskDeploymentDescriptorFactory =
+                    new TaskDeploymentDescriptorFactory(
+                            BlobWriter.serializeAndTryOffload(jobInformation, jobId, blobWriter),
+                            jobId,
                             partitionLocationConstraint,
-                            executionDeploymentListener,
-                            executionStateUpdateListener,
-                            initializationTimestamp,
-                            vertexAttemptNumberStore,
-                            vertexParallelismStore,
-                            isDynamicGraph,
-                            executionJobVertexFactory,
-                            jobGraph.getJobStatusHooks(),
-                            markPartitionFinishedStrategy,
+                            blobWriter,
                             nonFinishedHybridPartitionShouldBeUnknown);
         } catch (IOException e) {
-            throw new JobException("Could not create the ExecutionGraph.", e);
+            throw new JobException("Could not create the TaskDeploymentDescriptorFactory.", e);
         }
+
+        // create a new execution graph, if none exists so far
+        final DefaultExecutionGraph executionGraph =
+                new DefaultExecutionGraph(
+                        jobInformation,
+                        futureExecutor,
+                        ioExecutor,
+                        rpcTimeout,
+                        executionHistorySizeLimit,
+                        classLoader,
+                        blobWriter,
+                        partitionGroupReleaseStrategyFactory,
+                        shuffleMaster,
+                        partitionTracker,
+                        executionDeploymentListener,
+                        executionStateUpdateListener,
+                        initializationTimestamp,
+                        vertexAttemptNumberStore,
+                        vertexParallelismStore,
+                        isDynamicGraph,
+                        executionJobVertexFactory,
+                        jobGraph.getJobStatusHooks(),
+                        markPartitionFinishedStrategy,
+                        taskDeploymentDescriptorFactory);
 
         // set the basic properties
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -568,8 +568,10 @@ public class Execution
                     slot.getAllocationId());
 
             final TaskDeploymentDescriptor deployment =
-                    TaskDeploymentDescriptorFactory.fromExecution(this)
+                    vertex.getExecutionGraphAccessor()
+                            .getTaskDeploymentDescriptorFactory()
                             .createDeploymentDescriptor(
+                                    this,
                                     slot.getAllocationId(),
                                     taskRestore,
                                     producedPartitions.values());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -32,8 +32,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
-import org.apache.flink.types.Either;
-import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nonnull;
 
@@ -51,10 +49,6 @@ public interface InternalExecutionGraphAccessor {
     JobID getJobID();
 
     BlobWriter getBlobWriter();
-
-    Either<SerializedValue<JobInformation>, PermanentBlobKey> getJobInformationOrBlobKey();
-
-    TaskDeploymentDescriptorFactory.PartitionLocationConstraint getPartitionLocationConstraint();
 
     /**
      * Returns the ExecutionContext associated with this ExecutionGraph.
@@ -133,5 +127,5 @@ public interface InternalExecutionGraphAccessor {
     JobVertexInputInfo getJobVertexInputInfo(
             JobVertexID jobVertexId, IntermediateDataSetID resultId);
 
-    boolean isNonFinishedHybridPartitionShouldBeUnknown();
+    TaskDeploymentDescriptorFactory getTaskDeploymentDescriptorFactory();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -252,8 +252,13 @@ public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
     private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(ExecutionVertex ev)
             throws IOException, ClusterDatasetCorruptedException {
 
-        return TaskDeploymentDescriptorFactory.fromExecution(ev.getCurrentExecutionAttempt())
-                .createDeploymentDescriptor(new AllocationID(), null, Collections.emptyList());
+        return ev.getExecutionGraphAccessor()
+                .getTaskDeploymentDescriptorFactory()
+                .createDeploymentDescriptor(
+                        ev.getCurrentExecutionAttempt(),
+                        new AllocationID(),
+                        null,
+                        Collections.emptyList());
     }
 
     public static ShuffleDescriptor[] deserializeShuffleDescriptors(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -109,7 +109,8 @@ class DefaultExecutionGraphDeploymentTest {
      * @param eg the execution graph that was created
      */
     protected void checkJobOffloaded(DefaultExecutionGraph eg) throws Exception {
-        assertThat(eg.getJobInformationOrBlobKey().isLeft()).isTrue();
+        assertThat(eg.getTaskDeploymentDescriptorFactory().getSerializedJobInformation())
+                .isInstanceOf(TaskDeploymentDescriptor.NonOffloaded.class);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.executiongraph.InternalExecutionGraphAccessor;
-import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.JobVertexInputInfo;
 import org.apache.flink.runtime.executiongraph.MarkPartitionFinishedStrategy;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
@@ -72,8 +71,6 @@ import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.types.Either;
-import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
@@ -927,18 +924,6 @@ public class ExecutingTest extends TestLogger {
             return null;
         }
 
-        @Override
-        public Either<SerializedValue<JobInformation>, PermanentBlobKey>
-                getJobInformationOrBlobKey() {
-            return null;
-        }
-
-        @Override
-        public TaskDeploymentDescriptorFactory.PartitionLocationConstraint
-                getPartitionLocationConstraint() {
-            return null;
-        }
-
         @Nonnull
         @Override
         public ComponentMainThreadExecutor getJobMasterMainThreadExecutor() {
@@ -1037,12 +1022,6 @@ public class ExecutingTest extends TestLogger {
         }
 
         @Override
-        public boolean isNonFinishedHybridPartitionShouldBeUnknown() {
-            throw new UnsupportedOperationException(
-                    "This method is not supported by the MockInternalExecutionGraphAccessor.");
-        }
-
-        @Override
         public ExecutionGraphID getExecutionGraphID() {
             return new ExecutionGraphID();
         }
@@ -1057,6 +1036,12 @@ public class ExecutingTest extends TestLogger {
         @Override
         public JobVertexInputInfo getJobVertexInputInfo(
                 JobVertexID jobVertexId, IntermediateDataSetID resultId) {
+            throw new UnsupportedOperationException(
+                    "This method is not supported by the MockInternalExecutionGraphAccessor.");
+        }
+
+        @Override
+        public TaskDeploymentDescriptorFactory getTaskDeploymentDescriptorFactory() {
             throw new UnsupportedOperationException(
                     "This method is not supported by the MockInternalExecutionGraphAccessor.");
         }


### PR DESCRIPTION

## What is the purpose of the change

TaskDeploymentDescriptorFactory#fromExecution needs to retrieve several fields from the ExecutionGraphAccessor. We could introduce a new TaskDeploymentDescriptorHelper to merge all these fields to make the ExecutionGraph/TaskDeploymentDescriptor more readable.


## Brief change log
  - *Merge all task deployment related fields to TaskDeploymentDescriptorHelper*


## Verifying this change

This change is code refactoring without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
