### PR TITLE
[FLINK-32338][build] Add FailsOnJava17 annotation

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.tests.util.flink.FlinkResource;
 import org.apache.flink.tests.util.flink.FlinkResourceSetup;
 import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResourceFactory;
 import org.apache.flink.testutils.junit.FailsOnJava11;
+import org.apache.flink.testutils.junit.FailsOnJava17;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -66,7 +67,7 @@ import static org.junit.Assert.assertThat;
 
 /** End-to-end test for the HBase connectors. */
 @RunWith(Parameterized.class)
-@Category(value = {FailsOnJava11.class})
+@Category(value = {FailsOnJava11.class, FailsOnJava17.class})
 @Ignore("FLINK-21519")
 public class SQLClientHBaseITCase extends TestLogger {
 

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -136,6 +136,15 @@ under the License.
 				<excludeE2E>org.apache.flink.testutils.junit.FailsOnJava11</excludeE2E>
 			</properties>
 		</profile>
+		<profile>
+			<id>java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+			</activation>
+			<properties>
+				<excludeE2E>org.apache.flink.testutils.junit.FailsOnJava17</excludeE2E>
+			</properties>
+		</profile>
 	</profiles>
 
 	<build>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsOnJava17.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsOnJava17.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+/** Marker interface for tests that fail on Java 17. */
+public interface FailsOnJava17 {}

--- a/pom.xml
+++ b/pom.xml
@@ -1069,6 +1069,27 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+			</activation>
+
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<excludedGroups>org.apache.flink.testutils.junit.FailsOnJava17</excludedGroups>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
+		<profile>
 			<id>java17-target</id>
 			<build>
 				<plugins>


### PR DESCRIPTION
Adds an annotation for disabling tests on Java 17, similar to `FailsOnJava11`, and sets up the test exclusion in maven.

This annotation won't be used that much; probably only a 1 or 2 tests will use that once everything is done.

