### PR TITLE
[FLINK-32328][build] Set surefire base argLine in general settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1661,6 +1661,8 @@ under the License.
 						<!-- automatically adjust parallelism based on available cpu/processor cores-->
 						<junit.jupiter.execution.parallel.config.strategy>dynamic</junit.jupiter.execution.parallel.config.strategy>
 					</systemPropertyVariables>
+					<!-- This is picked up by IntelliJ -->
+					<argLine>${flink.surefire.baseArgLine}</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->


### PR DESCRIPTION
This ensures that IntelliJ also picks up these settings.

This is important for Java 17 because the `baseArgLine` will contain module declarations, which we need IntelliJ to also import.
Even beyond that though this is a nice change because it brings IDE work closer to what runs on CI.