### PR TITLE
[FLINK-30629][Client/Job Submission] Increase clientHeartbeatTimeout to 1 second

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests for client's heartbeat. */
 class ClientHeartbeatTest {
     private final long clientHeartbeatInterval = 50;
-    private final long clientHeartbeatTimeout = 500;
+    private final long clientHeartbeatTimeout = 1000;
 
     private MiniCluster miniCluster;
 


### PR DESCRIPTION
## What is the purpose of the change

*Increase clientHeartbeatTimeout to 1 second to avoid shutting down the job in ClientHeartbeatTest.*


## Brief change log
  - *Increase clientHeartbeatTimeout to 1 second*


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)