### PR TITLE
[FLINK-32267] Upgrade tesctcontainers from 1.17.6 to 1.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,7 @@ under the License.
 		<beam.version>2.43.0</beam.version>
 		<protoc.version>3.21.7</protoc.version>
 		<okhttp.version>3.14.9</okhttp.version>
-		<!-- keep net.java.dev.jna:jna version in sync -->
-		<testcontainers.version>1.17.6</testcontainers.version>
+		<testcontainers.version>1.18.3</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>


### PR DESCRIPTION
## What is the purpose of the change

Bump `testcontainers` from 1.17.6 to 1.18.3
## Brief change log

`pom.xml`
## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
