### PR TITLE
[FLINK-31535][table] Extend watermark-related features for SQL

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -146,7 +146,17 @@ public final class FactoryUtil {
             ConfigOptions.key("scan.watermark.alignment.update-interval")
                     .durationType()
                     .defaultValue(Duration.ofMillis(1000))
-                    .withDescription("update interval to align watermark.");
+                    .withDescription("Update interval to align watermark.");
+
+    public static final ConfigOption<Duration> SOURCE_IDLE_TIMEOUT =
+            ConfigOptions.key("scan.watermark.idle-timeout")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When a source do not receive any elements for the timeout time, "
+                                    + "it will be marked as temporarily idle. This allows downstream "
+                                    + "tasks to advance their watermarks without the need to wait for "
+                                    + "watermarks from this source while it is idle.");
 
     /**
      * Suffix for keys of {@link ConfigOption} in case a connector requires multiple formats (e.g.
@@ -171,6 +181,7 @@ public final class FactoryUtil {
         set.add(WATERMARK_ALIGNMENT_GROUP);
         set.add(WATERMARK_ALIGNMENT_MAX_DRIFT);
         set.add(WATERMARK_ALIGNMENT_UPDATE_INTERVAL);
+        set.add(SOURCE_IDLE_TIMEOUT);
         watermarkOptionSet = Collections.unmodifiableSet(set);
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkEmitStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkEmitStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.watermark;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.PipelineOptions;
+
+/** The strategy for emitting watermark. */
+@PublicEvolving
+public enum WatermarkEmitStrategy {
+    /** Emit watermark for every event. */
+    ON_EVENT("on-event"),
+
+    /**
+     * Emit watermark periodically. the period is configured by {@link
+     * PipelineOptions#AUTO_WATERMARK_INTERVAL}
+     */
+    ON_PERIODIC("on-periodic"),
+    ;
+
+    private final String alias;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    WatermarkEmitStrategy(String alias) {
+        this.alias = alias;
+    }
+
+    public boolean isOnEvent() {
+        return this == ON_EVENT;
+    }
+
+    public boolean isOnPeriodic() {
+        return this == ON_PERIODIC;
+    }
+
+    @Override
+    public String toString() {
+        return this.alias;
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkParams.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkParams.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.watermark;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Pojo class for watermark configs from table options or 'OPTIONS' hint. */
+@Internal
+public class WatermarkParams implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private WatermarkEmitStrategy emitStrategy;
+
+    public WatermarkParams() {}
+
+    public WatermarkParams(WatermarkEmitStrategy emitStrategy) {
+        this.emitStrategy = emitStrategy;
+    }
+
+    public WatermarkEmitStrategy getEmitStrategy() {
+        return emitStrategy;
+    }
+
+    public void setEmitStrategy(WatermarkEmitStrategy emitStrategy) {
+        this.emitStrategy = emitStrategy;
+    }
+
+    public static WatermarkParamsBuilder builder() {
+        return new WatermarkParamsBuilder();
+    }
+
+    @Override
+    public String toString() {
+        return "WatermarkParams{" + "emitStrategy=" + emitStrategy + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WatermarkParams that = (WatermarkParams) o;
+        return emitStrategy == that.emitStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(emitStrategy);
+    }
+
+    /** Builder of WatermarkHintParams. */
+    public static class WatermarkParamsBuilder {
+        private WatermarkEmitStrategy emitStrategy =
+                FactoryUtil.WATERMARK_EMIT_STRATEGY.defaultValue();
+
+        public WatermarkParamsBuilder emitStrategy(WatermarkEmitStrategy emitStrategy) {
+            this.emitStrategy = emitStrategy;
+            return this;
+        }
+
+        public WatermarkParams build() {
+            return new WatermarkParams(emitStrategy);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkParams.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/watermark/WatermarkParams.java
@@ -20,8 +20,10 @@ package org.apache.flink.table.watermark;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.StringUtils;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Objects;
 
 /** Pojo class for watermark configs from table options or 'OPTIONS' hint. */
@@ -30,11 +32,21 @@ public class WatermarkParams implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private WatermarkEmitStrategy emitStrategy;
+    private String alignGroupName;
+    private Duration alignMaxDrift;
+    private Duration alignUpdateInterval;
 
     public WatermarkParams() {}
 
-    public WatermarkParams(WatermarkEmitStrategy emitStrategy) {
+    public WatermarkParams(
+            WatermarkEmitStrategy emitStrategy,
+            String alignGroupName,
+            Duration alignMaxDrift,
+            Duration alignUpdateInterval) {
         this.emitStrategy = emitStrategy;
+        this.alignGroupName = alignGroupName;
+        this.alignMaxDrift = alignMaxDrift;
+        this.alignUpdateInterval = alignUpdateInterval;
     }
 
     public WatermarkEmitStrategy getEmitStrategy() {
@@ -45,13 +57,59 @@ public class WatermarkParams implements Serializable {
         this.emitStrategy = emitStrategy;
     }
 
+    public String getAlignGroupName() {
+        return alignGroupName;
+    }
+
+    public void setAlignGroupName(String alignGroupName) {
+        this.alignGroupName = alignGroupName;
+    }
+
+    public Duration getAlignMaxDrift() {
+        return alignMaxDrift;
+    }
+
+    public void setAlignMaxDrift(Duration alignMaxDrift) {
+        this.alignMaxDrift = alignMaxDrift;
+    }
+
+    public Duration getAlignUpdateInterval() {
+        return alignUpdateInterval;
+    }
+
+    public void setAlignUpdateInterval(Duration alignUpdateInterval) {
+        this.alignUpdateInterval = alignUpdateInterval;
+    }
+
+    public boolean alignWatermarkEnabled() {
+        return !StringUtils.isNullOrWhitespaceOnly(alignGroupName)
+                && alignMaxDrift != null
+                && isDurationPositive(alignMaxDrift)
+                && alignUpdateInterval != null
+                && isDurationPositive(alignUpdateInterval);
+    }
+
+    private boolean isDurationPositive(Duration duration) {
+        return !duration.isNegative() && !duration.isZero();
+    }
+
     public static WatermarkParamsBuilder builder() {
         return new WatermarkParamsBuilder();
     }
 
     @Override
     public String toString() {
-        return "WatermarkParams{" + "emitStrategy=" + emitStrategy + '}';
+        return "WatermarkParams{"
+                + "emitStrategy="
+                + emitStrategy
+                + ", alignGroupName='"
+                + alignGroupName
+                + '\''
+                + ", alignMaxDrift="
+                + alignMaxDrift
+                + ", alignUpdateInterval="
+                + alignUpdateInterval
+                + '}';
     }
 
     @Override
@@ -63,26 +121,53 @@ public class WatermarkParams implements Serializable {
             return false;
         }
         WatermarkParams that = (WatermarkParams) o;
-        return emitStrategy == that.emitStrategy;
+        return emitStrategy == that.emitStrategy
+                && Objects.equals(alignGroupName, that.alignGroupName)
+                && Objects.equals(alignMaxDrift, that.alignMaxDrift)
+                && Objects.equals(alignUpdateInterval, that.alignUpdateInterval);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(emitStrategy);
+        return Objects.hash(
+                emitStrategy,
+                alignGroupName,
+                alignMaxDrift,
+                alignUpdateInterval);
     }
 
     /** Builder of WatermarkHintParams. */
     public static class WatermarkParamsBuilder {
         private WatermarkEmitStrategy emitStrategy =
                 FactoryUtil.WATERMARK_EMIT_STRATEGY.defaultValue();
+        private String alignGroupName;
+        private Duration alignMaxDrift = Duration.ZERO;
+        private Duration alignUpdateInterval =
+                FactoryUtil.WATERMARK_ALIGNMENT_UPDATE_INTERVAL.defaultValue();
 
         public WatermarkParamsBuilder emitStrategy(WatermarkEmitStrategy emitStrategy) {
             this.emitStrategy = emitStrategy;
             return this;
         }
 
+        public WatermarkParamsBuilder alignGroupName(String alignGroupName) {
+            this.alignGroupName = alignGroupName;
+            return this;
+        }
+
+        public WatermarkParamsBuilder alignMaxDrift(Duration alignMaxDrift) {
+            this.alignMaxDrift = alignMaxDrift;
+            return this;
+        }
+
+        public WatermarkParamsBuilder alignUpdateInterval(Duration alignUpdateInterval) {
+            this.alignUpdateInterval = alignUpdateInterval;
+            return this;
+        }
+
         public WatermarkParams build() {
-            return new WatermarkParams(emitStrategy);
+            return new WatermarkParams(
+                    emitStrategy, alignGroupName, alignMaxDrift, alignUpdateInterval);
         }
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -198,6 +198,7 @@ class FactoryUtilTest {
                         + "scan.watermark.alignment.max-drift\n"
                         + "scan.watermark.alignment.update-interval\n"
                         + "scan.watermark.emit.strategy\n"
+                        + "scan.watermark.idle-timeout\n"
                         + "target\n"
                         + "value.format\n"
                         + "value.test-format.changelog-mode\n"
@@ -762,6 +763,7 @@ class FactoryUtilTest {
         options.put("scan.watermark.alignment.group", "group1");
         options.put("scan.watermark.alignment.max-drift", "1min");
         options.put("scan.watermark.alignment.update-interval", "1s");
+        options.put("scan.watermark.idle-timeout", "1min");
         return options;
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -194,6 +194,9 @@ class FactoryUtilTest {
                         + "key.test-format.readable-metadata\n"
                         + "password\n"
                         + "property-version\n"
+                        + "scan.watermark.alignment.group\n"
+                        + "scan.watermark.alignment.max-drift\n"
+                        + "scan.watermark.alignment.update-interval\n"
                         + "scan.watermark.emit.strategy\n"
                         + "target\n"
                         + "value.format\n"
@@ -214,6 +217,25 @@ class FactoryUtilTest {
                     options.put(FactoryUtil.WATERMARK_EMIT_STRATEGY.key(), "test_strategy");
                 },
                 "Invalid value for option 'scan.watermark.emit.strategy'.");
+    }
+
+    @Test
+    void testWatermarkAlignmentOptions() {
+        Map<String, String> watermarkOptions = createWatermarkOptions();
+        assertCreateTableSourceWithOptionModifier(
+                options -> {
+                    options.putAll(watermarkOptions);
+                    options.remove(FactoryUtil.WATERMARK_ALIGNMENT_GROUP.key());
+                },
+                "Error configuring watermark for 'test-connector', 'scan.watermark.alignment.group' "
+                        + "and 'scan.watermark.alignment.max-drift' must be set when configuring watermark alignment");
+        assertCreateTableSourceWithOptionModifier(
+                options -> {
+                    options.putAll(watermarkOptions);
+                    options.remove(FactoryUtil.WATERMARK_ALIGNMENT_MAX_DRIFT.key());
+                },
+                "Error configuring watermark for 'test-connector', 'scan.watermark.alignment.group' "
+                        + "and 'scan.watermark.alignment.max-drift' must be set when configuring watermark alignment");
     }
 
     @Test
@@ -737,6 +759,9 @@ class FactoryUtilTest {
     private static Map<String, String> createWatermarkOptions() {
         final Map<String, String> options = new HashMap<>();
         options.put("scan.watermark.emit.strategy", "on-event");
+        options.put("scan.watermark.alignment.group", "group1");
+        options.put("scan.watermark.alignment.max-drift", "1min");
+        options.put("scan.watermark.alignment.update-interval", "1s");
         return options;
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -194,6 +194,7 @@ class FactoryUtilTest {
                         + "key.test-format.readable-metadata\n"
                         + "password\n"
                         + "property-version\n"
+                        + "scan.watermark.emit.strategy\n"
                         + "target\n"
                         + "value.format\n"
                         + "value.test-format.changelog-mode\n"
@@ -202,6 +203,17 @@ class FactoryUtilTest {
                         + "value.test-format.fail-on-missing\n"
                         + "value.test-format.fallback-fail-on-missing\n"
                         + "value.test-format.readable-metadata");
+    }
+
+    @Test
+    void testWatermarkEmitOptions() {
+        Map<String, String> watermarkOptions = createWatermarkOptions();
+        assertCreateTableSourceWithOptionModifier(
+                options -> {
+                    options.putAll(watermarkOptions);
+                    options.put(FactoryUtil.WATERMARK_EMIT_STRATEGY.key(), "test_strategy");
+                },
+                "Invalid value for option 'scan.watermark.emit.strategy'.");
     }
 
     @Test
@@ -719,6 +731,12 @@ class FactoryUtilTest {
         options.put("value.format", "test-format");
         options.put("value.test-format.delimiter", "|");
         options.put("value.test-format.fail-on-missing", "true");
+        return options;
+    }
+
+    private static Map<String, String> createWatermarkOptions() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("scan.watermark.emit.strategy", "on-event");
         return options;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/WatermarkPushDownSpec.java
@@ -96,6 +96,13 @@ public final class WatermarkPushDownSpec extends SourceAbilitySpecBase {
                             generatedWatermarkGenerator, watermarkParams);
 
             WatermarkStrategy<RowData> watermarkStrategy = WatermarkStrategy.forGenerator(supplier);
+            if (watermarkParams != null && watermarkParams.alignWatermarkEnabled()) {
+                watermarkStrategy =
+                        watermarkStrategy.withWatermarkAlignment(
+                                watermarkParams.getAlignGroupName(),
+                                watermarkParams.getAlignMaxDrift(),
+                                watermarkParams.getAlignUpdateInterval());
+            }
             if (idleTimeoutMillis > 0) {
                 watermarkStrategy =
                         watermarkStrategy.withIdleness(Duration.ofMillis(idleTimeoutMillis));
@@ -124,6 +131,15 @@ public final class WatermarkPushDownSpec extends SourceAbilitySpecBase {
         if (watermarkParams != null) {
             WatermarkEmitStrategy emitStrategy = watermarkParams.getEmitStrategy();
             sb.append(", watermarkEmitStrategy=[").append(emitStrategy).append("]");
+            if (watermarkParams.alignWatermarkEnabled()) {
+                sb.append(", watermarkAlignment=[")
+                        .append(watermarkParams.getAlignGroupName())
+                        .append(", ")
+                        .append(watermarkParams.getAlignMaxDrift())
+                        .append(", ")
+                        .append(watermarkParams.getAlignUpdateInterval())
+                        .append("]");
+            }
         }
         return sb.toString();
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.planner.plan.rules.logical;
 
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -31,6 +33,7 @@ import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.hint.FlinkHints;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.abilities.source.SourceWatermarkSpec;
@@ -39,15 +42,21 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSource
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWatermarkAssigner;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.watermark.WatermarkParams;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static org.apache.flink.table.factories.FactoryUtil.WATERMARK_EMIT_STRATEGY;
 import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapFunctionDefinition;
 
 /**
@@ -117,8 +126,36 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
                 idleTimeoutMillis = -1L;
             }
 
+            Optional<RelHint> optionsHintOptional =
+                    scan.getHints().stream()
+                            .filter(
+                                    relHint ->
+                                            relHint.hintName.equalsIgnoreCase(
+                                                    FlinkHints.HINT_NAME_OPTIONS))
+                            .findFirst();
+            Configuration hintOptions =
+                    optionsHintOptional
+                            .map(relHint -> Configuration.fromMap(relHint.kvOptions))
+                            .orElseGet(Configuration::new);
+            RelOptTable table = scan.getTable();
+            Configuration tableOptions =
+                    Optional.of(table)
+                            .filter(TableSourceTable.class::isInstance)
+                            .map(
+                                    t -> {
+                                        Map<String, String> tableConfigs =
+                                                ((TableSourceTable) t)
+                                                        .contextResolvedTable()
+                                                        .getResolvedTable()
+                                                        .getOptions();
+                                        return Configuration.fromMap(tableConfigs);
+                                    })
+                            .orElseGet(Configuration::new);
+            WatermarkParams watermarkParams = parseWatermarkParams(hintOptions, tableOptions);
+
             final WatermarkPushDownSpec watermarkPushDownSpec =
-                    new WatermarkPushDownSpec(watermarkExpr, idleTimeoutMillis, producedType);
+                    new WatermarkPushDownSpec(
+                            watermarkExpr, idleTimeoutMillis, producedType, watermarkParams);
             watermarkPushDownSpec.apply(newDynamicTableSource, abilityContext);
             abilitySpec = watermarkPushDownSpec;
         }
@@ -156,5 +193,19 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
     private boolean hasSourceWatermarkDeclaration(RexNode rexNode) {
         final FunctionDefinition function = unwrapFunctionDefinition(rexNode);
         return function == BuiltInFunctionDefinitions.SOURCE_WATERMARK;
+    }
+
+    private WatermarkParams parseWatermarkParams(
+            Configuration hintOptions, Configuration tableOptions) {
+        WatermarkParams.WatermarkParamsBuilder builder = WatermarkParams.builder();
+        getOptions(WATERMARK_EMIT_STRATEGY, hintOptions, tableOptions)
+                .ifPresent(builder::emitStrategy);
+        return builder.build();
+    }
+
+    private <T> Optional<T> getOptions(
+            ConfigOption<T> option, Configuration priorityOptions, Configuration secondOptions) {
+        Optional<T> result = priorityOptions.getOptional(option);
+        return result.isPresent() ? result : secondOptions.getOptional(option);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleBase.java
@@ -56,6 +56,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.flink.table.factories.FactoryUtil.WATERMARK_ALIGNMENT_GROUP;
+import static org.apache.flink.table.factories.FactoryUtil.WATERMARK_ALIGNMENT_MAX_DRIFT;
+import static org.apache.flink.table.factories.FactoryUtil.WATERMARK_ALIGNMENT_UPDATE_INTERVAL;
 import static org.apache.flink.table.factories.FactoryUtil.WATERMARK_EMIT_STRATEGY;
 import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapFunctionDefinition;
 
@@ -200,6 +203,12 @@ public abstract class PushWatermarkIntoTableSourceScanRuleBase extends RelOptRul
         WatermarkParams.WatermarkParamsBuilder builder = WatermarkParams.builder();
         getOptions(WATERMARK_EMIT_STRATEGY, hintOptions, tableOptions)
                 .ifPresent(builder::emitStrategy);
+        getOptions(WATERMARK_ALIGNMENT_GROUP, hintOptions, tableOptions)
+                .ifPresent(builder::alignGroupName);
+        getOptions(WATERMARK_ALIGNMENT_MAX_DRIFT, hintOptions, tableOptions)
+                .ifPresent(builder::alignMaxDrift);
+        getOptions(WATERMARK_ALIGNMENT_UPDATE_INTERVAL, hintOptions, tableOptions)
+                .ifPresent(builder::alignUpdateInterval);
         return builder.build();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -217,6 +218,9 @@ public class DynamicTableSourceSpecSerdeTest {
                                                 new TimestampType(false, TimestampKind.ROWTIME, 3)),
                                         WatermarkParams.builder()
                                                 .emitStrategy(WatermarkEmitStrategy.ON_PERIODIC)
+                                                .alignGroupName("align-group-1")
+                                                .alignMaxDrift(Duration.ofMinutes(1))
+                                                .alignUpdateInterval(Duration.ofSeconds(1))
                                                 .build()),
                                 new SourceWatermarkSpec(
                                         true,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -221,6 +221,7 @@ public class DynamicTableSourceSpecSerdeTest {
                                                 .alignGroupName("align-group-1")
                                                 .alignMaxDrift(Duration.ofMinutes(1))
                                                 .alignUpdateInterval(Duration.ofSeconds(1))
+                                                .sourceIdleTimeout(60000)
                                                 .build()),
                                 new SourceWatermarkSpec(
                                         true,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -54,6 +54,8 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.watermark.WatermarkEmitStrategy;
+import org.apache.flink.table.watermark.WatermarkParams;
 
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rex.RexBuilder;
@@ -212,8 +214,10 @@ public class DynamicTableSourceSpecSerdeTest {
                                                 new BigIntType(),
                                                 new IntType(),
                                                 new IntType(),
-                                                new TimestampType(
-                                                        false, TimestampKind.ROWTIME, 3))),
+                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                                        WatermarkParams.builder()
+                                                .emitStrategy(WatermarkEmitStrategy.ON_PERIODIC)
+                                                .build()),
                                 new SourceWatermarkSpec(
                                         true,
                                         RowType.of(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.java
@@ -275,4 +275,43 @@ public class PushWatermarkIntoTableSourceScanRuleTest extends TableTestBase {
         util.tableEnv().executeSql(ddl);
         util.verifyRelPlan("SELECT * FROM MyTable");
     }
+
+    @Test
+    public void testWatermarkEmitStrategyWithOptions() {
+        String ddl =
+                "CREATE TABLE MyTable("
+                        + "  a INT,\n"
+                        + "  b BIGINT,\n"
+                        + "  c TIMESTAMP(3),\n"
+                        + "  WATERMARK FOR c AS c - INTERVAL '5' SECOND\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'enable-watermark-push-down' = 'true',\n"
+                        + "  'bounded' = 'false',\n"
+                        + "  'scan.watermark.emit.strategy' = 'on-event',\n"
+                        + "  'disable-lookup' = 'true'"
+                        + ")";
+        util.tableEnv().executeSql(ddl);
+        util.verifyRelPlan("select a, c from MyTable");
+    }
+
+    @Test
+    public void testWatermarkEmitStrategyWithHint() {
+        String ddl =
+                "CREATE TABLE MyTable("
+                        + "  a INT,\n"
+                        + "  b BIGINT,\n"
+                        + "  c TIMESTAMP(3),\n"
+                        + "  WATERMARK FOR c AS c - INTERVAL '5' SECOND\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'enable-watermark-push-down' = 'true',\n"
+                        + "  'bounded' = 'false',\n"
+                        + "  'disable-lookup' = 'true'"
+                        + ")";
+        util.tableEnv().executeSql(ddl);
+        util.verifyRelPlan(
+                "select a, c from MyTable /*+ OPTIONS("
+                        + "'scan.watermark.emit.strategy'='on-event') */");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -90,7 +90,10 @@
           } ]
         },
         "watermarkParams":{
-         "emitStrategy" : "ON_PERIODIC"
+         "emitStrategy" : "ON_PERIODIC",
+         "alignGroupName" : null,
+         "alignMaxDrift" : "PT0S",
+         "alignUpdateInterval" : "PT1S"
         }
       } ]
     },
@@ -111,7 +114,7 @@
         }
       } ]
     },
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "id" : 2,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -88,6 +88,9 @@
               "kind" : "ROWTIME"
             }
           } ]
