### PR TITLE
[FLINK-32305] [History Server] Add number of workers to parallelize job archive processing

### DIFF
--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -45,6 +45,12 @@
             <td>Pattern of the log URL of TaskManager. The HistoryServer will generate actual URLs from it, with replacing the special placeholders, `&lt;jobid&gt;` and `&lt;tmid&gt;`, to the id of job and TaskManager respectively. Only http / https schemes are supported.</td>
         </tr>
         <tr>
+            <td><h5>historyserver.num.workers</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>The maximum number of worker threads to archives in parallelIf set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
+        </tr>
+        <tr>
             <td><h5>historyserver.web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -142,16 +142,14 @@ public class HistoryServerOptions {
                                             "If set to `0` or less than `-1` HistoryServer will throw an %s. ",
                                             code("IllegalConfigurationException"))
                                     .build());
-
-    private HistoryServerOptions() {}
-
     public static final ConfigOption<Integer> HISTORY_SERVER_NUM_WORKERS =
             key("historyserver.num.workers")
                     .intType()
                     .defaultValue(1)
                     .withDescription(
                             Description.builder()
-                                    .text("The maximum number of worker threads to archives in parallel")
+                                    .text(
+                                            "The maximum number of worker threads to archives in parallel")
                                     .text(
                                             "If set to `0` or less than `-1` HistoryServer will throw an %s. ",
                                             code("IllegalConfigurationException"))

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -144,4 +144,18 @@ public class HistoryServerOptions {
                                     .build());
 
     private HistoryServerOptions() {}
+
+    public static final ConfigOption<Integer> HISTORY_SERVER_NUM_WORKERS =
+            key("historyserver.num.workers")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text("The maximum number of worker threads to archives in parallel")
+                                    .text(
+                                            "If set to `0` or less than `-1` HistoryServer will throw an %s. ",
+                                            code("IllegalConfigurationException"))
+                                    .build());
+
+    private HistoryServerOptions() {}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -386,6 +386,7 @@ public class HistoryServer {
                                     ZonedDateTime.now(),
                                     false,
                                     false,
+                                    false,
                                     true)));
             fw.flush();
         } catch (IOException ioe) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -245,13 +245,20 @@ public class HistoryServer {
                     "Cannot set %s to 0 or less than -1",
                     HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.key());
         }
