### PR TITLE
[FLINK-32250][configuration] Revert the field name of BUFFER_TIMEOUT

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -103,7 +103,7 @@ public class ExecutionOptions {
                                                     + "buffer is full thus maximizing throughput")
                                     .build());
 
-    public static final ConfigOption<Duration> BUFFER_TIMEOUT_INTERVAL =
+    public static final ConfigOption<Duration> BUFFER_TIMEOUT =
             ConfigOptions.key("execution.buffer-timeout.interval")
                     .durationType()
                     .defaultValue(Duration.ofMillis(100))

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -192,7 +192,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
 
     private final Map<AbstractID, CacheTransformation<?>> cachedTransformations = new HashMap<>();
 
-    private long bufferTimeout = ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.defaultValue().toMillis();
+    private long bufferTimeout = ExecutionOptions.BUFFER_TIMEOUT.defaultValue().toMillis();
 
     protected boolean isChainingEnabled = true;
 
@@ -1079,7 +1079,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
     private void configBufferTimeout(ReadableConfig configuration) {
         if (configuration.get(ExecutionOptions.BUFFER_TIMEOUT_ENABLED)) {
             configuration
-                    .getOptional(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL)
+                    .getOptional(ExecutionOptions.BUFFER_TIMEOUT)
                     .ifPresent(t -> this.setBufferTimeout(t.toMillis()));
         } else {
             this.setBufferTimeout(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -177,8 +177,7 @@ public class StreamGraphGenerator {
 
     private SavepointRestoreSettings savepointRestoreSettings;
 
-    private long defaultBufferTimeout =
-            ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.defaultValue().toMillis();
+    private long defaultBufferTimeout = ExecutionOptions.BUFFER_TIMEOUT.defaultValue().toMillis();
 
     private boolean shouldExecuteInBatchMode;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -403,13 +403,13 @@ class StreamExecutionEnvironmentTest {
                 .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
 
         // Setting execution.buffer-timeout's to 0ms will not take effect.
-        config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "0ms");
+        config.setString(ExecutionOptions.BUFFER_TIMEOUT.key(), "0ms");
         env.configure(config, this.getClass().getClassLoader());
         assertThat(env.getBufferTimeout())
                 .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
 
         // Setting execution.buffer-timeout's to -1ms will not take effect.
-        config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "-1ms");
+        config.setString(ExecutionOptions.BUFFER_TIMEOUT.key(), "-1ms");
         env.configure(config, this.getClass().getClassLoader());
         assertThat(env.getBufferTimeout())
                 .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
@@ -418,16 +418,15 @@ class StreamExecutionEnvironmentTest {
     private void testBufferTimeout(Configuration config, StreamExecutionEnvironment env) {
         env.configure(config, this.getClass().getClassLoader());
         assertThat(env.getBufferTimeout())
-                .isEqualTo(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.defaultValue().toMillis());
+                .isEqualTo(ExecutionOptions.BUFFER_TIMEOUT.defaultValue().toMillis());
 
-        config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "0ms");
+        config.setString(ExecutionOptions.BUFFER_TIMEOUT.key(), "0ms");
         env.configure(config, this.getClass().getClassLoader());
         assertThat(env.getBufferTimeout()).isZero();
 
         assertThatThrownBy(
                         () -> {
-                            config.setString(
-                                    ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "-1ms");
+                            config.setString(ExecutionOptions.BUFFER_TIMEOUT.key(), "-1ms");
                             env.configure(config, this.getClass().getClassLoader());
                         })
                 .isInstanceOf(IllegalArgumentException.class);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -45,51 +45,51 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.SplittableIterator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link StreamExecutionEnvironment}. */
-public class StreamExecutionEnvironmentTest {
+class StreamExecutionEnvironmentTest {
 
     @Test
-    public void fromElementsWithBaseTypeTest1() {
+    void fromElementsWithBaseTypeTest1() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.fromElements(ParentClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void fromElementsWithBaseTypeTest2() {
+    @Test
+    void fromElementsWithBaseTypeTest2() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.fromElements(SubClass.class, new SubClass(1, "Java"), new ParentClass(1, "hello"));
+        assertThatThrownBy(
+                        () ->
+                                env.fromElements(
+                                        SubClass.class,
+                                        new SubClass(1, "Java"),
+                                        new ParentClass(1, "hello")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testFromElementsDeducedType() {
+    void testFromElementsDeducedType() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         DataStreamSource<String> source = env.fromElements("a", "b");
 
         FromElementsFunction<String> elementsFunction =
                 (FromElementsFunction<String>) getFunctionFromDataSource(source);
-        assertEquals(
-                BasicTypeInfo.STRING_TYPE_INFO.createSerializer(env.getConfig()),
-                elementsFunction.getSerializer());
+        assertThat(elementsFunction.getSerializer())
+                .isEqualTo(BasicTypeInfo.STRING_TYPE_INFO.createSerializer(env.getConfig()));
     }
 
     @Test
-    public void testFromElementsPostConstructionType() {
+    void testFromElementsPostConstructionType() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         DataStreamSource<String> source = env.fromElements("a", "b");
         TypeInformation<String> customType = new GenericTypeInfo<>(String.class);
@@ -98,16 +98,15 @@ public class StreamExecutionEnvironmentTest {
 
         FromElementsFunction<String> elementsFunction =
                 (FromElementsFunction<String>) getFunctionFromDataSource(source);
-        assertNotEquals(
-                BasicTypeInfo.STRING_TYPE_INFO.createSerializer(env.getConfig()),
-                elementsFunction.getSerializer());
-        assertEquals(
-                customType.createSerializer(env.getConfig()), elementsFunction.getSerializer());
+        assertThat(elementsFunction.getSerializer())
+                .isNotEqualTo(BasicTypeInfo.STRING_TYPE_INFO.createSerializer(env.getConfig()));
+        assertThat(elementsFunction.getSerializer())
+                .isEqualTo(customType.createSerializer(env.getConfig()));
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testFromCollectionParallelism() {
+    void testFromCollectionParallelism() {
         try {
             TypeInformation<Integer> typeInfo = BasicTypeInfo.INT_TYPE_INFO;
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -115,12 +114,8 @@ public class StreamExecutionEnvironmentTest {
             DataStreamSource<Integer> dataStream1 =
                     env.fromCollection(new DummySplittableIterator<Integer>(), typeInfo);
 
-            try {
-                dataStream1.setParallelism(4);
-                fail("should throw an exception");
-            } catch (IllegalArgumentException e) {
-                // expected
-            }
+            assertThatThrownBy(() -> dataStream1.setParallelism(4))
+                    .isInstanceOf(IllegalArgumentException.class);
 
             dataStream1.addSink(new DiscardingSink<Integer>());
 
@@ -133,14 +128,12 @@ public class StreamExecutionEnvironmentTest {
             final StreamGraph streamGraph = env.getStreamGraph();
             streamGraph.getStreamingPlanAsJSON();
 
-            assertEquals(
-                    "Parallelism of collection source must be 1.",
-                    1,
-                    streamGraph.getStreamNode(dataStream1.getId()).getParallelism());
-            assertEquals(
-                    "Parallelism of parallel collection source must be 4.",
-                    4,
-                    streamGraph.getStreamNode(dataStream2.getId()).getParallelism());
+            assertThat(streamGraph.getStreamNode(dataStream1.getId()).getParallelism())
+                    .as("Parallelism of collection source must be 1.")
+                    .isOne();
+            assertThat(streamGraph.getStreamNode(dataStream2.getId()).getParallelism())
+                    .as("Parallelism of parallel collection source must be 4.")
+                    .isEqualTo(4);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -148,7 +141,7 @@ public class StreamExecutionEnvironmentTest {
     }
 
     @Test
-    public void testSources() {
+    void testSources() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         SourceFunction<Integer> srcFun =
@@ -163,32 +156,32 @@ public class StreamExecutionEnvironmentTest {
                 };
         DataStreamSource<Integer> src1 = env.addSource(srcFun);
         src1.addSink(new DiscardingSink<Integer>());
-        assertEquals(srcFun, getFunctionFromDataSource(src1));
+        assertThat(getFunctionFromDataSource(src1)).isEqualTo(srcFun);
 
         List<Long> list = Arrays.asList(0L, 1L, 2L);
 
         DataStreamSource<Long> src2 = env.generateSequence(0, 2);
-        assertTrue(getFunctionFromDataSource(src2) instanceof StatefulSequenceSource);
+        assertThat(getFunctionFromDataSource(src2)).isInstanceOf(StatefulSequenceSource.class);
 
         DataStreamSource<Long> src3 = env.fromElements(0L, 1L, 2L);
-        assertTrue(getFunctionFromDataSource(src3) instanceof FromElementsFunction);
+        assertThat(getFunctionFromDataSource(src3)).isInstanceOf(FromElementsFunction.class);
 
         DataStreamSource<Long> src4 = env.fromCollection(list);
-        assertTrue(getFunctionFromDataSource(src4) instanceof FromElementsFunction);
+        assertThat(getFunctionFromDataSource(src4)).isInstanceOf(FromElementsFunction.class);
     }
 
     /** Verifies that the API method doesn't throw and creates a source of the expected type. */
     @Test
-    public void testFromSequence() {
+    void testFromSequence() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStreamSource<Long> src = env.fromSequence(0, 2);
 
-        assertEquals(BasicTypeInfo.LONG_TYPE_INFO, src.getType());
+        assertThat(src.getType()).isEqualTo(BasicTypeInfo.LONG_TYPE_INFO);
     }
 
     @Test
-    public void testParallelismBounds() {
+    void testParallelismBounds() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         SourceFunction<Integer> srcFun =
@@ -215,75 +208,60 @@ public class StreamExecutionEnvironmentTest {
                                 });
 
         // default value for max parallelism
-        Assert.assertEquals(-1, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isEqualTo(-1);
 
         // bounds for parallelism 1
-        try {
-            operator.setParallelism(0);
-            Assert.fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> operator.setParallelism(0))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // bounds for parallelism 2
         operator.setParallelism(1);
-        Assert.assertEquals(1, operator.getParallelism());
+        assertThat(operator.getParallelism()).isOne();
 
         // bounds for parallelism 3
         operator.setParallelism(1 << 15);
-        Assert.assertEquals(1 << 15, operator.getParallelism());
+        assertThat(operator.getParallelism()).isEqualTo(1 << 15);
 
         // default value after generating
         env.getStreamGraph(false).getJobGraph();
-        Assert.assertEquals(-1, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isEqualTo(-1);
 
         // configured value after generating
         env.setMaxParallelism(42);
         env.getStreamGraph(false).getJobGraph();
-        Assert.assertEquals(42, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isEqualTo(42);
 
         // bounds configured parallelism 1
-        try {
-            env.setMaxParallelism(0);
-            Assert.fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> env.setMaxParallelism(0))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // bounds configured parallelism 2
-        try {
-            env.setMaxParallelism(1 + (1 << 15));
-            Assert.fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> env.setMaxParallelism(1 + (1 << 15)))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // bounds for max parallelism 1
-        try {
-            operator.setMaxParallelism(0);
-            Assert.fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> operator.setMaxParallelism(0))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // bounds for max parallelism 2
-        try {
-            operator.setMaxParallelism(1 + (1 << 15));
-            Assert.fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        assertThatThrownBy(() -> operator.setMaxParallelism(1 + (1 << 15)))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // bounds for max parallelism 3
         operator.setMaxParallelism(1);
-        Assert.assertEquals(1, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isOne();
 
         // bounds for max parallelism 4
         operator.setMaxParallelism(1 << 15);
-        Assert.assertEquals(1 << 15, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isEqualTo(1 << 15);
 
         // override config
         env.getStreamGraph(false).getJobGraph();
-        Assert.assertEquals(1 << 15, operator.getTransformation().getMaxParallelism());
+        assertThat(operator.getTransformation().getMaxParallelism()).isEqualTo(1 << 15);
     }
 
     @Test
-    public void testRegisterSlotSharingGroup() {
+    void testRegisterSlotSharingGroup() {
         final SlotSharingGroup ssg1 =
                 SlotSharingGroup.newBuilder("ssg1").setCpuCores(1).setTaskHeapMemoryMB(100).build();
         final SlotSharingGroup ssg2 =
@@ -297,17 +275,15 @@ public class StreamExecutionEnvironmentTest {
         source.map(value -> value).slotSharingGroup(ssg2).addSink(new DiscardingSink<>());
 
         final StreamGraph streamGraph = env.getStreamGraph();
-        assertThat(
-                streamGraph.getSlotSharingGroupResource("ssg1").get(),
-                is(ResourceProfile.fromResources(1, 100)));
-        assertThat(
-                streamGraph.getSlotSharingGroupResource("ssg2").get(),
-                is(ResourceProfile.fromResources(2, 200)));
-        assertFalse(streamGraph.getSlotSharingGroupResource("ssg3").isPresent());
+        assertThat(streamGraph.getSlotSharingGroupResource("ssg1").get())
+                .isEqualTo(ResourceProfile.fromResources(1, 100));
+        assertThat(streamGraph.getSlotSharingGroupResource("ssg2").get())
+                .isEqualTo(ResourceProfile.fromResources(2, 200));
+        assertThat(streamGraph.getSlotSharingGroupResource("ssg3")).isNotPresent();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testRegisterSlotSharingGroupConflict() {
+    @Test
+    void testRegisterSlotSharingGroupConflict() {
         final SlotSharingGroup ssg =
                 SlotSharingGroup.newBuilder("ssg1").setCpuCores(1).setTaskHeapMemoryMB(100).build();
         final SlotSharingGroup ssgConflict =
@@ -318,11 +294,11 @@ public class StreamExecutionEnvironmentTest {
         final DataStream<Integer> source = env.fromElements(1).slotSharingGroup("ssg1");
         source.map(value -> value).slotSharingGroup(ssgConflict).addSink(new DiscardingSink<>());
 
-        env.getStreamGraph();
+        assertThatThrownBy(env::getStreamGraph).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testGetStreamGraph() {
+    void testGetStreamGraph() {
         try {
             TypeInformation<Integer> typeInfo = BasicTypeInfo.INT_TYPE_INFO;
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -330,12 +306,12 @@ public class StreamExecutionEnvironmentTest {
             DataStreamSource<Integer> dataStream1 =
                     env.fromCollection(new DummySplittableIterator<Integer>(), typeInfo);
             dataStream1.addSink(new DiscardingSink<Integer>());
-            assertEquals(2, env.getStreamGraph().getStreamNodes().size());
+            assertThat(env.getStreamGraph().getStreamNodes().size()).isEqualTo(2);
 
             DataStreamSource<Integer> dataStream2 =
                     env.fromCollection(new DummySplittableIterator<Integer>(), typeInfo);
             dataStream2.addSink(new DiscardingSink<Integer>());
-            assertEquals(2, env.getStreamGraph().getStreamNodes().size());
+            assertThat(env.getStreamGraph().getStreamNodes().size()).isEqualTo(2);
 
             DataStreamSource<Integer> dataStream3 =
                     env.fromCollection(new DummySplittableIterator<Integer>(), typeInfo);
@@ -345,7 +321,7 @@ public class StreamExecutionEnvironmentTest {
             DataStreamSource<Integer> dataStream4 =
                     env.fromCollection(new DummySplittableIterator<Integer>(), typeInfo);
             dataStream4.addSink(new DiscardingSink<Integer>());
-            assertEquals(4, env.getStreamGraph().getStreamNodes().size());
+            assertThat(env.getStreamGraph().getStreamNodes().size()).isEqualTo(4);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -353,7 +329,7 @@ public class StreamExecutionEnvironmentTest {
     }
 
     @Test
-    public void testDefaultJobName() {
+    void testDefaultJobName() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         testJobName(StreamGraphGenerator.DEFAULT_STREAMING_JOB_NAME, env);
@@ -363,7 +339,7 @@ public class StreamExecutionEnvironmentTest {
     }
 
     @Test
-    public void testUserDefinedJobName() {
+    void testUserDefinedJobName() {
         String jobName = "MyTestJob";
         Configuration config = new Configuration();
         config.set(PipelineOptions.NAME, jobName);
@@ -372,7 +348,7 @@ public class StreamExecutionEnvironmentTest {
     }
 
     @Test
-    public void testUserDefinedJobNameWithConfigure() {
+    void testUserDefinedJobNameWithConfigure() {
         String jobName = "MyTestJob";
         Configuration config = new Configuration();
         config.set(PipelineOptions.NAME, jobName);
@@ -384,31 +360,31 @@ public class StreamExecutionEnvironmentTest {
     private void testJobName(String expectedJobName, StreamExecutionEnvironment env) {
         env.fromElements(1, 2, 3).print();
         StreamGraph streamGraph = env.getStreamGraph();
-        assertEquals(expectedJobName, streamGraph.getJobName());
+        assertThat(streamGraph.getJobName()).isEqualTo(expectedJobName);
     }
 
     @Test
-    public void testAddSourceWithUserDefinedTypeInfo() {
+    void testAddSourceWithUserDefinedTypeInfo() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         DataStreamSource<Row> source1 =
                 env.addSource(new RowSourceFunction(), Types.ROW(Types.STRING));
         // the source type information should be the user defined type
-        assertEquals(Types.ROW(Types.STRING), source1.getType());
+        assertThat(source1.getType()).isEqualTo(Types.ROW(Types.STRING));
 
         DataStreamSource<Row> source2 = env.addSource(new RowSourceFunction());
         // the source type information should be derived from RowSourceFunction#getProducedType
-        assertEquals(new GenericTypeInfo<>(Row.class), source2.getType());
+        assertThat(source2.getType()).isEqualTo(new GenericTypeInfo<>(Row.class));
     }
 
     @Test
-    public void testBufferTimeoutByDefault() {
+    void testBufferTimeoutByDefault() {
         Configuration config = new Configuration();
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         testBufferTimeout(config, env);
     }
 
     @Test
-    public void testBufferTimeoutEnabled() {
+    void testBufferTimeoutEnabled() {
         Configuration config = new Configuration();
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         config.set(ExecutionOptions.BUFFER_TIMEOUT_ENABLED, true);
@@ -416,42 +392,45 @@ public class StreamExecutionEnvironmentTest {
     }
 
     @Test
-    public void testBufferTimeoutDisabled() {
+    void testBufferTimeoutDisabled() {
         Configuration config = new Configuration();
         config.set(ExecutionOptions.BUFFER_TIMEOUT_ENABLED, false);
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         // The execution.buffer-timeout's default value 100ms will not take effect.
         env.configure(config, this.getClass().getClassLoader());
-        assertEquals(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT, env.getBufferTimeout());
+        assertThat(env.getBufferTimeout())
+                .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
 
         // Setting execution.buffer-timeout's to 0ms will not take effect.
         config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "0ms");
         env.configure(config, this.getClass().getClassLoader());
-        assertEquals(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT, env.getBufferTimeout());
+        assertThat(env.getBufferTimeout())
+                .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
 
         // Setting execution.buffer-timeout's to -1ms will not take effect.
         config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "-1ms");
         env.configure(config, this.getClass().getClassLoader());
-        assertEquals(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT, env.getBufferTimeout());
+        assertThat(env.getBufferTimeout())
+                .isEqualTo(ExecutionOptions.DISABLED_NETWORK_BUFFER_TIMEOUT);
     }
 
     private void testBufferTimeout(Configuration config, StreamExecutionEnvironment env) {
         env.configure(config, this.getClass().getClassLoader());
-        assertEquals(
-                ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.defaultValue().toMillis(),
-                env.getBufferTimeout());
+        assertThat(env.getBufferTimeout())
+                .isEqualTo(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.defaultValue().toMillis());
 
         config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "0ms");
         env.configure(config, this.getClass().getClassLoader());
-        assertEquals(0, env.getBufferTimeout());
+        assertThat(env.getBufferTimeout()).isZero();
 
-        try {
-            config.setString(ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "-1ms");
-            env.configure(config, this.getClass().getClassLoader());
-            fail("exception expected");
-        } catch (IllegalArgumentException ignored) {
-        }
+        assertThatThrownBy(
+                        () -> {
+                            config.setString(
+                                    ExecutionOptions.BUFFER_TIMEOUT_INTERVAL.key(), "-1ms");
+                            env.configure(config, this.getClass().getClassLoader());
+                        })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-32023](https://issues.apache.org/jira/browse/FLINK-32023) changed the `ExecutionOptions.BUFFER_TIMEOUT` to `ExecutionOptions.BUFFER_TIMEOUT_INTERVAL`, the filed name should be reverted.

Because the `ExecutionOptions` is a public evolving API, some flink users are using the `ExecutionOptions.BUFFER_TIMEOUT` in their code. If we update it, the code cannot upgrade to 1.18 directly.

## Brief change log

Revert the field name of BUFFER_TIMEOUT


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
