### PR TITLE
[FLINK-32188][Table SQL / Planner] Support to "where" query and simplify condition for an array-type filed of temporary table.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -566,7 +566,8 @@ public class RexSimplify {
             //add for array-type
             if (predicate instanceof Comparison) {
                 Comparison cmp = (Comparison) predicate;
-                if (cmp.rexCall != null && cmp.rexCall.getKind().equals(SqlKind.ARRAY_VALUE_CONSTRUCTOR)) {
+                if (cmp.rexCall != null
+                        && cmp.rexCall.getKind().equals(SqlKind.ARRAY_VALUE_CONSTRUCTOR)) {
                     RexCall arrayCall = cmp.rexCall;
                     if (i == 0) {
                         recordedArray = arrayCall.operands.toArray();
@@ -2502,7 +2503,7 @@ public class RexSimplify {
     private static class Comparison implements Predicate {
         final RexNode ref;
         final SqlKind kind;
-        //RexCall or RexLiteral
+        // RexCall or RexLiteral
         final RexLiteral literal;
         final RexCall rexCall;
 
@@ -2513,9 +2514,7 @@ public class RexSimplify {
             this.rexCall = null;
         }
 
-        /**
-         * Add for RexCall, such as ARRAY[...,...].
-         */
+        /** Add for RexCall, such as ARRAY[...,...]. */
         private Comparison(RexNode ref, SqlKind kind, RexCall arrayCall) {
             this.ref = Objects.requireNonNull(ref);
             this.kind = Objects.requireNonNull(kind);
@@ -2552,19 +2551,20 @@ public class RexSimplify {
                             if (nodePredicate.test(left)) {
                                 return new Comparison(left, e.getKind(), (RexLiteral) right);
                             }
-                        //add for RexCall like "CAST(ARRAY(..., ...))..."
+                            // add for RexCall like "CAST(ARRAY(..., ...))..."
                         case CAST:
                             final RexCall castCall = (RexCall) right;
                             final RexNode castLeft = castCall.getOperands().get(0);
                             switch (castLeft.getKind()) {
                                 case ARRAY_VALUE_CONSTRUCTOR:
-                                    //array-type RexCall --> create a comparison of RexCall
+                                    // array-type RexCall --> create a comparison of RexCall
                                     if (nodePredicate.test(left)) {
-                                        return new Comparison(left, e.getKind(), (RexCall) castLeft);
+                                        return new Comparison(
+                                                left, e.getKind(), (RexCall) castLeft);
                                     }
                             }
                         case ARRAY_VALUE_CONSTRUCTOR:
-                            //array-type RexCall --> create a comparison of RexCall
+                            // array-type RexCall --> create a comparison of RexCall
                             if (nodePredicate.test(left)) {
                                 return new Comparison(left, e.getKind(), (RexCall) right);
                             }    
@@ -2575,19 +2575,20 @@ public class RexSimplify {
                                 return new Comparison(
                                         right, e.getKind().reverse(), (RexLiteral) left);
                             }
-                        //add for RexCall like "CAST(ARRAY(..., ...))..."
+                            // add for RexCall like "CAST(ARRAY(..., ...))..."
                         case CAST:
                             final RexCall castCall = (RexCall) left;
                             final RexNode castLeft = castCall.getOperands().get(0);
                             switch (castLeft.getKind()) {
                                 case ARRAY_VALUE_CONSTRUCTOR:
-                                    //array-type RexCall --> create a comparison of RexCall
+                                    // array-type RexCall --> create a comparison of RexCall
                                     if (nodePredicate.test(right)) {
-                                        return new Comparison(right, e.getKind().reverse(), (RexCall) castLeft);
+                                        return new Comparison(
+                                                right, e.getKind().reverse(), (RexCall) castLeft);
                                     }
                             }
                         case ARRAY_VALUE_CONSTRUCTOR:
-                            //array-type RexCall --> create a comparison of RexCall
+                            // array-type RexCall --> create a comparison of RexCall
                             if (nodePredicate.test(right)) {
                                 return new Comparison(right, e.getKind().reverse(), (RexCall) left);
                             } 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.data.util.DataFormatConverters.{LocalDateConverter
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.expressions.ApiExpressionUtils._
 import org.apache.flink.table.functions.{BuiltInFunctionDefinition, FunctionIdentifier}
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{AND, CAST, OR, TRY_CAST, ARRAY}
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{AND, ARRAY, CAST, OR, TRY_CAST}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.utils.Logging

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.data.util.DataFormatConverters.{LocalDateConverter
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.expressions.ApiExpressionUtils._
 import org.apache.flink.table.functions.{BuiltInFunctionDefinition, FunctionIdentifier}
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{AND, CAST, OR, TRY_CAST}
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{AND, CAST, OR, TRY_CAST, ARRAY}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.utils.Logging
@@ -524,6 +524,8 @@ class RexNodeToExpressionConverter(
           Option(
             CallExpression
               .permanent(TRY_CAST, Seq(operands.head, typeLiteral(outputType)), outputType))
+        case SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR =>
+          Some(new CallExpression(ARRAY, operands, outputType))
         case _: SqlFunction | _: SqlPostfixOperator =>
           val names = new util.ArrayList[String](rexCall.getOperator.getNameAsId.names)
           names.set(names.size() - 1, replace(names.get(names.size() - 1)))


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*When submitting an SQL task with Flink to test a customized data source connector, I specified to query an array-type field of a temporary table with a fixed-value array. For example, "select * from image-source where URL=ARRAY ['/flink. jpg', '/flink_1. jpg']", but it couldn't obtain the corresponding predicate filters at all in the connector's DynamicTableSource.applyFilters method. This change can fix it.*
*By the way, linked to https://issues.apache.org/jira/browse/CALCITE-5733. Simplification seem to not take into account that the specified field is of array type. In other words，it can simplify "a = 1 AND a = 2" to "false"，but can not simplify “a = [1,2] AND a = [2,3]” to "false". For example, "select * from image-source where URL=ARRAY ['/flink. jpg', '/flink_1. jpg'] AND URL=ARRAY ['/f. jpg', '/f_1. jpg']" can obtain two predicate conditions, this is illogical. Generally speaking, simplifying this SQL condition should not result in any predicates. Changes related to “RexSimplify.java” can fix it.* 


## Brief change log


  - *Changes related to “RexSimplify.java” can simplify for array type.*
  - *Changes related to "RexNodeExtractor.scala" can support where query like "where URL=ARRAY ['aaa', 'bbb']".*


## Verifying this change

This change involves customized data source connector, you can customize a connector by implement ScanTableSource, SupportsFilterPushDown. How to develop custom connectors is detailed in the Flink community. And then it can be verified as follows:
```
StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
tableEnv.executeSql("CREATE TABLE IF NOT EXISTS mytable (\n" +
                "        a ARRAY<STRING>,\n" + 
                "        b STRING,\n" +
                "        proc AS proctime()\n" +
                "        ) WITH (\n" +
                "        'connector' = 'your customized data source connector',\n" +
                "        'options_1'='xxx',\n" +
                "        'options_2'='xxx',\n" +
                "        )");
String s1 = "select * from mytable where a = ARRAY['111', '222']";
TableResult result = tableEnv.executeSql(s1);
result.print();

//to test simplify for array-type, follow sql should return no results.
String s1 = "select * from mytable  where a = ARRAY['111', '222'] and a = ARRAY['222', '333']";
TableResult result = tableEnv.executeSql(s1);
result.print();
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
