### PR TITLE
[FLINK-32297][tests] FlinkImageBuilder uses Temurin images

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
@@ -245,7 +245,10 @@ public class FlinkImageBuilder {
         new ImageFromDockerfile(FLINK_BASE_IMAGE_BUILD_NAME)
                 .withDockerfileFromBuilder(
                         builder ->
-                                builder.from("openjdk:" + getJavaVersionSuffix())
+                                builder.from(
+                                                "eclipse-temurin:"
+                                                        + getJavaVersionSuffix()
+                                                        + "-jre-jammy")
                                         .copy(flinkHome, flinkHome)
                                         .build())
                 .withFileFromPath(flinkHome, flinkDist)


### PR DESCRIPTION
Use the same base image as the prod docker images.