### PR TITLE
[FLINK-32300][jdbc-driver] Support get object for result set

### DIFF
--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -83,12 +83,18 @@
 
 	<build>
 		<plugins>
-			<!-- Build flink-sql-gateway jar -->
+			<plugin>
+				<groupId>io.github.zentol.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<!-- Build flink sql jdbc driver bundle jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
-					<!-- Exclude all flink-dist files and only contain sql-gateway files -->
 					<execution>
 						<id>shade-flink</id>
 						<phase>package</phase>
@@ -104,6 +110,14 @@
 									<include>org.apache.flink:flink-sql-gateway</include>
 									<include>org.apache.flink:flink-table-common</include>
 									<include>org.apache.flink:flink-annotations</include>
+									<include>org.apache.flink:flink-core</include>
+									<incldue>org.apache.flink:flink-runtime</incldue>
+									<include>org.apache.flink:flink-clients</include>
+									<include>org.apache.flink:flink-table-api-java</include>
+									<include>org.apache.flink:flink-json</include>
+									<include>org.apache.flink:flink-shaded-netty</include>
+									<include>org.apache.flink:flink-shaded-jackson</include>
+									<include>org.apache.flink:flink-shaded-guava</include>
 								</includes>
 							</artifactSet>
 						</configuration>

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/BaseStatement.java
@@ -220,11 +220,6 @@ public abstract class BaseStatement implements Statement {
     }
 
     @Override
