### PR TITLE
[FLINK-32219][sql-client] Fix SqlClient hangs when executing EXECUTE PLAN statement

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -109,7 +109,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESULT_OK;
@@ -428,7 +427,7 @@ public class OperationExecutor {
                     tableEnv, handle, Collections.singletonList((ModifyOperation) op));
         } else if (op instanceof CompileAndExecutePlanOperation
                 || op instanceof ExecutePlanOperation) {
-            return callExecutionOperation(tableEnv, handle, () -> op);
+            return callExecuteOperation(tableEnv, handle, op);
         } else if (op instanceof StatementSetOperation) {
             return callModifyOperations(
                     tableEnv, handle, ((StatementSetOperation) op).getOperations());
@@ -521,11 +520,11 @@ public class OperationExecutor {
         return fetchJobId(result, handle);
     }
 
-    private ResultFetcher callExecutionOperation(
+    private ResultFetcher callExecuteOperation(
             TableEnvironmentInternal tableEnv,
             OperationHandle handle,
-            Supplier<Operation> operationSupplier) {
-        return fetchJobId(tableEnv.executeInternal(operationSupplier.get()), handle);
+            Operation executePlanOperation) {
+        return fetchJobId(tableEnv.executeInternal(executePlanOperation), handle);
     }
 
     private ResultFetcher fetchJobId(TableResultInternal result, OperationHandle handle) {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
@@ -117,6 +117,9 @@ public abstract class AbstractSqlGatewayStatementITCase extends AbstractTestBase
                 "$VAR_STREAMING_PATH2",
                 Files.createDirectory(temporaryFolder.resolve("streaming2")).toFile().getPath());
         replaceVars.put(
+                "$VAR_STREAMING_PATH3",
+                Files.createDirectory(temporaryFolder.resolve("streaming3")).toFile().getPath());
+        replaceVars.put(
                 "$VAR_BATCH_PATH",
                 Files.createDirectory(temporaryFolder.resolve("batch")).toFile().getPath());
         replaceVars.put(
@@ -124,6 +127,11 @@ public abstract class AbstractSqlGatewayStatementITCase extends AbstractTestBase
                 Files.createDirectory(temporaryFolder.resolve("batch_ctas")).toFile().getPath());
         replaceVars.put(
                 "$VAR_REST_PORT", MINI_CLUSTER.getClientConfiguration().get(PORT).toString());
+        replaceVars.put(
+                "$VAR_STREAMING_PLAN_PATH",
+                Files.createDirectory(temporaryFolder.resolve("streaming_compiled_plan"))
+                        .toFile()
+                        .getPath());
     }
 
     @TestTemplate

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/insert.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/insert.q
@@ -88,6 +88,89 @@ SELECT * FROM StreamingTable;
 !ok
 
 # ==========================================================================
+# test streaming insert through compiled plan
+# ==========================================================================
+
+create table StreamingTableForPlan (
+  id int,
+  str string
+) with (
+  'connector' = 'filesystem',
+  'path' = '$VAR_STREAMING_PATH3',
+  'format' = 'csv'
+);
+!output
++--------+
+| result |
++--------+
+|     OK |
++--------+
+1 row in set
+!ok
+
+COMPILE AND EXECUTE PLAN '$VAR_STREAMING_PLAN_PATH/plan1.json' FOR INSERT INTO StreamingTableForPlan SELECT * FROM (VALUES (1, 'Hello'));
+!output
+Job ID:
+!info
+
+RESET '$internal.pipeline.job-id';
+!output
++--------+
+| result |
++--------+
+|     OK |
++--------+
+1 row in set
+!ok
+
+SELECT * FROM StreamingTableForPlan;
+!output
++----+----+-------+
+| op | id |   str |
++----+----+-------+
+| +I |  1 | Hello |
++----+----+-------+
+1 row in set
+!ok
+
+
+COMPILE PLAN '$VAR_STREAMING_PLAN_PATH/plan2.json' FOR INSERT INTO StreamingTableForPlan SELECT * FROM (VALUES (1, 'Hello'));
+!output
++--------+
+| result |
++--------+
+|     OK |
++--------+
+1 row in set
+!ok
+
+EXECUTE PLAN '$VAR_STREAMING_PLAN_PATH/plan2.json';
+!output
+Job ID:
+!info
+
+RESET '$internal.pipeline.job-id';
+!output
++--------+
+| result |
++--------+
+|     OK |
++--------+
+1 row in set
+!ok
+
+SELECT * FROM StreamingTableForPlan;
+!output
++----+----+-------+
+| op | id |   str |
++----+----+-------+
+| +I |  1 | Hello |
+| +I |  1 | Hello |
++----+----+-------+
+2 rows in set
+!ok
+
+# ==========================================================================
 # test batch insert
 # ==========================================================================
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -806,16 +806,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
         List<Transformation<?>> transformations = translate(mapOperations);
         List<String> sinkIdentifierNames = extractSinkIdentifierNames(mapOperations);
-        TableResultInternal result = executeInternal(transformations, sinkIdentifierNames);
-        if (tableConfig.get(TABLE_DML_SYNC)) {
-            try {
-                result.await();
-            } catch (InterruptedException | ExecutionException e) {
-                result.getJobClient().ifPresent(JobClient::cancel);
-                throw new TableException("Fail to wait execution finish.", e);
-            }
-        }
-        return result;
+        return executeInternal(transformations, sinkIdentifierNames);
     }
 
     private TableResultInternal executeInternal(
@@ -853,13 +844,24 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 affectedRowCounts[i] = -1L;
             }
 
-            return TableResultImpl.builder()
-                    .jobClient(jobClient)
-                    .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-                    .schema(ResolvedSchema.of(columns))
-                    .resultProvider(
-                            new InsertResultProvider(affectedRowCounts).setJobClient(jobClient))
-                    .build();
+            TableResultInternal result =
+                    TableResultImpl.builder()
+                            .jobClient(jobClient)
+                            .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+                            .schema(ResolvedSchema.of(columns))
+                            .resultProvider(
+                                    new InsertResultProvider(affectedRowCounts)
+                                            .setJobClient(jobClient))
+                            .build();
+            if (tableConfig.get(TABLE_DML_SYNC)) {
+                try {
+                    result.await();
+                } catch (InterruptedException | ExecutionException e) {
+                    result.getJobClient().ifPresent(JobClient::cancel);
+                    throw new TableException("Fail to wait execution finish.", e);
+                }
+            }
+            return result;
         } catch (Exception e) {
             throw new TableException("Failed to execute sql", e);
         }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the issue that the `COMPILE AND EXECUTE PLAN` or `EXECUTE PLAN` statement causes the SQL client to hang forever. The reason is that `OperationExecutor` didn't take these two kinds of operation kind into account. Instead, they should be dealt with like `ModifyOperation`.


## Brief change log

  - Let`OperationExecutor` cope with `ExecutionPlanOperation` and `CompileAndExecutePlanOperation`.
  - `TableEnvironmentImpl` should apply `TABLE_DML_SYNC` for both `ModifyOpeartion` and `ExecutePlanOperation`. Both of them are compiled from `insert into` queries.


## Verifying this change

- Add plan-related tests in the`insert.q` to verify that the `EXECUTE PLAN` and `COMPILE AND EXECUTE PLAN` statements work as expected after the fix. 
- Verify the SqlClient works normally after submitting `EXECUTE PLAN` statement.
![image](https://github.com/apache/flink/assets/55568005/ce6a7b91-2f63-443f-8e9d-1edf8ce52b75)



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
