### PR TITLE
[FLINK-32302][hbase] Disable tests on Java 17

### DIFF
--- a/flink-connectors/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-connector-hbase-2.2/pom.xml
@@ -462,4 +462,26 @@ under the License.
 		</dependencies>
 	</dependencyManagement>
 
+	<profiles>
+		<profile>
+			<id>java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<!-- hbase currently does not support Java 17, see HBASE-26038 -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>


### PR DESCRIPTION
Consistently fail on Java 17, probably because our dependencies are horrendously out-dated.
We can revert this later if someone looks into bumping our HBase dependency.