### PR TITLE
[FLINK-32309][sql-gateway] Use independent resource manager for table environment

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/resource/ClientResourceManager.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/resource/ClientResourceManager.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The {@link ClientResourceManager} is able to remove the registered JAR resources with the
@@ -47,6 +49,13 @@ public class ClientResourceManager extends ResourceManager {
         super(config, userClassLoader);
     }
 
+    private ClientResourceManager(
+            Path localResourceDir,
+            Map<ResourceUri, URL> resourceInfos,
+            MutableURLClassLoader userClassLoader) {
+        super(localResourceDir, resourceInfos, userClassLoader);
+    }
+
     @Nullable
     public URL unregisterJarResource(String jarPath) {
         Path path = new Path(jarPath);
@@ -58,5 +67,11 @@ public class ClientResourceManager extends ResourceManager {
             throw new SqlExecutionException(
                     String.format("Failed to unregister the jar resource [%s]", jarPath), e);
         }
+    }
+
+    @Override
+    public ResourceManager copy() {
+        return new ClientResourceManager(
+                localResourceDir, new HashMap<>(resourceInfos), userClassLoader);
     }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/resource/ClientResourceManager.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/resource/ClientResourceManager.java
@@ -31,8 +31,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * The {@link ClientResourceManager} is able to remove the registered JAR resources with the
@@ -49,13 +47,6 @@ public class ClientResourceManager extends ResourceManager {
         super(config, userClassLoader);
     }
 
-    private ClientResourceManager(
-            Path localResourceDir,
-            Map<ResourceUri, URL> resourceInfos,
-            MutableURLClassLoader userClassLoader) {
-        super(localResourceDir, resourceInfos, userClassLoader);
-    }
-
     @Nullable
     public URL unregisterJarResource(String jarPath) {
         Path path = new Path(jarPath);
@@ -67,11 +58,5 @@ public class ClientResourceManager extends ResourceManager {
             throw new SqlExecutionException(
                     String.format("Failed to unregister the jar resource [%s]", jarPath), e);
         }
-    }
-
-    @Override
-    public ResourceManager copy() {
-        return new ClientResourceManager(
-                localResourceDir, new HashMap<>(resourceInfos), userClassLoader);
     }
 }

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -306,6 +306,11 @@ create function upperudf AS 'UpperUDF' using jar '$VAR_UDF_JAR_PATH';
 [INFO] Execute statement succeed.
 !info
 
+# `SHOW JARS` does not list the jars being used by function, it only list all the jars added by `ADD JAR`
+SHOW JARS;
+Empty set
+!ok
+
 # run a query to verify the registered UDF works
 SELECT id, upperudf(str) FROM (VALUES (1, 'hello world'), (2, 'hi')) as T(id, str);
 +----+-------------+--------------------------------+
