### PR TITLE
[FLINK-32254][runtime] FineGrainedSlotManager may not allocate enough taskmangers if maxSlotNum is configured

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -228,8 +228,8 @@ public class SlotManagerConfiguration {
                                         ? new CPUResource(Double.MAX_VALUE)
                                         : defaultWorkerResourceSpec
                                                 .getCpuCores()
-                                                .divide(defaultWorkerResourceSpec.getNumSlots())
-                                                .multiply(maxSlotNum));
+                                                .multiply(maxSlotNum)
+                                                .divide(defaultWorkerResourceSpec.getNumSlots()));
     }
 
     private static MemorySize getMaxTotalMem(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -244,7 +244,12 @@ public class SlotManagerConfiguration {
                                         ? MemorySize.MAX_VALUE
                                         : defaultWorkerResourceSpec
                                                 .getTotalMemSize()
-                                                .divide(defaultWorkerResourceSpec.getNumSlots())
-                                                .multiply(maxSlotNum));
+                                                // In theory, there is a possibility of long
+                                                // overflow here. However, in actual scenarios, for
+                                                // a 1TB of TM memory and a very large number of
+                                                // maxSlotNum (e.g. 1_000_000), there is still no
+                                                // overflow.
+                                                .multiply(maxSlotNum)
+                                                .divide(defaultWorkerResourceSpec.getNumSlots()));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -69,6 +69,24 @@ class SlotManagerConfigurationTest {
     }
 
     @Test
+    void testComputeMaxTotalCpu() throws Exception {
+        final Configuration configuration = new Configuration();
+        final int maxSlotNum = 9;
+        final int numSlots = 3;
+        final double cpuCores = 10;
+        configuration.set(ResourceManagerOptions.MAX_SLOT_NUM, maxSlotNum);
+        final SlotManagerConfiguration slotManagerConfiguration =
+                SlotManagerConfiguration.fromConfiguration(
+                        configuration,
+                        new WorkerResourceSpec.Builder()
+                                .setNumSlots(numSlots)
+                                .setCpuCores(cpuCores)
+                                .build());
+        assertThat(slotManagerConfiguration.getMaxTotalCpu().getValue().doubleValue())
+                .isEqualTo(cpuCores * maxSlotNum / 3);
+    }
+
+    @Test
     void testComputeMaxTotalMemory() throws Exception {
         final Configuration configuration = new Configuration();
         final int maxSlotNum = 1_000_000;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -22,23 +22,20 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SlotManagerConfiguration}. */
-public class SlotManagerConfigurationTest extends TestLogger {
+class SlotManagerConfigurationTest {
 
     /**
      * Tests that {@link SlotManagerConfiguration#getSlotRequestTimeout()} returns the value
      * configured under key {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.
      */
     @Test
-    public void testSetSlotRequestTimeout() throws Exception {
+    void testSetSlotRequestTimeout() throws Exception {
         final long slotIdleTimeout = 42;
 
         final Configuration configuration = new Configuration();
@@ -46,9 +43,8 @@ public class SlotManagerConfigurationTest extends TestLogger {
         final SlotManagerConfiguration slotManagerConfiguration =
                 SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
-        assertThat(
-                slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(),
-                is(equalTo(slotIdleTimeout)));
+        assertThat(slotIdleTimeout)
+                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
     }
 
     /**
@@ -56,7 +52,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
      * JobManagerOptions#SLOT_REQUEST_TIMEOUT} if set.
      */
     @Test
-    public void testPreferLegacySlotRequestTimeout() throws Exception {
+    void testPreferLegacySlotRequestTimeout() throws Exception {
         final long legacySlotIdleTimeout = 42;
 
         final Configuration configuration = new Configuration();
@@ -65,8 +61,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
         final SlotManagerConfiguration slotManagerConfiguration =
                 SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
-        assertThat(
-                slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(),
-                is(equalTo(legacySlotIdleTimeout)));
+        assertThat(legacySlotIdleTimeout)
+                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -20,10 +20,13 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,5 +66,28 @@ class SlotManagerConfigurationTest {
 
         assertThat(legacySlotIdleTimeout)
                 .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
+    }
+
+    @Test
+    void testComputeMaxTotalMemory() throws Exception {
+        final Configuration configuration = new Configuration();
+        final int maxSlotNum = 1_000_000;
+        final int numSlots = 10;
+        final int totalTaskManagerMB =
+                MemorySize.parse("1", MemorySize.MemoryUnit.TERA_BYTES).getMebiBytes();
+        configuration.set(ResourceManagerOptions.MAX_SLOT_NUM, maxSlotNum);
+        final SlotManagerConfiguration slotManagerConfiguration =
+                SlotManagerConfiguration.fromConfiguration(
+                        configuration,
+                        new WorkerResourceSpec.Builder()
+                                .setNumSlots(numSlots)
+                                .setTaskHeapMemoryMB(totalTaskManagerMB)
+                                .build());
+        assertThat(slotManagerConfiguration.getMaxTotalMem().getBytes())
+                .isEqualTo(
+                        BigDecimal.valueOf(MemorySize.ofMebiBytes(totalTaskManagerMB).getBytes())
+                                .multiply(BigDecimal.valueOf(maxSlotNum))
+                                .divide(BigDecimal.valueOf(numSlots))
+                                .longValue());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*There is a problem with the calculation logic of `SlotManagerConfiguration#getMaxTotalMem`. Due to the rounding down of division, the calculated `MemorySize` is too small.*


## Brief change log

  - *Multiply first, then divide for `SlotManagerConfiguration#getMaxTotalMem`.*


## Verifying this change

This change added unit test.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
