### PR TITLE
[FLINK-32236][yarn][tests] Ease allow-list regex

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -148,9 +148,9 @@ public abstract class YarnTestBase {
         // very specific on purpose; whitelist meaningless exceptions that occur during akka
         // shutdown:
         Pattern.compile(
-                "Remote connection to \\[null\\] failed with java.net.ConnectException: Connection refused"),
+                "Remote connection to \\[.*\\] failed with java.net.ConnectException: Connection refused"),
         Pattern.compile(
-                "Remote connection to \\[null\\] failed with java.nio.channels.NotYetConnectedException"),
+                "Remote connection to \\[.*\\] failed with java.nio.channels.NotYetConnectedException"),
         Pattern.compile("java\\.io\\.IOException: Connection reset by peer"),
         Pattern.compile(
                 "Association with remote system \\[akka.tcp://flink@[^]]+\\] has failed, address is now gated for \\[50\\] ms. Reason: \\[Association failed with \\[akka.tcp://flink@[^]]+\\]\\] Caused by: \\[java.net.ConnectException: Connection refused: [^]]+\\]"),


### PR DESCRIPTION
II've seen this exception a few times without the address being null.
This could be due to difference in how Java 17 resolves addresses .
In any case I don't see any harm in relaxing this regex to accept any address.