### PR TITLE
[BP-1.15][FLINK-32231][Build System] Update libssl to 5.13, which is needed for all E2E tests

### DIFF
--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -102,8 +102,8 @@ jobs:
         echo "Installing required software"
         sudo apt-get install -y bc libapr1
         # install libssl1.0.0 for netty tcnative
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.11_amd64.deb
-        sudo apt install ./libssl1.0.0_1.0.2n-1ubuntu5.11_amd64.deb
+        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
+        sudo apt install ./libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
       displayName: Prepare E2E run
       condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile.sh

--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -102,8 +102,8 @@ jobs:
         echo "Installing required software"
         sudo apt-get install -y bc libapr1
         # install libssl1.0.0 for netty tcnative
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
-        sudo apt install ./libssl1.0.0_1.0.2n-1ubuntu5.12_amd64.deb
+        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb
+        sudo apt install ./libssl1.0.0_1.0.2n-1ubuntu5.13_amd64.deb
       displayName: Prepare E2E run
       condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile.sh


### PR DESCRIPTION
This is a backport of https://github.com/snuyanzin/flink/commit/ed7ca22efc68203d4882887a3856434137e6980f and https://github.com/apache/flink/commit/cc552f970e2673f2895ca3c73a8150cdf720915a to 1.15