### PR TITLE
[FLINK-32289][kafka] Fix incorrect metadata column type in docs

### DIFF
--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -49,7 +49,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',
@@ -128,7 +128,7 @@ CREATE TABLE KafkaTable (
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `partition` BIGINT METADATA VIRTUAL,
   `offset` BIGINT METADATA VIRTUAL,
   `user_id` BIGINT,
@@ -152,7 +152,7 @@ CREATE TABLE KafkaTable (
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
   `origin_table` STRING METADATA FROM 'value.source.table' VIRTUAL, -- from Debezium format
   `partition_id` BIGINT METADATA FROM 'partition' VIRTUAL,  -- from Kafka connector
   `offset` BIGINT METADATA VIRTUAL,  -- from Kafka connector
@@ -390,7 +390,7 @@ Kafka 消息的消息键和消息体部分都可以使用某种 [格式]({{< ref
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -416,7 +416,7 @@ ROW<`user_id` BIGINT, `item_id` BIGINT, `behavior` STRING>
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -580,7 +580,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...
@@ -595,7 +595,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -51,7 +51,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',
@@ -130,7 +130,7 @@ The extended `CREATE TABLE` example demonstrates the syntax for exposing these m
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `partition` BIGINT METADATA VIRTUAL,
   `offset` BIGINT METADATA VIRTUAL,
   `user_id` BIGINT,
@@ -155,7 +155,7 @@ The following example shows how to access both Kafka and Debezium metadata field
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
   `origin_table` STRING METADATA FROM 'value.source.table' VIRTUAL, -- from Debezium format
   `partition_id` BIGINT METADATA FROM 'partition' VIRTUAL,  -- from Kafka connector
   `offset` BIGINT METADATA VIRTUAL,  -- from Kafka connector
@@ -436,7 +436,7 @@ options are prefixed with the format identifier.
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -462,7 +462,7 @@ prefixed with either the `'key'` or `'value'` plus format identifier.
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -636,7 +636,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...
@@ -651,7 +651,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes incorrect metadata column type in Kafka connector docs and test cases.


## Brief change log

  - Changed timestamp metadata column type from `TIMESTAMP` to `TIMESTAMP_LTZ` (with local timezone) in [Kafka SQL connector examples](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/table/kafka/#how-to-create-a-kafka-table) in both English and Chinese docs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)