@@ -317,19 +322,7 @@ SELECT id, upperudf(str) FROM (VALUES (1, 'hello world'), (2, 'hi')) as T(id, st
 Received a total of 2 rows
 !ok
 
-SHOW JARS;
-+-$VAR_UDF_JAR_PATH_DASH-----+
-| $VAR_UDF_JAR_PATH_SPACEjars |
-+-$VAR_UDF_JAR_PATH_DASH-----+
-| $VAR_UDF_JAR_PATH |
-+-$VAR_UDF_JAR_PATH_DASH-----+
-1 row in set
-!ok
-
-REMOVE JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
-!info
-
+# Each query registers its jar to resource manager could not affect the session in sql gateway
 SHOW JARS;
 Empty set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -326,3 +326,23 @@ Received a total of 2 rows
 SHOW JARS;
 Empty set
 !ok
+
+# Show all users functions which should not add function jars to session resource manager
+show user functions;
++---------------+
+| function name |
++---------------+
+|        func11 |
+|         func3 |
+|         func4 |
+| temp_upperudf |
+|      tmp_func |
+|      upperudf |
++---------------+
+6 rows in set
+!ok
+
+# Show functions will not affect the session in sql gateway
+SHOW JARS;
+Empty set
+!ok

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
+import org.apache.flink.table.api.internal.ExecutableOperationContextImpl;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
@@ -70,10 +71,12 @@ import org.apache.flink.table.operations.CallProcedureOperation;
 import org.apache.flink.table.operations.CompileAndExecutePlanOperation;
 import org.apache.flink.table.operations.DeleteFromFilterOperation;
 import org.apache.flink.table.operations.EndStatementSetOperation;
+import org.apache.flink.table.operations.ExecutableOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.StatementSetOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseOperation;
@@ -82,10 +85,13 @@ import org.apache.flink.table.operations.command.ExecutePlanOperation;
 import org.apache.flink.table.operations.command.RemoveJarOperation;
 import org.apache.flink.table.operations.command.ResetOperation;
 import org.apache.flink.table.operations.command.SetOperation;
+import org.apache.flink.table.operations.command.ShowJarsOperation;
 import org.apache.flink.table.operations.command.ShowJobsOperation;
 import org.apache.flink.table.operations.command.StopJobOperation;
 import org.apache.flink.table.operations.ddl.AlterOperation;
+import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateOperation;
+import org.apache.flink.table.operations.ddl.CreateTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropOperation;
 import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.table.utils.DateTimeUtils;
@@ -110,6 +116,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.api.common.RuntimeExecutionMode.STREAMING;
+import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
 import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESULT_OK;
 import static org.apache.flink.table.gateway.service.utils.Constants.COMPLETION_CANDIDATES;
 import static org.apache.flink.table.gateway.service.utils.Constants.JOB_ID;
@@ -176,6 +184,8 @@ public class OperationExecutor {
             return callSetOperation(tableEnv, handle, (SetOperation) op);
         } else if (op instanceof ResetOperation) {
             return callResetOperation(handle, (ResetOperation) op);
+        } else if (op instanceof AddJarOperation) {
+            return callExecutableOperation(handle, (ExecutableOperation) op);
         } else {
             return callOperation(tableEnv, handle, op);
         }
@@ -335,6 +345,7 @@ public class OperationExecutor {
 
         final Executor executor =
                 lookupExecutor(streamExecEnv, sessionContext.getUserClassloader());
+        ResourceManager resourceManager = sessionContext.getSessionState().resourceManager.copy();
         return createStreamTableEnvironment(
                 streamExecEnv,
                 settings,
@@ -342,8 +353,8 @@ public class OperationExecutor {
                 executor,
                 sessionContext.getSessionState().catalogManager,
                 sessionContext.getSessionState().moduleManager,
-                sessionContext.getSessionState().resourceManager,
-                sessionContext.getSessionState().functionCatalog);
+                resourceManager,
+                sessionContext.getSessionState().functionCatalog.copy(resourceManager));
     }
 
     private static Executor lookupExecutor(
@@ -440,9 +451,39 @@ public class OperationExecutor {
             return callShowJobsOperation(tableEnv, handle, (ShowJobsOperation) op);
         } else if (op instanceof RemoveJarOperation) {
             return callRemoveJar(handle, ((RemoveJarOperation) op).getPath());
+        } else if (op instanceof AddJarOperation
+                || op instanceof ShowJarsOperation
+                || op instanceof CreateTempSystemFunctionOperation
+                || op instanceof CreateCatalogFunctionOperation
+                || op instanceof ShowFunctionsOperation) {
+            return callExecutableOperation(handle, (ExecutableOperation) op);
         } else {
             return callOperation(tableEnv, handle, op);
         }
+    }
+
+    private ResultFetcher callExecutableOperation(OperationHandle handle, ExecutableOperation op) {
+        TableResultInternal result =
+                op.execute(
+                        new ExecutableOperationContextImpl(
+                                sessionContext.getSessionState().catalogManager,
+                                sessionContext.getSessionState().functionCatalog,
+                                sessionContext.getSessionState().moduleManager,
+                                sessionContext.getSessionState().resourceManager,
+                                tableConfig(),
+                                sessionContext.getSessionConf().get(RUNTIME_MODE) == STREAMING));
+        return ResultFetcher.fromTableResult(handle, result, false);
+    }
+
+    private TableConfig tableConfig() {
+        Configuration operationConfig = sessionContext.getSessionConf().clone();
+        operationConfig.addAll(executionConfig);
+
+        TableConfig tableConfig = TableConfig.getDefault();
+        tableConfig.setRootConfiguration(sessionContext.getDefaultContext().getFlinkConfig());
+        tableConfig.addConfiguration(operationConfig);
+
+        return tableConfig;
     }
 
     private ResultFetcher callSetOperation(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -184,8 +184,6 @@ public class OperationExecutor {
             return callSetOperation(tableEnv, handle, (SetOperation) op);
         } else if (op instanceof ResetOperation) {
             return callResetOperation(handle, (ResetOperation) op);
-        } else if (op instanceof AddJarOperation) {
-            return callExecutableOperation(handle, (ExecutableOperation) op);
         } else {
             return callOperation(tableEnv, handle, op);
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -78,9 +78,8 @@ public final class FunctionCatalog {
     private final CatalogManager catalogManager;
     private final ModuleManager moduleManager;
 
-    private final Map<String, CatalogFunction> tempSystemFunctions = new LinkedHashMap<>();
-    private final Map<ObjectIdentifier, CatalogFunction> tempCatalogFunctions =
-            new LinkedHashMap<>();
+    private final Map<String, CatalogFunction> tempSystemFunctions;
+    private final Map<ObjectIdentifier, CatalogFunction> tempCatalogFunctions;
 
     /**
      * Temporary utility until the new type inference is fully functional. It needs to be set by the
@@ -93,10 +92,31 @@ public final class FunctionCatalog {
             ResourceManager resourceManager,
             CatalogManager catalogManager,
             ModuleManager moduleManager) {
+        this(
+                config,
+                resourceManager,
+                catalogManager,
+                moduleManager,
+                new LinkedHashMap<>(),
+                new LinkedHashMap<>(),
+                null);
+    }
+
+    private FunctionCatalog(
+            ReadableConfig config,
+            ResourceManager resourceManager,
+            CatalogManager catalogManager,
+            ModuleManager moduleManager,
+            Map<String, CatalogFunction> tempSystemFunctions,
+            Map<ObjectIdentifier, CatalogFunction> tempCatalogFunctions,
+            PlannerTypeInferenceUtil plannerTypeInferenceUtil) {
         this.config = checkNotNull(config);
         this.resourceManager = checkNotNull(resourceManager);
         this.catalogManager = checkNotNull(catalogManager);
         this.moduleManager = checkNotNull(moduleManager);
+        this.tempSystemFunctions = tempSystemFunctions;
+        this.tempCatalogFunctions = tempCatalogFunctions;
+        this.plannerTypeInferenceUtil = plannerTypeInferenceUtil;
     }
 
     public void setPlannerTypeInferenceUtil(PlannerTypeInferenceUtil plannerTypeInferenceUtil) {
@@ -775,6 +795,17 @@ public final class FunctionCatalog {
                             resourceUris, functionName),
                     e);
         }
+    }
+
+    public FunctionCatalog copy(ResourceManager newResourceManager) {
+        return new FunctionCatalog(
+                config,
+                newResourceManager,
+                catalogManager,
+                moduleManager,
+                tempSystemFunctions,
+                tempCatalogFunctions,
+                plannerTypeInferenceUtil);
     }
 
     private void registerCatalogFunction(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/resource/ResourceManagerTest.java
@@ -432,6 +432,25 @@ public class ResourceManagerTest {
     }
 
     @Test
+    void testCloseCopiedResourceManager() throws Exception {
+        ResourceUri resourceUri = new ResourceUri(ResourceType.JAR, udfJar.getPath());
+        resourceManager.declareFunctionResources(Collections.singleton(resourceUri));
+        resourceManager.registerJarResources(Collections.singletonList(resourceUri));
+        assertThat(resourceManager.functionResourceInfos().size()).isEqualTo(1);
+        assertThat(resourceManager.resourceInfos.size()).isEqualTo(1);
+
+        ResourceManager copiedResourceManager = resourceManager.copy();
+        assertThat(copiedResourceManager.functionResourceInfos().size()).isEqualTo(1);
+        assertThat(copiedResourceManager.resourceInfos.size()).isEqualTo(1);
+        copiedResourceManager.close();
+        assertThat(copiedResourceManager.functionResourceInfos().size()).isEqualTo(0);
+        assertThat(copiedResourceManager.resourceInfos.size()).isEqualTo(0);
+
+        assertThat(resourceManager.functionResourceInfos().size()).isEqualTo(1);
+        assertThat(resourceManager.resourceInfos.size()).isEqualTo(1);
+    }
+
+    @Test
     public void testCloseResourceManagerCleanDownloadedResources() throws Exception {
         resourceManager.close();
         FileSystem fileSystem = FileSystem.getLocalFileSystem();


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to create new resource manager for table environment in sql gateway

## Brief change log

  - Create new resource manager which will share the classloader and local path with the previous manager
  - Create table environment for each operation in gateway with the new resource manager
  - Add jars and functions related operation in gateway which will be performed on the session resource manager.


## Verifying this change

This change added tests and can be verified as follows:

  - Updated `function.q` to test that previous job will not affect the jars in gateway

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
