### PR TITLE
[FLINK-32249][table-planner] Use proper toString conversion when constructing column comments for CatalogTable

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkCalciteSqlValidator;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.utils.OperationConverterUtils;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
@@ -165,7 +166,8 @@ class SqlCreateTableConverter {
                                         col -> col.getName().getSimple(),
                                         col ->
                                                 StringUtils.strip(
-                                                        col.getComment().get().toString(), "'")));
+                                                        OperationConverterUtils.getComment(col),
+                                                        "'")));
 
         TableSchema mergedSchema =
                 mergeTableLikeUtil.mergeTables(


### PR DESCRIPTION
## What is the purpose of the change
The current `SqlCreateTableConverter` does not use the correct toString method when constructing column comments for `CatalogTable`, which may cause sql-client users and catalog implementers to encounter problems with Chinese characters in column comments not being displayed as expected.

## Brief change log
update the toString logic for column comments in `SqlCreateTableConverter`

## Verifying this change
Add Chinese characters in test cases of `SqlDdlToOperationConverterTest` 

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)