+        },
+        "watermarkParams":{
+         "emitStrategy" : "ON_PERIODIC"
         }
       } ]
     },

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -93,7 +93,8 @@
          "emitStrategy" : "ON_PERIODIC",
          "alignGroupName" : null,
          "alignMaxDrift" : "PT0S",
-         "alignUpdateInterval" : "PT1S"
+         "alignUpdateInterval" : "PT1S",
+         "sourceIdleTimeout" : -1
         }
       } ]
     },

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -251,4 +251,40 @@ FlinkLogicalCalc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWatermarkAlignmentWithOptions">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic], watermarkAlignment=[group1, PT1M, PT1S]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWatermarkAlignmentWithHint">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable /*+ OPTIONS('scan.watermark.alignment.group'='group1', 'scan.watermark.alignment.max-drift'='1min') */]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]], hints=[[[OPTIONS inheritPath:[] options:{scan.watermark.alignment.max-drift=1min, scan.watermark.alignment.group=group1}]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic], watermarkAlignment=[group1, PT1M, PT1S]]], fields=[a, b, c], hints=[[[OPTIONS options:{scan.watermark.alignment.max-drift=1min, scan.watermark.alignment.group=group1}]]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -287,4 +287,40 @@ FlinkLogicalCalc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testIdleSourceWithOptions">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[60000], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIdleSourceWithHint">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable /*+ OPTIONS('scan.watermark.idle-timeout' = '60s')*/]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]], hints=[[[OPTIONS inheritPath:[] options:{scan.watermark.idle-timeout=60s}]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[60000], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c], hints=[[[OPTIONS options:{scan.watermark.idle-timeout=60s}]]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -50,7 +50,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -72,7 +72,7 @@ LogicalProject(a=[$0], b=[$1])
 FlinkLogicalCalc(select=[a, b])
 +- FlinkLogicalCalc(select=[a, b, c, d], where=[>(d, TO_TIMESTAMP('2020-10-09 12:12:12'))])
    +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(+(c, 5000:INTERVAL SECOND)) AS d])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -92,7 +92,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(TO_TIMESTAMP(a, b)) AS c])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP(a, b), 5000:INTERVAL SECOND)]]], fields=[a, b])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(TO_TIMESTAMP(a, b), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -112,7 +112,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[$3], computed=[$4])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, metadata, computed])
 +- FlinkLogicalCalc(select=[a, b, Reinterpret(c) AS c, CAST(metadata AS BIGINT) AS metadata, +(CAST(metadata AS BIGINT), b) AS computed])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata AS BIGINT), +(CAST(metadata AS BIGINT), b)) AS INTERVAL SECOND))]]], fields=[a, b, c, metadata])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, CAST(+(CAST(metadata AS BIGINT), +(CAST(metadata AS BIGINT), b)) AS INTERVAL SECOND))], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c, metadata])
 ]]>
     </Resource>
   </TestCase>
