### PR TITLE
[FLINK-24998] Update CI image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   # Container with Maven 3.8.6, SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_maven_386
+    image: chesnay/flink-ci:java_8_11_17_maven_386_v2
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -39,7 +39,7 @@ resources:
   # Container with Maven 3.8.6, SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_maven_386
+    image: chesnay/flink-ci:java_8_11_17_maven_386_v2
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
- switch to Temurin JDK 11 (latest)
- update Temurin JDK 17 to latest

JDK 17 update is the important bit, fixing the observed SIGSEGV.
