### PR TITLE
[FLINK-32326][state] Disable WAL in RocksDBWriteBatchWrapper by default.

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -117,7 +117,7 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
     public void remove(@Nonnull ColumnFamilyHandle handle, @Nonnull byte[] key)
             throws RocksDBException {
 
-        batch.remove(handle, key);
+        batch.delete(handle, key);
 
         flushIfNeeded();
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -32,6 +32,9 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * It's a wrapper class around RocksDB's {@link WriteBatch} for writing in bulk.
  *
@@ -54,6 +57,9 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
     private final int capacity;
 
     @Nonnegative private final long batchSize;
+
+    /** List of all objects that we need to close in close(). */
+    private final List<AutoCloseable> toClose;
 
     public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, long writeBatchSize) {
         this(rocksDB, null, 500, writeBatchSize);
@@ -79,15 +85,24 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
         Preconditions.checkArgument(batchSize >= 0, "Max batch size have to be no negative.");
 
         this.db = rocksDB;
-        this.options = options;
         this.capacity = capacity;
         this.batchSize = batchSize;
+        this.toClose = new ArrayList<>(2);
         if (this.batchSize > 0) {
             this.batch =
                     new WriteBatch(
                             (int) Math.min(this.batchSize, this.capacity * PER_RECORD_BYTES));
         } else {
             this.batch = new WriteBatch(this.capacity * PER_RECORD_BYTES);
+        }
+        this.toClose.add(this.batch);
+        if (options != null) {
+            this.options = options;
+        } else {
+            // Use default write options with disabled WAL
+            this.options = new WriteOptions().setDisableWAL(true);
+            // We own this object, so we must ensure that we close it.
+            this.toClose.add(this.options);
         }
     }
 
@@ -108,27 +123,24 @@ public class RocksDBWriteBatchWrapper implements AutoCloseable {
     }
 
     public void flush() throws RocksDBException {
-        if (options != null) {
-            db.write(options, batch);
-        } else {
-            // use the default WriteOptions, if wasn't provided.
-            try (WriteOptions writeOptions = new WriteOptions()) {
-                db.write(writeOptions, batch);
-            }
-        }
+        db.write(options, batch);
         batch.clear();
     }
 
-    public WriteOptions getOptions() {
+    @VisibleForTesting
+    WriteOptions getOptions() {
         return options;
     }
 
     @Override
     public void close() throws RocksDBException {
-        if (batch.count() != 0) {
-            flush();
+        try {
+            if (batch.count() != 0) {
+                flush();
+            }
+        } finally {
+            IOUtils.closeAllQuietly(toClose);
         }
-        IOUtils.closeQuietly(batch);
     }
 
     private void flushIfNeeded() throws RocksDBException {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Disables WAL by default in RocksDBWriteBatchWrapper for the case that now explicit WriteOption is passed in. This is the case in all restore operations and can impact the performance.


## Brief change log

- Creates default WriteOptions with WAL disabled in RocksDBWriteBatchWrapper.
- Unit tests in RocksDBWriteBatchWrapperTest


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

Run RocksDBWriteBatchWrapperTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