@@ -132,7 +132,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], g=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, g])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d.f) AS g])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d.f, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -152,7 +152,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], e=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, e])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(c.d) AS e])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d, 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c.d, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -170,7 +170,7 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, c])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[1000]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], idletimeout=[1000], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -190,7 +190,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c, d])
 +- FlinkLogicalCalc(select=[a, b, c, Reinterpret(func(c, a)) AS d])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[func(func(func(c, a), a), a)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -212,6 +212,42 @@ FlinkLogicalCalc(select=[a, b])
 +- FlinkLogicalWatermarkAssigner(rowtime=[b], watermark=[$1])
    +- FlinkLogicalCalc(select=[a, parse_ts(a) AS b])
       +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWatermarkEmitStrategyWithOptions">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-event]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWatermarkEmitStrategyWithHint">
+    <Resource name="sql">
+      <![CDATA[select a, c from MyTable /*+ OPTIONS('scan.watermark.emit.strategy'='on-event') */]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, 5000:INTERVAL SECOND)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]], hints=[[[OPTIONS inheritPath:[] options:{scan.watermark.emit.strategy=on-event}]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-(c, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-event]]], fields=[a, b, c], hints=[[[OPTIONS options:{scan.watermark.emit.strategy=on-event}]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -30,7 +30,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[=(LOWER(d), _UTF-16LE'hello':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
+TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], watermarkEmitStrategy=[on-periodic], filter=[=(LOWER(d), _UTF-16LE'hello':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, d], where=[d IS NOT NULL])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[=(LOWER(d), _UTF-16LE'h':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], watermarkEmitStrategy=[on-periodic], filter=[=(LOWER(d), _UTF-16LE'h':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, d], where=[(b > 5)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], filter=[]]], fields=[a, b, c, d])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[c], watermarkEmitStrategy=[on-periodic], filter=[]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -107,7 +107,7 @@ LogicalProject(event_time=[$0], name=[$1], lowercase_name=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[Reinterpret(event_time) AS event_time, name, CAST('foo' AS VARCHAR(2147483647)) AS lowercase_name])
-+- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[event_time], filter=[=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[event_time, name])
++- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[event_time], watermarkEmitStrategy=[on-periodic], filter=[=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[event_time, name])
 ]]>
     </Resource>
   </TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], filter=[=(UPPER(f), _UTF-16LE'welcome':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], watermarkEmitStrategy=[on-periodic], filter=[=(UPPER(f), _UTF-16LE'welcome':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[a, b, c, f])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -31,7 +31,7 @@ LogicalProject(EXPR$0=[-($0, $1)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[(a - b) AS EXPR$0])
-+- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func(c, a), a), a)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -49,7 +49,7 @@ LogicalProject(a=[$0], b=[$1], ts=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)]]], fields=[a, b, t])
+TableSourceScan(table=[[default_catalog, default_database, t1, project=[a, b, t], metadata=[], watermark=[-(t, 10000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, t])
 ]]>
     </Resource>
   </TestCase>
@@ -67,7 +67,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b], where=[(b > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic], filter=[]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -106,7 +106,7 @@ LogicalProject(a=[$0], b=[$1], rowtime=[$2])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, Reinterpret(TO_TIMESTAMP_LTZ(b, 0)) AS rowtime])
-+- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ(b, 0)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, timeTestTable, watermark=[TO_TIMESTAMP_LTZ(b, 0)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -125,7 +125,7 @@ LogicalProject(e=[$2.d.e], d=[$2.d])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[c.d.e AS e, c.d AS d])
-+- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-(c.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
++- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], metadata=[], watermark=[-(c.d.f, 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[c])
 ]]>
     </Resource>
   </TestCase>
