### PR TITLE
[FLINK-32336][tests] PartitionITCase#ComparablePojo now public

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
@@ -718,6 +718,7 @@ public class PartitionITCase extends MultipleProgramsTestBase {
         }
     }
 
+    /** A comparable POJO. */
     public static class ComparablePojo implements Comparable<ComparablePojo> {
         private Long first;
         private Long second;

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/PartitionITCase.java
@@ -718,7 +718,7 @@ public class PartitionITCase extends MultipleProgramsTestBase {
         }
     }
 
-    private static class ComparablePojo implements Comparable<ComparablePojo> {
+    public static class ComparablePojo implements Comparable<ComparablePojo> {
         private Long first;
         private Long second;
 
@@ -774,6 +774,9 @@ public class PartitionITCase extends MultipleProgramsTestBase {
         @Override
         public void mapPartition(Iterable<T> values, Collector<Tuple2<T, T>> out) throws Exception {
             Iterator<T> itr = values.iterator();
+            if (!itr.hasNext()) {
+                return;
+            }
             T min = itr.next();
             T max = min;
             T value;


### PR DESCRIPTION
POJOs should be public so they are serialized with the pojo serializer.

The modification to the `MinMaxSelector` is necessary because by being treated as a pojo the partitioning is being changed. Seemingly the `first` field of the `ComparablePojo` dominates the partitioning (ranging from 0-2), causing only 3 partitions to be created but the job runs with p=4.

I don't really know what the semantics for range partitioning of Kryo records are, and am somewhat confused that this test passed with Kryo in the first place because it does check for order of elements within partitions. :thinking: 

Anyhow, since this is a `DataSet` test I'm not too inclined to dig any deeper into the why's. The `hasNext` check is useful anyway because the test should pass with any parallelism, even one greater than the number of elements.