### PR TITLE
[FLINK-32337][table] ARRAY_UNION's element getter should respect not only first arg's nullability

### DIFF
--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -727,6 +727,36 @@ collection:
   - sql: map ‘[’ value ‘]’
     table: MAP.at(ANY)
     description: 返回 map 中指定 key 对应的值。
+  - sql: ARRAY_CONTAINS(haystack, needle)
+    table: haystack.arrayContains(needle)
+    description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ARRAY_DISTINCT(haystack)
+    table: haystack.arrayDistinct()
+    description: Returns an array with unique elements. If the array itself is null, the function will return null. Keeps ordering of elements.
+  - sql: ARRAY_POSITION(haystack, needle)
+    table: haystack.arrayPosition(needle)
+    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
+  - sql: ARRAY_REMOVE(haystack, needle)
+    table: haystack.arrayRemove(needle)
+    description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.
+  - sql: ARRAY_REVERSE(haystack)
+    table: haystack.arrayReverse()
+    description: Returns an array in reverse order. If the array itself is null, the function will return null.
+  - sql: ARRAY_UNION(array1, array2)
+    table: haystack.arrayUnion(array)
+    description: Returns an array of the elements in the union of array1 and array2, without duplicates. If any of the array is null, the function will return null.
+  - sql: MAP_KEYS(map)
+    table: MAP.mapKeys()
+    description: Returns the keys of the map as array. No order guaranteed.
+  - sql: MAP_VALUES(map)
+    table: MAP.mapValues()
+    description: Returns the values of the map as array. No order guaranteed.
+  - sql: MAP_ENTRIES(map)
+    table: MAP.mapEntries()
+    description: Returns an array of all entries in the given map. No order guaranteed.
+  - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
+    table: mapFromArrays(array_of_keys, array_of_values)
+    description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -422,6 +422,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_UNION)
                         .onFieldsWithData(
                                 new Integer[] {1, 2, null},
+                                new Integer[] {1},
                                 null,
                                 new Row[] {
                                     Row.of(true, LocalDate.of(2022, 4, 20)),
@@ -431,6 +432,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 1)
                         .andDataTypes(
                                 DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT().notNull()),
                                 DataTypes.ARRAY(DataTypes.INT()),
                                 DataTypes.ARRAY(
                                         DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
@@ -440,6 +442,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayUnion(new Integer[] {1, null, 4}),
                                 "ARRAY_UNION(f0, ARRAY[1, NULL, 4])",
                                 new Integer[] {1, 2, null, 4},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f1").arrayUnion(new Integer[] {2, null}),
+                                "ARRAY_UNION(f1, ARRAY[2, NULL])",
+                                new Integer[] {1, 2, null},
                                 DataTypes.ARRAY(DataTypes.INT()))
                         // insert cast bug https://issues.apache.org/jira/browse/CALCITE-5674.
                         //                        .testResult(
@@ -451,17 +458,17 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         //                                DataTypes.ARRAY(DataTypes.DOUBLE()))
                         // ARRAY<INT> of null value
                         .testResult(
-                                $("f1").arrayUnion(new Integer[] {1, null, 4}),
-                                "ARRAY_UNION(f1, ARRAY[1, NULL, 4])",
+                                $("f2").arrayUnion(new Integer[] {1, null, 4}),
+                                "ARRAY_UNION(f2, ARRAY[1, NULL, 4])",
                                 null,
                                 DataTypes.ARRAY(DataTypes.INT()))
                         // ARRAY<ROW<BOOLEAN, DATE>>
                         .testResult(
-                                $("f2").arrayUnion(
+                                $("f3").arrayUnion(
                                                 new Row[] {
                                                     null, Row.of(true, LocalDate.of(1990, 10, 14)),
                                                 }),
-                                "ARRAY_UNION(f2, ARRAY[NULL, (TRUE, DATE '1990-10-14')])",
+                                "ARRAY_UNION(f3, ARRAY[NULL, (TRUE, DATE '1990-10-14')])",
                                 new Row[] {
                                     Row.of(true, LocalDate.of(2022, 4, 20)),
                                     Row.of(true, LocalDate.of(1990, 10, 14)),
@@ -471,11 +478,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                         DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())))
                         // invalid signatures
                         .testSqlValidationError(
-                                "ARRAY_UNION(f3, TRUE)",
+                                "ARRAY_UNION(f4, TRUE)",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_UNION(<COMMON>, <COMMON>)")
                         .testTableApiValidationError(
-                                $("f3").arrayUnion(true),
+                                $("f4").arrayUnion(true),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_UNION(<COMMON>, <COMMON>)"));
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayUnionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayUnionFunction.java
@@ -49,7 +49,9 @@ public class ArrayUnionFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.ARRAY_UNION, context);
 
         final DataType dataType =
-                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                // Since input arrays could be with different nullability we can not rely just on
+                // the first element.
+                ((CollectionDataType) context.getCallContext().getOutputDataType().get())
                         .getElementDataType();
         elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
         equalityEvaluator =


### PR DESCRIPTION
## What is the purpose of the change

The problem case for `array_union` is
```sql
SELECT array_union(ARRAY[CAST(NULL AS INT)], ARRAY[1]); -- returns [NULL, 1], this is OK
SELECT array_union(ARRAY[1], ARRAY[CAST(NULL AS INT)]); -- returns [1, 0], this is NOT OK

```
the PR is going to fix it.
The reason of the issue is that element getter relies on the first arg of `array_union` without taking into account the second one.

Also it was noticed that there are some funnctions missed in chinese version of doc, adding them in a separate hotfix commit

## Verifying this change

A test was added at `CollectionFunctionsITCase.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