@@ -144,7 +144,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyLtzTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP_LTZ(originTime, 3)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>
@@ -163,7 +163,7 @@ LogicalProject(a=[$0], b=[$1], EXPR$2=[EXTRACT(FLAG(SECOND), $3)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, EXTRACT(SECOND, CAST(Reinterpret((c + 5000:INTERVAL SECOND)) AS TIMESTAMP(3))) AS EXPR$2])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+(c, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -182,7 +182,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/(originTime, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')], watermarkEmitStrategy=[on-periodic]]], fields=[a, b, originTime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -659,7 +659,7 @@ LogicalProject(id=[$0], ts=[$4])
 Calc(select=[id, Reinterpret(TO_TIMESTAMP(c)) AS ts], changelogMode=[I,UA,D])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
-      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(c), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], metadata=[], watermark=[-(TO_TIMESTAMP(c), 1000:INTERVAL SECOND)], watermarkEmitStrategy=[on-periodic]]], fields=[id, c], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGeneratorSupplier.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/GeneratedWatermarkGeneratorSupplier.java
@@ -24,6 +24,10 @@ import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.watermark.WatermarkEmitStrategy;
+import org.apache.flink.table.watermark.WatermarkParams;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,10 +44,13 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
     private static final long serialVersionUID = 1L;
 
     private final GeneratedWatermarkGenerator generatedWatermarkGenerator;
