### PR TITLE
[FLINK-32034][python] Updated GET_SITE_PACKAGES_SCRIPT to remove distutils dependency

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
@@ -55,16 +55,8 @@ public class PythonEnvironmentManagerUtils {
 
     private static final String GET_SITE_PACKAGES_PATH_SCRIPT =
             "import sys;"
-                    + "from distutils.dist import Distribution;"
-                    + "install_obj = Distribution().get_command_obj('install', create=True);"
-                    + "install_obj.prefix = sys.argv[1];"
-                    + "install_obj.finalize_options();"
-                    + "installed_dir = [install_obj.install_purelib];"
-                    + "install_obj.install_purelib != install_obj.install_platlib and "
-                    + "installed_dir.append(install_obj.install_platlib);"
-                    + "print(installed_dir[0]);"
-                    + "len(installed_dir) > 1 and "
-                    + "print(installed_dir[1])";
+                    + "import sysconfig;"
+                    + "print(sysconfig.get_path('platlib', vars={'base': sys.argv[1], 'platbase': sys.argv[1]}))";
 
     private static final String CHECK_PIP_VERSION_SCRIPT =
             "import sys;"


### PR DESCRIPTION
## What is the purpose of the change

Distutils is deprecated in pythons version 3.10 and above, this script provides the same functionality and works with all the supported python version of flink version 1.17

## Brief change log

* Updated the variable `GET_SITE_PACKAGES_PATH_SCRIPT` inside of the file `PythonEnvironmentManagerUtils` to the new script which replaces the dependency on distutils

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
