### PR TITLE
[FLINK-32329][tests] Do not override env.java.opts.all

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -45,7 +45,8 @@ function run_ha_test() {
     # change the pid dir to start log files always from 0, this is important for checks in the
     # jm killing loop
     set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
-    set_config_key "env.java.opts.all" "-ea"
+    set_config_key "env.java.opts.jobmanager" "-ea"
+    set_config_key "env.java.opts.taskmanager" "-ea"
     start_local_zk
     start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -45,8 +45,8 @@ function run_ha_test() {
     # change the pid dir to start log files always from 0, this is important for checks in the
     # jm killing loop
     set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
-    set_config_key "env.java.opts.jobmanager" "-ea"
-    set_config_key "env.java.opts.taskmanager" "-ea"
+    set_config_key "env.java.opts.jobmanager" "-enableassertions"
+    set_config_key "env.java.opts.taskmanager" "-enableassertions"
     start_local_zk
     start_cluster
 


### PR DESCRIPTION
env.java.opts.all will soon become very important because it contains the Java 17 module declarations. Tests thus shouldn't just override this value.

(In the future we could add a utility bash method to append a value to an existing option)