### PR TITLE
[Hotfix] Fix NPE in print sink writer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/PrintSinkOutputWriter.java
@@ -70,7 +70,7 @@ public class PrintSinkOutputWriter<IN> implements Serializable, SinkWriter<IN> {
     }
 
     public void write(IN record) {
-        stream.println(completedPrefix + record.toString());
+        stream.println(completedPrefix + (record == null ? "null" : record.toString()));
     }
 
     @Override


### PR DESCRIPTION

## What is the purpose of the change

If record is null , function `write(IN record)` throws NullPointerException.


## Brief change log

Fix NPE in print sink writer


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