+        int numWorkers = config.getInteger(HistoryServerOptions.HISTORY_SERVER_NUM_WORKERS);
+        if (numWorkers <= 0) {
+            throw new IllegalConfigurationException(
+                    "Cannot set %s to 0 or less than -1",
+                    HistoryServerOptions.HISTORY_SERVER_NUM_WORKERS.key());
+        }
         archiveFetcher =
                 new HistoryServerArchiveFetcher(
                         refreshDirs,
                         webDir,
                         jobArchiveEventListener,
                         cleanupExpiredArchives,
-                        maxHistorySize);
+                        maxHistorySize,
+                        numWorkers);
 
         this.shutdownHook =
                 ShutdownHookUtil.addShutdownHook(
@@ -377,7 +384,6 @@ public class HistoryServer {
                             DashboardConfiguration.from(
                                     webRefreshIntervalMillis,
                                     ZonedDateTime.now(),
-                                    false,
                                     false,
                                     false,
                                     true)));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -490,8 +490,9 @@ class HistoryServerArchiveFetcher {
      * <p>For the display in the HistoryServer WebFrontend we have to combine these overviews.
      */
     private void updateJobOverview(File webOverviewDir, File webDir) {
-        try (JsonGenerator gen = jacksonFactory.createGenerator(
-                HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
+        try (JsonGenerator gen =
+                jacksonFactory.createGenerator(
+                    HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
             File[] overviews = new File(webOverviewDir.getPath()).listFiles();
             if (overviews != null) {
                 Collection<JobDetails> allJobs = new ArrayList<>(overviews.length);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -490,9 +490,8 @@ class HistoryServerArchiveFetcher {
      * <p>For the display in the HistoryServer WebFrontend we have to combine these overviews.
      */
     private void updateJobOverview(File webOverviewDir, File webDir) {
-        try (JsonGenerator gen =
-                     jacksonFactory.createGenerator(
-                             HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
+        try (JsonGenerator gen = jacksonFactory.createGenerator(
+                HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
             File[] overviews = new File(webOverviewDir.getPath()).listFiles();
             if (overviews != null) {
                 Collection<JobDetails> allJobs = new ArrayList<>(overviews.length);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -162,7 +162,7 @@ class HistoryServerArchiveFetcher {
 
     void fetchArchives() {
         try {
-            LOG.info("[Flink-Debug] Starting archive fetching.");
+            LOG.info("Starting archive fetching.");
             List<ArchiveEvent> events = Collections.synchronizedList(new ArrayList<>());
             Map<Path, Set<String>> jobsToRemove = new HashMap<>();
             cachedArchivesPerRefreshDirectory.forEach(
@@ -207,20 +207,20 @@ class HistoryServerArchiveFetcher {
                                 "Ignoring archive {} because it was already fetched.",
                                 jobArchivePath);
                     } else {
-                        LOG.info("[Flink-Debug] Start processing archive {}.", jobArchivePath);
+                        LOG.info("Start processing archive {}.", jobArchivePath);
                         try {
                             processArchive(jobID, jobArchivePath);
                             events.add(new ArchiveEvent(jobID, ArchiveEventType.CREATED));
                             cachedArchivesPerRefreshDirectory.get(refreshDir).add(jobID);
                             LOG.info(
-                                    "[Flink-Debug] Finished processing archive {}.",
+                                    "Finished processing archive {}.",
                                     jobArchivePath);
                             // update the webview each time we finish processing a new job
                             // to improve user experience
                             updateJobOverview(webOverviewDir, webDir);
                         } catch (IOException e) {
                             LOG.error(
-                                    "[Flink-Debug] Failure while fetching/processing job archive for job {}.",
+                                    "Failure while fetching/processing job archive for job {}.",
                                     jobID,
                                     e);
                             deleteJobFiles(jobID);
@@ -282,7 +282,7 @@ class HistoryServerArchiveFetcher {
             throws IOException, InterruptedException {
         Collection<ArchivedJson> archives = FsJobArchivist.getArchivedJsons(jobArchive);
         LOG.info(
-                "[Flink-Debug] Start processing total {} json archives for job {}",
+                "Start processing total {} json archives for job {}",
                 archives.size(),
                 jobArchive.toString());
         Map<File, String> filesToFlush = new HashMap<>(archives.size());
@@ -338,7 +338,7 @@ class HistoryServerArchiveFetcher {
         }
         latch.await();
         LOG.info(
-                "[Flink-Debug] Completed processing total {} unique targets from {} json archives,  for job {}",
+                "Completed processing total {} unique targets from {} json archives,  for job {}",
                 filesToFlush.size(),
                 archives.size(),
                 jobArchive);
@@ -500,7 +500,7 @@ class HistoryServerArchiveFetcher {
                 }
                 mapper.writeValue(gen, new MultipleJobsDetails(allJobs));
             }
-            LOG.info("[Flink-Debug] Updated job overview page");
+            LOG.info("Updated job overview page");
         } catch (IOException ioe) {
             LOG.error("Failed to update job overview.", ioe);
         }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -125,7 +125,7 @@ class HistoryServerArchiveFetcher {
     private final File webDir;
     private final File webJobDir;
     private final File webOverviewDir;
-    /** Number of worker threads to flush archive json data in parallel for different targets */
+    /** Number of worker threads to flush archive json data in parallel for different targets. */
     private final ExecutorService workerPool;
 
     HistoryServerArchiveFetcher(
@@ -219,7 +219,7 @@ class HistoryServerArchiveFetcher {
                                     jobArchivePath,
                                     numOfCompletedJobs);
                             // update the webview each time we finish processing a new job
-                            // to improve user experience
+                            // to improve user experience.
                             updateJobOverview(webOverviewDir, webDir);
 
                         } catch (IOException e) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -59,7 +59,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -492,7 +492,7 @@ class HistoryServerArchiveFetcher {
     private void updateJobOverview(File webOverviewDir, File webDir) {
         try (JsonGenerator gen =
                 jacksonFactory.createGenerator(
-                    HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
+                        HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
             File[] overviews = new File(webOverviewDir.getPath()).listFiles();
             if (overviews != null) {
                 Collection<JobDetails> allJobs = new ArrayList<>(overviews.length);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -56,6 +56,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -121,13 +125,16 @@ class HistoryServerArchiveFetcher {
     private final File webDir;
     private final File webJobDir;
     private final File webOverviewDir;
+    /** Number of worker threads to flush archive json data in parallel for different targets */
+    private final ExecutorService workerPool;
 
     HistoryServerArchiveFetcher(
             List<HistoryServer.RefreshLocation> refreshDirs,
             File webDir,
             Consumer<ArchiveEvent> jobArchiveEventListener,
             boolean cleanupExpiredArchives,
-            int maxHistorySize)
+            int maxHistorySize,
+            int numWorkers)
             throws IOException {
         this.refreshDirs = checkNotNull(refreshDirs);
         this.jobArchiveEventListener = jobArchiveEventListener;
@@ -144,6 +151,7 @@ class HistoryServerArchiveFetcher {
         this.webOverviewDir = new File(webDir, "overviews");
         Files.createDirectories(webOverviewDir.toPath());
         updateJobOverview(webOverviewDir, webDir);
+        this.workerPool = Executors.newFixedThreadPool(numWorkers);
 
         if (LOG.isInfoEnabled()) {
             for (HistoryServer.RefreshLocation refreshDir : refreshDirs) {
@@ -154,8 +162,8 @@ class HistoryServerArchiveFetcher {
 
     void fetchArchives() {
         try {
-            LOG.debug("Starting archive fetching.");
-            List<ArchiveEvent> events = new ArrayList<>();
+            LOG.info("[Flink-Debug] Starting archive fetching.");
+            List<ArchiveEvent> events = Collections.synchronizedList(new ArrayList<>());
             Map<Path, Set<String>> jobsToRemove = new HashMap<>();
             cachedArchivesPerRefreshDirectory.forEach(
                     (path, archives) -> jobsToRemove.put(path, new HashSet<>(archives)));
@@ -199,15 +207,20 @@ class HistoryServerArchiveFetcher {
                                 "Ignoring archive {} because it was already fetched.",
                                 jobArchivePath);
                     } else {
-                        LOG.info("Processing archive {}.", jobArchivePath);
+                        LOG.info("[Flink-Debug] Start processing archive {}.", jobArchivePath);
                         try {
                             processArchive(jobID, jobArchivePath);
                             events.add(new ArchiveEvent(jobID, ArchiveEventType.CREATED));
                             cachedArchivesPerRefreshDirectory.get(refreshDir).add(jobID);
-                            LOG.info("Processing archive {} finished.", jobArchivePath);
+                            LOG.info(
+                                    "[Flink-Debug] Finished processing archive {}.",
+                                    jobArchivePath);
+                            // update the webview each time we finish processing a new job
+                            // to improve user experience
+                            updateJobOverview(webOverviewDir, webDir);
                         } catch (IOException e) {
                             LOG.error(
-                                    "Failure while fetching/processing job archive for job {}.",
+                                    "[Flink-Debug] Failure while fetching/processing job archive for job {}.",
                                     jobID,
                                     e);
                             deleteJobFiles(jobID);
@@ -220,12 +233,15 @@ class HistoryServerArchiveFetcher {
                     && processExpiredArchiveDeletion) {
                 events.addAll(cleanupExpiredJobs(jobsToRemove));
             }
+
             if (!archivesBeyondSizeLimit.isEmpty() && processBeyondLimitArchiveDeletion) {
                 events.addAll(cleanupJobsBeyondSizeLimit(archivesBeyondSizeLimit));
             }
+
             if (!events.isEmpty()) {
                 updateJobOverview(webOverviewDir, webDir);
             }
+
             events.forEach(jobArchiveEventListener::accept);
             LOG.debug("Finished archive fetching.");
         } catch (Exception e) {
@@ -262,8 +278,15 @@ class HistoryServerArchiveFetcher {
         }
     }
 
-    private void processArchive(String jobID, Path jobArchive) throws IOException {
-        for (ArchivedJson archive : FsJobArchivist.getArchivedJsons(jobArchive)) {
+    private void processArchive(String jobID, Path jobArchive)
+            throws IOException, InterruptedException {
+        Collection<ArchivedJson> archives = FsJobArchivist.getArchivedJsons(jobArchive);
+        LOG.info(
+                "[Flink-Debug] Start processing total {} json archives for job {}",
+                archives.size(),
+                jobArchive.toString());
+        Map<File, String> filesToFlush = new HashMap<>(archives.size());
+        for (ArchivedJson archive : archives) {
             String path = archive.getPath();
             String json = archive.getJson();
 
@@ -296,11 +319,29 @@ class HistoryServerArchiveFetcher {
             Files.deleteIfExists(targetPath);
 
             Files.createFile(target.toPath());
-            try (FileWriter fw = new FileWriter(target)) {
-                fw.write(json);
-                fw.flush();
-            }
+            filesToFlush.put(target, json);
         }
+
+        CountDownLatch latch = new CountDownLatch(filesToFlush.size());
+        for (File target : filesToFlush.keySet()) {
+            workerPool.execute(
+                    () -> {
+                        try (FileWriter fw = new FileWriter(target)) {
+                            fw.write(filesToFlush.get(target));
+                            fw.flush();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+        }
+        latch.await();
+        LOG.info(
+                "[Flink-Debug] Completed processing total {} unique targets from {} json archives,  for job {}",
+                filesToFlush.size(),
+                archives.size(),
+                jobArchive);
     }
 
     private List<ArchiveEvent> cleanupJobsBeyondSizeLimit(
@@ -445,10 +486,10 @@ class HistoryServerArchiveFetcher {
      *
      * <p>For the display in the HistoryServer WebFrontend we have to combine these overviews.
      */
-    private static void updateJobOverview(File webOverviewDir, File webDir) {
+    private void updateJobOverview(File webOverviewDir, File webDir) {
         try (JsonGenerator gen =
-                jacksonFactory.createGenerator(
-                        HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
+                     jacksonFactory.createGenerator(
+                             HistoryServer.createOrGetFile(webDir, JobsOverviewHeaders.URL))) {
             File[] overviews = new File(webOverviewDir.getPath()).listFiles();
             if (overviews != null) {
                 Collection<JobDetails> allJobs = new ArrayList<>(overviews.length);
@@ -459,6 +500,7 @@ class HistoryServerArchiveFetcher {
                 }
                 mapper.writeValue(gen, new MultipleJobsDetails(allJobs));
             }
+            LOG.info("[Flink-Debug] Updated job overview page");
         } catch (IOException ioe) {
             LOG.error("Failed to update job overview.", ioe);
         }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -168,6 +168,7 @@ class HistoryServerArchiveFetcher {
             cachedArchivesPerRefreshDirectory.forEach(
                     (path, archives) -> jobsToRemove.put(path, new HashSet<>(archives)));
             Map<Path, Set<Path>> archivesBeyondSizeLimit = new HashMap<>();
+            int numOfCompletedJobs = 0;
             for (HistoryServer.RefreshLocation refreshLocation : refreshDirs) {
                 Path refreshDir = refreshLocation.getPath();
                 LOG.debug("Checking archive directory {}.", refreshDir);
@@ -212,12 +213,15 @@ class HistoryServerArchiveFetcher {
                             processArchive(jobID, jobArchivePath);
                             events.add(new ArchiveEvent(jobID, ArchiveEventType.CREATED));
                             cachedArchivesPerRefreshDirectory.get(refreshDir).add(jobID);
+                            numOfCompletedJobs++;
                             LOG.info(
-                                    "Finished processing archive {}.",
-                                    jobArchivePath);
+                                    "Finished processing archive {}, total completed {} jobs",
+                                    jobArchivePath,
+                                    numOfCompletedJobs);
                             // update the webview each time we finish processing a new job
                             // to improve user experience
                             updateJobOverview(webOverviewDir, webDir);
+
                         } catch (IOException e) {
                             LOG.error(
                                     "Failure while fetching/processing job archive for job {}.",

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -261,6 +261,24 @@ class HistoryServerTest {
     }
 
     @Test
+    void testFailIfNumberOfWorkersIsLessThanOrEqualToZero() throws Exception {
+        assertThatThrownBy(() -> startHistoryServerWithNumOfWorkers(-1))
+                .isInstanceOf(IllegalConfigurationException.class);
+        assertThatThrownBy(() -> startHistoryServerWithNumOfWorkers(0))
+                .isInstanceOf(IllegalConfigurationException.class);
+    }
+
+    private void startHistoryServerWithNumOfWorkers(int numOfWorkers)
+            throws IOException, FlinkException, InterruptedException {
+        Configuration historyServerConfig =
+                createTestConfiguration(
+                        HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS.defaultValue());
+        historyServerConfig.setInteger(
+                HistoryServerOptions.HISTORY_SERVER_NUM_WORKERS, numOfWorkers);
+        new HistoryServer(historyServerConfig).start();
+    }
+
+    @Test
     void testCleanExpiredJob() throws Exception {
         runArchiveExpirationTest(true);
     }
@@ -396,6 +414,8 @@ class HistoryServerTest {
                 HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS, cleanupExpiredJobs);
 
         historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
+
+        historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_NUM_WORKERS, 4);
         return historyServerConfig;
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
**Problem:**
Currently, if we have hundreds or thousands of history jobs sitting in HDFS, everytime when we restart or redeploy history server, it will take 30 minutes or up to hours to show some data on the web page. During this time, the history server is loading all the history job metadata from HDFS to build local webviews, however the web page is not usable since there's no content showing up until all jobs are done for the first round.

**Goal:**
This PR is aiming to
- Improve the time and speed of displaying history completed jobs on startup 
- Improve the performance of history server processing a single job by adding parallelism
- Improve the overall user experience of history server


## Brief change log
- Add a new configuration historyserver.num.workers for history server to set the number of worker threads for parallelizm
- Optimized the logic for history server webview update:
Before: Update the webview only after we finish processing ALL job achieves
After: Update the webview each time we finish processing a new job archive



## Verifying this change
- Added corresponding unit test for verify the new configuration.
- Modified existing unit test to cover multi-threaded scenario.
- Manually did integration test and canary in Twitter's environment with hundreds of job history

