### PR TITLE
[FLINK-19010][metric] Introduce subtask level restore metric

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1752,6 +1752,11 @@ Note that the metrics are only available via reporters.
       <td>The number of actions in the task's mailbox that are waiting to be processed.</td>
       <td>Gauge</td>
     </tr>
+   <tr>
+      <td>initializationTime</td>
+      <td>The time in milliseconds that one task spends on initialization, return 0 when the task is not in initialization/running status. Most of the initialization time is usually spent in restoring from the checkpoint.</td>
+      <td>Counter</td>
+    </tr>
     <tr>
       <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>
       <td>estimatedTimeToConsumeBuffersMs</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1617,7 +1617,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="24"><strong>Task</strong></th>
+      <th rowspan="25"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
@@ -1736,6 +1736,11 @@ Note that the metrics are only available via reporters.
       <td>mailboxQueueSize</td>
       <td>The number of actions in the task's mailbox that are waiting to be processed.</td>
       <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>initializationTime</td>
+      <td>The time in milliseconds that one task spends on initialization, return 0 when the task is not in initialization/running status. Most of the initialization time is usually spent in restoring from the checkpoint.</td>
+      <td>Counter</td>
     </tr>
     <tr>
       <td rowspan="2"><strong>Task (only if buffer debloating is enabled and in non-source tasks)</strong></td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -62,6 +62,7 @@ public class MetricNames {
 
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";
+    public static final String INITIALIZATION_TIME = "initializationTime";
 
     public static final String START_WORKER_FAILURE_RATE = "startWorkFailure" + SUFFIX_RATE;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -31,17 +31,24 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.TimerGauge;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.runtime.metrics.MetricNames.INITIALIZATION_TIME;
+
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
  * forwarded to the parent task metric group.
  */
 public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
+    private static final long INVALID_TIMESTAMP = -1L;
+
+    private final Clock clock;
 
     private final Counter numBytesIn;
     private final Counter numBytesOut;
@@ -69,17 +76,23 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private final Meter mailboxThroughput;
     private final Histogram mailboxLatency;
     private final SizeGauge mailboxSize;
+    private final Counter initializationDuration;
 
     private volatile boolean busyTimeEnabled;
 
     private long taskStartTime;
+    private long taskInitializeTime;
 
     private final Map<IntermediateResultPartitionID, ResultPartitionBytesCounter>
             resultPartitionBytes = new HashMap<>();
 
     public TaskIOMetricGroup(TaskMetricGroup parent) {
-        super(parent);
+        this(parent, SystemClock.getInstance());
+    }
 
+    public TaskIOMetricGroup(TaskMetricGroup parent, Clock clock) {
+        super(parent);
+        this.clock = clock;
         this.numBytesIn = counter(MetricNames.IO_NUM_BYTES_IN);
         this.numBytesOut = counter(MetricNames.IO_NUM_BYTES_OUT);
         this.numBytesInRate = meter(MetricNames.IO_NUM_BYTES_IN_RATE, new MeterView(numBytesIn));
@@ -96,11 +109,11 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.numBuffersOutRate =
                 meter(MetricNames.IO_NUM_BUFFERS_OUT_RATE, new MeterView(numBuffersOut));
 
-        this.idleTimePerSecond = gauge(MetricNames.TASK_IDLE_TIME, new TimerGauge());
+        this.idleTimePerSecond = gauge(MetricNames.TASK_IDLE_TIME, new TimerGauge(clock));
         this.softBackPressuredTimePerSecond =
-                gauge(MetricNames.TASK_SOFT_BACK_PRESSURED_TIME, new TimerGauge());
+                gauge(MetricNames.TASK_SOFT_BACK_PRESSURED_TIME, new TimerGauge(clock));
         this.hardBackPressuredTimePerSecond =
-                gauge(MetricNames.TASK_HARD_BACK_PRESSURED_TIME, new TimerGauge());
+                gauge(MetricNames.TASK_HARD_BACK_PRESSURED_TIME, new TimerGauge(clock));
         this.backPressuredTimePerSecond =
                 gauge(MetricNames.TASK_BACK_PRESSURED_TIME, this::getBackPressuredTimeMsPerSecond);
 
@@ -116,7 +129,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.busyTimePerSecond = gauge(MetricNames.TASK_BUSY_TIME, this::getBusyTimePerSecond);
 
         this.changelogBusyTimeMsPerSecond =
-                gauge(MetricNames.CHANGELOG_BUSY_TIME, new TimerGauge());
+                gauge(MetricNames.CHANGELOG_BUSY_TIME, new TimerGauge(clock));
 
         this.accumulatedBusyTime =
                 gauge(MetricNames.ACC_TASK_BUSY_TIME, this::getAccumulatedBusyTime);
@@ -133,6 +146,29 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.mailboxLatency =
                 histogram(MetricNames.MAILBOX_LATENCY, new DescriptiveStatisticsHistogram(60));
         this.mailboxSize = gauge(MetricNames.MAILBOX_SIZE, new SizeGauge());
+        this.initializationDuration =
+                counter(
+                        INITIALIZATION_TIME,
+                        new Counter() {
+                            @Override
+                            public void inc() {}
+
+                            @Override
+                            public void inc(long n) {}
+
+                            @Override
+                            public void dec() {}
+
+                            @Override
+                            public void dec(long n) {}
+
+                            @Override
+                            public long getCount() {
+                                return getTaskInitializationDuration();
+                            }
+                        });
+        this.taskStartTime = INVALID_TIMESTAMP;
+        this.taskInitializeTime = INVALID_TIMESTAMP;
     }
 
     public IOMetrics createSnapshot() {
@@ -202,7 +238,29 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     }
 
     public void markTaskStart() {
-        this.taskStartTime = System.currentTimeMillis();
+        this.taskStartTime = clock.absoluteTimeMillis();
+    }
+
+    public void markTaskInitializationStarted() {
+        if (taskInitializeTime == INVALID_TIMESTAMP) {
+            this.taskInitializeTime = clock.absoluteTimeMillis();
+        }
+    }
+
+    /**
+     * Returns the duration of time required for a task's restoring/initialization, which reaches
+     * its maximum when the task begins running and remains constant throughout the task's running.
+     * Return 0 when the task is not in initialization/running status.
+     */
+    @VisibleForTesting
+    public long getTaskInitializationDuration() {
+        if (taskInitializeTime == INVALID_TIMESTAMP) {
+            return 0L;
+        } else if (taskStartTime == INVALID_TIMESTAMP) {
+            return clock.absoluteTimeMillis() - taskInitializeTime;
+        } else {
+            return taskStartTime - taskInitializeTime;
+        }
     }
 
     public void setEnableBusyTime(boolean enabled) {
@@ -217,14 +275,19 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
     @VisibleForTesting
     double getAccumulatedBusyTime() {
-        return busyTimeEnabled
-                ? Math.max(
-                        System.currentTimeMillis()
-                                - taskStartTime
-                                - idleTimePerSecond.getAccumulatedCount()
-                                - getAccumulatedBackPressuredTimeMs(),
-                        0)
-                : Double.NaN;
+        if (!busyTimeEnabled) {
+            return Double.NaN;
+        }
+        if (taskStartTime == INVALID_TIMESTAMP) {
+            return Double.NaN;
+        } else {
+            return Math.max(
+                    clock.absoluteTimeMillis()
+                            - taskStartTime
+                            - idleTimePerSecond.getAccumulatedCount()
+                            - getAccumulatedBackPressuredTimeMs(),
+                    0);
+        }
     }
 
     public Meter getMailboxThroughput() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -699,6 +699,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         }
         isRestoring = true;
         closedOperators = false;
+        getEnvironment().getMetricGroup().getIOMetricGroup().markTaskInitializationStarted();
         LOG.debug("Initializing {}.", getName());
 
         operatorChain =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This PR wants to introduce restoring metric:
- Job level: The initializing stage is used to initialize the state of job, `initializingTime` can be treated as the restore time of the whole job when restoring from a checkpoint/savepoint. Since [FLINK-23976](https://issues.apache.org/jira/browse/FLINK-23976) added standardized metrics for capturing how much time we spend in each JobStatus, we can reuse `initializingTime/initializingTotalTime` directly. 
- Task level: This PR introduce `checkpointRestoreTime` for capturing how much time each task spends on restoring/initializing, returning 0 if task is not in initialization status. 

## Brief change log
  - Add `checkpointRestoreTime` metric.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified by `TaskIOMetricGroupTest#testTaskIOMetricGroup`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
