### PR TITLE
[BP-1.16][FLINK-32254][runtime] FineGrainedSlotManager may not allocate enough taskmanagers if maxSlotNum is configured

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -209,8 +209,8 @@ public class SlotManagerConfiguration {
                                         ? new CPUResource(Double.MAX_VALUE)
                                         : defaultWorkerResourceSpec
                                                 .getCpuCores()
-                                                .divide(defaultWorkerResourceSpec.getNumSlots())
-                                                .multiply(maxSlotNum));
+                                                .multiply(maxSlotNum)
+                                                .divide(defaultWorkerResourceSpec.getNumSlots()));
     }
 
     private static MemorySize getMaxTotalMem(
@@ -225,7 +225,12 @@ public class SlotManagerConfiguration {
                                         ? MemorySize.MAX_VALUE
                                         : defaultWorkerResourceSpec
                                                 .getTotalMemSize()
-                                                .divide(defaultWorkerResourceSpec.getNumSlots())
-                                                .multiply(maxSlotNum));
+                                                // In theory, there is a possibility of long
+                                                // overflow here. However, in actual scenarios, for
+                                                // a 1TB of TM memory and a very large number of
+                                                // maxSlotNum (e.g. 1_000_000), there is still no
+                                                // overflow.
+                                                .multiply(maxSlotNum)
+                                                .divide(defaultWorkerResourceSpec.getNumSlots()));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -22,23 +22,20 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SlotManagerConfiguration}. */
-public class SlotManagerConfigurationTest extends TestLogger {
+class SlotManagerConfigurationTest {
 
     /**
      * Tests that {@link SlotManagerConfiguration#getSlotRequestTimeout()} returns the value
      * configured under key {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.
      */
     @Test
-    public void testSetSlotRequestTimeout() throws Exception {
+    void testSetSlotRequestTimeout() throws Exception {
         final long slotIdleTimeout = 42;
 
         final Configuration configuration = new Configuration();
@@ -46,9 +43,8 @@ public class SlotManagerConfigurationTest extends TestLogger {
         final SlotManagerConfiguration slotManagerConfiguration =
                 SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
-        assertThat(
-                slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(),
-                is(equalTo(slotIdleTimeout)));
+        assertThat(slotIdleTimeout)
+                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
     }
 
     /**
@@ -56,7 +52,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
      * JobManagerOptions#SLOT_REQUEST_TIMEOUT} if set.
      */
     @Test
-    public void testPreferLegacySlotRequestTimeout() throws Exception {
+    void testPreferLegacySlotRequestTimeout() throws Exception {
         final long legacySlotIdleTimeout = 42;
 
         final Configuration configuration = new Configuration();
@@ -65,8 +61,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
         final SlotManagerConfiguration slotManagerConfiguration =
                 SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
-        assertThat(
-                slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(),
-                is(equalTo(legacySlotIdleTimeout)));
+        assertThat(legacySlotIdleTimeout)
+                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
     }
 }


### PR DESCRIPTION
Backport FLINK-32254 to `release-1.16` branch.