+    private final WatermarkParams watermarkParams;
 
     public GeneratedWatermarkGeneratorSupplier(
-            GeneratedWatermarkGenerator generatedWatermarkGenerator) {
+            GeneratedWatermarkGenerator generatedWatermarkGenerator,
+            @Nullable WatermarkParams watermarkParams) {
         this.generatedWatermarkGenerator = generatedWatermarkGenerator;
+        this.watermarkParams = watermarkParams;
     }
 
     @Override
@@ -66,8 +73,13 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
         } catch (Exception e) {
             throw new RuntimeException("Fail to instantiate generated watermark generator.", e);
         }
+
+        WatermarkEmitStrategy watermarkEmitStrategy =
+                watermarkParams == null
+                        ? WatermarkEmitStrategy.ON_PERIODIC
+                        : watermarkParams.getEmitStrategy();
         return new GeneratedWatermarkGeneratorSupplier.DefaultWatermarkGenerator(
-                innerWatermarkGenerator);
+                innerWatermarkGenerator, watermarkEmitStrategy);
     }
 
     /** Wrapper of the code-generated {@link WatermarkGenerator}. */
@@ -76,10 +88,14 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
         private static final long serialVersionUID = 1L;
 
         private final WatermarkGenerator innerWatermarkGenerator;
