### PR TITLE
[FLINK-32259][table] Add built-in ARRAY_JOIN function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -652,6 +652,9 @@ collection:
   - sql: ARRAY_MAX(array)
     table: array.arrayMax()
     description: Returns the maximum value from the array, if array itself is null, the function returns null.
+  - sql: ARRAY_JOIN(array, delimiter[, nullReplacement])
+    table: array.arrayJoin(delimiter[, nullReplacement])
+    description: Returns a string that represents the concatenation of the elements in the given array and the elements' data type in the given array is string. The delimiter is a string that separates each pair of consecutive elements of the array. The optional nullReplacement is a string that replaces null elements in the array. If nullReplacement is not specified, null elements in the array will be omitted from the resulting string. Returns null if input array or delimiter or nullReplacement are null.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -228,6 +228,7 @@ advanced type helper functions
     Expression.array_concat
     Expression.array_contains
     Expression.array_distinct
+    Expression.array_join
     Expression.array_position
     Expression.array_remove
     Expression.array_reverse

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1535,6 +1535,20 @@ class Expression(Generic[T]):
         """
         return _unary_op("arrayMax")(self)
 
+    def array_join(self, delimiter, null_replacement=None) -> 'Expression':
+        """
+        Returns a string that represents the concatenation of the elements in the given array and
+        the elements' data type in the given array is string. The `delimiter` is a string that
+        separates each pair of consecutive elements of the array. The optional `null_replacement`
+        is a string that replaces null elements in the array. If `null_replacement` is not
+        specified, null elements in the array will be omitted from the resulting string.
+        Returns null if input array or delimiter or nullReplacement are null.
+        """
+        if null_replacement is None:
+            return _binary_op("array_join")(self, delimiter)
+        else:
+            return _ternary_op("array_join")(self, delimiter, null_replacement)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.strategies.ArrayElementOutputTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.ArrayOfStringArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
 import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -306,6 +307,24 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(new ArrayElementOutputTypeStrategy())
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMaxFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_JOIN =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_JOIN")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            new ArrayOfStringArgumentTypeStrategy(),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
+                                            new ArrayOfStringArgumentTypeStrategy(),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayJoinFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfStringArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfStringArgumentTypeStrategy.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.Boolean.TRUE;
+
+/** Strategy for an argument that must be an array of strings. */
+@Internal
+public final class ArrayOfStringArgumentTypeStrategy implements ArgumentTypeStrategy {
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+
+        final List<DataType> actualDataTypes = callContext.getArgumentDataTypes();
+        DataType actualType = actualDataTypes.get(argumentPos);
+        if (!actualType.getLogicalType().getTypeRoot().equals(LogicalTypeRoot.ARRAY)) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Invalid input arguments. Expected signatures are:\n"
+                            + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                            + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)",
+                    actualDataTypes.toArray());
+        }
+        DataType elementDataType = ((CollectionDataType) actualType).getElementDataType();
+        Optional<DataType> closedDataType =
+                StrategyUtils.findDataType(
+                        callContext,
+                        throwOnFailure,
+                        elementDataType,
+                        LogicalTypeRoot.VARCHAR,
+                        TRUE);
+        if (closedDataType.isPresent()) {
+            return Optional.of(actualType);
+        }
+        return callContext.fail(
+                throwOnFailure,
+                "The input argument should be ARRAY<STRING>",
+                actualDataTypes.toArray());
+    }
+
+    @Override
+    public Argument getExpectedArgument(FunctionDefinition functionDefinition, int argumentPos) {
+        return Argument.of("ARRAY<STRING>");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.row;
 import static org.apache.flink.util.CollectionUtil.entry;
@@ -45,7 +46,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayReverseTestCases(),
                         arrayUnionTestCases(),
                         arrayConcatTestCases(),
-                        arrayMaxTestCases())
+                        arrayMaxTestCases(),
+                        arrayJoinTestCases())
                 .flatMap(s -> s);
     }
 
@@ -654,7 +656,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult($("f1").arrayMax(), "ARRAY_MAX(f1)", null, DataTypes.INT())
                         .testResult($("f2").arrayMax(), "ARRAY_MAX(f2)", 8.0, DataTypes.DOUBLE())
                         .testResult($("f3").arrayMax(), "ARRAY_MAX(f3)", "def", DataTypes.STRING())
-                        .testResult($("f14").arrayMax(), "ARRAY_MAX(f1)", null, DataTypes.INT())
+                        .testResult($("f14").arrayMax(), "ARRAY_MAX(f14)", null, DataTypes.INT())
                         .testResult(
                                 $("f13").arrayMax(),
                                 "ARRAY_MAX(f13)",
@@ -724,5 +726,310 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ARRAY_MAX(f12)",
                                 "SQL validation failed. Invalid function call:\n"
                                         + "ARRAY_MAX(ARRAY<ARRAY<INT>>)"));
+    }
+
+    private Stream<TestSetSpec> arrayJoinTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_JOIN)
+                        .onFieldsWithData(
+                                new String[] {"abv", "bbb", "cb"},
+                                new String[] {"a", "b", null},
+                                new String[] {null, "1", null},
+                                new String[] {null, null, "1", null, null},
+                                null,
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Integer[] {1, 2, 3, null},
+                                new Boolean[] {null, false, true},
+                                new Double[] {1.2, 34.0, 4.0, 4.5},
+                                1)
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull(),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.BOOLEAN()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE()).notNull(),
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), null),
+                                "ARRAY_JOIN(f0, null)",
+                                null,
+                                DataTypes.STRING())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), "+", null),
+                                "ARRAY_JOIN(f0, '+', null)",
+                                null,
+                                DataTypes.STRING())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), null, null),
+                                "ARRAY_JOIN(f0, null, null)",
+                                null,
+                                DataTypes.STRING())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), "+"),
+                                "ARRAY_JOIN(f0, '+')",
+                                "abv+bbb+cb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), "+", "abc"),
+                                "ARRAY_JOIN(f0, '+', 'abc')",
+                                "abv+bbb+cb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), " "),
+                                "ARRAY_JOIN(f0, ' ')",
+                                "abv bbb cb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), ""),
+                                "ARRAY_JOIN(f0, '')",
+                                "abvbbbcb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), " ", ""),
+                                "ARRAY_JOIN(f0, ' ', '')",
+                                "abv bbb cb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), " ", " "),
+                                "ARRAY_JOIN(f0, ' ', ' ')",
+                                "abv bbb cb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), "", ""),
+                                "ARRAY_JOIN(f0, '', '')",
+                                "abvbbbcb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f0"), "", " "),
+                                "ARRAY_JOIN(f0, '', ' ')",
+                                "abvbbbcb",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "+", "abc"),
+                                "ARRAY_JOIN(f1, '+', 'abc')",
+                                "a+b+abc",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "+", ""),
+                                "ARRAY_JOIN(f1, '+', '')",
+                                "a+b+",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "+"),
+                                "ARRAY_JOIN(f1, '+')",
+                                "a+b",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "+", " "),
+                                "ARRAY_JOIN(f1, '+', ' ')",
+                                "a+b+ ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "", "+"),
+                                "ARRAY_JOIN(f1, '', '+')",
+                                "ab+",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), "", ""),
+                                "ARRAY_JOIN(f1, '', '')",
+                                "ab",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), " ", ""),
+                                "ARRAY_JOIN(f1, ' ', '')",
+                                "a b ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f1"), " ", " "),
+                                "ARRAY_JOIN(f1, ' ', ' ')",
+                                "a b  ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "+", "abc"),
+                                "ARRAY_JOIN(f2, '+', 'abc')",
+                                "abc+1+abc",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "+"),
+                                "ARRAY_JOIN(f2, '+')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), ""),
+                                "ARRAY_JOIN(f2, '')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), " "),
+                                "ARRAY_JOIN(f2, ' ')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "+", ""),
+                                "ARRAY_JOIN(f2, '+', '')",
+                                "+1+",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "+", " "),
+                                "ARRAY_JOIN(f2, '+', ' ')",
+                                " +1+ ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "", ""),
+                                "ARRAY_JOIN(f2, '', '')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), "", " "),
+                                "ARRAY_JOIN(f2, '', ' ')",
+                                " 1 ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), " ", " "),
+                                "ARRAY_JOIN(f2, ' ', ' ')",
+                                "  1  ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f2"), " ", ""),
+                                "ARRAY_JOIN(f2, ' ', '')",
+                                " 1 ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "+", "abc"),
+                                "ARRAY_JOIN(f3, '+', 'abc')",
+                                "abc+abc+1+abc+abc",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "+"),
+                                "ARRAY_JOIN(f3, '+')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), ""),
+                                "ARRAY_JOIN(f3, '')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), " "),
+                                "ARRAY_JOIN(f3, ' ')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "+", ""),
+                                "ARRAY_JOIN(f3, '+', '')",
+                                "++1++",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "+", " "),
+                                "ARRAY_JOIN(f3, '+', ' ')",
+                                " + +1+ + ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "", ""),
+                                "ARRAY_JOIN(f3, '', '')",
+                                "1",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), "", " "),
+                                "ARRAY_JOIN(f3, '', ' ')",
+                                "  1  ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), " ", " "),
+                                "ARRAY_JOIN(f3, ' ', ' ')",
+                                "    1    ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f3"), " ", ""),
+                                "ARRAY_JOIN(f3, ' ', '')",
+                                "  1  ",
+                                DataTypes.STRING().nullable())
+                        .testResult(
+                                call("ARRAY_JOIN", $("f4"), " ", ""),
+                                "ARRAY_JOIN(f4, ' ', '')",
+                                null,
+                                DataTypes.STRING().nullable())
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f0)",
+                                "No match found for function "
+                                        + "signature ARRAY_JOIN(<VARCHAR(2147483647) ARRAY>)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN()",
+                                "No match found for function signature ARRAY_JOIN()")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f5, '+')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f5"), "+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f6, '+')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f6"), "+", "abc"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f7, '+', 'abc')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f7"), "+"),
+                                "Invalid function call:\n"
+                                        + "ARRAY_JOIN(ARRAY<INT>, CHAR(1) NOT NULL)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f8, '+', 'abc')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f8"), "+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f9, '+', 'abc')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f9"), "+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "ARRAY_JOIN(f10, '+', 'abc')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f10"), "+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                call("ARRAY_JOIN", $("f0"), "+", "+", "+"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayJoinFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayJoinFunction.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.Iterator;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_JOIN}. */
+@Internal
+public class ArrayJoinFunction extends BuiltInScalarFunction {
+
+    private final ArrayData.ElementGetter elementGetter;
+
+    public ArrayJoinFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_JOIN, context);
+        final DataType elementDataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(elementDataType.getLogicalType());
+    }
+
+    public @Nullable StringData eval(
+            ArrayData array, StringData delimiter, StringData... nullReplacement) {
+        try {
+            if (array == null
+                    || delimiter == null
+                    || (nullReplacement.length != 0 && nullReplacement[0] == null)) {
+                return null;
+            }
+            final StringData normalizedReplacement =
+                    (nullReplacement.length != 0 && nullReplacement[0] != null)
+                            ? nullReplacement[0]
+                            : null;
+            return BinaryStringDataUtil.concatWs(
+                    (BinaryStringData) delimiter,
+                    () ->
+                            new ArrayIterator(
+                                    elementGetter,
+                                    array,
+                                    (BinaryStringData) normalizedReplacement));
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    static final class ArrayIterator implements Iterator<BinaryStringData> {
+
+        private final int size;
+        private final ArrayData.ElementGetter elementGetter;
+        private final ArrayData arrayData;
+        private final BinaryStringData nullReplacement;
+        private int currentPos;
+
+        public ArrayIterator(
+                ArrayData.ElementGetter elementGetter,
+                ArrayData arrayData,
+                BinaryStringData nullReplacement) {
+            this.size = arrayData.size();
+            this.elementGetter = elementGetter;
+            this.arrayData = arrayData;
+            this.nullReplacement = nullReplacement;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return currentPos < size;
+        }
+
+        @Override
+        public BinaryStringData next() {
+            if (!hasNext()) {
+                return null;
+            }
+            final Object str = elementGetter.getElementOrNull(arrayData, currentPos);
+            currentPos++;
+
+            if (str == null && nullReplacement != null) {
+                return nullReplacement;
+            }
+
+            return (BinaryStringData) str;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of ARRAY_JOIN


## Brief change log
Returns a string that represents the concatenation of the elements in the given array and the elements' data type in the given array is string. The delimiter is a string that separates each pair of consecutive elements of the array. The optional nullReplacement is a string that replaces null elements in the array. If nullReplacement is not specified, null elements in the array will be omitted from the resulting string. Returns null if the input array and delimiter are null.
 
- Syntax:
`array_join(array, delimiter, [, null_replacement])`

- Arguments:
array: An ARRAY to be handled.
delimiter: A STRING used to separate the concatenated array elements.
null_replacement: A STRING used to express a NULL value in the result. It is a optional

- Return:
returns a string that represents the concatenation of the elements in the given array and the elements' data type in the given array is string.
Returns null if input array or delimiter or nullReplacement are null.

- Examples:
```
> SELECT array_join(array('hello', 'world'), ' ');
hello world

> SELECT array_join(array('hello', NULL ,'world'), ' ');
hello world

> SELECT array_join(array('hello', NULL ,'world'), ' ', ',');
hello , world
```
- See also:
spark - https://spark.apache.org/docs/latest/api/sql/index.html#array_join
presto - https://prestodb.io/docs/current/functions/array.html

## Verifying this change

- This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