-    public int getUpdateCount() throws SQLException {
-        throw new SQLFeatureNotSupportedException("FlinkStatement#getUpdateCount is not supported");
-    }
-
-    @Override
     public void closeOnCompletion() throws SQLException {
         throw new SQLFeatureNotSupportedException(
                 "FlinkStatement#closeOnCompletion is not supported");

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
@@ -20,12 +20,18 @@ package org.apache.flink.table.jdbc;
 
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.gateway.StatementResult;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.jdbc.utils.ArrayFieldGetter;
 import org.apache.flink.table.jdbc.utils.CloseableResultIterator;
 import org.apache.flink.table.jdbc.utils.StatementResultIterator;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -38,8 +44,11 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.jdbc.utils.DriverUtils.checkNotNull;
 
@@ -50,6 +59,7 @@ import static org.apache.flink.table.jdbc.utils.DriverUtils.checkNotNull;
 public class FlinkResultSet extends BaseResultSet {
     private final List<DataType> dataTypeList;
     private final List<String> columnNameList;
+    private final List<RowData.FieldGetter> fieldGetterList;
     private final Statement statement;
     private final CloseableResultIterator<RowData> iterator;
     private final FlinkResultSetMetaData resultSetMetaData;
@@ -71,7 +81,17 @@ public class FlinkResultSet extends BaseResultSet {
 
         this.dataTypeList = schema.getColumnDataTypes();
         this.columnNameList = schema.getColumnNames();
+        this.fieldGetterList = createFieldGetterList(dataTypeList);
         this.resultSetMetaData = new FlinkResultSetMetaData(columnNameList, dataTypeList);
+    }
+
+    private List<RowData.FieldGetter> createFieldGetterList(List<DataType> dataTypeList) {
+        List<RowData.FieldGetter> fieldGetterList = new ArrayList<>(dataTypeList.size());
+        for (int i = 0; i < dataTypeList.size(); i++) {
+            fieldGetterList.add(RowData.createFieldGetter(dataTypeList.get(i).getLogicalType(), i));
+        }
+
+        return fieldGetterList;
     }
 
     @Override
@@ -353,8 +373,67 @@ public class FlinkResultSet extends BaseResultSet {
 
     @Override
     public Object getObject(int columnIndex) throws SQLException {
-        // TODO support get object
-        throw new SQLFeatureNotSupportedException("FlinkResultSet#getObject is not supported");
+        checkClosed();
+        checkValidRow();
+        checkValidColumn(columnIndex);
+        try {
+            Object object = fieldGetterList.get(columnIndex - 1).getFieldOrNull(currentRow);
+            DataType dataType = dataTypeList.get(columnIndex - 1);
+            return convertToJavaObject(object, dataType.getLogicalType());
+        } catch (Exception e) {
+            throw new SQLDataException(e);
+        }
+    }
+
+    private Object convertToJavaObject(Object object, LogicalType dataType) throws SQLException {
+        switch (dataType.getTypeRoot()) {
+            case BOOLEAN:
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case BINARY:
+            case VARBINARY:
+                {
+                    return object;
+                }
+            case VARCHAR:
+            case CHAR:
+                {
+                    return object.toString();
+                }
+            case DECIMAL:
+                {
+                    return ((DecimalData) object).toBigDecimal();
+                }
+            case MAP:
+                {
+                    LogicalType keyType = ((MapType) dataType).getKeyType();
+                    LogicalType valueType = ((MapType) dataType).getValueType();
+                    ArrayFieldGetter keyGetter = ArrayFieldGetter.createFieldGetter(keyType);
+                    ArrayFieldGetter valueGetter = ArrayFieldGetter.createFieldGetter(valueType);
+                    MapData mapData = (MapData) object;
+                    int size = mapData.size();
+                    ArrayData keyArrayData = mapData.keyArray();
+                    ArrayData valueArrayData = mapData.valueArray();
+                    Map<Object, Object> mapResult = new HashMap<>();
+                    for (int i = 0; i < size; i++) {
+                        mapResult.put(
+                                convertToJavaObject(
+                                        keyGetter.getObjectOrNull(keyArrayData, i), keyType),
+                                convertToJavaObject(
+                                        valueGetter.getObjectOrNull(valueArrayData, i), valueType));
+                    }
+                    return mapResult;
+                }
+            default:
+                {
+                    throw new SQLDataException(
+                            String.format("Not supported value type %s", dataType));
+                }
+        }
     }
 
     @Override

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkResultSet.java
@@ -386,6 +386,10 @@ public class FlinkResultSet extends BaseResultSet {
     }
 
     private Object convertToJavaObject(Object object, LogicalType dataType) throws SQLException {
+        if (object == null) {
+            return null;
+        }
+
         switch (dataType.getTypeRoot()) {
             case BOOLEAN:
             case TINYINT:

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/ArrayFieldGetter.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/utils/ArrayFieldGetter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.jdbc.utils;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldCount;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
+
+/** Creates an accessor for getting elements in an array data structure at the given position. */
+public interface ArrayFieldGetter {
+    @Nullable
+    Object getObjectOrNull(ArrayData array, int index);
+
+    static ArrayFieldGetter createFieldGetter(LogicalType type) {
+
+        final ArrayFieldGetter fieldGetter;
+        // ordered by type root definition
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                fieldGetter = ArrayData::getString;
+                break;
+            case BOOLEAN:
+                fieldGetter = ArrayData::getBoolean;
+                break;
+            case BINARY:
+            case VARBINARY:
+                fieldGetter = ArrayData::getBinary;
+                break;
+            case DECIMAL:
+                final int decimalPrecision = getPrecision(type);
+                final int decimalScale = getScale(type);
+                fieldGetter =
+                        (array, index) -> array.getDecimal(index, decimalPrecision, decimalScale);
+                break;
+            case TINYINT:
+                fieldGetter = ArrayData::getByte;
+                break;
+            case SMALLINT:
+                fieldGetter = ArrayData::getShort;
+                break;
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case INTERVAL_YEAR_MONTH:
+                fieldGetter = ArrayData::getInt;
+                break;
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                fieldGetter = ArrayData::getLong;
+                break;
+            case FLOAT:
+                fieldGetter = ArrayData::getFloat;
+                break;
+            case DOUBLE:
+                fieldGetter = ArrayData::getDouble;
+                break;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                final int timestampPrecision = getPrecision(type);
+                fieldGetter = (array, index) -> array.getTimestamp(index, timestampPrecision);
+                break;
+            case TIMESTAMP_WITH_TIME_ZONE:
+                throw new UnsupportedOperationException();
+            case ARRAY:
+                fieldGetter = ArrayData::getArray;
+                break;
+            case MULTISET:
+            case MAP:
+                fieldGetter = ArrayData::getMap;
+                break;
+            case ROW:
+            case STRUCTURED_TYPE:
+                final int arrayFieldCount = getFieldCount(type);
+                fieldGetter = (array, index) -> array.getRow(index, arrayFieldCount);
+                break;
+            case DISTINCT_TYPE:
+                fieldGetter = createFieldGetter(((DistinctType) type).getSourceType());
+                break;
+            case RAW:
+                fieldGetter = ArrayData::getRawValue;
+                break;
+            case NULL:
+            case SYMBOL:
+            case UNRESOLVED:
+            default:
+                throw new IllegalArgumentException();
+        }
+        if (!type.isNullable()) {
+            return fieldGetter;
+        }
+        return (array, index) -> {
+            if (array.isNullAt(index)) {
+                return null;
+            }
+            return fieldGetter.getObjectOrNull(array, index);
+        };
+    }
+}

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
@@ -119,7 +119,7 @@ public class FlinkResultSetTest {
                                         (RowData)
                                                 GenericRowData.of(
                                                         null, null, null, null, null, null, null,
-                                                        null, null, null))
+                                                        null, null, null, null))
                                 .iterator());
         try (ResultSet resultSet =
                 new FlinkResultSet(
@@ -128,15 +128,26 @@ public class FlinkResultSetTest {
                                 SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()))) {
             assertTrue(resultSet.next());
             assertFalse(resultSet.getBoolean(1));
+            assertNull(resultSet.getObject(1));
             assertEquals((byte) 0, resultSet.getByte(2));
+            assertNull(resultSet.getObject(2));
             assertEquals((short) 0, resultSet.getShort(3));
+            assertNull(resultSet.getObject(3));
             assertEquals(0, resultSet.getInt(4));
+            assertNull(resultSet.getObject(4));
             assertEquals(0L, resultSet.getLong(5));
+            assertNull(resultSet.getObject(5));
             assertEquals((float) 0.0, resultSet.getFloat(6));
+            assertNull(resultSet.getObject(6));
             assertEquals(0.0, resultSet.getDouble(7));
+            assertNull(resultSet.getObject(7));
             assertNull(resultSet.getBigDecimal(8));
+            assertNull(resultSet.getObject(8));
             assertNull(resultSet.getString(9));
+            assertNull(resultSet.getObject(9));
             assertNull(resultSet.getBytes(10));
+            assertNull(resultSet.getObject(10));
+            assertNull(resultSet.getObject(11));
             assertFalse(resultSet.next());
         }
     }

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkResultSetTest.java
@@ -25,7 +25,9 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.gateway.StatementResult;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.util.CloseableIterator;
@@ -37,6 +39,8 @@ import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,7 +63,12 @@ public class FlinkResultSetTest {
                     Column.physical("v7", DataTypes.DOUBLE()),
                     Column.physical("v8", DataTypes.DECIMAL(10, 5)),
                     Column.physical("v9", DataTypes.STRING()),
-                    Column.physical("v10", DataTypes.BYTES()));
+                    Column.physical("v10", DataTypes.BYTES()),
+                    Column.physical(
+                            "v11",
+                            DataTypes.MAP(
+                                    DataTypes.STRING(),
+                                    DataTypes.MAP(DataTypes.INT(), DataTypes.BIGINT()))));
 
     @Test
     public void testResultSetPrimitiveData() throws Exception {
@@ -68,57 +77,30 @@ public class FlinkResultSetTest {
                         IntStream.range(0, RECORD_SIZE)
                                 .boxed()
                                 .map(
-                                        v ->
-                                                (RowData)
-                                                        GenericRowData.of(
-                                                                v % 2 == 0,
-                                                                v.byteValue(),
-                                                                v.shortValue(),
-                                                                v,
-                                                                v.longValue(),
-                                                                (float) (v + 0.1),
-                                                                v + 0.22,
-                                                                DecimalData.fromBigDecimal(
-                                                                        new BigDecimal(
-                                                                                v + ".55555"),
-                                                                        10,
-                                                                        5),
-                                                                StringData.fromString(v.toString()),
-                                                                v.toString().getBytes()))
-                                .iterator());
-        try (ResultSet resultSet =
-                new FlinkResultSet(
-                        new TestingStatement(),
-                        new StatementResult(
-                                SCHEMA, data, true, ResultKind.SUCCESS, JobID.generate()))) {
-            validateResultData(resultSet);
-        }
-    }
-
-    @Test
-    public void testStringResultSetPrimitiveData() throws Exception {
-        CloseableIterator<RowData> data =
-                CloseableIterator.adapterForIterator(
-                        IntStream.range(0, RECORD_SIZE)
-                                .boxed()
-                                .map(
-                                        v ->
-                                                (RowData)
-                                                        GenericRowData.of(
-                                                                v % 2 == 0,
-                                                                v.byteValue(),
-                                                                v.shortValue(),
-                                                                v,
-                                                                v.longValue(),
-                                                                (float) (v + 0.1),
-                                                                v + 0.22,
-                                                                DecimalData.fromBigDecimal(
-                                                                        new BigDecimal(
-                                                                                v + ".55555"),
-                                                                        10,
-                                                                        5),
-                                                                StringData.fromString(v.toString()),
-                                                                v.toString().getBytes()))
+                                        v -> {
+                                            Map<StringData, MapData> map = new HashMap<>();
+                                            Map<Integer, Long> valueMap = new HashMap<>();
+                                            valueMap.put(v, v.longValue());
+                                            map.put(
+                                                    StringData.fromString(v.toString()),
+                                                    new GenericMapData(valueMap));
+                                            return (RowData)
+                                                    GenericRowData.of(
+                                                            v % 2 == 0,
+                                                            v.byteValue(),
+                                                            v.shortValue(),
+                                                            v,
+                                                            v.longValue(),
+                                                            (float) (v + 0.1),
+                                                            v + 0.22,
+                                                            DecimalData.fromBigDecimal(
+                                                                    new BigDecimal(v + ".55555"),
+                                                                    10,
+                                                                    5),
+                                                            StringData.fromString(v.toString()),
+                                                            v.toString().getBytes(),
+                                                            new GenericMapData(map));
+                                        })
                                 .iterator());
         try (ResultSet resultSet =
                 new FlinkResultSet(
@@ -169,24 +151,52 @@ public class FlinkResultSetTest {
             // Get and validate each column value
             assertEquals(val % 2 == 0, resultSet.getBoolean(1));
             assertEquals(val % 2 == 0, resultSet.getBoolean("v1"));
+            assertEquals(val % 2 == 0, resultSet.getObject(1));
+            assertEquals(val % 2 == 0, resultSet.getObject("v1"));
             assertEquals(val.byteValue(), resultSet.getByte(2));
             assertEquals(val.byteValue(), resultSet.getByte("v2"));
+            assertEquals(val.byteValue(), resultSet.getObject(2));
+            assertEquals(val.byteValue(), resultSet.getObject("v2"));
             assertEquals(val.shortValue(), resultSet.getShort(3));
             assertEquals(val.shortValue(), resultSet.getShort("v3"));
+            assertEquals(val.shortValue(), resultSet.getObject(3));
+            assertEquals(val.shortValue(), resultSet.getObject("v3"));
             assertEquals(val, resultSet.getInt(4));
             assertEquals(val, resultSet.getInt("v4"));
+            assertEquals(val, resultSet.getObject(4));
+            assertEquals(val, resultSet.getObject("v4"));
             assertEquals(val.longValue(), resultSet.getLong(5));
             assertEquals(val.longValue(), resultSet.getLong("v5"));
+            assertEquals(val.longValue(), resultSet.getObject(5));
+            assertEquals(val.longValue(), resultSet.getObject("v5"));
             assertTrue(resultSet.getFloat(6) - val - 0.1 < 0.0001);
             assertTrue(resultSet.getFloat("v6") - val - 0.1 < 0.0001);
+            assertTrue((float) resultSet.getObject(6) - val - 0.1 < 0.0001);
+            assertTrue((float) resultSet.getObject("v6") - val - 0.1 < 0.0001);
             assertTrue(resultSet.getDouble(7) - val - 0.22 < 0.0001);
             assertTrue(resultSet.getDouble("v7") - val - 0.22 < 0.0001);
+            assertTrue((double) resultSet.getObject(7) - val - 0.22 < 0.0001);
+            assertTrue((double) resultSet.getObject("v7") - val - 0.22 < 0.0001);
             assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal(8));
             assertEquals(new BigDecimal(val + ".55555"), resultSet.getBigDecimal("v8"));
+            assertEquals(new BigDecimal(val + ".55555"), resultSet.getObject(8));
+            assertEquals(new BigDecimal(val + ".55555"), resultSet.getObject("v8"));
             assertEquals(val.toString(), resultSet.getString(9));
             assertEquals(val.toString(), resultSet.getString("v9"));
+            assertEquals(val.toString(), resultSet.getObject(9));
+            assertEquals(val.toString(), resultSet.getObject("v9"));
             assertEquals(val.toString(), new String(resultSet.getBytes(10)));
             assertEquals(val.toString(), new String(resultSet.getBytes("v10")));
+            assertEquals(val.toString(), new String((byte[]) resultSet.getObject(10)));
+            assertEquals(val.toString(), new String((byte[]) resultSet.getObject("v10")));
+
+            // Validate map data
+            Map<String, Map<Integer, Long>> map = new HashMap<>();
+            Map<Integer, Long> valueMap = new HashMap<>();
+            valueMap.put(val, val.longValue());
+            map.put(String.valueOf(val), valueMap);
+            assertEquals(map, resultSet.getObject(11));
+            assertEquals(map, resultSet.getObject("v11"));
 
             // Get data according to wrong data type
             assertThrowsExactly(
@@ -212,7 +222,7 @@ public class FlinkResultSetTest {
                     () -> resultSet.getLong("id1"),
                     "Column[id1] is not exist");
             assertThrowsExactly(
-                    SQLException.class, () -> resultSet.getLong(11), "Column[11] is not exist");
+                    SQLException.class, () -> resultSet.getLong(12), "Column[11] is not exist");
             assertThrowsExactly(
                     SQLException.class, () -> resultSet.getLong(-1), "Column[-1] is not exist");
         }

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -24,11 +24,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.sql.ResultSet;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,6 +55,7 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
                                                 + "'format'='csv',\n"
                                                 + "'path'='%s')",
                                         tempDir)));
+                assertEquals(0, statement.getUpdateCount());
 
                 // INSERT TABLE returns job id
                 assertTrue(
@@ -62,6 +65,10 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
                                         + "(3, 33, '333'), "
                                         + "(2, 22, '222'), "
                                         + "(4, 44, '444')"));
+                assertThatThrownBy(statement::getUpdateCount)
+                        .isInstanceOf(SQLFeatureNotSupportedException.class)
+                        .hasMessage("FlinkStatement#getUpdateCount is not supported for query");
+
                 String jobId;
                 try (ResultSet resultSet = statement.getResultSet()) {
                     assertTrue(resultSet.next());


### PR DESCRIPTION
## What is the purpose of the change

Support get object for result and support map data

## Brief change log

  - Support get object for `FlinkResultSet`
  - Parse nest map result data
  - Support getUpdataCount for ddl which is used by beeline

## Verifying this change
This change added tests and can be verified as follows:

  - Added test case for getObject in FlinkResultSetTest
  - Added test case for getUpdateCount in FlinkStatementTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