+        private final org.apache.flink.table.watermark.WatermarkEmitStrategy watermarkEmitStrategy;
         private Long currentWatermark = Long.MIN_VALUE;
 
-        public DefaultWatermarkGenerator(WatermarkGenerator watermarkGenerator) {
+        public DefaultWatermarkGenerator(
+                WatermarkGenerator watermarkGenerator,
+                org.apache.flink.table.watermark.WatermarkEmitStrategy watermarkEmitStrategy) {
             this.innerWatermarkGenerator = watermarkGenerator;
+            this.watermarkEmitStrategy = watermarkEmitStrategy;
         }
 
         @Override
@@ -88,6 +104,9 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
                 Long watermark = innerWatermarkGenerator.currentWatermark(event);
                 if (watermark != null) {
                     currentWatermark = watermark;
+                    if (watermarkEmitStrategy.isOnEvent()) {
+                        output.emitWatermark(new Watermark(currentWatermark));
+                    }
                 }
             } catch (Exception e) {
                 throw new RuntimeException(
@@ -100,7 +119,9 @@ public class GeneratedWatermarkGeneratorSupplier implements WatermarkGeneratorSu
 
         @Override
         public void onPeriodicEmit(WatermarkOutput output) {
-            output.emitWatermark(new Watermark(currentWatermark));
+            if (watermarkEmitStrategy.isOnPeriodic()) {
+                output.emitWatermark(new Watermark(currentWatermark));
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The PR proposes to extend watermark-related features in SQL layer, these fetures have been implemented on the datastream API, but not available in sql yet.
The extening features as follows:
  
  1. configurable watermark emit strategy in sql
  2. dealing with idle sources in sql
  3. configurable watermark alignment in sql


## Brief change log

- Added `org.apache.flink.table.watermark.WatermarkParams` to express the parameters of extended watermark-related features
- Added and validated releated params in `org.apache.flink.table.factories.FactoryUtil`
- Parse out the watermark-related configs from hint or table options in `org.apache.flink.table.planner.plan.rules.logical.PushWatermarkIntoTableSourceScanRuleBase`
- Handle watermark-related features in `org.apache.flink.table.planner.plan.abilities.source.WatermarkPushDownSpec`


## Verifying this change

This change added tests and can be verified as follows:

- Added test cases in `org.apache.flink.table.planner.plan.rules.logical.PushWatermarkIntoTableSourceScanRuleTest` to test using these extended features with sql hint or tabe options
- The serialization and deserialization of `DynamicTableSourceSpec` is covered by existing tests: `org.apache.flink.table.planner.plan.nodes.exec.serde.DynamicTableSourceSpecSerdeTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) docs
