### PR TITLE
[FLINK-32345][state] Improve parallel download of RocksDB incremental state.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -151,7 +151,9 @@ public final class CollectionUtil {
      * @param <V> the type of mapped values.
      */
     public static <K, V> HashMap<K, V> newHashMapWithExpectedSize(int expectedSize) {
-        return new HashMap<>(computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+        return new HashMap<>(
+                computeRequiredCapacity(expectedSize, HASH_MAP_DEFAULT_LOAD_FACTOR),
+                HASH_MAP_DEFAULT_LOAD_FACTOR);
     }
 
     /**
@@ -165,7 +167,8 @@ public final class CollectionUtil {
      */
     public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
         return new LinkedHashMap<>(
-                computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+                computeRequiredCapacity(expectedSize, HASH_MAP_DEFAULT_LOAD_FACTOR),
+                HASH_MAP_DEFAULT_LOAD_FACTOR);
     }
 
     /**
@@ -177,7 +180,9 @@ public final class CollectionUtil {
      * @param <E> the type of elements stored by this set.
      */
     public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
-        return new HashSet<>(computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+        return new HashSet<>(
+                computeRequiredCapacity(expectedSize, HASH_MAP_DEFAULT_LOAD_FACTOR),
+                HASH_MAP_DEFAULT_LOAD_FACTOR);
     }
 
     /**
@@ -190,7 +195,8 @@ public final class CollectionUtil {
      */
     public static <E> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(int expectedSize) {
         return new LinkedHashSet<>(
-                computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+                computeRequiredCapacity(expectedSize, HASH_MAP_DEFAULT_LOAD_FACTOR),
+                HASH_MAP_DEFAULT_LOAD_FACTOR);
     }
 
     /**
@@ -198,13 +204,14 @@ public final class CollectionUtil {
      * HASH_MAP_DEFAULT_LOAD_FACTOR.
      */
     @VisibleForTesting
-    static int computeRequiredCapacity(int expectedSize) {
+    static int computeRequiredCapacity(int expectedSize, float loadFactor) {
         Preconditions.checkArgument(expectedSize >= 0);
+        Preconditions.checkArgument(loadFactor > 0f);
         if (expectedSize <= 2) {
             return expectedSize + 1;
         }
         return expectedSize < (Integer.MAX_VALUE / 2 + 1)
-                ? (int) ((float) expectedSize / HASH_MAP_DEFAULT_LOAD_FACTOR + 1.0f)
+                ? (int) ((float) expectedSize / loadFactor + 1.0f)
                 : Integer.MAX_VALUE;
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -19,6 +19,7 @@
 package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 
 import javax.annotation.Nullable;
 
@@ -27,7 +28,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +48,9 @@ public final class CollectionUtil {
 
     /** A safe maximum size for arrays in the JVM. */
     public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    /** The default load factor for hash maps create with this util class. */
+    static final float HASH_MAP_DEFAULT_LOAD_FACTOR = 0.75f;
 
     private CollectionUtil() {
         throw new AssertionError();
@@ -132,5 +139,72 @@ public final class CollectionUtil {
             map.put(entry.getKey(), entry.getValue());
         }
         return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Creates a new {@link HashMap} of the expected size, i.e. a hash map that will not rehash if
+     * expectedSize many keys are inserted, considering the load factor.
+     *
+     * @param expectedSize the expected size of the created hash map.
+     * @return a new hash map instance with enough capacity for the expected size.
+     * @param <K> the type of keys maintained by this map.
+     * @param <V> the type of mapped values.
+     */
+    public static <K, V> HashMap<K, V> newHashMapWithExpectedSize(int expectedSize) {
+        return new HashMap<>(computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Creates a new {@link LinkedHashMap} of the expected size, i.e. a hash map that will not
+     * rehash if expectedSize many keys are inserted, considering the load factor.
+     *
+     * @param expectedSize the expected size of the created hash map.
+     * @return a new hash map instance with enough capacity for the expected size.
+     * @param <K> the type of keys maintained by this map.
+     * @param <V> the type of mapped values.
+     */
+    public static <K, V> LinkedHashMap<K, V> newLinkedHashMapWithExpectedSize(int expectedSize) {
+        return new LinkedHashMap<>(
+                computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Creates a new {@link HashSet} of the expected size, i.e. a hash set that will not rehash if
+     * expectedSize many unique elements are inserted, considering the load factor.
+     *
+     * @param expectedSize the expected size of the created hash map.
+     * @return a new hash map instance with enough capacity for the expected size.
+     * @param <E> the type of elements stored by this set.
+     */
+    public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+        return new HashSet<>(computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Creates a new {@link LinkedHashSet} of the expected size, i.e. a hash set that will not
+     * rehash if expectedSize many unique elements are inserted, considering the load factor.
+     *
+     * @param expectedSize the expected size of the created hash map.
+     * @return a new hash map instance with enough capacity for the expected size.
+     * @param <E> the type of elements stored by this set.
+     */
+    public static <E> LinkedHashSet<E> newLinkedHashSetWithExpectedSize(int expectedSize) {
+        return new LinkedHashSet<>(
+                computeRequiredCapacity(expectedSize), HASH_MAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Helper method to compute the right capacity for a hash map with load factor
+     * HASH_MAP_DEFAULT_LOAD_FACTOR.
+     */
+    @VisibleForTesting
+    static int computeRequiredCapacity(int expectedSize) {
+        Preconditions.checkArgument(expectedSize >= 0);
+        if (expectedSize <= 2) {
+            return expectedSize + 1;
+        }
+        return expectedSize < (Integer.MAX_VALUE / 2 + 1)
+                ? (int) ((float) expectedSize / HASH_MAP_DEFAULT_LOAD_FACTOR + 1.0f)
+                : Integer.MAX_VALUE;
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.util.CollectionUtil.HASH_MAP_DEFAULT_LOAD_FACTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for java collection utilities. */
@@ -56,28 +57,44 @@ public class CollectionUtilTest {
 
     @Test
     public void testComputeCapacity() {
-        Assertions.assertEquals(1, CollectionUtil.computeRequiredCapacity(0));
-        Assertions.assertEquals(2, CollectionUtil.computeRequiredCapacity(1));
-        Assertions.assertEquals(3, CollectionUtil.computeRequiredCapacity(2));
-        Assertions.assertEquals(5, CollectionUtil.computeRequiredCapacity(3));
-        Assertions.assertEquals(6, CollectionUtil.computeRequiredCapacity(4));
-        Assertions.assertEquals(134, CollectionUtil.computeRequiredCapacity(100));
-        Assertions.assertEquals(1334, CollectionUtil.computeRequiredCapacity(1000));
-        Assertions.assertEquals(13334, CollectionUtil.computeRequiredCapacity(10000));
         Assertions.assertEquals(
-                1431655808, CollectionUtil.computeRequiredCapacity(Integer.MAX_VALUE / 2));
+                1, CollectionUtil.computeRequiredCapacity(0, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                2, CollectionUtil.computeRequiredCapacity(1, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                3, CollectionUtil.computeRequiredCapacity(2, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                5, CollectionUtil.computeRequiredCapacity(3, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                6, CollectionUtil.computeRequiredCapacity(4, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                134, CollectionUtil.computeRequiredCapacity(100, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                1334, CollectionUtil.computeRequiredCapacity(1000, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                13334, CollectionUtil.computeRequiredCapacity(10000, HASH_MAP_DEFAULT_LOAD_FACTOR));
+
+        Assertions.assertEquals(20001, CollectionUtil.computeRequiredCapacity(10000, 0.5f));
+
+        Assertions.assertEquals(100001, CollectionUtil.computeRequiredCapacity(10000, 0.1f));
+
+        Assertions.assertEquals(
+                1431655808,
+                CollectionUtil.computeRequiredCapacity(
+                        Integer.MAX_VALUE / 2, HASH_MAP_DEFAULT_LOAD_FACTOR));
         Assertions.assertEquals(
                 Integer.MAX_VALUE,
-                CollectionUtil.computeRequiredCapacity(1 + Integer.MAX_VALUE / 2));
+                CollectionUtil.computeRequiredCapacity(
+                        1 + Integer.MAX_VALUE / 2, HASH_MAP_DEFAULT_LOAD_FACTOR));
 
         try {
-            CollectionUtil.computeRequiredCapacity(-1);
+            CollectionUtil.computeRequiredCapacity(-1, HASH_MAP_DEFAULT_LOAD_FACTOR);
             Assertions.fail();
         } catch (IllegalArgumentException expected) {
         }
 
         try {
-            CollectionUtil.computeRequiredCapacity(Integer.MIN_VALUE);
+            CollectionUtil.computeRequiredCapacity(Integer.MIN_VALUE, HASH_MAP_DEFAULT_LOAD_FACTOR);
             Assertions.fail();
         } catch (IllegalArgumentException expected) {
         }

--- a/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.util;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -51,5 +52,34 @@ public class CollectionUtilTest {
     public void testFromNullableWithObject() {
         final Object element = new Object();
         assertThat(CollectionUtil.ofNullable(element)).singleElement().isEqualTo(element);
+    }
+
+    @Test
+    public void testComputeCapacity() {
+        Assertions.assertEquals(1, CollectionUtil.computeRequiredCapacity(0));
+        Assertions.assertEquals(2, CollectionUtil.computeRequiredCapacity(1));
+        Assertions.assertEquals(3, CollectionUtil.computeRequiredCapacity(2));
+        Assertions.assertEquals(5, CollectionUtil.computeRequiredCapacity(3));
+        Assertions.assertEquals(6, CollectionUtil.computeRequiredCapacity(4));
+        Assertions.assertEquals(134, CollectionUtil.computeRequiredCapacity(100));
+        Assertions.assertEquals(1334, CollectionUtil.computeRequiredCapacity(1000));
+        Assertions.assertEquals(13334, CollectionUtil.computeRequiredCapacity(10000));
+        Assertions.assertEquals(
+                1431655808, CollectionUtil.computeRequiredCapacity(Integer.MAX_VALUE / 2));
+        Assertions.assertEquals(
+                Integer.MAX_VALUE,
+                CollectionUtil.computeRequiredCapacity(1 + Integer.MAX_VALUE / 2));
+
+        try {
+            CollectionUtil.computeRequiredCapacity(-1);
+            Assertions.fail();
+        } catch (IllegalArgumentException expected) {
+        }
+
+        try {
+            CollectionUtil.computeRequiredCapacity(Integer.MIN_VALUE);
+            Assertions.fail();
+        } catch (IllegalArgumentException expected) {
+        }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -186,7 +186,7 @@ public class RocksDBIncrementalCheckpointUtils {
             Score handleScore =
                     stateHandleEvaluator(
                             rawStateHandle, targetKeyGroupRange, overlapFractionThreshold);
-            if (handleScore.compareTo(bestScore) > 0) {
+            if (bestStateHandle == null || handleScore.compareTo(bestScore) > 0) {
                 bestStateHandle = rawStateHandle;
                 bestScore = handleScore;
             }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/StateHandleDownloadSpec.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/StateHandleDownloadSpec.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+
+import java.nio.file.Path;
+
+/**
+ * This class represents a download specification for the content of one {@link
+ * IncrementalRemoteKeyedStateHandle} to a target {@link Path}.
+ */
+public class StateHandleDownloadSpec {
+    /** The state handle to download. */
+    private final IncrementalRemoteKeyedStateHandle stateHandle;
+
+    /** The path to which the content of the state handle shall be downloaded. */
+    private final Path downloadDestination;
+
+    public StateHandleDownloadSpec(
+            IncrementalRemoteKeyedStateHandle stateHandle, Path downloadDestination) {
+        this.stateHandle = stateHandle;
+        this.downloadDestination = downloadDestination;
+    }
+
+    public IncrementalRemoteKeyedStateHandle getStateHandle() {
+        return stateHandle;
+    }
+
+    public Path getDownloadDestination() {
+        return downloadDestination;
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -27,6 +27,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBOperationUtils;
 import org.apache.flink.contrib.streaming.state.RocksDBStateDownloader;
 import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
 import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.contrib.streaming.state.StateHandleDownloadSpec;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputView;
@@ -48,6 +49,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -69,6 +71,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -186,12 +189,12 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             IncrementalRemoteKeyedStateHandle incrementalRemoteKeyedStateHandle =
                     (IncrementalRemoteKeyedStateHandle) keyedStateHandle;
             restorePreviousIncrementalFilesStatus(incrementalRemoteKeyedStateHandle);
-            restoreFromRemoteState(incrementalRemoteKeyedStateHandle);
+            restoreBaseDBFromRemoteState(incrementalRemoteKeyedStateHandle);
         } else if (keyedStateHandle instanceof IncrementalLocalKeyedStateHandle) {
             IncrementalLocalKeyedStateHandle incrementalLocalKeyedStateHandle =
                     (IncrementalLocalKeyedStateHandle) keyedStateHandle;
             restorePreviousIncrementalFilesStatus(incrementalLocalKeyedStateHandle);
-            restoreFromLocalState(incrementalLocalKeyedStateHandle);
+            restoreBaseDBFromLocalState(incrementalLocalKeyedStateHandle);
         } else {
             throw unexpectedStateHandleException(
                     new Class[] {
@@ -213,20 +216,46 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         lastCompletedCheckpointId = localKeyedStateHandle.getCheckpointId();
     }
 
-    private void restoreFromRemoteState(IncrementalRemoteKeyedStateHandle stateHandle)
+    private void restoreBaseDBFromRemoteState(IncrementalRemoteKeyedStateHandle stateHandle)
             throws Exception {
         // used as restore source for IncrementalRemoteKeyedStateHandle
         final Path tmpRestoreInstancePath =
                 instanceBasePath.getAbsoluteFile().toPath().resolve(UUID.randomUUID().toString());
+        final StateHandleDownloadSpec downloadRequest =
+                new StateHandleDownloadSpec(stateHandle, tmpRestoreInstancePath);
         try {
-            restoreFromLocalState(
-                    transferRemoteStateToLocalDirectory(tmpRestoreInstancePath, stateHandle));
+            transferRemoteStateToLocalDirectory(Collections.singletonList(downloadRequest));
+            restoreBaseDBFromDownloadedState(downloadRequest);
         } finally {
-            cleanUpPathQuietly(tmpRestoreInstancePath);
+            cleanUpPathQuietly(downloadRequest.getDownloadDestination());
         }
     }
 
-    private void restoreFromLocalState(IncrementalLocalKeyedStateHandle localKeyedStateHandle)
+    /**
+     * This helper method creates a {@link IncrementalLocalKeyedStateHandle} for state that was
+     * previously downloaded for a {@link IncrementalRemoteKeyedStateHandle} and then invokes the
+     * restore procedure for local state on the downloaded state.
+     *
+     * @param downloadedState the specification of a completed state download.
+     * @throws Exception for restore problems.
+     */
+    private void restoreBaseDBFromDownloadedState(StateHandleDownloadSpec downloadedState)
+            throws Exception {
+        // since we transferred all remote state to a local directory, we can use the same code
+        // as for local recovery.
+        IncrementalRemoteKeyedStateHandle stateHandle = downloadedState.getStateHandle();
+        restoreBaseDBFromLocalState(
+                new IncrementalLocalKeyedStateHandle(
+                        stateHandle.getBackendIdentifier(),
+                        stateHandle.getCheckpointId(),
+                        new DirectoryStateHandle(downloadedState.getDownloadDestination()),
+                        stateHandle.getKeyGroupRange(),
+                        stateHandle.getMetaStateHandle(),
+                        stateHandle.getSharedState()));
+    }
+
+    /** Restores RocksDB instance from local state. */
+    private void restoreBaseDBFromLocalState(IncrementalLocalKeyedStateHandle localKeyedStateHandle)
             throws Exception {
         KeyedBackendSerializationProxy<K> serializationProxy =
                 readMetaData(localKeyedStateHandle.getMetaDataState());
@@ -246,26 +275,13 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 restoreSourcePath);
     }
 
-    private IncrementalLocalKeyedStateHandle transferRemoteStateToLocalDirectory(
-            Path temporaryRestoreInstancePath, IncrementalRemoteKeyedStateHandle restoreStateHandle)
+    private void transferRemoteStateToLocalDirectory(List<StateHandleDownloadSpec> downloadRequests)
             throws Exception {
-
         try (RocksDBStateDownloader rocksDBStateDownloader =
                 new RocksDBStateDownloader(numberOfTransferringThreads)) {
             rocksDBStateDownloader.transferAllStateDataToDirectory(
-                    restoreStateHandle, temporaryRestoreInstancePath, cancelStreamRegistry);
+                    downloadRequests, cancelStreamRegistry);
         }
-
-        // since we transferred all remote state to a local directory, we can use the same code as
-        // for
-        // local recovery.
-        return new IncrementalLocalKeyedStateHandle(
-                restoreStateHandle.getBackendIdentifier(),
-                restoreStateHandle.getCheckpointId(),
-                new DirectoryStateHandle(temporaryRestoreInstancePath),
-                restoreStateHandle.getKeyGroupRange(),
-                restoreStateHandle.getMetaStateHandle(),
-                restoreStateHandle.getSharedState());
     }
 
     private void cleanUpPathQuietly(@Nonnull Path path) {
@@ -284,18 +300,44 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
     private void restoreWithRescaling(Collection<KeyedStateHandle> restoreStateHandles)
             throws Exception {
 
-        // Prepare for restore with rescaling
-        KeyedStateHandle initialHandle =
+        Preconditions.checkArgument(restoreStateHandles != null && !restoreStateHandles.isEmpty());
+
+        // Choose the best state handle for the initial DB
+        final KeyedStateHandle selectedInitialHandle =
                 RocksDBIncrementalCheckpointUtils.chooseTheBestStateHandleForInitial(
                         restoreStateHandles, keyGroupRange, overlapFractionThreshold);
 
-        // Init base DB instance
-        if (initialHandle != null) {
-            restoreStateHandles.remove(initialHandle);
-            initDBWithRescaling(initialHandle);
-        } else {
-            this.rocksHandle.openDB();
+        Preconditions.checkNotNull(selectedInitialHandle);
+
+        final Path absolutInstanceBasePath = instanceBasePath.getAbsoluteFile().toPath();
+
+        final List<StateHandleDownloadSpec> allDownloadSpecs =
+                new ArrayList<>(restoreStateHandles.size());
+
+        // Prepare and collect all the download request to pull remote state to a local directory
+        for (KeyedStateHandle stateHandle : restoreStateHandles) {
+            if (!(stateHandle instanceof IncrementalRemoteKeyedStateHandle)) {
+                throw unexpectedStateHandleException(
+                        IncrementalRemoteKeyedStateHandle.class, stateHandle.getClass());
+            }
+            StateHandleDownloadSpec downloadRequest =
+                    new StateHandleDownloadSpec(
+                            (IncrementalRemoteKeyedStateHandle) stateHandle,
+                            absolutInstanceBasePath.resolve(UUID.randomUUID().toString()));
+
+            if (stateHandle == selectedInitialHandle) {
+                // Insert the initial handle at the head of the list
+                allDownloadSpecs.add(0, downloadRequest);
+            } else {
+                allDownloadSpecs.add(downloadRequest);
+            }
         }
+
+        // Process all state downloads
+        transferRemoteStateToLocalDirectory(allDownloadSpecs);
+
+        // Init the base DB instance with the initial state
+        initBaseDBForRescaling(allDownloadSpecs.get(0));
 
         // Transfer remaining key-groups from temporary instance into base DB
         byte[] startKeyGroupPrefixBytes = new byte[keyGroupPrefixBytes];
@@ -306,24 +348,17 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         CompositeKeySerializationUtils.serializeKeyGroup(
                 keyGroupRange.getEndKeyGroup() + 1, stopKeyGroupPrefixBytes);
 
-        for (KeyedStateHandle rawStateHandle : restoreStateHandles) {
+        // Insert all remaining state through creating temporary RocksDB instances
+        for (int stateIdx = 1; stateIdx < allDownloadSpecs.size(); ++stateIdx) {
 
-            if (!(rawStateHandle instanceof IncrementalRemoteKeyedStateHandle)) {
-                throw unexpectedStateHandleException(
-                        IncrementalRemoteKeyedStateHandle.class, rawStateHandle.getClass());
-            }
+            final StateHandleDownloadSpec downloadRequest = allDownloadSpecs.get(stateIdx);
 
             logger.info(
-                    "Starting to restore from state handle: {} with rescaling.", rawStateHandle);
-            Path temporaryRestoreInstancePath =
-                    instanceBasePath
-                            .getAbsoluteFile()
-                            .toPath()
-                            .resolve(UUID.randomUUID().toString());
+                    "Starting to restore from state handle: {} with rescaling.",
+                    downloadRequest.getStateHandle());
+
             try (RestoredDBInstance tmpRestoreDBInfo =
-                            restoreDBInstanceFromStateHandle(
-                                    (IncrementalRemoteKeyedStateHandle) rawStateHandle,
-                                    temporaryRestoreInstancePath);
+                            restoreTempDBInstanceFromDownloadedState(downloadRequest);
                     RocksDBWriteBatchWrapper writeBatchWrapper =
                             new RocksDBWriteBatchWrapper(
                                     this.rocksHandle.getDb(), writeBatchSize)) {
@@ -335,12 +370,13 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
 
                 // iterating only the requested descriptors automatically skips the default column
                 // family handle
-                for (int i = 0; i < tmpColumnFamilyDescriptors.size(); ++i) {
-                    ColumnFamilyHandle tmpColumnFamilyHandle = tmpColumnFamilyHandles.get(i);
+                for (int descIdx = 0; descIdx < tmpColumnFamilyDescriptors.size(); ++descIdx) {
+                    ColumnFamilyHandle tmpColumnFamilyHandle = tmpColumnFamilyHandles.get(descIdx);
 
                     ColumnFamilyHandle targetColumnFamilyHandle =
                             this.rocksHandle.getOrRegisterStateColumnFamilyHandle(
-                                            null, tmpRestoreDBInfo.stateMetaInfoSnapshots.get(i))
+                                            null,
+                                            tmpRestoreDBInfo.stateMetaInfoSnapshots.get(descIdx))
                                     .columnFamilyHandle;
 
                     try (RocksIteratorWrapper iterator =
@@ -369,19 +405,19 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                     } // releases native iterator resources
                 }
                 logger.info(
-                        "Finished restoring from state handle: {} with rescaling.", rawStateHandle);
+                        "Finished restoring from state handle: {} with rescaling.",
+                        downloadRequest.getStateHandle());
             } finally {
-                cleanUpPathQuietly(temporaryRestoreInstancePath);
+                cleanUpPathQuietly(downloadRequest.getDownloadDestination());
             }
         }
     }
 
-    private void initDBWithRescaling(KeyedStateHandle initialHandle) throws Exception {
-
-        assert (initialHandle instanceof IncrementalRemoteKeyedStateHandle);
+    private void initBaseDBForRescaling(StateHandleDownloadSpec downloadedInitialState)
+            throws Exception {
 
         // 1. Restore base DB from selected initial handle
-        restoreFromRemoteState((IncrementalRemoteKeyedStateHandle) initialHandle);
+        restoreBaseDBFromDownloadedState(downloadedInitialState);
 
         // 2. Clip the base DB instance
         try {
@@ -389,7 +425,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                     this.rocksHandle.getDb(),
                     this.rocksHandle.getColumnFamilyHandles(),
                     keyGroupRange,
-                    initialHandle.getKeyGroupRange(),
+                    downloadedInitialState.getStateHandle().getKeyGroupRange(),
                     keyGroupPrefixBytes);
         } catch (RocksDBException e) {
             String errMsg = "Failed to clip DB after initialization.";
@@ -441,18 +477,11 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         }
     }
 
-    private RestoredDBInstance restoreDBInstanceFromStateHandle(
-            IncrementalRemoteKeyedStateHandle restoreStateHandle, Path temporaryRestoreInstancePath)
-            throws Exception {
-
-        try (RocksDBStateDownloader rocksDBStateDownloader =
-                new RocksDBStateDownloader(numberOfTransferringThreads)) {
-            rocksDBStateDownloader.transferAllStateDataToDirectory(
-                    restoreStateHandle, temporaryRestoreInstancePath, cancelStreamRegistry);
-        }
+    private RestoredDBInstance restoreTempDBInstanceFromDownloadedState(
+            StateHandleDownloadSpec downloadRequest) throws Exception {
 
         KeyedBackendSerializationProxy<K> serializationProxy =
-                readMetaData(restoreStateHandle.getMetaStateHandle());
+                readMetaData(downloadRequest.getStateHandle().getMetaStateHandle());
         // read meta data
         List<StateMetaInfoSnapshot> stateMetaInfoSnapshots =
                 serializationProxy.getStateMetaInfoSnapshots();
@@ -465,7 +494,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
 
         RocksDB restoreDb =
                 RocksDBOperationUtils.openDB(
-                        temporaryRestoreInstancePath.toString(),
+                        downloadRequest.getDownloadDestination().toString(),
                         columnFamilyDescriptors,
                         columnFamilyHandles,
                         RocksDBOperationUtils.createColumnFamilyOptions(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This commit improves RocksDBStateDownloader to support parallelized state download across multiple state types and across multiple state handles. This can improve our download times for scale-in.


## Brief change log
- Introduced `StateHandleDownloadSpec` to combine incremental remote handles with their download paths.
- Modified `RocksDBStateDownloader` to accept a list of `StateHandleDownloadSpec` that can combine files from multiple handles and sub-states (shared, private).
- Modified `RocksDBIncrementalRestoreOperation` to first assemble a complete list of `StateHandleDownloadSpec` before invoking the download process.
- Adapted and added unit tests in `RocksDBStateDownloaderTest`.


## Verifying this change

This change is already covered by existing tests, such as 
- `RocksDBStateDownloaderTest`. I added more tests there.
- `EmbeddedRocksDBStateBackendTest`
-  `EmbeddedRocksDBStateBackendMigrationTest`
- `RescalingBenchmarkTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
