### PR TITLE
[FLINK-31642][network] Introduce the MemoryTierConsumerAgent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGateID;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyServiceImpl;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
@@ -107,6 +108,8 @@ public class NettyShuffleEnvironment
 
     private final ScheduledExecutorService batchShuffleReadIOExecutor;
 
+    private final TieredStorageNettyServiceImpl nettyService;
+
     private boolean isClosed;
 
     NettyShuffleEnvironment(
@@ -134,6 +137,10 @@ public class NettyShuffleEnvironment
         this.batchShuffleReadBufferPool = batchShuffleReadBufferPool;
         this.batchShuffleReadIOExecutor = batchShuffleReadIOExecutor;
         this.isClosed = false;
+        this.nettyService =
+                config.getTieredStorageConfiguration() == null
+                        ? null
+                        : new TieredStorageNettyServiceImpl();
     }
 
     // --------------------------------------------------------------------------------------------
@@ -265,7 +272,8 @@ public class NettyShuffleEnvironment
                                 gateIndex,
                                 igdd,
                                 partitionProducerStateProvider,
-                                inputChannelMetrics);
+                                inputChannelMetrics,
+                                nettyService);
                 InputGateID id =
                         new InputGateID(
                                 igdd.getConsumedResultId(), ownerContext.getExecutionAttemptID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -53,6 +53,13 @@ public interface NetworkSequenceViewReader {
      */
     void addCredit(int creditDeltas);
 
+    /**
+     * Notify the id of required segment from consumer.
+     *
+     * @param segmentId The id of required segment.
+     */
+    void notifyRequiredSegmentId(int segmentId);
+
     /** Resumes data consumption after an exactly once checkpoint. */
     void resumeConsumption();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
@@ -58,6 +58,14 @@ public interface PartitionRequestClient {
     void notifyNewBufferSize(RemoteInputChannel inputChannel, int bufferSize);
 
     /**
+     * Notifies the id of segment required from one remote input channel.
+     *
+     * @param inputChannel The remote input channel who requires segment.
+     * @param segmentId The id of segment.
+     */
+    void notifyRequiredSegmentId(RemoteInputChannel inputChannel, int segmentId);
+
+    /**
      * Requests to resume data consumption from one remote input channel.
      *
      * @param inputChannel The remote input channel who is ready to resume data consumption.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -107,6 +107,11 @@ class CreditBasedSequenceNumberingViewReader
     }
 
     @Override
+    public void notifyRequiredSegmentId(int segmentId) {
+        subpartitionView.notifyRequiredSegmentId(segmentId);
+    }
+
+    @Override
     public void resumeConsumption() {
         if (initialCredit == 0) {
             // reset available credit if no exclusive buffer is available at the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -223,6 +223,11 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
     }
 
     @Override
+    public void notifyRequiredSegmentId(RemoteInputChannel inputChannel, int segmentId) {
+        sendToChannel(new SegmentIdMessage(inputChannel, segmentId));
+    }
+
+    @Override
     public void resumeConsumption(RemoteInputChannel inputChannel) {
         sendToChannel(new ResumeConsumptionMessage(inputChannel));
     }
@@ -331,6 +336,21 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
         @Override
         Object buildMessage() {
             return new NettyMessage.AckAllUserRecordsProcessed(inputChannel.getInputChannelId());
+        }
+    }
+
+    private static class SegmentIdMessage extends ClientOutboundMessage {
+
+        private final int segmentId;
+
+        private SegmentIdMessage(RemoteInputChannel inputChannel, int segmentId) {
+            super(checkNotNull(inputChannel));
+            this.segmentId = segmentId;
+        }
+
+        @Override
+        Object buildMessage() {
+            return new NettyMessage.SegmentId(segmentId, inputChannel.getInputChannelId());
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -194,6 +194,22 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
         }
     }
 
+    /**
+     * Notify the id of required segment from the consumer.
+     *
+     * @param receiverId The input channel id to identify the consumer.
+     * @param segmentId The id of required segment.
+     */
+    void notifyRequiredSegmentId(InputChannelID receiverId, int segmentId) {
+        if (fatalError) {
+            return;
+        }
+        NetworkSequenceViewReader reader = allReaders.get(receiverId);
+        if (reader != null) {
+            reader.notifyRequiredSegmentId(segmentId);
+        }
+    }
+
     NetworkSequenceViewReader obtainReader(InputChannelID receiverId) {
         NetworkSequenceViewReader reader = allReaders.get(receiverId);
         if (reader == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.netty.NettyMessage.CloseRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.NewBufferSize;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ResumeConsumption;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.SegmentId;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.TaskEventRequest;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
@@ -132,6 +133,9 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
                 NewBufferSize request = (NewBufferSize) msg;
 
                 outboundQueue.notifyNewBufferSize(request.receiverId, request.bufferSize);
+            } else if (msgClazz == SegmentId.class) {
+                SegmentId request = (SegmentId) msg;
+                outboundQueue.notifyRequiredSegmentId(request.receiverId, request.segmentId);
             } else {
                 LOG.warn("Received unexpected client request: {}", msg);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -314,12 +314,9 @@ public abstract class InputChannel {
     /**
      * Notify the upstream the id of required segment that should be sent to netty connection.
      *
-     * <p>TODO, This method will be implemented by {@link LocalInputChannel} and {@link
-     * RemoteInputChannel} in the future.
-     *
      * @param segmentId segment id indicates the id of segment.
      */
-    public void notifyRequiredSegmentId(int segmentId) {}
+    public void notifyRequiredSegmentId(int segmentId) throws IOException {}
 
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -372,6 +372,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     @Override
+    public void notifyRequiredSegmentId(int segmentId) {
+        if (subpartitionView != null) {
+            checkNotNull(subpartitionView).notifyRequiredSegmentId(segmentId);
+        }
+    }
+
+    @Override
     public String toString() {
         return "LocalInputChannel [" + partitionId + "]";
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -813,6 +813,13 @@ public class RemoteInputChannel extends InputChannel {
                 "Bug: partitionRequestClient is not initialized before processing data and no error is detected.");
     }
 
+    @Override
+    public void notifyRequiredSegmentId(int segmentId) throws IOException {
+        checkState(!isReleased.get(), "Channel released.");
+        checkPartitionRequestQueueInitialized();
+        partitionRequestClient.notifyRequiredSegmentId(this, segmentId);
+    }
+
     private static class BufferReorderingException extends IOException {
 
         private static final long serialVersionUID = -888282210356266816L;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -41,7 +41,10 @@ import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionReaderAvailabilityAndPriorityHelper;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyServiceImpl;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerClient;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -68,6 +71,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -217,6 +221,9 @@ public class SingleInputGate extends IndexedInputGate {
     // The consumer client will be null if the tiered storage is not enabled.
     @Nullable private final TieredStorageConsumerClient tieredStorageConsumerClient;
 
+    // The consumer specs in tiered storage will be null if the tiered storage is not enabled.
+    @Nullable private final List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs;
+
     public SingleInputGate(
             String owningTaskName,
             int gateIndex,
@@ -231,7 +238,9 @@ public class SingleInputGate extends IndexedInputGate {
             int segmentSize,
             ThroughputCalculator throughputCalculator,
             @Nullable BufferDebloater bufferDebloater,
-            @Nullable TieredStorageConsumerClient tieredStorageConsumerClient) {
+            @Nullable TieredStorageConsumerClient tieredStorageConsumerClient,
+            @Nullable TieredStorageNettyServiceImpl nettyService,
+            @Nullable List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs) {
 
         this.owningTaskName = checkNotNull(owningTaskName);
         Preconditions.checkArgument(0 <= gateIndex, "The gate index must be positive.");
@@ -266,6 +275,10 @@ public class SingleInputGate extends IndexedInputGate {
         this.throughputCalculator = checkNotNull(throughputCalculator);
 
         this.tieredStorageConsumerClient = tieredStorageConsumerClient;
+        this.tieredStorageConsumerSpecs = tieredStorageConsumerSpecs;
+        if (enabledTieredStorage()) {
+            setupTieredStorageNettyService(nettyService, tieredStorageConsumerSpecs);
+        }
     }
 
     protected PrioritizedDeque<InputChannel> getInputChannelsWithData() {
@@ -323,7 +336,7 @@ public class SingleInputGate extends IndexedInputGate {
             // Start the reader only when all InputChannels have been converted to either
             // LocalInputChannel or RemoteInputChannel, as this will prevent RecoveredInputChannels
             // from being queued again.
-            if (enabledTieredStore()) {
+            if (enabledTieredStorage()) {
                 tieredStorageConsumerClient.start();
             }
         }
@@ -705,7 +718,7 @@ public class SingleInputGate extends IndexedInputGate {
             synchronized (inputChannelsWithData) {
                 inputChannelsWithData.notifyAll();
             }
-            if (enabledTieredStore()) {
+            if (enabledTieredStorage()) {
                 tieredStorageConsumerClient.close();
             }
         }
@@ -791,8 +804,8 @@ public class SingleInputGate extends IndexedInputGate {
 
                 final InputChannel inputChannel = inputChannelOpt.get();
                 Optional<Buffer> buffer;
-                if (enabledTieredStore()) {
-                    buffer = readBufferFromTieredStore(inputChannel.getChannelIndex());
+                if (enabledTieredStorage()) {
+                    buffer = readBufferFromTieredStore(inputChannel);
                 } else {
                     buffer = readBufferFromInputChannel(inputChannel);
                 }
@@ -837,11 +850,16 @@ public class SingleInputGate extends IndexedInputGate {
         return Optional.of(bufferAndAvailability.buffer());
     }
 
-    private Optional<Buffer> readBufferFromTieredStore(int subpartitionId) {
-        return checkNotNull(tieredStorageConsumerClient).getNextBuffer(subpartitionId);
+    private Optional<Buffer> readBufferFromTieredStore(InputChannel inputChannel) {
+        TieredStorageConsumerSpec tieredStorageConsumerSpec =
+                checkNotNull(tieredStorageConsumerSpecs).get(inputChannel.getChannelIndex());
+        return checkNotNull(tieredStorageConsumerClient)
+                .getNextBuffer(
+                        tieredStorageConsumerSpec.getPartitionId(),
+                        tieredStorageConsumerSpec.getSubpartitionId());
     }
 
-    private boolean enabledTieredStore() {
+    private boolean enabledTieredStorage() {
         return tieredStorageConsumerClient != null;
     }
 
@@ -979,7 +997,7 @@ public class SingleInputGate extends IndexedInputGate {
     @Override
     public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
         checkState(!isFinished(), "InputGate already finished.");
-        if (!enabledTieredStore()) {
+        if (!enabledTieredStorage()) {
             channels[channelInfo.getInputChannelIdx()].acknowledgeAllRecordsProcessed();
         }
     }
@@ -1118,6 +1136,31 @@ public class SingleInputGate extends IndexedInputGate {
         enqueuedInputChannelsWithData.clear(inputChannel.getChannelIndex());
 
         return Optional.of(inputChannel);
+    }
+
+    private void setupTieredStorageNettyService(
+            TieredStorageNettyServiceImpl nettyService,
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs) {
+        List<Supplier<InputChannel>> channelSuppliers = new ArrayList<>();
+        for (int index = 0; index < channels.length; ++index) {
+            int channelIndex = index;
+            channelSuppliers.add(() -> channels[channelIndex]);
+        }
+        nettyService.setupInputChannels(
+                tieredStorageConsumerSpecs,
+                channelSuppliers,
+                new NettyConnectionReaderAvailabilityAndPriorityHelper() {
+                    @Override
+                    public void notifyReaderAvailableAndPriority(
+                            int channelIndex, boolean isPriority) {
+                        queueChannel(channels[channelIndex], null, isPriority);
+                    }
+
+                    @Override
+                    public void updatePrioritySequenceNumber(int channelIndex, int sequenceNumber) {
+                        lastPrioritySequenceNumber[channelIndex] = sequenceNumber;
+                    }
+                });
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionReaderImpl.java
@@ -54,7 +54,11 @@ public class NettyConnectionReaderImpl implements NettyConnectionReader {
     public Optional<Buffer> readBuffer(int segmentId) {
         if (segmentId > 0L && (segmentId != lastRequiredSegmentId)) {
             lastRequiredSegmentId = segmentId;
-            inputChannelProvider.get().notifyRequiredSegmentId(segmentId);
+            try {
+                inputChannelProvider.get().notifyRequiredSegmentId(segmentId);
+            } catch (IOException e) {
+                ExceptionUtils.rethrow(e, "Failed to notify required segment id");
+            }
         }
         Optional<InputChannel.BufferAndAvailability> bufferAndAvailability = Optional.empty();
         try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyService.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.shuffle.Tiere
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 
+import java.util.concurrent.CompletableFuture;
+
 /** {@link TieredStorageNettyService} is used to create writers and readers to netty. */
 public interface TieredStorageNettyService {
 
@@ -39,13 +41,13 @@ public interface TieredStorageNettyService {
             TieredStoragePartitionId partitionId, NettyServiceProducer serviceProducer);
 
     /**
-     * {@link TierConsumerAgent} will register to {@link TieredStorageNettyService} and get a {@link
-     * NettyConnectionReader}.
+     * {@link TierConsumerAgent} will register to {@link TieredStorageNettyService} and get a future
+     * of {@link NettyConnectionReader}.
      *
      * @param partitionId partition id indicates the unique id of {@link TieredResultPartition}.
      * @param subpartitionId subpartition id indicates the unique id of subpartition.
-     * @return the netty connection reader.
+     * @return the future of netty connection reader.
      */
-    NettyConnectionReader registerConsumer(
+    CompletableFuture<NettyConnectionReader> registerConsumer(
             TieredStoragePartitionId partitionId, TieredStorageSubpartitionId subpartitionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerClient.java
@@ -18,22 +18,47 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /** {@link TieredStorageConsumerClient} is used to read buffer from tiered store. */
 public class TieredStorageConsumerClient {
 
+    private final List<TierFactory> tierFactories;
+
+    private final TieredStorageNettyService nettyService;
+
     private final List<TierConsumerAgent> tierConsumerAgents;
 
-    public TieredStorageConsumerClient(List<TierFactory> tierFactories) {
-        this.tierConsumerAgents = createTierConsumerAgents(tierFactories);
+    /**
+     * This map is used to record the consumer agent being used and the id of segment being read for
+     * each data source, which is represented by {@link TieredStoragePartitionId} and {@link
+     * TieredStorageSubpartitionId}.
+     */
+    private final Map<
+                    TieredStoragePartitionId,
+                    Map<TieredStorageSubpartitionId, Tuple2<TierConsumerAgent, Integer>>>
+            currentConsumerAgentAndSegmentIds = new HashMap<>();
+
+    public TieredStorageConsumerClient(
+            List<TierFactory> tierFactories,
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService) {
+        this.tierFactories = tierFactories;
+        this.nettyService = nettyService;
+        this.tierConsumerAgents = createTierConsumerAgents(tieredStorageConsumerSpecs);
     }
 
     public void start() {
@@ -42,9 +67,46 @@ public class TieredStorageConsumerClient {
         }
     }
 
-    public Optional<Buffer> getNextBuffer(int subpartitionId) {
-        // TODO, the detailed logic will be completed when the memory tier is introduced..
-        return Optional.empty();
+    public Optional<Buffer> getNextBuffer(
+            TieredStoragePartitionId partitionId, TieredStorageSubpartitionId subpartitionId) {
+        Tuple2<TierConsumerAgent, Integer> currentConsumerAgentAndSegmentId =
+                currentConsumerAgentAndSegmentIds
+                        .computeIfAbsent(partitionId, ignore -> new HashMap<>())
+                        .getOrDefault(subpartitionId, Tuple2.of(null, 0));
+        Optional<Buffer> buffer = Optional.empty();
+        if (currentConsumerAgentAndSegmentId.f0 == null) {
+            for (TierConsumerAgent tierConsumerAgent : tierConsumerAgents) {
+                buffer =
+                        tierConsumerAgent.getNextBuffer(
+                                partitionId, subpartitionId, currentConsumerAgentAndSegmentId.f1);
+                if (buffer.isPresent()) {
+                    currentConsumerAgentAndSegmentIds
+                            .get(partitionId)
+                            .put(
+                                    subpartitionId,
+                                    Tuple2.of(
+                                            tierConsumerAgent,
+                                            currentConsumerAgentAndSegmentId.f1));
+                    break;
+                }
+            }
+        } else {
+            buffer =
+                    currentConsumerAgentAndSegmentId.f0.getNextBuffer(
+                            partitionId, subpartitionId, currentConsumerAgentAndSegmentId.f1);
+        }
+        if (!buffer.isPresent()) {
+            return Optional.empty();
+        }
+        Buffer bufferData = buffer.get();
+        if (bufferData.getDataType() == Buffer.DataType.END_OF_SEGMENT) {
+            currentConsumerAgentAndSegmentIds
+                    .get(partitionId)
+                    .put(subpartitionId, Tuple2.of(null, currentConsumerAgentAndSegmentId.f1 + 1));
+            bufferData.recycleBuffer();
+            return getNextBuffer(partitionId, subpartitionId);
+        }
+        return Optional.of(bufferData);
     }
 
     public void close() throws IOException {
@@ -57,10 +119,12 @@ public class TieredStorageConsumerClient {
     //  Internal methods
     // --------------------------------------------------------------------------------------------
 
-    private List<TierConsumerAgent> createTierConsumerAgents(List<TierFactory> tierFactories) {
+    private List<TierConsumerAgent> createTierConsumerAgents(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs) {
         ArrayList<TierConsumerAgent> tierConsumerAgents = new ArrayList<>();
         for (TierFactory tierFactory : tierFactories) {
-            tierConsumerAgents.add(tierFactory.createConsumerAgent());
+            tierConsumerAgents.add(
+                    tierFactory.createConsumerAgent(tieredStorageConsumerSpecs, nettyService));
         }
         return tierConsumerAgents;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageConsumerSpec.java
@@ -16,37 +16,30 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 
-import java.io.IOException;
-import java.util.Optional;
+/** Describe the different data sources in {@link TieredStorageConsumerClient}. */
+public class TieredStorageConsumerSpec {
 
-/**
- * The {@link TierConsumerAgent} is the consumer agent of each tier in tiered store, which could
- * read data from responding tier.
- */
-public interface TierConsumerAgent {
+    private final TieredStoragePartitionId tieredStoragePartitionId;
 
-    /** Start the consumer agent. */
-    void start();
+    private final TieredStorageSubpartitionId tieredStorageSubpartitionId;
 
-    /**
-     * Get buffer from the consumer agent.
-     *
-     * @param partitionId the id of partition.
-     * @param subpartitionId the id of subpartition.
-     * @param segmentId the id of segment.
-     * @return buffer.
-     */
-    Optional<Buffer> getNextBuffer(
-            TieredStoragePartitionId partitionId,
-            TieredStorageSubpartitionId subpartitionId,
-            int segmentId);
+    public TieredStorageConsumerSpec(
+            TieredStoragePartitionId tieredStoragePartitionId,
+            TieredStorageSubpartitionId tieredStorageSubpartitionId) {
+        this.tieredStoragePartitionId = tieredStoragePartitionId;
+        this.tieredStorageSubpartitionId = tieredStorageSubpartitionId;
+    }
 
-    /** Close the consumer agent. */
-    void close() throws IOException;
+    public TieredStoragePartitionId getPartitionId() {
+        return tieredStoragePartitionId;
+    }
+
+    public TieredStorageSubpartitionId getSubpartitionId() {
+        return tieredStorageSubpartitionId;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
@@ -20,8 +20,11 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
 
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMemoryManager;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+
+import java.util.List;
 
 /** A factory that creates all the components of a tier. */
 public interface TierFactory {
@@ -40,5 +43,7 @@ public interface TierFactory {
             TieredStorageResourceRegistry resourceRegistry);
 
     /** Creates the consumer-side agent of a Tier. */
-    TierConsumerAgent createConsumerAgent();
+    TierConsumerAgent createConsumerAgent(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierConsumerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierConsumerAgent.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.memory;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionReader;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/** The data client is used to fetch data from memory tier. */
+public class MemoryTierConsumerAgent implements TierConsumerAgent {
+
+    private final Map<
+                    TieredStoragePartitionId,
+                    Map<TieredStorageSubpartitionId, CompletableFuture<NettyConnectionReader>>>
+            nettyConnectionReaders = new HashMap<>();
+
+    public MemoryTierConsumerAgent(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService) {
+        for (TieredStorageConsumerSpec tieredStorageConsumerSpec : tieredStorageConsumerSpecs) {
+            TieredStoragePartitionId partitionId = tieredStorageConsumerSpec.getPartitionId();
+            TieredStorageSubpartitionId subpartitionId =
+                    tieredStorageConsumerSpec.getSubpartitionId();
+            nettyConnectionReaders
+                    .computeIfAbsent(partitionId, ignore -> new HashMap<>())
+                    .put(
+                            subpartitionId,
+                            nettyService.registerConsumer(partitionId, subpartitionId));
+        }
+    }
+
+    @Override
+    public void start() {
+        // noop
+    }
+
+    @Override
+    public Optional<Buffer> getNextBuffer(
+            TieredStoragePartitionId partitionId,
+            TieredStorageSubpartitionId subpartitionId,
+            int segmentId) {
+        try {
+            return nettyConnectionReaders
+                    .get(partitionId)
+                    .get(subpartitionId)
+                    .get()
+                    .readBuffer(segmentId);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to get next buffer.", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // noop
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.memory;
 
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMemoryManager;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.NoOpMasterAgent;
@@ -27,6 +28,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierCons
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFactory;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+import java.util.List;
 
 /** The implementation of {@link TierFactory} for memory tier. */
 public class MemoryTierFactory implements TierFactory {
@@ -67,8 +70,9 @@ public class MemoryTierFactory implements TierFactory {
     }
 
     @Override
-    public TierConsumerAgent createConsumerAgent() {
-        // TODO, create the memory tier consumer agent.
-        return null;
+    public TierConsumerAgent createConsumerAgent(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService) {
+        return new MemoryTierConsumerAgent(tieredStorageConsumerSpecs, nettyService);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
@@ -48,6 +48,9 @@ public class TestingPartitionRequestClient implements PartitionRequestClient {
     public void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel) {}
 
     @Override
+    public void notifyRequiredSegmentId(RemoteInputChannel inputChannel, int segmentId) {}
+
+    @Override
     public void sendTaskEvent(
             ResultPartitionID partitionId, TaskEvent event, RemoteInputChannel inputChannel) {}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -383,6 +383,8 @@ public class InputGateFairnessTest {
                     BUFFER_SIZE,
                     new ThroughputCalculator(SystemClock.getInstance()),
                     null,
+                    null,
+                    null,
                     null);
 
             channelsWithData = getInputChannelsWithData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -100,6 +100,7 @@ import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtil
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
@@ -1938,6 +1939,16 @@ public class RemoteInputChannelTest {
         // already empty.
         remoteInputChannel.getNextBuffer();
         assertEquals(3, remoteInputChannel.getBuffersInUseCount());
+    }
+
+    @Test
+    public void testReleasedChannelNotifyRequiredSegmentId() throws Exception {
+        SingleInputGate inputGate = createSingleInputGate(1);
+        RemoteInputChannel remoteChannel = createRemoteInputChannel(inputGate);
+
+        remoteChannel.releaseAllResources();
+        assertThatThrownBy(() -> remoteChannel.notifyRequiredSegmentId(0))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -182,7 +182,9 @@ public class SingleInputGateBuilder {
                         bufferSize,
                         createThroughputCalculator.apply(bufferDebloatConfiguration),
                         maybeCreateBufferDebloater(gateIndex),
-                        tieredStorageConsumerClient);
+                        tieredStorageConsumerClient,
+                        null,
+                        null);
         if (channelFactory != null) {
             gate.setInputChannels(
                     IntStream.range(0, numberOfChannels)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -1345,7 +1345,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                         0,
                         gateDesc,
                         SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-                        newUnregisteredInputChannelMetrics());
+                        newUnregisteredInputChannelMetrics(),
+                        null);
     }
 
     private static Map<InputGateID, SingleInputGate> createInputGateWithLocalChannels(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReader.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/** Test implementation for {@link NettyConnectionReader}. */
+public class TestingNettyConnectionReader implements NettyConnectionReader {
+
+    private final Function<Integer, Buffer> readBufferFunction;
+
+    private TestingNettyConnectionReader(Function<Integer, Buffer> readBufferFunction) {
+        this.readBufferFunction = readBufferFunction;
+    }
+
+    @Override
+    public Optional<Buffer> readBuffer(int segmentId) {
+        return Optional.of(readBufferFunction.apply(segmentId));
+    }
+
+    /** Builder for {@link TestingNettyConnectionReader}. */
+    public static class Builder {
+
+        private Function<Integer, Buffer> readBufferFunction = segmentId -> null;
+
+        public Builder() {}
+
+        public Builder setReadBufferFunction(Function<Integer, Buffer> readBufferFunction) {
+            this.readBufferFunction = readBufferFunction;
+            return this;
+        }
+
+        public TestingNettyConnectionReader build() {
+            return new TestingNettyConnectionReader(readBufferFunction);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingTieredStorageNettyService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingTieredStorageNettyService.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
@@ -31,12 +32,17 @@ public class TestingTieredStorageNettyService implements TieredStorageNettyServi
             registerProducerConsumer;
 
     private final BiFunction<
-                    TieredStoragePartitionId, TieredStorageSubpartitionId, NettyConnectionReader>
+                    TieredStoragePartitionId,
+                    TieredStorageSubpartitionId,
+                    CompletableFuture<NettyConnectionReader>>
             registerConsumerFunction;
 
     private TestingTieredStorageNettyService(
             BiConsumer<TieredStoragePartitionId, NettyServiceProducer> registerProducerConsumer,
-            BiFunction<TieredStoragePartitionId, TieredStorageSubpartitionId, NettyConnectionReader>
+            BiFunction<
+                            TieredStoragePartitionId,
+                            TieredStorageSubpartitionId,
+                            CompletableFuture<NettyConnectionReader>>
                     registerConsumerFunction) {
         this.registerProducerConsumer = registerProducerConsumer;
         this.registerConsumerFunction = registerConsumerFunction;
@@ -49,7 +55,7 @@ public class TestingTieredStorageNettyService implements TieredStorageNettyServi
     }
 
     @Override
-    public NettyConnectionReader registerConsumer(
+    public CompletableFuture<NettyConnectionReader> registerConsumer(
             TieredStoragePartitionId partitionId, TieredStorageSubpartitionId subpartitionId) {
         return registerConsumerFunction.apply(partitionId, subpartitionId);
     }
@@ -63,7 +69,7 @@ public class TestingTieredStorageNettyService implements TieredStorageNettyServi
         private BiFunction<
                         TieredStoragePartitionId,
                         TieredStorageSubpartitionId,
-                        NettyConnectionReader>
+                        CompletableFuture<NettyConnectionReader>>
                 registerConsumerFunction = (tieredStoragePartitionId, subpartitionId) -> null;
 
         public Builder() {}
@@ -79,7 +85,7 @@ public class TestingTieredStorageNettyService implements TieredStorageNettyServi
                 BiFunction<
                                 TieredStoragePartitionId,
                                 TieredStorageSubpartitionId,
-                                NettyConnectionReader>
+                                CompletableFuture<NettyConnectionReader>>
                         registerConsumerFunction) {
             this.registerConsumerFunction = registerConsumerFunction;
             return this;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageConsumerClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageConsumerClientTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TestingTierFactory;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerClient;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.memory.MemoryTierConsumerAgent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TieredStorageConsumerClient}. */
+class TieredStorageConsumerClientTest {
+
+    private final TieredStoragePartitionId partitionId =
+            TieredStorageIdMappingUtils.convertId(new ResultPartitionID());
+
+    private final TieredStorageSubpartitionId subpartitionId = new TieredStorageSubpartitionId(0);
+
+    @Test
+    void testGetNextBuffer() {
+        Buffer buffer = BufferBuilderTestUtils.buildSomeBuffer(0);
+        TestingTieredStorageNettyService nettyService =
+                new TestingTieredStorageNettyService.Builder()
+                        .setRegisterConsumerFunction(
+                                (partitionId, subpartitionId) ->
+                                        CompletableFuture.completedFuture(
+                                                new TestingNettyConnectionReader.Builder()
+                                                        .setReadBufferFunction(segmentId -> buffer)
+                                                        .build()))
+                        .build();
+        TieredStorageConsumerClient tieredStorageConsumerClient =
+                new TieredStorageConsumerClient(
+                        Collections.singletonList(
+                                new TestingTierFactory.Builder()
+                                        .setTierConsumerAgentSupplier(MemoryTierConsumerAgent::new)
+                                        .build()),
+                        Collections.singletonList(
+                                new TieredStorageConsumerSpec(partitionId, subpartitionId)),
+                        nettyService);
+        Optional<Buffer> nextBuffer =
+                tieredStorageConsumerClient.getNextBuffer(partitionId, subpartitionId);
+        assertThat(nextBuffer).hasValue(buffer);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFactory;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/** Test implementation for {@link TierFactory}. */
+public class TestingTierFactory implements TierFactory {
+
+    private final Supplier<TierMasterAgent> tierMasterAgentSupplier;
+
+    private final Supplier<TierProducerAgent> tierProducerAgentSupplier;
+
+    private final BiFunction<
+                    List<TieredStorageConsumerSpec>, TieredStorageNettyService, TierConsumerAgent>
+            tierConsumerAgentSupplier;
+
+    private TestingTierFactory(
+            Supplier<TierMasterAgent> tierMasterAgentSupplier,
+            Supplier<TierProducerAgent> tierProducerAgentSupplier,
+            BiFunction<
+                            List<TieredStorageConsumerSpec>,
+                            TieredStorageNettyService,
+                            TierConsumerAgent>
+                    tierConsumerAgentSupplier) {
+        this.tierMasterAgentSupplier = tierMasterAgentSupplier;
+        this.tierProducerAgentSupplier = tierProducerAgentSupplier;
+        this.tierConsumerAgentSupplier = tierConsumerAgentSupplier;
+    }
+
+    @Override
+    public TierMasterAgent createMasterAgent(
+            TieredStorageResourceRegistry tieredStorageResourceRegistry) {
+        return tierMasterAgentSupplier.get();
+    }
+
+    @Override
+    public TierProducerAgent createProducerAgent(
+            int numSubpartitions,
+            TieredStoragePartitionId partitionID,
+            String dataFileBasePath,
+            boolean isBroadcastOnly,
+            TieredStorageMemoryManager storageMemoryManager,
+            TieredStorageNettyService nettyService,
+            TieredStorageResourceRegistry resourceRegistry) {
+        return tierProducerAgentSupplier.get();
+    }
+
+    @Override
+    public TierConsumerAgent createConsumerAgent(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService) {
+        return tierConsumerAgentSupplier.apply(tieredStorageConsumerSpecs, nettyService);
+    }
+
+    /** Builder for {@link TestingTierFactory}. */
+    public static class Builder {
+
+        private Supplier<TierMasterAgent> tierMasterAgentSupplier = () -> null;
+
+        private Supplier<TierProducerAgent> tierProducerAgentSupplier = () -> null;
+
+        private BiFunction<
+                        List<TieredStorageConsumerSpec>,
+                        TieredStorageNettyService,
+                        TierConsumerAgent>
+                tierConsumerAgentSupplier = (partitionIdAndSubpartitionId, nettyService) -> null;
+
+        public Builder() {}
+
+        public Builder setTierMasterAgentSupplier(
+                Supplier<TierMasterAgent> tierMasterAgentSupplier) {
+            this.tierMasterAgentSupplier = tierMasterAgentSupplier;
+            return this;
+        }
+
+        public Builder setTierProducerAgentSupplier(
+                Supplier<TierProducerAgent> tierProducerAgentSupplier) {
+            this.tierProducerAgentSupplier = tierProducerAgentSupplier;
+            return this;
+        }
+
+        public Builder setTierConsumerAgentSupplier(
+                BiFunction<
+                                List<TieredStorageConsumerSpec>,
+                                TieredStorageNettyService,
+                                TierConsumerAgent>
+                        tierConsumerAgentSupplier) {
+            this.tierConsumerAgentSupplier = tierConsumerAgentSupplier;
+            return this;
+        }
+
+        public TestingTierFactory build() {
+            return new TestingTierFactory(
+                    tierMasterAgentSupplier, tierProducerAgentSupplier, tierConsumerAgentSupplier);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -280,7 +280,8 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
                         gateIndex,
                         gateDescriptor,
                         SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
-                        newUnregisteredInputChannelMetrics());
+                        newUnregisteredInputChannelMetrics(),
+                        null);
 
         return new InputGateWithMetrics(singleGate, new SimpleCounter());
     }


### PR DESCRIPTION
## What is the purpose of the change

### Introduce the MemoryTierConsumerAgent

1. Implement the MemoryTierConsumerAgent
2. Introduce the MemoryTierConsumerAgent to TieredStorageConsumerClient
3. Enable NettyConnectionReader to notify upstream required segment id
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)