### PR TITLE
[FLINK-27146] [Filesystem] Migrate to Junit5

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
@@ -25,11 +25,12 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.StringUtils;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for the {@link AzureBlobRecoverableWriter}. */
 class AzureBlobRecoverableWriterTest extends AbstractRecoverableWriterTest {
@@ -45,13 +46,8 @@ class AzureBlobRecoverableWriterTest extends AbstractRecoverableWriterTest {
     @BeforeAll
     static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials and container details exist
-        Assumptions.assumeFalse(
-                StringUtils.isNullOrWhitespaceOnly(CONTAINER),
-                "Azure container not configured, skipping test...");
-        Assumptions.assumeFalse(
-                StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
-                "Azure access key not configured, skipping test...");
-
+        assumeThat(StringUtils.isNullOrWhitespaceOnly(CONTAINER)).isFalse();
+        assumeThat(StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY)).isFalse();
         // adjusting the minbuffer length for tests
         AzureBlobFsRecoverableDataOutputStream.minBufferLength = 4;
         // initialize configuration with valid credentials

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
@@ -25,12 +25,11 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.StringUtils;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
-
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for the {@link AzureBlobRecoverableWriter}. */
 class AzureBlobRecoverableWriterTest extends AbstractRecoverableWriterTest {
@@ -46,8 +45,13 @@ class AzureBlobRecoverableWriterTest extends AbstractRecoverableWriterTest {
     @BeforeAll
     static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials and container details exist
-        assumeThat(StringUtils.isNullOrWhitespaceOnly(CONTAINER)).isFalse();
-        assumeThat(StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY)).isFalse();
+        Assumptions.assumeFalse(
+                StringUtils.isNullOrWhitespaceOnly(CONTAINER),
+                "Azure container not configured, skipping test...");
+        Assumptions.assumeFalse(
+                StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY),
+                "Azure access key not configured, skipping test...");
+
         // adjusting the minbuffer length for tests
         AzureBlobFsRecoverableDataOutputStream.minBufferLength = 4;
         // initialize configuration with valid credentials

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobStorageFSFactoryTest.java
@@ -22,26 +22,31 @@ import org.apache.flink.configuration.Configuration;
 
 import org.apache.hadoop.fs.azure.AzureException;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.net.URI;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the AzureFSFactory. */
 class AzureBlobStorageFSFactoryTest {
 
-    private AbstractAzureFSFactory getFactory(String scheme) {
-        return scheme.equals("wasb")
-                ? new AzureBlobStorageFSFactory()
-                : new SecureAzureBlobStorageFSFactory();
+    @ParameterizedTest(name = "Factory = {0}")
+    @MethodSource("getFactories")
+    @Retention(value = RetentionPolicy.RUNTIME)
+    private @interface TestAllFsImpl {}
+
+    @SuppressWarnings("unused")
+    private static Stream<AbstractAzureFSFactory> getFactories() {
+        return Stream.of(new AzureBlobStorageFSFactory(), new SecureAzureBlobStorageFSFactory());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"wasb", "wasbs"})
-    void testNullFsURI(String scheme) throws Exception {
+    @TestAllFsImpl
+    void testNullFsURI(AbstractAzureFSFactory factory) throws Exception {
         URI uri = null;
-        AbstractAzureFSFactory factory = getFactory(scheme);
 
         assertThatThrownBy(() -> factory.create(uri))
                 .isInstanceOf(NullPointerException.class)
@@ -49,15 +54,14 @@ class AzureBlobStorageFSFactoryTest {
     }
 
     // missing credentials
-    @ParameterizedTest
-    @ValueSource(strings = {"wasb", "wasbs"})
-    void testCreateFsWithAuthorityMissingCreds(String scheme) throws Exception {
+    @TestAllFsImpl
+    void testCreateFsWithAuthorityMissingCreds(AbstractAzureFSFactory factory) throws Exception {
         String uriString =
                 String.format(
-                        "%s://yourcontainer@youraccount.blob.core.windows.net/testDir", scheme);
+                        "%s://yourcontainer@youraccount.blob.core.windows.net/testDir",
+                        factory.getScheme());
         final URI uri = URI.create(uriString);
 
-        AbstractAzureFSFactory factory = getFactory(scheme);
         Configuration config = new Configuration();
         config.setInteger("fs.azure.io.retry.max.retries", 0);
         factory.configure(config);
@@ -65,13 +69,11 @@ class AzureBlobStorageFSFactoryTest {
         assertThatThrownBy(() -> factory.create(uri)).isInstanceOf(AzureException.class);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"wasb", "wasbs"})
-    void testCreateFsWithMissingAuthority(String scheme) throws Exception {
-        String uriString = String.format("%s:///my/path", scheme);
+    @TestAllFsImpl
+    void testCreateFsWithMissingAuthority(AbstractAzureFSFactory factory) throws Exception {
+        String uriString = String.format("%s:///my/path", factory.getScheme());
         final URI uri = URI.create(uriString);
 
-        AbstractAzureFSFactory factory = getFactory(scheme);
         factory.configure(new Configuration());
 
         assertThatThrownBy(() -> factory.create(uri))

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GSFileSystemFactory}. */
-public class GSFileSystemFactoryTest {
+class GSFileSystemFactoryTest {
 
     @Test
     public void testOverrideStorageRootUrl() {

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link GSFileSystemFactory}. */
 public class GSFileSystemFactoryTest {

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GSFileSystemFactory}. */
 public class GSFileSystemFactoryTest {
@@ -36,6 +36,6 @@ public class GSFileSystemFactoryTest {
         factory.configure(flinkConfig);
 
         String gsStorageClientHost = factory.getStorage().getOptions().getHost();
-        assertEquals(gsStorageClientHost, "http://240.0.0.0:12345");
+        assertThat(gsStorageClientHost).isEqualTo("http://240.0.0.0:12345");
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemFactoryTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GSFileSystemFactoryTest {
 
     @Test
-    public void testOverrideStorageRootUrl() {
+    void testOverrideStorageRootUrl() {
         Configuration flinkConfig = new Configuration();
         flinkConfig.setString("gs.storage.root.url", "http://240.0.0.0:12345");
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
@@ -147,7 +147,7 @@ class GSFileSystemScenarioTest {
         // there should be a single blob now, in the specified temporary bucket or, if no temporary
         // bucket
         // specified, in the final bucket
-        assertThat(storage.blobs.size()).isEqualTo(1);
+        assertThat(storage.blobs.size()).isOne();
         GSBlobIdentifier temporaryBlobIdentifier =
                 (GSBlobIdentifier) storage.blobs.keySet().toArray()[0];
         String expectedTemporaryBucket =
@@ -161,7 +161,7 @@ class GSFileSystemScenarioTest {
 
         // there should be exactly one blob after commit, with the expected contents.
         // all temporary blobs should be removed.
-        assertThat(storage.blobs.size()).isEqualTo(1);
+        assertThat(storage.blobs.size()).isOne();
         MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
         assertThat(blobValue.content).isEqualTo(data);
     }
@@ -198,7 +198,7 @@ class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertThat(storage.blobs.size()).isEqualTo(1);
+            assertThat(storage.blobs.size()).isOne();
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
             assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }
@@ -252,7 +252,7 @@ class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertThat(storage.blobs.size()).isEqualTo(1);
+            assertThat(storage.blobs.size()).isOne();
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
             assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests of various write and recovery scenarios. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSFileSystemScenarioTest {
+class GSFileSystemScenarioTest {
 
     /* The temporary bucket name to use. */
     @Parameter public String temporaryBucketName;

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
@@ -26,12 +26,14 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
 import org.apache.flink.fs.gs.storage.MockBlobStorage;
 import org.apache.flink.fs.gs.writer.GSRecoverableWriter;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.StringUtils;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -39,25 +41,24 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Tests of various write and recovery scenarios. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSFileSystemScenarioTest {
 
     /* The temporary bucket name to use. */
-    @Parameterized.Parameter(value = 0)
-    public String temporaryBucketName;
+    @Parameter public String temporaryBucketName;
 
     /* The chunk size to use for writing to GCS. */
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public MemorySize writeChunkSize;
 
-    @Parameterized.Parameters(name = "temporaryBucketName={0}")
+    @Parameters(name = "temporaryBucketName={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -92,7 +93,7 @@ public class GSFileSystemScenarioTest {
 
     private boolean writeChunkSizeIsValid;
 
-    @Before
+    @BeforeEach
     public void before() {
 
         random = new Random(TestUtils.RANDOM_SEED);
@@ -126,7 +127,7 @@ public class GSFileSystemScenarioTest {
     }
 
     /* Test writing a single array of bytes to a stream. */
-    @Test
+    @TestTemplate
     public void simpleWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
@@ -168,7 +169,7 @@ public class GSFileSystemScenarioTest {
     }
 
     /* Test writing multiple arrays of bytes to a stream. */
-    @Test
+    @TestTemplate
     public void compoundWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
@@ -206,7 +207,7 @@ public class GSFileSystemScenarioTest {
     }
 
     /* Test writing multiple arrays of bytes to a stream. */
-    @Test
+    @TestTemplate
     public void compoundWriteTestWithRestore() throws IOException {
 
         // only run the test for valid chunk sizes
@@ -259,7 +260,7 @@ public class GSFileSystemScenarioTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void invalidChunkSizeTest() {
 
         // only run the test for invalid chunk sizes

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
@@ -41,11 +41,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests of various write and recovery scenarios. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -131,7 +129,7 @@ public class GSFileSystemScenarioTest {
     public void simpleWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
-        assumeTrue(writeChunkSizeIsValid);
+        assumeThat(writeChunkSizeIsValid).isTrue();
 
         // create the options and writer
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
@@ -149,23 +147,23 @@ public class GSFileSystemScenarioTest {
         // there should be a single blob now, in the specified temporary bucket or, if no temporary
         // bucket
         // specified, in the final bucket
-        assertEquals(1, storage.blobs.size());
+        assertThat(storage.blobs.size()).isEqualTo(1);
         GSBlobIdentifier temporaryBlobIdentifier =
                 (GSBlobIdentifier) storage.blobs.keySet().toArray()[0];
         String expectedTemporaryBucket =
                 StringUtils.isNullOrWhitespaceOnly(temporaryBucketName)
                         ? blobIdentifier.bucketName
                         : temporaryBucketName;
-        assertEquals(expectedTemporaryBucket, temporaryBlobIdentifier.bucketName);
+        assertThat(temporaryBlobIdentifier.bucketName).isEqualTo(expectedTemporaryBucket);
 
         // commit
         committer.commit();
 
         // there should be exactly one blob after commit, with the expected contents.
         // all temporary blobs should be removed.
-        assertEquals(1, storage.blobs.size());
+        assertThat(storage.blobs.size()).isEqualTo(1);
         MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
-        assertArrayEquals(data, blobValue.content);
+        assertThat(blobValue.content).isEqualTo(data);
     }
 
     /* Test writing multiple arrays of bytes to a stream. */
@@ -173,7 +171,7 @@ public class GSFileSystemScenarioTest {
     public void compoundWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
-        assumeTrue(writeChunkSizeIsValid);
+        assumeThat(writeChunkSizeIsValid).isTrue();
 
         // create the options and writer
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
@@ -200,9 +198,9 @@ public class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertEquals(1, storage.blobs.size());
+            assertThat(storage.blobs.size()).isEqualTo(1);
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
-            assertArrayEquals(expectedData.toByteArray(), blobValue.content);
+            assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }
     }
 
@@ -211,7 +209,7 @@ public class GSFileSystemScenarioTest {
     public void compoundWriteTestWithRestore() throws IOException {
 
         // only run the test for valid chunk sizes
-        assumeTrue(writeChunkSizeIsValid);
+        assumeThat(writeChunkSizeIsValid).isTrue();
 
         // create the options and writer
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
@@ -254,9 +252,9 @@ public class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertEquals(1, storage.blobs.size());
+            assertThat(storage.blobs.size()).isEqualTo(1);
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
-            assertArrayEquals(expectedData.toByteArray(), blobValue.content);
+            assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }
     }
 
@@ -264,13 +262,10 @@ public class GSFileSystemScenarioTest {
     public void invalidChunkSizeTest() {
 
         // only run the test for invalid chunk sizes
-        assumeFalse(writeChunkSizeIsValid);
+        assumeThat(writeChunkSizeIsValid).isFalse();
 
         // create the options and writer
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
-                });
+        assertThatThrownBy(() -> new GSFileSystemOptions(flinkConfig))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/GSFileSystemScenarioTest.java
@@ -50,14 +50,14 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class GSFileSystemScenarioTest {
 
     /* The temporary bucket name to use. */
-    @Parameter public String temporaryBucketName;
+    @Parameter private String temporaryBucketName;
 
     /* The chunk size to use for writing to GCS. */
     @Parameter(value = 1)
-    public MemorySize writeChunkSize;
+    private MemorySize writeChunkSize;
 
     @Parameters(name = "temporaryBucketName={0}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // no specified bucket, no chunk size
@@ -92,7 +92,7 @@ class GSFileSystemScenarioTest {
     private boolean writeChunkSizeIsValid;
 
     @BeforeEach
-    public void before() {
+    void before() {
 
         random = new Random(TestUtils.RANDOM_SEED);
 
@@ -126,7 +126,7 @@ class GSFileSystemScenarioTest {
 
     /* Test writing a single array of bytes to a stream. */
     @TestTemplate
-    public void simpleWriteTest() throws IOException {
+    void simpleWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
         assumeThat(writeChunkSizeIsValid).isTrue();
@@ -147,7 +147,7 @@ class GSFileSystemScenarioTest {
         // there should be a single blob now, in the specified temporary bucket or, if no temporary
         // bucket
         // specified, in the final bucket
-        assertThat(storage.blobs.size()).isOne();
+        assertThat(storage.blobs).hasSize(1);
         GSBlobIdentifier temporaryBlobIdentifier =
                 (GSBlobIdentifier) storage.blobs.keySet().toArray()[0];
         String expectedTemporaryBucket =
@@ -161,14 +161,14 @@ class GSFileSystemScenarioTest {
 
         // there should be exactly one blob after commit, with the expected contents.
         // all temporary blobs should be removed.
-        assertThat(storage.blobs.size()).isOne();
+        assertThat(storage.blobs).hasSize(1);
         MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
         assertThat(blobValue.content).isEqualTo(data);
     }
 
     /* Test writing multiple arrays of bytes to a stream. */
     @TestTemplate
-    public void compoundWriteTest() throws IOException {
+    void compoundWriteTest() throws IOException {
 
         // only run the test for valid chunk sizes
         assumeThat(writeChunkSizeIsValid).isTrue();
@@ -198,7 +198,7 @@ class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertThat(storage.blobs.size()).isOne();
+            assertThat(storage.blobs).hasSize(1);
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
             assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }
@@ -206,7 +206,7 @@ class GSFileSystemScenarioTest {
 
     /* Test writing multiple arrays of bytes to a stream. */
     @TestTemplate
-    public void compoundWriteTestWithRestore() throws IOException {
+    void compoundWriteTestWithRestore() throws IOException {
 
         // only run the test for valid chunk sizes
         assumeThat(writeChunkSizeIsValid).isTrue();
@@ -252,14 +252,14 @@ class GSFileSystemScenarioTest {
 
             // there should be exactly one blob after commit, with the expected contents.
             // all temporary blobs should be removed.
-            assertThat(storage.blobs.size()).isOne();
+            assertThat(storage.blobs).hasSize(1);
             MockBlobStorage.BlobValue blobValue = storage.blobs.get(blobIdentifier);
             assertThat(blobValue.content).isEqualTo(expectedData.toByteArray());
         }
     }
 
     @TestTemplate
-    public void invalidChunkSizeTest() {
+    void invalidChunkSizeTest() {
 
         // only run the test for invalid chunk sizes
         assumeThat(writeChunkSizeIsValid).isFalse();

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/BlobUtilsTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/BlobUtilsTest.java
@@ -22,40 +22,44 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fs.gs.GSFileSystemOptions;
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link BlobUtils}. */
-public class BlobUtilsTest {
+class BlobUtilsTest {
 
     @Test
-    public void shouldParseValidUri() {
+    void shouldParseValidUri() {
         GSBlobIdentifier blobIdentifier = BlobUtils.parseUri(URI.create("gs://bucket/foo/bar"));
         assertEquals("bucket", blobIdentifier.bucketName);
         assertEquals("foo/bar", blobIdentifier.objectName);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldFailToParseUriBadScheme() {
-        BlobUtils.parseUri(URI.create("s3://bucket/foo/bar"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldFailToParseUriMissingBucketName() {
-        BlobUtils.parseUri(URI.create("gs:///foo/bar"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldFailToParseUriMissingObjectName() {
-        BlobUtils.parseUri(URI.create("gs://bucket/"));
+    @Test
+    void shouldFailToParseUriBadScheme() {
+        assertThatThrownBy(() -> BlobUtils.parseUri(URI.create("s3://bucket/foo/bar")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void shouldUseTemporaryBucketNameIfSpecified() {
+    void shouldFailToParseUriMissingBucketName() {
+        assertThatThrownBy(() -> BlobUtils.parseUri(URI.create("gs:///foo/bar")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldFailToParseUriMissingObjectName() {
+        assertThatThrownBy(() -> BlobUtils.parseUri(URI.create("gs://bucket/")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldUseTemporaryBucketNameIfSpecified() {
         Configuration flinkConfig = new Configuration();
         flinkConfig.set(GSFileSystemOptions.WRITER_TEMPORARY_BUCKET_NAME, "temp");
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
@@ -66,7 +70,7 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldUseIdentifierBucketNameNameIfTemporaryBucketNotSpecified() {
+    void shouldUseIdentifierBucketNameNameIfTemporaryBucketNotSpecified() {
         Configuration flinkConfig = new Configuration();
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
@@ -76,7 +80,7 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldProperlyConstructTemporaryObjectPartialName() {
+    void shouldProperlyConstructTemporaryObjectPartialName() {
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
 
         String partialName = BlobUtils.getTemporaryObjectPartialName(identifier);
@@ -84,7 +88,7 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldProperlyConstructTemporaryObjectName() {
+    void shouldProperlyConstructTemporaryObjectName() {
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
         UUID temporaryObjectId = UUID.fromString("f09c43e5-ea49-4537-a406-0586f8f09d47");
 
@@ -93,7 +97,7 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldProperlyConstructTemporaryObjectNameWithEntropy() {
+    void shouldProperlyConstructTemporaryObjectNameWithEntropy() {
         Configuration flinkConfig = new Configuration();
         flinkConfig.set(GSFileSystemOptions.ENABLE_FILESINK_ENTROPY, Boolean.TRUE);
 
@@ -108,7 +112,8 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldProperlyConstructTemporaryBlobIdentifierWithDefaultBucket() {
+    void shouldProperlyConstructTemporaryBlobIdentifierWithDefaultBucket() {
+
         Configuration flinkConfig = new Configuration();
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
@@ -123,7 +128,7 @@ public class BlobUtilsTest {
     }
 
     @Test
-    public void shouldProperlyConstructTemporaryBlobIdentifierWithTemporaryBucket() {
+    void shouldProperlyConstructTemporaryBlobIdentifierWithTemporaryBucket() {
         Configuration flinkConfig = new Configuration();
         flinkConfig.set(GSFileSystemOptions.WRITER_TEMPORARY_BUCKET_NAME, "temp");
         GSFileSystemOptions options = new GSFileSystemOptions(flinkConfig);

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/BlobUtilsTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/BlobUtilsTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link BlobUtils}. */
 class BlobUtilsTest {
@@ -36,8 +36,8 @@ class BlobUtilsTest {
     @Test
     void shouldParseValidUri() {
         GSBlobIdentifier blobIdentifier = BlobUtils.parseUri(URI.create("gs://bucket/foo/bar"));
-        assertEquals("bucket", blobIdentifier.bucketName);
-        assertEquals("foo/bar", blobIdentifier.objectName);
+        assertThat(blobIdentifier.bucketName).isEqualTo("bucket");
+        assertThat(blobIdentifier.objectName).isEqualTo("foo/bar");
     }
 
     @Test
@@ -66,7 +66,7 @@ class BlobUtilsTest {
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
 
         String bucketName = BlobUtils.getTemporaryBucketName(identifier, options);
-        assertEquals("temp", bucketName);
+        assertThat(bucketName).isEqualTo("temp");
     }
 
     @Test
@@ -76,7 +76,7 @@ class BlobUtilsTest {
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
 
         String bucketName = BlobUtils.getTemporaryBucketName(identifier, options);
-        assertEquals("foo", bucketName);
+        assertThat(bucketName).isEqualTo("foo");
     }
 
     @Test
@@ -84,7 +84,7 @@ class BlobUtilsTest {
         GSBlobIdentifier identifier = new GSBlobIdentifier("foo", "bar");
 
         String partialName = BlobUtils.getTemporaryObjectPartialName(identifier);
-        assertEquals(".inprogress/foo/bar/", partialName);
+        assertThat(partialName).isEqualTo(".inprogress/foo/bar/");
     }
 
     @Test
@@ -93,7 +93,8 @@ class BlobUtilsTest {
         UUID temporaryObjectId = UUID.fromString("f09c43e5-ea49-4537-a406-0586f8f09d47");
 
         String partialName = BlobUtils.getTemporaryObjectName(identifier, temporaryObjectId);
-        assertEquals(".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47", partialName);
+        assertThat(partialName)
+                .isEqualTo(".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47");
     }
 
     @Test
@@ -106,9 +107,9 @@ class BlobUtilsTest {
 
         String partialName =
                 BlobUtils.getTemporaryObjectNameWithEntropy(identifier, temporaryObjectId);
-        assertEquals(
-                "f09c43e5-ea49-4537-a406-0586f8f09d47.inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47",
-                partialName);
+        assertThat(
+                        "f09c43e5-ea49-4537-a406-0586f8f09d47.inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47")
+                .isEqualTo(partialName);
     }
 
     @Test
@@ -121,10 +122,9 @@ class BlobUtilsTest {
 
         GSBlobIdentifier temporaryBlobIdentifier =
                 BlobUtils.getTemporaryBlobIdentifier(identifier, temporaryObjectId, options);
-        assertEquals("foo", temporaryBlobIdentifier.bucketName);
-        assertEquals(
-                ".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47",
-                temporaryBlobIdentifier.objectName);
+        assertThat(temporaryBlobIdentifier.bucketName).isEqualTo("foo");
+        assertThat(temporaryBlobIdentifier.objectName)
+                .isEqualTo(".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47");
     }
 
     @Test
@@ -137,9 +137,8 @@ class BlobUtilsTest {
 
         GSBlobIdentifier temporaryBlobIdentifier =
                 BlobUtils.getTemporaryBlobIdentifier(identifier, temporaryObjectId, options);
-        assertEquals("temp", temporaryBlobIdentifier.bucketName);
-        assertEquals(
-                ".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47",
-                temporaryBlobIdentifier.objectName);
+        assertThat(temporaryBlobIdentifier.bucketName).isEqualTo("temp");
+        assertThat(temporaryBlobIdentifier.objectName)
+                .isEqualTo(".inprogress/foo/bar/f09c43e5-ea49-4537-a406-0586f8f09d47");
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ChecksumUtilsTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ChecksumUtilsTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.fs.gs.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link ChecksumUtils}. */
-public class ChecksumUtilsTest {
+class ChecksumUtilsTest {
 
     @Test
-    public void shouldConvertToStringChecksum() {
+    void shouldConvertToStringChecksum() {
         assertEquals("AAAwOQ==", ChecksumUtils.convertChecksumToString(12345));
         assertEquals("AADUMQ==", ChecksumUtils.convertChecksumToString(54321));
     }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ChecksumUtilsTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ChecksumUtilsTest.java
@@ -20,14 +20,14 @@ package org.apache.flink.fs.gs.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test {@link ChecksumUtils}. */
 class ChecksumUtilsTest {
 
     @Test
     void shouldConvertToStringChecksum() {
-        assertEquals("AAAwOQ==", ChecksumUtils.convertChecksumToString(12345));
-        assertEquals("AADUMQ==", ChecksumUtils.convertChecksumToString(54321));
+        assertThat(ChecksumUtils.convertChecksumToString(12345)).isEqualTo("AAAwOQ==");
+        assertThat(ChecksumUtils.convertChecksumToString(54321)).isEqualTo("AADUMQ==");
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -44,31 +44,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConfigUtilsHadoopTest {
 
     /* The test case description. */
-    @Parameter public String description;
+    @Parameter private String description;
 
     /* The value to use for the HADOOP_CONF_DIR environment variable. */
     @Parameter(value = 1)
     @Nullable
-    String envHadoopConfDir;
+    private String envHadoopConfDir;
 
     /* The value to use for the Flink config. */
     @Parameter(value = 2)
-    Configuration flinkConfig;
+    private Configuration flinkConfig;
 
     /* The Hadoop resources to load from the config dir. */
     @Parameter(value = 3)
-    org.apache.hadoop.conf.Configuration loadedHadoopConfig;
+    private org.apache.hadoop.conf.Configuration loadedHadoopConfig;
 
     /* The expected Hadoop configuration directory. */
     @Parameter(value = 4)
-    String expectedHadoopConfigDir;
+    private String expectedHadoopConfigDir;
 
     /* The expected Hadoop configuration. */
     @Parameter(value = 5)
-    org.apache.hadoop.conf.Configuration expectedHadoopConfig;
+    private org.apache.hadoop.conf.Configuration expectedHadoopConfig;
 
     @Parameters(name = "description={0}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     {

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -42,30 +42,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test construction of Hadoop config in GSFileSystemFactory. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class ConfigUtilsHadoopTest {
+class ConfigUtilsHadoopTest {
 
     /* The test case description. */
     @Parameter public String description;
 
     /* The value to use for the HADOOP_CONF_DIR environment variable. */
     @Parameter(value = 1)
-    public @Nullable String envHadoopConfDir;
+    @Nullable
+    String envHadoopConfDir;
 
     /* The value to use for the Flink config. */
     @Parameter(value = 2)
-    public Configuration flinkConfig;
+    Configuration flinkConfig;
 
     /* The Hadoop resources to load from the config dir. */
     @Parameter(value = 3)
-    public org.apache.hadoop.conf.Configuration loadedHadoopConfig;
+    org.apache.hadoop.conf.Configuration loadedHadoopConfig;
 
     /* The expected Hadoop configuration directory. */
     @Parameter(value = 4)
-    public String expectedHadoopConfigDir;
+    String expectedHadoopConfigDir;
 
     /* The expected Hadoop configuration. */
     @Parameter(value = 5)
-    public org.apache.hadoop.conf.Configuration expectedHadoopConfig;
+    org.apache.hadoop.conf.Configuration expectedHadoopConfig;
 
     @Parameters(name = "description={0}")
     public static Collection<Object[]> data() {
@@ -255,7 +256,7 @@ public class ConfigUtilsHadoopTest {
     }
 
     @TestTemplate
-    public void shouldProperlyCreateHadoopConfig() {
+    void shouldProperlyCreateHadoopConfig() {
 
         // construct the testing config context
         HashMap<String, String> envs = new HashMap<>();

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -280,8 +279,8 @@ class ConfigUtilsHadoopTest {
         Map<String, String> hadoopConfigMap = TestUtils.hadoopConfigToMap(hadoopConfig);
         MapDifference<String, String> difference =
                 Maps.difference(expectedHadoopConfigMap, hadoopConfigMap);
-        assertThat(difference.entriesDiffering()).isEqualTo(Collections.EMPTY_MAP);
-        assertThat(difference.entriesOnlyOnLeft()).isEqualTo(Collections.EMPTY_MAP);
-        assertThat(difference.entriesOnlyOnRight()).isEqualTo(Collections.EMPTY_MAP);
+        assertThat(difference.entriesDiffering()).isEmpty();
+        assertThat(difference.entriesOnlyOnLeft()).isEmpty();
+        assertThat(difference.entriesOnlyOnRight()).isEmpty();
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test construction of Hadoop config in GSFileSystemFactory. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -279,8 +279,8 @@ public class ConfigUtilsHadoopTest {
         Map<String, String> hadoopConfigMap = TestUtils.hadoopConfigToMap(hadoopConfig);
         MapDifference<String, String> difference =
                 Maps.difference(expectedHadoopConfigMap, hadoopConfigMap);
-        assertEquals(Collections.EMPTY_MAP, difference.entriesDiffering());
-        assertEquals(Collections.EMPTY_MAP, difference.entriesOnlyOnLeft());
-        assertEquals(Collections.EMPTY_MAP, difference.entriesOnlyOnRight());
+        assertThat(difference.entriesDiffering()).isEqualTo(Collections.EMPTY_MAP);
+        assertThat(difference.entriesOnlyOnLeft()).isEqualTo(Collections.EMPTY_MAP);
+        assertThat(difference.entriesOnlyOnRight()).isEqualTo(Collections.EMPTY_MAP);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsHadoopTest.java
@@ -20,13 +20,15 @@ package org.apache.flink.fs.gs.utils;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fs.gs.TestUtils;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
 import org.apache.flink.shaded.guava32.com.google.common.collect.MapDifference;
 import org.apache.flink.shaded.guava32.com.google.common.collect.Maps;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -39,34 +41,33 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test construction of Hadoop config in GSFileSystemFactory. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class ConfigUtilsHadoopTest {
 
     /* The test case description. */
-    @Parameterized.Parameter(value = 0)
-    public String description;
+    @Parameter public String description;
 
     /* The value to use for the HADOOP_CONF_DIR environment variable. */
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public @Nullable String envHadoopConfDir;
 
     /* The value to use for the Flink config. */
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public Configuration flinkConfig;
 
     /* The Hadoop resources to load from the config dir. */
-    @Parameterized.Parameter(value = 3)
+    @Parameter(value = 3)
     public org.apache.hadoop.conf.Configuration loadedHadoopConfig;
 
     /* The expected Hadoop configuration directory. */
-    @Parameterized.Parameter(value = 4)
+    @Parameter(value = 4)
     public String expectedHadoopConfigDir;
 
     /* The expected Hadoop configuration. */
-    @Parameterized.Parameter(value = 5)
+    @Parameter(value = 5)
     public org.apache.hadoop.conf.Configuration expectedHadoopConfig;
 
-    @Parameterized.Parameters(name = "description={0}")
+    @Parameters(name = "description={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -253,7 +254,7 @@ public class ConfigUtilsHadoopTest {
                 });
     }
 
-    @Test
+    @TestTemplate
     public void shouldProperlyCreateHadoopConfig() {
 
         // construct the testing config context

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
@@ -38,27 +38,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test construction of Storage instance in GSFileSystemFactory. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class ConfigUtilsStorageTest {
+class ConfigUtilsStorageTest {
 
     /* The test case description. */
-    public @Parameter String description;
+    private @Parameter String description;
 
     /* The value to use for the GOOGLE_APPLICATION_CREDENTIALS environment variable. */
     @Parameter(value = 1)
     @Nullable
-    public String envGoogleApplicationCredentials;
+    private String envGoogleApplicationCredentials;
 
     /* The Hadoop config. */
     @Parameter(value = 2)
-    public org.apache.hadoop.conf.Configuration hadoopConfig;
+    private org.apache.hadoop.conf.Configuration hadoopConfig;
 
     /* The expected credentials file to use. */
     @Parameter(value = 3)
     @Nullable
-    public String expectedCredentialsFilePath;
+    private String expectedCredentialsFilePath;
 
     @Parameters(name = "description={0}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     {

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test construction of Storage instance in GSFileSystemFactory. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -150,6 +150,6 @@ public class ConfigUtilsStorageTest {
         Optional<GoogleCredentials> loadedCredentials =
                 ConfigUtils.getStorageCredentials(hadoopConfig, configContext);
 
-        assertEquals(expectedCredentials, loadedCredentials);
+        assertThat(loadedCredentials).isEqualTo(expectedCredentials);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/ConfigUtilsStorageTest.java
@@ -19,11 +19,13 @@
 package org.apache.flink.fs.gs.utils;
 
 import org.apache.flink.fs.gs.TestUtils;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -35,26 +37,27 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test construction of Storage instance in GSFileSystemFactory. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class ConfigUtilsStorageTest {
 
     /* The test case description. */
-    @Parameterized.Parameter(value = 0)
-    public String description;
+    public @Parameter String description;
 
     /* The value to use for the GOOGLE_APPLICATION_CREDENTIALS environment variable. */
-    @Parameterized.Parameter(value = 1)
-    public @Nullable String envGoogleApplicationCredentials;
+    @Parameter(value = 1)
+    @Nullable
+    public String envGoogleApplicationCredentials;
 
     /* The Hadoop config. */
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public org.apache.hadoop.conf.Configuration hadoopConfig;
 
     /* The expected credentials file to use. */
-    @Parameterized.Parameter(value = 3)
-    public @Nullable String expectedCredentialsFilePath;
+    @Parameter(value = 3)
+    @Nullable
+    public String expectedCredentialsFilePath;
 
-    @Parameterized.Parameters(name = "description={0}")
+    @Parameters(name = "description={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -124,8 +127,8 @@ public class ConfigUtilsStorageTest {
                 });
     }
 
-    @Test
-    public void shouldProperlyCreateStorageCredentials() {
+    @TestTemplate
+    void shouldProperlyCreateStorageCredentials() {
 
         // populate this if we store credentials in the testing context
         Optional<GoogleCredentials> expectedCredentials = Optional.empty();

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/TestingConfigContext.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/utils/TestingConfigContext.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /** Implementation of ConfigUtils.ConfigContext for testing. */
-public class TestingConfigContext implements ConfigUtils.ConfigContext {
+class TestingConfigContext implements ConfigUtils.ConfigContext {
 
     private final Map<String, String> envs;
     private final Map<String, org.apache.hadoop.conf.Configuration> hadoopConfigs;

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
@@ -21,11 +21,13 @@ package org.apache.flink.fs.gs.writer;
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
 import org.apache.flink.fs.gs.storage.GSBlobStorage;
 import org.apache.flink.fs.gs.storage.MockBlobStorage;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,29 +36,30 @@ import java.util.Collection;
 import java.util.Random;
 
 import static org.apache.flink.fs.gs.TestUtils.RANDOM_SEED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link GSChecksumWriteChannel}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSChecksumWriteChannelTest {
 
     /* The sizes of each buffer of bytes used for writing. */
-    @Parameterized.Parameter(value = 0)
+    @Parameter(value = 0)
     public int[] bufferSizes;
 
     /* The start positions in write buffers. */
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public int[] writeStarts;
 
     /* The length of each write. */
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public int[] writeLengths;
 
-    @Parameterized.Parameter(value = 3)
+    @Parameter(value = 3)
     public String description;
 
-    @Parameterized.Parameters(name = "{3}")
+    @Parameters(name = "{3}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -91,7 +94,7 @@ public class GSChecksumWriteChannelTest {
 
     private GSBlobIdentifier blobIdentifier;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         Random random = new Random();
         random.setSeed(RANDOM_SEED);
@@ -124,7 +127,7 @@ public class GSChecksumWriteChannelTest {
      *
      * @throws IOException On storage failure.
      */
-    @Test
+    @TestTemplate
     public void shouldWriteProperly() throws IOException {
 
         MockBlobStorage blobStorage = new MockBlobStorage();
@@ -152,7 +155,7 @@ public class GSChecksumWriteChannelTest {
      *
      * @throws IOException On checksum failure.
      */
-    @Test(expected = IOException.class)
+    @TestTemplate
     public void shouldThrowOnChecksumMismatch() throws IOException {
 
         MockBlobStorage blobStorage = new MockBlobStorage();
@@ -170,6 +173,6 @@ public class GSChecksumWriteChannelTest {
         }
 
         // close the write, this also validates the checksum
-        checksumWriteChannel.close();
+        assertThatThrownBy(() -> checksumWriteChannel.close()).isInstanceOf(IOException.class);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
@@ -41,22 +41,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSChecksumWriteChannel}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSChecksumWriteChannelTest {
+class GSChecksumWriteChannelTest {
 
     /* The sizes of each buffer of bytes used for writing. */
     @Parameter(value = 0)
-    public int[] bufferSizes;
+    int[] bufferSizes;
 
     /* The start positions in write buffers. */
     @Parameter(value = 1)
-    public int[] writeStarts;
+    int[] writeStarts;
 
     /* The length of each write. */
     @Parameter(value = 2)
-    public int[] writeLengths;
+    int[] writeLengths;
 
     @Parameter(value = 3)
-    public String description;
+    String description;
 
     @Parameters(name = "{3}")
     public static Collection<Object[]> data() {

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
@@ -127,7 +127,7 @@ class GSChecksumWriteChannelTest {
      * @throws IOException On storage failure.
      */
     @TestTemplate
-    public void shouldWriteProperly() throws IOException {
+    void shouldWriteProperly() throws IOException {
 
         MockBlobStorage blobStorage = new MockBlobStorage();
         GSBlobStorage.WriteChannel writeChannel = blobStorage.writeBlob(blobIdentifier);

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
@@ -45,21 +45,21 @@ class GSChecksumWriteChannelTest {
 
     /* The sizes of each buffer of bytes used for writing. */
     @Parameter(value = 0)
-    int[] bufferSizes;
+    private int[] bufferSizes;
 
     /* The start positions in write buffers. */
     @Parameter(value = 1)
-    int[] writeStarts;
+    private int[] writeStarts;
 
     /* The length of each write. */
     @Parameter(value = 2)
-    int[] writeLengths;
+    private int[] writeLengths;
 
     @Parameter(value = 3)
-    String description;
+    private String description;
 
     @Parameters(name = "{3}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     {
@@ -94,7 +94,7 @@ class GSChecksumWriteChannelTest {
     private GSBlobIdentifier blobIdentifier;
 
     @BeforeEach
-    public void before() throws IOException {
+    void before() throws IOException {
         Random random = new Random();
         random.setSeed(RANDOM_SEED);
 
@@ -155,7 +155,7 @@ class GSChecksumWriteChannelTest {
      * @throws IOException On checksum failure.
      */
     @TestTemplate
-    public void shouldThrowOnChecksumMismatch() throws IOException {
+    void shouldThrowOnChecksumMismatch() throws IOException {
 
         MockBlobStorage blobStorage = new MockBlobStorage();
         blobStorage.forcedChecksum = "";

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSChecksumWriteChannelTest.java
@@ -36,9 +36,8 @@ import java.util.Collection;
 import java.util.Random;
 
 import static org.apache.flink.fs.gs.TestUtils.RANDOM_SEED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link GSChecksumWriteChannel}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -139,7 +138,7 @@ public class GSChecksumWriteChannelTest {
         for (int i = 0; i < byteBuffers.length; i++) {
             int writtenCount =
                     checksumWriteChannel.write(byteBuffers[i], writeStarts[i], writeLengths[i]);
-            assertEquals(writeLengths[i], writtenCount);
+            assertThat(writtenCount).isEqualTo(writeLengths[i]);
         }
 
         // close the write, this also validates the checksum
@@ -147,7 +146,7 @@ public class GSChecksumWriteChannelTest {
 
         // read the value out of storage, the bytes should match
         MockBlobStorage.BlobValue blobValue = blobStorage.blobs.get(blobIdentifier);
-        assertArrayEquals(expectedWrittenBytes, blobValue.content);
+        assertThat(blobValue.content).isEqualTo(expectedWrittenBytes);
     }
 
     /**
@@ -169,7 +168,7 @@ public class GSChecksumWriteChannelTest {
 
             int writtenCount =
                     checksumWriteChannel.write(byteBuffers[i], writeStarts[i], writeLengths[i]);
-            assertEquals(writeLengths[i], writtenCount);
+            assertThat(writtenCount).isEqualTo(writeLengths[i]);
         }
 
         // close the write, this also validates the checksum

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
@@ -38,16 +38,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSCommitRecoverableSerializerTest {
 
-    @Parameter public String bucketName;
+    @Parameter private String bucketName;
 
     @Parameter(value = 1)
-    public String objectName;
+    private String objectName;
 
     @Parameter(value = 2)
-    public int componentCount;
+    private int componentCount;
 
     @Parameters(name = "bucketName={0}, objectName={1}, componentCount={2}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // commit recoverable for foo/bar with 4 component object uuids
@@ -62,7 +62,7 @@ class GSCommitRecoverableSerializerTest {
     }
 
     @TestTemplate
-    public void shouldSerdeState() throws IOException {
+    void shouldSerdeState() throws IOException {
 
         // create the state
         GSBlobIdentifier finalBlobIdentifier = new GSBlobIdentifier(bucketName, objectName);
@@ -82,7 +82,7 @@ class GSCommitRecoverableSerializerTest {
         // check that states match
         assertThat(deserializedState.finalBlobIdentifier.bucketName).isEqualTo(bucketName);
         assertThat(deserializedState.finalBlobIdentifier.objectName).isEqualTo(objectName);
-        assertThat(deserializedState.componentObjectIds.size()).isEqualTo(componentCount);
+        assertThat(deserializedState.componentObjectIds).hasSize(componentCount);
         for (int i = 0; i < componentCount; i++) {
             assertThat(deserializedState.componentObjectIds.get(i))
                     .isEqualTo(state.componentObjectIds.get(i));

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
@@ -19,10 +19,12 @@
 package org.apache.flink.fs.gs.writer;
 
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,22 +32,21 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test recoverable writer serializer. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSCommitRecoverableSerializerTest {
 
-    @Parameterized.Parameter(value = 0)
-    public String bucketName;
+    @Parameter public String bucketName;
 
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public String objectName;
 
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public int componentCount;
 
-    @Parameterized.Parameters(name = "bucketName={0}, objectName={1}, componentCount={2}")
+    @Parameters(name = "bucketName={0}, objectName={1}, componentCount={2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -60,7 +61,7 @@ public class GSCommitRecoverableSerializerTest {
                 });
     }
 
-    @Test
+    @TestTemplate
     public void shouldSerdeState() throws IOException {
 
         // create the state

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test recoverable writer serializer. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -80,12 +80,12 @@ public class GSCommitRecoverableSerializerTest {
                 (GSCommitRecoverable) serializer.deserialize(serializer.getVersion(), serialized);
 
         // check that states match
-        assertEquals(bucketName, deserializedState.finalBlobIdentifier.bucketName);
-        assertEquals(objectName, deserializedState.finalBlobIdentifier.objectName);
-        assertEquals(componentCount, deserializedState.componentObjectIds.size());
+        assertThat(deserializedState.finalBlobIdentifier.bucketName).isEqualTo(bucketName);
+        assertThat(deserializedState.finalBlobIdentifier.objectName).isEqualTo(objectName);
+        assertThat(deserializedState.componentObjectIds.size()).isEqualTo(componentCount);
         for (int i = 0; i < componentCount; i++) {
-            assertEquals(
-                    state.componentObjectIds.get(i), deserializedState.componentObjectIds.get(i));
+            assertThat(deserializedState.componentObjectIds.get(i))
+                    .isEqualTo(state.componentObjectIds.get(i));
         }
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableSerializerTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test recoverable writer serializer. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSCommitRecoverableSerializerTest {
+class GSCommitRecoverableSerializerTest {
 
     @Parameter public String bucketName;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
@@ -42,13 +42,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSCommitRecoverableTest {
 
-    @Parameter public List<UUID> componentObjectIds;
+    @Parameter private List<UUID> componentObjectIds;
 
     @Parameter(value = 1)
-    public String temporaryBucketName;
+    private String temporaryBucketName;
 
     @Parameters(name = "componentObjectIds={0}, temporaryBucketName={1}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
 
         ArrayList<UUID> emptyComponentObjectIds = new ArrayList<>();
         ArrayList<UUID> populatedComponentObjectIds = new ArrayList<>();
@@ -73,12 +73,12 @@ class GSCommitRecoverableTest {
     private GSBlobIdentifier blobIdentifier;
 
     @BeforeEach
-    public void before() {
+    void before() {
         blobIdentifier = new GSBlobIdentifier("foo", "bar");
     }
 
     @TestTemplate
-    public void shouldConstructProperly() {
+    void shouldConstructProperly() {
         GSCommitRecoverable commitRecoverable =
                 new GSCommitRecoverable(blobIdentifier, componentObjectIds);
         assertThat(commitRecoverable.finalBlobIdentifier).isEqualTo(blobIdentifier);
@@ -87,7 +87,7 @@ class GSCommitRecoverableTest {
 
     /** Ensure that the list of component object ids cannot be added to. */
     @TestTemplate
-    public void shouldNotAddComponentId() {
+    void shouldNotAddComponentId() {
         GSCommitRecoverable commitRecoverable =
                 new GSCommitRecoverable(blobIdentifier, componentObjectIds);
         assertThatThrownBy(() -> commitRecoverable.componentObjectIds.add(UUID.randomUUID()))
@@ -96,7 +96,7 @@ class GSCommitRecoverableTest {
 
     /** Ensure that component object ids can't be updated. */
     @TestTemplate
-    public void shouldNotModifyComponentId() {
+    void shouldNotModifyComponentId() {
         GSCommitRecoverable commitRecoverable =
                 new GSCommitRecoverable(blobIdentifier, componentObjectIds);
 
@@ -105,7 +105,7 @@ class GSCommitRecoverableTest {
     }
 
     @TestTemplate
-    public void shouldGetComponentBlobIds() {
+    void shouldGetComponentBlobIds() {
 
         // configure options, if this test configuration has a temporary bucket name, set it
         Configuration flinkConfig = new Configuration();
@@ -142,7 +142,7 @@ class GSCommitRecoverableTest {
     }
 
     @TestTemplate
-    public void shouldGetComponentBlobIdsWithEntropy() {
+    void shouldGetComponentBlobIdsWithEntropy() {
 
         // configure options, if this test configuration has a temporary bucket name, set it
         Configuration flinkConfig = new Configuration();

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +35,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link GSResumeRecoverable}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -82,8 +81,8 @@ public class GSCommitRecoverableTest {
     public void shouldConstructProperly() {
         GSCommitRecoverable commitRecoverable =
                 new GSCommitRecoverable(blobIdentifier, componentObjectIds);
-        assertEquals(blobIdentifier, commitRecoverable.finalBlobIdentifier);
-        assertEquals(componentObjectIds, commitRecoverable.componentObjectIds);
+        assertThat(commitRecoverable.finalBlobIdentifier).isEqualTo(blobIdentifier);
+        assertThat(commitRecoverable.componentObjectIds).isEqualTo(componentObjectIds);
     }
 
     /** Ensure that the list of component object ids cannot be added to. */
@@ -125,9 +124,11 @@ public class GSCommitRecoverableTest {
 
             // if a temporary bucket is specified in options, the component blob identifier
             // should be in this bucket; otherwise, it should be in the bucket with the final blob
-            assertEquals(
-                    temporaryBucketName == null ? blobIdentifier.bucketName : temporaryBucketName,
-                    componentBlobIdentifier.bucketName);
+            assertThat(componentBlobIdentifier.bucketName)
+                    .isEqualTo(
+                            temporaryBucketName == null
+                                    ? blobIdentifier.bucketName
+                                    : temporaryBucketName);
 
             // make sure the name is what is expected
             String expectedObjectName =
@@ -136,7 +137,7 @@ public class GSCommitRecoverableTest {
                             blobIdentifier.bucketName,
                             blobIdentifier.objectName,
                             componentObjectId);
-            assertEquals(expectedObjectName, componentBlobIdentifier.objectName);
+            assertThat(componentBlobIdentifier.objectName).isEqualTo(expectedObjectName);
         }
     }
 
@@ -162,9 +163,11 @@ public class GSCommitRecoverableTest {
 
             // if a temporary bucket is specified in options, the component blob identifier
             // should be in this bucket; otherwise, it should be in the bucket with the final blob
-            Assertions.assertEquals(
-                    temporaryBucketName == null ? blobIdentifier.bucketName : temporaryBucketName,
-                    componentBlobIdentifier.bucketName);
+            assertThat(componentBlobIdentifier.bucketName)
+                    .isEqualTo(
+                            temporaryBucketName == null
+                                    ? blobIdentifier.bucketName
+                                    : temporaryBucketName);
 
             // make sure the name is what is expected
             String expectedObjectName =
@@ -174,7 +177,7 @@ public class GSCommitRecoverableTest {
                             blobIdentifier.bucketName,
                             blobIdentifier.objectName,
                             componentObjectId);
-            Assertions.assertEquals(expectedObjectName, componentBlobIdentifier.objectName);
+            assertThat(componentBlobIdentifier.objectName).isEqualTo(expectedObjectName);
         }
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSCommitRecoverableTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSResumeRecoverable}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSCommitRecoverableTest {
+class GSCommitRecoverableTest {
 
     @Parameter public List<UUID> componentObjectIds;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSResumeRecoverable}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSRecoverableFsDataOutputStreamTest {
+class GSRecoverableFsDataOutputStreamTest {
 
     @Parameter public boolean empty;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
@@ -23,12 +23,14 @@ import org.apache.flink.fs.gs.GSFileSystemOptions;
 import org.apache.flink.fs.gs.TestUtils;
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
 import org.apache.flink.fs.gs.storage.MockBlobStorage;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -39,33 +41,32 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test {@link GSResumeRecoverable}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSRecoverableFsDataOutputStreamTest {
 
-    @Parameterized.Parameter(value = 0)
-    public boolean empty;
+    @Parameter public boolean empty;
 
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     @Nullable
     public String temporaryBucketName;
 
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public int componentObjectCount;
 
-    @Parameterized.Parameter(value = 3)
+    @Parameter(value = 3)
     public long position;
 
-    @Parameterized.Parameter(value = 4)
+    @Parameter(value = 4)
     public boolean closed;
 
-    @Parameterized.Parameters(
+    @Parameters(
             name =
                     "empty={0}, temporaryBucketName={1}, componentObjectCount={2}, position={3}, closed={4}")
     public static Collection<Object[]> data() {
@@ -101,7 +102,7 @@ public class GSRecoverableFsDataOutputStreamTest {
 
     private byte byteValue;
 
-    @Before
+    @BeforeEach
     public void before() {
 
         random = new Random(TestUtils.RANDOM_SEED);
@@ -133,7 +134,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void emptyStreamShouldHaveProperPositionAndComponentObjectCount() {
         if (empty) {
             assertEquals(0, position);
@@ -141,7 +142,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldConstructStream() throws IOException {
         if (empty) {
             assertEquals(0, fsDataOutputStream.getPos());
@@ -151,7 +152,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldReturnPosition() throws IOException {
         assertEquals(position, fsDataOutputStream.getPos());
     }
@@ -180,7 +181,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         writeContent(() -> fsDataOutputStream.write(byteValue), new byte[] {byteValue});
     }
 
-    @Test
+    @TestTemplate
     public void shouldWriteByte() throws IOException {
         if (closed) {
             assertThrows(IOException.class, this::writeByte);
@@ -195,7 +196,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         writeContent(() -> fsDataOutputStream.write(bytes), bytes);
     }
 
-    @Test
+    @TestTemplate
     public void shouldWriteArray() throws IOException {
         if (closed) {
             assertThrows(IOException.class, this::writeArray);
@@ -214,7 +215,7 @@ public class GSRecoverableFsDataOutputStreamTest {
                 Arrays.copyOfRange(bytes, start, start + length));
     }
 
-    @Test
+    @TestTemplate
     public void shouldWriteArraySlice() throws IOException {
         if (closed) {
             assertThrows(IOException.class, this::writeArraySlice);
@@ -223,7 +224,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldFlush() throws IOException {
         if (!closed) {
             fsDataOutputStream.write(byteValue);
@@ -231,7 +232,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldSync() throws IOException {
         if (!closed) {
             fsDataOutputStream.write(byteValue);
@@ -239,7 +240,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldPersist() throws IOException {
         if (!closed) {
             GSResumeRecoverable recoverable = (GSResumeRecoverable) fsDataOutputStream.persist();
@@ -255,7 +256,7 @@ public class GSRecoverableFsDataOutputStreamTest {
         }
     }
 
-    @Test
+    @TestTemplate
     public void shouldFailOnPartialWrite() throws IOException {
         if (!closed) {
             blobStorage.maxWriteCount = 1;

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
@@ -134,8 +134,8 @@ class GSRecoverableFsDataOutputStreamTest {
     @TestTemplate
     public void emptyStreamShouldHaveProperPositionAndComponentObjectCount() {
         if (empty) {
-            assertThat(position).isEqualTo(0);
-            assertThat(componentObjectCount).isEqualTo(0);
+            assertThat(position).isZero();
+            assertThat(componentObjectCount).isOne();
         }
     }
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
@@ -48,25 +48,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSRecoverableFsDataOutputStreamTest {
 
-    @Parameter public boolean empty;
+    @Parameter private boolean empty;
 
     @Parameter(value = 1)
     @Nullable
-    public String temporaryBucketName;
+    private String temporaryBucketName;
 
     @Parameter(value = 2)
-    public int componentObjectCount;
+    private int componentObjectCount;
 
     @Parameter(value = 3)
-    public long position;
+    private long position;
 
     @Parameter(value = 4)
-    public boolean closed;
+    private boolean closed;
 
     @Parameters(
             name =
                     "empty={0}, temporaryBucketName={1}, componentObjectCount={2}, position={3}, closed={4}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // not empty, no explicit temporary bucket, 0 components, position=0, not closed
@@ -100,7 +100,7 @@ class GSRecoverableFsDataOutputStreamTest {
     private byte byteValue;
 
     @BeforeEach
-    public void before() {
+    void before() {
 
         random = new Random(TestUtils.RANDOM_SEED);
         blobIdentifier = new GSBlobIdentifier("foo", "bar");
@@ -132,7 +132,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void emptyStreamShouldHaveProperPositionAndComponentObjectCount() {
+    void emptyStreamShouldHaveProperPositionAndComponentObjectCount() {
         if (empty) {
             assertThat(position).isZero();
             assertThat(componentObjectCount).isZero();
@@ -140,7 +140,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldConstructStream() throws IOException {
+    void shouldConstructStream() throws IOException {
         if (empty) {
             assertThat(fsDataOutputStream.getPos()).isEqualTo(0);
 
@@ -150,7 +150,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldReturnPosition() throws IOException {
+    void shouldReturnPosition() throws IOException {
         assertThat(fsDataOutputStream.getPos()).isEqualTo(position);
     }
 
@@ -164,9 +164,9 @@ class GSRecoverableFsDataOutputStreamTest {
 
         // close and persist. there should be exactly zero blobs before and one after, with this
         // byte value in it
-        assertThat(blobStorage.blobs.size()).isEqualTo(0);
+        assertThat(blobStorage.blobs).isEmpty();
         fsDataOutputStream.closeForCommit();
-        assertThat(blobStorage.blobs.size()).isEqualTo(1);
+        assertThat(blobStorage.blobs).hasSize(1);
         GSBlobIdentifier blobIdentifier =
                 blobStorage.blobs.keySet().toArray(new GSBlobIdentifier[0])[0];
         MockBlobStorage.BlobValue blobValue = blobStorage.blobs.get(blobIdentifier);
@@ -179,7 +179,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldWriteByte() throws IOException {
+    void shouldWriteByte() throws IOException {
         if (closed) {
             assertThatThrownBy(this::writeByte).isInstanceOf(IOException.class);
         } else {
@@ -194,7 +194,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldWriteArray() throws IOException {
+    void shouldWriteArray() throws IOException {
         if (closed) {
             assertThatThrownBy(this::writeArray).isInstanceOf(IOException.class);
         } else {
@@ -213,7 +213,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldWriteArraySlice() throws IOException {
+    void shouldWriteArraySlice() throws IOException {
         if (closed) {
             assertThatThrownBy(this::writeArraySlice).isInstanceOf(IOException.class);
         } else {
@@ -222,7 +222,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldFlush() throws IOException {
+    void shouldFlush() throws IOException {
         if (!closed) {
             fsDataOutputStream.write(byteValue);
             fsDataOutputStream.flush();
@@ -230,7 +230,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldSync() throws IOException {
+    void shouldSync() throws IOException {
         if (!closed) {
             fsDataOutputStream.write(byteValue);
             fsDataOutputStream.sync();
@@ -238,12 +238,12 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldPersist() throws IOException {
+    void shouldPersist() throws IOException {
         if (!closed) {
             GSResumeRecoverable recoverable = (GSResumeRecoverable) fsDataOutputStream.persist();
             assertThat(recoverable.finalBlobIdentifier).isEqualTo(blobIdentifier);
             if (empty) {
-                assertThat(recoverable.componentObjectIds.size()).isEqualTo(0);
+                assertThat(recoverable.componentObjectIds).isEmpty();
             } else {
                 assertThat(recoverable.componentObjectIds.toArray())
                         .isEqualTo(componentObjectIds.toArray());
@@ -254,7 +254,7 @@ class GSRecoverableFsDataOutputStreamTest {
     }
 
     @TestTemplate
-    public void shouldFailOnPartialWrite() {
+    void shouldFailOnPartialWrite() {
         if (!closed) {
             blobStorage.maxWriteCount = 1;
             byte[] bytes = new byte[2];

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableFsDataOutputStreamTest.java
@@ -135,7 +135,7 @@ class GSRecoverableFsDataOutputStreamTest {
     public void emptyStreamShouldHaveProperPositionAndComponentObjectCount() {
         if (empty) {
             assertThat(position).isZero();
-            assertThat(componentObjectCount).isOne();
+            assertThat(componentObjectCount).isZero();
         }
     }
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
@@ -122,7 +122,7 @@ class GSRecoverableWriterCommitterTest {
     }
 
     @AfterEach
-    public void after() throws IOException {
+    void after() throws IOException {
         expectedBytes.close();
     }
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
@@ -50,21 +50,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSRecoverableWriterCommitterTest {
 
-    @Parameter @Nullable public String temporaryBucketName;
+    @Parameter @Nullable private String temporaryBucketName;
 
     @Parameter(value = 1)
-    public int composeMaxBlobs;
+    private int composeMaxBlobs;
 
     @Parameter(value = 2)
-    public int[] blobSizes;
+    private int[] blobSizes;
 
     @Parameter(value = 3)
-    public int commitBlobCount;
+    private int commitBlobCount;
 
     @Parameters(
             name =
                     "temporaryBucketName={0}, composeMaxBlobs={1}, blobSizes={2}, commitBlobCount={3}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // no specified temporary bucket, compose up to 4 blobs at once, compose no
@@ -105,7 +105,7 @@ class GSRecoverableWriterCommitterTest {
     private GSBlobIdentifier blobIdentifier;
 
     @BeforeEach
-    public void before() {
+    void before() {
         Configuration flinkConfig = new Configuration();
         if (temporaryBucketName != null) {
             flinkConfig.set(GSFileSystemOptions.WRITER_TEMPORARY_BUCKET_NAME, temporaryBucketName);
@@ -132,12 +132,12 @@ class GSRecoverableWriterCommitterTest {
      * @throws IOException On underlying failure
      */
     @TestTemplate
-    public void commitTest() throws IOException {
+    void commitTest() throws IOException {
         GSRecoverableWriterCommitter committer = commitTestInternal();
         committer.commit();
 
         // there should be exactly one blob left, the final blob identifier. validate its contents.
-        assertThat(blobStorage.blobs.size()).isOne();
+        assertThat(blobStorage.blobs).hasSize(1);
         MockBlobStorage.BlobValue blobValue = blobStorage.blobs.get(blobIdentifier);
         assertThat(blobValue).isNotNull();
         assertThat(blobValue.content).isEqualTo(expectedBytes.toByteArray());
@@ -149,7 +149,7 @@ class GSRecoverableWriterCommitterTest {
      * @throws IOException On underlying failure
      */
     @TestTemplate
-    public void commitOverwriteShouldFailTest() throws IOException {
+    void commitOverwriteShouldFailTest() throws IOException {
         blobStorage.createBlob(blobIdentifier);
         GSRecoverableWriterCommitter committer = commitTestInternal();
 
@@ -163,7 +163,7 @@ class GSRecoverableWriterCommitterTest {
      * @throws IOException On underlying failure
      */
     @TestTemplate
-    public void commitWithRecoveryOverwriteShouldSucceedTest() throws IOException {
+    void commitWithRecoveryOverwriteShouldSucceedTest() throws IOException {
         blobStorage.createBlob(blobIdentifier);
         GSRecoverableWriterCommitter committer = commitTestInternal();
         committer.commitAfterRecovery();

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSRecoverableWriterCommitter}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSRecoverableWriterCommitterTest {
+class GSRecoverableWriterCommitterTest {
 
     @Parameter @Nullable public String temporaryBucketName;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
@@ -137,7 +137,7 @@ class GSRecoverableWriterCommitterTest {
         committer.commit();
 
         // there should be exactly one blob left, the final blob identifier. validate its contents.
-        assertThat(blobStorage.blobs.size()).isEqualTo(1);
+        assertThat(blobStorage.blobs.size()).isOne();
         MockBlobStorage.BlobValue blobValue = blobStorage.blobs.get(blobIdentifier);
         assertThat(blobValue).isNotNull();
         assertThat(blobValue.content).isEqualTo(expectedBytes.toByteArray());

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterCommitterTest.java
@@ -43,10 +43,8 @@ import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Test {@link GSRecoverableWriterCommitter}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -139,10 +137,10 @@ public class GSRecoverableWriterCommitterTest {
         committer.commit();
 
         // there should be exactly one blob left, the final blob identifier. validate its contents.
-        assertEquals(1, blobStorage.blobs.size());
+        assertThat(blobStorage.blobs.size()).isEqualTo(1);
         MockBlobStorage.BlobValue blobValue = blobStorage.blobs.get(blobIdentifier);
-        assertNotNull(blobValue);
-        assertArrayEquals(expectedBytes.toByteArray(), blobValue.content);
+        assertThat(blobValue).isNotNull();
+        assertThat(blobValue.content).isEqualTo(expectedBytes.toByteArray());
     }
 
     /**

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
@@ -38,11 +38,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test {@link GSRecoverableWriter}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -104,12 +101,12 @@ public class GSRecoverableWriterTest {
 
     @TestTemplate
     public void testRequiresCleanupOfRecoverableState() {
-        assertFalse(writer.requiresCleanupOfRecoverableState());
+        assertThat(writer.requiresCleanupOfRecoverableState()).isFalse();
     }
 
     @TestTemplate
     public void testSupportsResume() {
-        assertTrue(writer.supportsResume());
+        assertThat(writer.supportsResume()).isTrue();
     }
 
     @TestTemplate
@@ -117,7 +114,7 @@ public class GSRecoverableWriterTest {
         Path path = new Path("gs://foo/bar");
         GSRecoverableFsDataOutputStream stream =
                 (GSRecoverableFsDataOutputStream) writer.open(path);
-        assertNotNull(stream);
+        assertThat(stream).isNotNull();
     }
 
     @TestTemplate
@@ -143,33 +140,33 @@ public class GSRecoverableWriterTest {
 
     @TestTemplate
     public void testCleanupRecoverableState() {
-        assertTrue(writer.cleanupRecoverableState(resumeRecoverable));
+        assertThat(writer.cleanupRecoverableState(resumeRecoverable)).isTrue();
     }
 
     @TestTemplate
     public void testRecover() throws IOException {
         GSRecoverableFsDataOutputStream stream =
                 (GSRecoverableFsDataOutputStream) writer.recover(resumeRecoverable);
-        assertEquals(position, stream.getPos());
+        assertThat(stream.getPos()).isEqualTo(position);
     }
 
     @TestTemplate
     public void testRecoverForCommit() {
         GSRecoverableWriterCommitter committer =
                 (GSRecoverableWriterCommitter) writer.recoverForCommit(commitRecoverable);
-        assertEquals(options, committer.options);
-        assertEquals(commitRecoverable, committer.recoverable);
+        assertThat(committer.options).isEqualTo(options);
+        assertThat(committer.recoverable).isEqualTo(commitRecoverable);
     }
 
     @TestTemplate
     public void testGetCommitRecoverableSerializer() {
         Object serializer = writer.getCommitRecoverableSerializer();
-        assertEquals(GSCommitRecoverableSerializer.class, serializer.getClass());
+        assertThat(serializer.getClass()).isEqualTo(GSCommitRecoverableSerializer.class);
     }
 
     @TestTemplate
     public void testGetResumeRecoverableSerializer() {
         Object serializer = writer.getResumeRecoverableSerializer();
-        assertEquals(GSResumeRecoverableSerializer.class, serializer.getClass());
+        assertThat(serializer.getClass()).isEqualTo(GSResumeRecoverableSerializer.class);
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
@@ -45,16 +45,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSRecoverableWriterTest {
 
-    @Parameter public long position = 16;
+    @Parameter private long position = 16;
 
     @Parameter(value = 1)
-    public boolean closed = false;
+    private boolean closed = false;
 
     @Parameter(value = 2)
-    public int componentCount;
+    private int componentCount;
 
     @Parameters(name = "position={0}, closed={1}, componentCount={2}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // position 0, not closed, component count = 0
@@ -81,7 +81,7 @@ class GSRecoverableWriterTest {
     private GSBlobIdentifier blobIdentifier;
 
     @BeforeEach
-    public void before() {
+    void before() {
         MockBlobStorage storage = new MockBlobStorage();
         blobIdentifier = new GSBlobIdentifier("foo", "bar");
 
@@ -100,17 +100,17 @@ class GSRecoverableWriterTest {
     }
 
     @TestTemplate
-    public void testRequiresCleanupOfRecoverableState() {
+    void testRequiresCleanupOfRecoverableState() {
         assertThat(writer.requiresCleanupOfRecoverableState()).isFalse();
     }
 
     @TestTemplate
-    public void testSupportsResume() {
+    void testSupportsResume() {
         assertThat(writer.supportsResume()).isTrue();
     }
 
     @TestTemplate
-    public void testOpen() throws IOException {
+    void testOpen() throws IOException {
         Path path = new Path("gs://foo/bar");
         GSRecoverableFsDataOutputStream stream =
                 (GSRecoverableFsDataOutputStream) writer.open(path);
@@ -118,40 +118,40 @@ class GSRecoverableWriterTest {
     }
 
     @TestTemplate
-    public void testOpenWithEmptyBucketName() throws IOException {
+    void testOpenWithEmptyBucketName() throws IOException {
         Path path = new Path("gs:///bar");
 
         assertThatThrownBy(() -> writer.open(path)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @TestTemplate
-    public void testOpenWithEmptyObjectName() throws IOException {
+    void testOpenWithEmptyObjectName() throws IOException {
         Path path = new Path("gs://foo/");
 
         assertThatThrownBy(() -> writer.open(path)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @TestTemplate
-    public void testOpenWithMissingObjectName() throws IOException {
+    void testOpenWithMissingObjectName() throws IOException {
         Path path = new Path("gs://foo");
 
         assertThatThrownBy(() -> writer.open(path)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @TestTemplate
-    public void testCleanupRecoverableState() {
+    void testCleanupRecoverableState() {
         assertThat(writer.cleanupRecoverableState(resumeRecoverable)).isTrue();
     }
 
     @TestTemplate
-    public void testRecover() throws IOException {
+    void testRecover() throws IOException {
         GSRecoverableFsDataOutputStream stream =
                 (GSRecoverableFsDataOutputStream) writer.recover(resumeRecoverable);
         assertThat(stream.getPos()).isEqualTo(position);
     }
 
     @TestTemplate
-    public void testRecoverForCommit() {
+    void testRecoverForCommit() {
         GSRecoverableWriterCommitter committer =
                 (GSRecoverableWriterCommitter) writer.recoverForCommit(commitRecoverable);
         assertThat(committer.options).isEqualTo(options);
@@ -159,13 +159,13 @@ class GSRecoverableWriterTest {
     }
 
     @TestTemplate
-    public void testGetCommitRecoverableSerializer() {
+    void testGetCommitRecoverableSerializer() {
         Object serializer = writer.getCommitRecoverableSerializer();
         assertThat(serializer.getClass()).isEqualTo(GSCommitRecoverableSerializer.class);
     }
 
     @TestTemplate
-    public void testGetResumeRecoverableSerializer() {
+    void testGetResumeRecoverableSerializer() {
         Object serializer = writer.getResumeRecoverableSerializer();
         assertThat(serializer.getClass()).isEqualTo(GSResumeRecoverableSerializer.class);
     }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSRecoverableWriterTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSRecoverableWriter}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSRecoverableWriterTest {
+class GSRecoverableWriterTest {
 
     @Parameter public long position = 16;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test recoverable writer serializer. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -90,14 +90,14 @@ public class GSResumeRecoverableSerializerTest {
                 (GSResumeRecoverable) serializer.deserialize(serializer.getVersion(), serialized);
 
         // check that states match
-        assertEquals(bucketName, deserializedState.finalBlobIdentifier.bucketName);
-        assertEquals(objectName, deserializedState.finalBlobIdentifier.objectName);
-        assertEquals(position, deserializedState.position);
-        assertEquals(closed, deserializedState.closed);
-        assertEquals(componentCount, deserializedState.componentObjectIds.size());
+        assertThat(deserializedState.finalBlobIdentifier.bucketName).isEqualTo(bucketName);
+        assertThat(deserializedState.finalBlobIdentifier.objectName).isEqualTo(objectName);
+        assertThat(deserializedState.position).isEqualTo(position);
+        assertThat(deserializedState.closed).isEqualTo(closed);
+        assertThat(deserializedState.componentObjectIds.size()).isEqualTo(componentCount);
         for (int i = 0; i < componentCount; i++) {
-            assertEquals(
-                    state.componentObjectIds.get(i), deserializedState.componentObjectIds.get(i));
+            assertThat(deserializedState.componentObjectIds.get(i))
+                    .isEqualTo(state.componentObjectIds.get(i));
         }
     }
 }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
@@ -38,23 +38,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSResumeRecoverableSerializerTest {
 
-    @Parameter public String bucketName;
+    @Parameter private String bucketName;
 
     @Parameter(value = 1)
-    public String objectName;
+    private String objectName;
 
     @Parameter(value = 2)
-    public long position;
+    private long position;
 
     @Parameter(value = 3)
-    public boolean closed;
+    private boolean closed;
 
     @Parameter(value = 4)
-    public int componentCount;
+    private int componentCount;
 
     @Parameters(
             name = "bucketName={0}, objectName={1}, position={2}, closed={3}, componentCount={4}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
                     // resume recoverable for foo/bar at position 0, closed, with 4 component ids
@@ -72,7 +72,7 @@ class GSResumeRecoverableSerializerTest {
     }
 
     @TestTemplate
-    public void shouldSerdeState() throws IOException {
+    void shouldSerdeState() throws IOException {
 
         // create the state
         GSBlobIdentifier finalBlobIdentifier = new GSBlobIdentifier(bucketName, objectName);
@@ -94,7 +94,7 @@ class GSResumeRecoverableSerializerTest {
         assertThat(deserializedState.finalBlobIdentifier.objectName).isEqualTo(objectName);
         assertThat(deserializedState.position).isEqualTo(position);
         assertThat(deserializedState.closed).isEqualTo(closed);
-        assertThat(deserializedState.componentObjectIds.size()).isEqualTo(componentCount);
+        assertThat(deserializedState.componentObjectIds).hasSize(componentCount);
         for (int i = 0; i < componentCount; i++) {
             assertThat(deserializedState.componentObjectIds.get(i))
                     .isEqualTo(state.componentObjectIds.get(i));

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
@@ -19,10 +19,12 @@
 package org.apache.flink.fs.gs.writer;
 
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,28 +32,27 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test recoverable writer serializer. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSResumeRecoverableSerializerTest {
 
-    @Parameterized.Parameter(value = 0)
-    public String bucketName;
+    @Parameter public String bucketName;
 
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public String objectName;
 
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public long position;
 
-    @Parameterized.Parameter(value = 3)
+    @Parameter(value = 3)
     public boolean closed;
 
-    @Parameterized.Parameter(value = 4)
+    @Parameter(value = 4)
     public int componentCount;
 
-    @Parameterized.Parameters(
+    @Parameters(
             name = "bucketName={0}, objectName={1}, position={2}, closed={3}, componentCount={4}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
@@ -70,7 +71,7 @@ public class GSResumeRecoverableSerializerTest {
                 });
     }
 
-    @Test
+    @TestTemplate
     public void shouldSerdeState() throws IOException {
 
         // create the state

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableSerializerTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test recoverable writer serializer. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSResumeRecoverableSerializerTest {
+class GSResumeRecoverableSerializerTest {
 
     @Parameter public String bucketName;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
@@ -33,8 +33,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link GSResumeRecoverable}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -93,10 +93,10 @@ public class GSResumeRecoverableTest {
     public void shouldConstructProperly() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
-        assertEquals(blobIdentifier, resumeRecoverable.finalBlobIdentifier);
-        assertEquals(position, resumeRecoverable.position);
-        assertEquals(closed, resumeRecoverable.closed);
-        assertEquals(componentObjectIds, resumeRecoverable.componentObjectIds);
+        assertThat(resumeRecoverable.finalBlobIdentifier).isEqualTo(blobIdentifier);
+        assertThat(resumeRecoverable.position).isEqualTo(position);
+        assertThat(resumeRecoverable.closed).isEqualTo(closed);
+        assertThat(resumeRecoverable.componentObjectIds).isEqualTo(componentObjectIds);
     }
 
     /** Ensure that the list of component object ids cannot be added to. */

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link GSResumeRecoverable}. */
 @ExtendWith(ParameterizedTestExtension.class)
-public class GSResumeRecoverableTest {
+class GSResumeRecoverableTest {
 
     @Parameter public int position;
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
@@ -40,19 +40,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(ParameterizedTestExtension.class)
 class GSResumeRecoverableTest {
 
-    @Parameter public int position;
+    @Parameter private int position;
 
     @Parameter(value = 1)
-    public boolean closed;
+    private boolean closed;
 
     @Parameter(value = 2)
-    public List<UUID> componentObjectIds;
+    private List<UUID> componentObjectIds;
 
     @Parameter(value = 3)
-    public String temporaryBucketName;
+    private String temporaryBucketName;
 
     @Parameters(name = "position={0}, closed={1}, componentObjectIds={2}, temporaryBucketName={3}")
-    public static Collection<Object[]> data() {
+    private static Collection<Object[]> data() {
 
         ArrayList<UUID> emptyComponentObjectIds = new ArrayList<>();
         ArrayList<UUID> populatedComponentObjectIds = new ArrayList<>();
@@ -85,12 +85,12 @@ class GSResumeRecoverableTest {
     private GSBlobIdentifier blobIdentifier;
 
     @BeforeEach
-    public void before() {
+    void before() {
         blobIdentifier = new GSBlobIdentifier("foo", "bar");
     }
 
     @TestTemplate
-    public void shouldConstructProperly() {
+    void shouldConstructProperly() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
         assertThat(resumeRecoverable.finalBlobIdentifier).isEqualTo(blobIdentifier);
@@ -101,7 +101,7 @@ class GSResumeRecoverableTest {
 
     /** Ensure that the list of component object ids cannot be added to. */
     @TestTemplate
-    public void shouldNotAddComponentId() {
+    void shouldNotAddComponentId() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
 
@@ -111,7 +111,7 @@ class GSResumeRecoverableTest {
 
     /** Ensure that component object ids can't be updated. */
     @TestTemplate
-    public void shouldNotModifyComponentId() {
+    void shouldNotModifyComponentId() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
 

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gs/writer/GSResumeRecoverableTest.java
@@ -19,11 +19,13 @@
 package org.apache.flink.fs.gs.writer;
 
 import org.apache.flink.fs.gs.storage.GSBlobIdentifier;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,26 +33,25 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test {@link GSResumeRecoverable}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class GSResumeRecoverableTest {
 
-    @Parameterized.Parameter(value = 0)
-    public int position;
+    @Parameter public int position;
 
-    @Parameterized.Parameter(value = 1)
+    @Parameter(value = 1)
     public boolean closed;
 
-    @Parameterized.Parameter(value = 2)
+    @Parameter(value = 2)
     public List<UUID> componentObjectIds;
 
-    @Parameterized.Parameter(value = 3)
+    @Parameter(value = 3)
     public String temporaryBucketName;
 
-    @Parameterized.Parameters(
-            name = "position={0}, closed={1}, componentObjectIds={2}, temporaryBucketName={3}")
+    @Parameters(name = "position={0}, closed={1}, componentObjectIds={2}, temporaryBucketName={3}")
     public static Collection<Object[]> data() {
 
         ArrayList<UUID> emptyComponentObjectIds = new ArrayList<>();
@@ -83,12 +84,12 @@ public class GSResumeRecoverableTest {
 
     private GSBlobIdentifier blobIdentifier;
 
-    @Before
+    @BeforeEach
     public void before() {
         blobIdentifier = new GSBlobIdentifier("foo", "bar");
     }
 
-    @Test
+    @TestTemplate
     public void shouldConstructProperly() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
@@ -99,18 +100,22 @@ public class GSResumeRecoverableTest {
     }
 
     /** Ensure that the list of component object ids cannot be added to. */
-    @Test(expected = UnsupportedOperationException.class)
+    @TestTemplate
     public void shouldNotAddComponentId() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
-        resumeRecoverable.componentObjectIds.add(UUID.randomUUID());
+
+        assertThatThrownBy(() -> resumeRecoverable.componentObjectIds.add(UUID.randomUUID()))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     /** Ensure that component object ids can't be updated. */
-    @Test(expected = UnsupportedOperationException.class)
+    @TestTemplate
     public void shouldNotModifyComponentId() {
         GSResumeRecoverable resumeRecoverable =
                 new GSResumeRecoverable(blobIdentifier, componentObjectIds, position, closed);
-        resumeRecoverable.componentObjectIds.set(0, UUID.randomUUID());
+
+        assertThatThrownBy(() -> resumeRecoverable.componentObjectIds.set(0, UUID.randomUUID()))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -35,11 +34,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.core.fs.FileSystemTestUtils.checkPathEventualExistence;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Abstract integration test class for implementations of hadoop file system. */
 public abstract class AbstractHadoopFileSystemITTest {
@@ -53,7 +49,7 @@ public abstract class AbstractHadoopFileSystemITTest {
             throws IOException, InterruptedException {
         if (consistencyToleranceNS == 0) {
             // strongly consistency
-            assertEquals(expectedExists, fs.exists(path));
+            assertThat(fs.exists(path)).isEqualTo(expectedExists);
         } else {
             // eventually consistency
             checkPathEventualExistence(fs, path, expectedExists, consistencyToleranceNS);
@@ -84,7 +80,7 @@ public abstract class AbstractHadoopFileSystemITTest {
                     InputStreamReader ir = new InputStreamReader(in, StandardCharsets.UTF_8);
                     BufferedReader reader = new BufferedReader(ir)) {
                 String line = reader.readLine();
-                assertEquals(testLine, line);
+                assertThat(line).isEqualTo(testLine);
             }
         } finally {
             fs.delete(path, false);
@@ -98,16 +94,16 @@ public abstract class AbstractHadoopFileSystemITTest {
         final Path directory = new Path(basePath, "testdir/");
 
         // directory must not yet exist
-        assertFalse(fs.exists(directory));
+        assertThat(fs.exists(directory)).isFalse();
 
         try {
             // create directory
-            assertTrue(fs.mkdirs(directory));
+            assertThat(fs.mkdirs(directory)).isTrue();
 
             checkEmptyDirectory(directory);
 
             // directory empty
-            assertEquals(0, fs.listStatus(directory).length);
+            assertThat(fs.listStatus(directory).length).isEqualTo(0);
 
             // create some files
             final int numFiles = 3;
@@ -124,15 +120,15 @@ public abstract class AbstractHadoopFileSystemITTest {
             }
 
             FileStatus[] files = fs.listStatus(directory);
-            assertNotNull(files);
-            assertEquals(3, files.length);
+            assertThat(files).isNotNull();
+            assertThat(files.length).isEqualTo(3);
 
             for (FileStatus status : files) {
-                assertFalse(status.isDir());
+                assertThat(status.isDir()).isFalse();
             }
 
             // now that there are files, the directory must exist
-            assertTrue(fs.exists(directory));
+            assertThat(fs.exists(directory)).isTrue();
         } finally {
             // clean up
             cleanupDirectoryWithRetry(fs, directory, consistencyToleranceNS);
@@ -159,6 +155,6 @@ public abstract class AbstractHadoopFileSystemITTest {
             fs.delete(path, true);
             Thread.sleep(50L);
         }
-        Assertions.assertFalse(fs.exists(path));
+        assertThat(fs.exists(path)).isFalse();
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
@@ -24,11 +24,10 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,13 +42,13 @@ import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.core.fs.FileSystemTestUtils.checkPathEventualExistence;
 
 /** Abstract integration test class for implementations of hadoop file system. */
-public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
+public abstract class AbstractHadoopFileSystemITTest {
 
     protected static FileSystem fs;
     protected static Path basePath;
     protected static long consistencyToleranceNS;
 
-    public static void checkPathExistence(
+    private static void checkPathExistence(
             Path path, boolean expectedExists, long consistencyToleranceNS)
             throws IOException, InterruptedException {
         if (consistencyToleranceNS == 0) {
@@ -66,7 +65,7 @@ public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
     }
 
     @Test
-    public void testSimpleFileWriteAndRead() throws Exception {
+    void testSimpleFileWriteAndRead() throws Exception {
         final String testLine = "Hello Upload!";
 
         final Path path = new Path(basePath, "test.txt");
@@ -95,7 +94,7 @@ public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
     }
 
     @Test
-    public void testDirectoryListing() throws Exception {
+    void testDirectoryListing() throws Exception {
         final Path directory = new Path(basePath, "testdir/");
 
         // directory must not yet exist
@@ -140,8 +139,8 @@ public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
         }
     }
 
-    @AfterClass
-    public static void teardown() throws IOException, InterruptedException {
+    @AfterAll
+    static void teardown() throws IOException, InterruptedException {
         try {
             if (fs != null) {
                 cleanupDirectoryWithRetry(fs, basePath, consistencyToleranceNS);
@@ -151,7 +150,7 @@ public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
         }
     }
 
-    public static void cleanupDirectoryWithRetry(
+    private static void cleanupDirectoryWithRetry(
             FileSystem fs, Path path, long consistencyToleranceNS)
             throws IOException, InterruptedException {
         fs.delete(path, true);
@@ -160,6 +159,6 @@ public abstract class AbstractHadoopFileSystemITTest extends TestLogger {
             fs.delete(path, true);
             Thread.sleep(50L);
         }
-        Assert.assertFalse(fs.exists(path));
+        Assertions.assertFalse(fs.exists(path));
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopFileSystemITTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractHadoopFileSystemITTest {
             checkEmptyDirectory(directory);
 
             // directory empty
-            assertThat(fs.listStatus(directory).length).isEqualTo(0);
+            assertThat(fs.listStatus(directory).length).isZero();
 
             // create some files
             final int numFiles = 3;

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterExceptionITCase.java
@@ -24,26 +24,27 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Random;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /**
  * Abstract integration test class for implementations of hadoop recoverable writer when exception
  * thrown.
  */
-public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends TestLogger {
+public abstract class AbstractHadoopRecoverableWriterExceptionITCase {
 
     // ----------------------- Test Specific configuration -----------------------
 
@@ -53,7 +54,7 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
 
     protected static FileSystem fileSystem;
 
-    // this is set for every test @Before
+    // this is set for every test @BeforeEach
     protected Path basePathForTest;
 
     // ----------------------- Test Data to be used -----------------------
@@ -64,10 +65,10 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
 
     protected static boolean skipped = true;
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+    @TempDir protected static File tempFolder;
 
-    @AfterClass
-    public static void cleanUp() throws Exception {
+    @AfterAll
+    static void cleanUp() throws Exception {
         if (!skipped) {
             getFileSystem().delete(basePath, true);
         }
@@ -76,8 +77,8 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
 
     protected abstract String getLocalTmpDir() throws Exception;
 
-    @Before
-    public void prepare() throws Exception {
+    @BeforeEach
+    void prepare() throws Exception {
         basePathForTest = new Path(basePath, StringUtils.getRandomString(RND, 16, 16, 'a', 'z'));
 
         final String defaultTmpDir = getLocalTmpDir();
@@ -88,8 +89,8 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
         }
     }
 
-    @After
-    public void cleanup() throws Exception {
+    @AfterEach
+    void cleanup() throws Exception {
         getFileSystem().delete(basePathForTest, true);
     }
 
@@ -100,8 +101,8 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
         return fileSystem;
     }
 
-    @Test(expected = IOException.class)
-    public void testExceptionWritingAfterCloseForCommit() throws Exception {
+    @Test
+    void testExceptionWritingAfterCloseForCommit() throws Exception {
         final Path path = new Path(basePathForTest, "part-0");
 
         final RecoverableFsDataOutputStream stream =
@@ -109,7 +110,9 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
         stream.write(testData1.getBytes(StandardCharsets.UTF_8));
 
         stream.closeForCommit().getRecoverable();
-        stream.write(testData2.getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> stream.write(testData2.getBytes(StandardCharsets.UTF_8)))
+                .isInstanceOf(IOException.class);
     }
 
     // IMPORTANT FOR THE FOLLOWING TWO TESTS:
@@ -120,8 +123,8 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
     // when we try to "publish" the multipart upload and we realize that the MPU is no longer
     // active.
 
-    @Test(expected = IOException.class)
-    public void testResumeAfterCommit() throws Exception {
+    @Test
+    void testResumeAfterCommit() throws Exception {
         final RecoverableWriter writer = getFileSystem().createRecoverableWriter();
         final Path path = new Path(basePathForTest, "part-0");
 
@@ -134,11 +137,13 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
         stream.closeForCommit().commit();
 
         final RecoverableFsDataOutputStream recoveredStream = writer.recover(recoverable);
-        recoveredStream.closeForCommit().commit();
+
+        assertThatThrownBy(() -> recoveredStream.closeForCommit().commit())
+                .isInstanceOf(IOException.class);
     }
 
-    @Test(expected = IOException.class)
-    public void testResumeWithWrongOffset() throws Exception {
+    @Test
+    void testResumeWithWrongOffset() throws Exception {
         // this is a rather unrealistic scenario, but it is to trigger
         // truncation of the file and try to resume with missing data.
 
@@ -159,6 +164,8 @@ public abstract class AbstractHadoopRecoverableWriterExceptionITCase extends Tes
 
         // this should throw an exception
         final RecoverableFsDataOutputStream newRecoveredStream = writer.recover(recoverable2);
-        newRecoveredStream.closeForCommit().commit();
+
+        assertThatThrownBy(() -> newRecoveredStream.closeForCommit().commit())
+                .isInstanceOf(IOException.class);
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
@@ -126,7 +126,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         // delete local tmp dir.
         assertThat(Files.exists(localTmpDir)).isTrue();
         try (Stream<java.nio.file.Path> files = Files.list(localTmpDir)) {
-            assertThat(files.count()).isEqualTo(0L);
+            assertThat(files).isEmpty();
         }
         Files.delete(localTmpDir);
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.util.StringUtils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,6 +47,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Abstract integration test class for implementations of hadoop recoverable writer. */
@@ -124,9 +124,9 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         final java.nio.file.Path localTmpDir = Paths.get(defaultTmpDir);
 
         // delete local tmp dir.
-        Assertions.assertTrue(Files.exists(localTmpDir));
+        assertThat(Files.exists(localTmpDir)).isTrue();
         try (Stream<java.nio.file.Path> files = Files.list(localTmpDir)) {
-            Assertions.assertEquals(0L, files.count());
+            assertThat(files.count()).isEqualTo(0L);
         }
         Files.delete(localTmpDir);
 
@@ -162,7 +162,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         stream.write(bytesOf(testData1));
         stream.closeForCommit().commit();
 
-        Assertions.assertEquals(testData1, getContentsOfFile(path));
+        assertThat(getContentsOfFile(path)).isEqualTo(testData1);
     }
 
     @Test
@@ -177,7 +177,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         stream.write(bytesOf(testData2));
         stream.closeForCommit().commit();
 
-        Assertions.assertEquals(testData1 + testData2, getContentsOfFile(path));
+        assertThat(getContentsOfFile(path)).isEqualTo(testData1 + testData2);
     }
 
     @Test
@@ -194,10 +194,11 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         // still the data is there as we have not deleted them from the tmp object
         final String content =
                 getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
-        Assertions.assertEquals(testData1, content);
+
+        assertThat(content).isEqualTo(testData1);
 
         boolean successfullyDeletedState = writer.cleanupRecoverableState(recoverable);
-        Assertions.assertTrue(successfullyDeletedState);
+        assertThat(successfullyDeletedState).isTrue();
 
         assertThatThrownBy(
                         () -> {
@@ -232,13 +233,14 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         // still the data is there as we have not deleted them from the tmp object
         final String content =
                 getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
-        Assertions.assertEquals(testData1, content);
+
+        assertThat(content).isEqualTo(testData1);
 
         boolean successfullyDeletedState = writer.cleanupRecoverableState(recoverable);
-        Assertions.assertTrue(successfullyDeletedState);
+        assertThat(successfullyDeletedState).isTrue();
 
         boolean unsuccessfulDeletion = writer.cleanupRecoverableState(recoverable);
-        Assertions.assertFalse(unsuccessfulDeletion);
+        assertThat(unsuccessfulDeletion).isFalse();
     }
 
     // ----------------------- Test Recovery -----------------------
@@ -277,7 +279,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
                 newWriter.recoverForCommit(recoveredRecoverable);
         committer.commitAfterRecovery();
 
-        Assertions.assertEquals(testData1 + testData2, getContentsOfFile(path));
+        assertThat(getContentsOfFile(path)).isEqualTo(testData1 + testData2);
     }
 
     private static final String INIT_EMPTY_PERSIST = "EMPTY";
@@ -381,7 +383,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase {
         recoveredStream.write(bytesOf(thirdItemToWrite));
         recoveredStream.closeForCommit().commit();
 
-        Assertions.assertEquals(expectedFinalContents, getContentsOfFile(path));
+        assertThat(getContentsOfFile(path)).isEqualTo(expectedFinalContents);
     }
 
     // -------------------------- Test Utilities --------------------------

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/AbstractHadoopRecoverableWriterITCase.java
@@ -27,17 +27,16 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -49,8 +48,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /** Abstract integration test class for implementations of hadoop recoverable writer. */
-public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
+public abstract class AbstractHadoopRecoverableWriterITCase {
     // ----------------------- Test Specific configuration -----------------------
 
     private static final Random RND = new Random();
@@ -59,7 +60,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
 
     private static FileSystem fileSystem;
 
-    // this is set for every test @Before
+    // this is set for every test @BeforeEach
     protected Path basePathForTest;
 
     // ----------------------- Test Data to be used -----------------------
@@ -75,18 +76,18 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
 
     protected static boolean skipped = true;
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+    @TempDir protected static File tempFolder;
 
-    @AfterClass
-    public static void cleanUp() throws Exception {
+    @AfterAll
+    static void cleanUp() throws Exception {
         if (!skipped) {
             getFileSystem().delete(basePath, true);
         }
         FileSystem.initialize(new Configuration());
     }
 
-    @Before
-    public void prepare() throws Exception {
+    @BeforeEach
+    void prepare() throws Exception {
         basePathForTest = new Path(basePath, StringUtils.getRandomString(RND, 16, 16, 'a', 'z'));
 
         cleanupLocalDir();
@@ -117,15 +118,15 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
         }
     }
 
-    @After
-    public void cleanupAndCheckTmpCleanup() throws Exception {
+    @AfterEach
+    void cleanupAndCheckTmpCleanup() throws Exception {
         final String defaultTmpDir = getLocalTmpDir();
         final java.nio.file.Path localTmpDir = Paths.get(defaultTmpDir);
 
         // delete local tmp dir.
-        Assert.assertTrue(Files.exists(localTmpDir));
+        Assertions.assertTrue(Files.exists(localTmpDir));
         try (Stream<java.nio.file.Path> files = Files.list(localTmpDir)) {
-            Assert.assertEquals(0L, files.count());
+            Assertions.assertEquals(0L, files.count());
         }
         Files.delete(localTmpDir);
 
@@ -143,7 +144,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
     // ----------------------- Test Normal Execution -----------------------
 
     @Test
-    public void testCloseWithNoData() throws Exception {
+    void testCloseWithNoData() throws Exception {
         final RecoverableWriter writer = getRecoverableWriter();
         final Path path = new Path(basePathForTest, "part-0");
 
@@ -153,7 +154,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
     }
 
     @Test
-    public void testCommitAfterNormalClose() throws Exception {
+    void testCommitAfterNormalClose() throws Exception {
         final RecoverableWriter writer = getRecoverableWriter();
         final Path path = new Path(basePathForTest, "part-0");
 
@@ -161,11 +162,11 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
         stream.write(bytesOf(testData1));
         stream.closeForCommit().commit();
 
-        Assert.assertEquals(testData1, getContentsOfFile(path));
+        Assertions.assertEquals(testData1, getContentsOfFile(path));
     }
 
     @Test
-    public void testCommitAfterPersist() throws Exception {
+    void testCommitAfterPersist() throws Exception {
         final RecoverableWriter writer = getRecoverableWriter();
         final Path path = new Path(basePathForTest, "part-0");
 
@@ -176,43 +177,11 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
         stream.write(bytesOf(testData2));
         stream.closeForCommit().commit();
 
-        Assert.assertEquals(testData1 + testData2, getContentsOfFile(path));
-    }
-
-    @Test(expected = FileNotFoundException.class)
-    public void testCleanupRecoverableState() throws Exception {
-        final RecoverableWriter writer = getRecoverableWriter();
-        final Path path = new Path(basePathForTest, "part-0");
-
-        final RecoverableFsDataOutputStream stream = writer.open(path);
-        stream.write(bytesOf(testData1));
-        RecoverableWriter.ResumeRecoverable recoverable = stream.persist();
-
-        stream.closeForCommit().commit();
-
-        // still the data is there as we have not deleted them from the tmp object
-        final String content =
-                getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
-        Assert.assertEquals(testData1, content);
-
-        boolean successfullyDeletedState = writer.cleanupRecoverableState(recoverable);
-        Assert.assertTrue(successfullyDeletedState);
-
-        int retryTimes = 10;
-        final long delayMs = 1000;
-        // Because the s3 is eventually consistency the s3 file might still be found after we delete
-        // it.
-        // So we try multi-times to verify that the file was deleted at last.
-        while (retryTimes > 0) {
-            // this should throw the exception as we deleted the file.
-            getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
-            retryTimes--;
-            Thread.sleep(delayMs);
-        }
+        Assertions.assertEquals(testData1 + testData2, getContentsOfFile(path));
     }
 
     @Test
-    public void testCallingDeleteObjectTwiceDoesNotThroughException() throws Exception {
+    void testCleanupRecoverableState() throws Exception {
         final RecoverableWriter writer = getRecoverableWriter();
         final Path path = new Path(basePathForTest, "part-0");
 
@@ -225,19 +194,57 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
         // still the data is there as we have not deleted them from the tmp object
         final String content =
                 getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
-        Assert.assertEquals(testData1, content);
+        Assertions.assertEquals(testData1, content);
 
         boolean successfullyDeletedState = writer.cleanupRecoverableState(recoverable);
-        Assert.assertTrue(successfullyDeletedState);
+        Assertions.assertTrue(successfullyDeletedState);
+
+        assertThatThrownBy(
+                        () -> {
+                            int retryTimes = 10;
+                            final long delayMs = 1000;
+                            // Because the s3 is eventually consistency the s3 file might still be
+                            // found after we delete
+                            // it.
+                            // So we try multi-times to verify that the file was deleted at last.
+                            while (retryTimes > 0) {
+                                // this should throw the exception as we deleted the file.
+                                getContentsOfFile(
+                                        new Path('/' + getIncompleteObjectName(recoverable)));
+                                retryTimes--;
+                                Thread.sleep(delayMs);
+                            }
+                        })
+                .isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    void testCallingDeleteObjectTwiceDoesNotThroughException() throws Exception {
+        final RecoverableWriter writer = getRecoverableWriter();
+        final Path path = new Path(basePathForTest, "part-0");
+
+        final RecoverableFsDataOutputStream stream = writer.open(path);
+        stream.write(bytesOf(testData1));
+        RecoverableWriter.ResumeRecoverable recoverable = stream.persist();
+
+        stream.closeForCommit().commit();
+
+        // still the data is there as we have not deleted them from the tmp object
+        final String content =
+                getContentsOfFile(new Path('/' + getIncompleteObjectName(recoverable)));
+        Assertions.assertEquals(testData1, content);
+
+        boolean successfullyDeletedState = writer.cleanupRecoverableState(recoverable);
+        Assertions.assertTrue(successfullyDeletedState);
 
         boolean unsuccessfulDeletion = writer.cleanupRecoverableState(recoverable);
-        Assert.assertFalse(unsuccessfulDeletion);
+        Assertions.assertFalse(unsuccessfulDeletion);
     }
 
     // ----------------------- Test Recovery -----------------------
 
     @Test
-    public void testCommitAfterRecovery() throws Exception {
+    void testCommitAfterRecovery() throws Exception {
         final Path path = new Path(basePathForTest, "part-0");
 
         final RecoverableWriter initWriter = getRecoverableWriter();
@@ -270,7 +277,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
                 newWriter.recoverForCommit(recoveredRecoverable);
         committer.commitAfterRecovery();
 
-        Assert.assertEquals(testData1 + testData2, getContentsOfFile(path));
+        Assertions.assertEquals(testData1 + testData2, getContentsOfFile(path));
     }
 
     private static final String INIT_EMPTY_PERSIST = "EMPTY";
@@ -279,42 +286,42 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
     private static final String FINAL_WITH_EXTRA_STATE = "FINAL";
 
     @Test
-    public void testRecoverWithEmptyState() throws Exception {
+    void testRecoverWithEmptyState() throws Exception {
         testResumeAfterMultiplePersistWithSmallData(INIT_EMPTY_PERSIST, testData3);
     }
 
     @Test
-    public void testRecoverWithState() throws Exception {
+    void testRecoverWithState() throws Exception {
         testResumeAfterMultiplePersistWithSmallData(
                 INTERM_WITH_STATE_PERSIST, testData1 + testData3);
     }
 
     @Test
-    public void testRecoverFromIntermWithoutAdditionalState() throws Exception {
+    void testRecoverFromIntermWithoutAdditionalState() throws Exception {
         testResumeAfterMultiplePersistWithSmallData(
                 INTERM_WITH_NO_ADDITIONAL_STATE_PERSIST, testData1 + testData3);
     }
 
     @Test
-    public void testRecoverAfterMultiplePersistsState() throws Exception {
+    void testRecoverAfterMultiplePersistsState() throws Exception {
         testResumeAfterMultiplePersistWithSmallData(
                 FINAL_WITH_EXTRA_STATE, testData1 + testData2 + testData3);
     }
 
     @Test
-    public void testRecoverWithStateWithMultiPart() throws Exception {
+    void testRecoverWithStateWithMultiPart() throws Exception {
         testResumeAfterMultiplePersistWithMultiPartUploads(
                 INTERM_WITH_STATE_PERSIST, bigDataChunk + bigDataChunk);
     }
 
     @Test
-    public void testRecoverFromIntermWithoutAdditionalStateWithMultiPart() throws Exception {
+    void testRecoverFromIntermWithoutAdditionalStateWithMultiPart() throws Exception {
         testResumeAfterMultiplePersistWithMultiPartUploads(
                 INTERM_WITH_NO_ADDITIONAL_STATE_PERSIST, bigDataChunk + bigDataChunk);
     }
 
     @Test
-    public void testRecoverAfterMultiplePersistsStateWithMultiPart() throws Exception {
+    void testRecoverAfterMultiplePersistsStateWithMultiPart() throws Exception {
         testResumeAfterMultiplePersistWithMultiPartUploads(
                 FINAL_WITH_EXTRA_STATE, bigDataChunk + bigDataChunk + bigDataChunk);
     }
@@ -374,7 +381,7 @@ public abstract class AbstractHadoopRecoverableWriterITCase extends TestLogger {
         recoveredStream.write(bytesOf(thirdItemToWrite));
         recoveredStream.closeForCommit().commit();
 
-        Assert.assertEquals(expectedFinalContents, getContentsOfFile(path));
+        Assertions.assertEquals(expectedFinalContents, getContentsOfFile(path));
     }
 
     // -------------------------- Test Utilities --------------------------

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
@@ -23,9 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.HadoopUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -34,23 +33,21 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that validate the loading of the Hadoop configuration, relative to entries in the Flink
  * configuration and the environment variables.
  */
 @SuppressWarnings("deprecation")
-public class HadoopConfigLoadingTest {
+class HadoopConfigLoadingTest {
 
     private static final String IN_CP_CONFIG_KEY = "cp_conf_key";
     private static final String IN_CP_CONFIG_VALUE = "oompf!";
 
-    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
-
     @Test
-    public void loadFromClasspathByDefault() {
+    void loadFromClasspathByDefault() {
         org.apache.hadoop.conf.Configuration hadoopConf =
                 HadoopUtils.getHadoopConfiguration(new Configuration());
 
@@ -58,15 +55,15 @@ public class HadoopConfigLoadingTest {
     }
 
     @Test
-    public void loadFromLegacyConfigEntries() throws Exception {
+    void loadFromLegacyConfigEntries(@TempDir File tempFolder) throws Exception {
         final String k1 = "shipmate";
         final String v1 = "smooth sailing";
 
         final String k2 = "pirate";
         final String v2 = "Arrg, yer scurvy dog!";
 
-        final File file1 = tempFolder.newFile("core-site.xml");
-        final File file2 = tempFolder.newFile("hdfs-site.xml");
+        final File file1 = new File(tempFolder, "core-site.xml");
+        final File file2 = new File(tempFolder, "hdfs-site.xml");
 
         printConfig(file1, k1, v1);
         printConfig(file2, k2, v2);
@@ -86,14 +83,12 @@ public class HadoopConfigLoadingTest {
     }
 
     @Test
-    public void loadFromHadoopConfEntry() throws Exception {
+    void loadFromHadoopConfEntry(@TempDir File confDir) throws Exception {
         final String k1 = "singing?";
         final String v1 = "rain!";
 
         final String k2 = "dancing?";
         final String v2 = "shower!";
-
-        final File confDir = tempFolder.newFolder();
 
         final File file1 = new File(confDir, "core-site.xml");
         final File file2 = new File(confDir, "hdfs-site.xml");
@@ -115,7 +110,8 @@ public class HadoopConfigLoadingTest {
     }
 
     @Test
-    public void loadFromEnvVariables() throws Exception {
+    void loadFromEnvVariables(@TempDir File hadoopConfDir, @TempDir File hadoopHome)
+            throws Exception {
         final String k1 = "where?";
         final String v1 = "I'm on a boat";
         final String k2 = "when?";
@@ -128,10 +124,6 @@ public class HadoopConfigLoadingTest {
         final String v5 = "an eternity";
         final String k6 = "for real?";
         final String v6 = "quite so...";
-
-        final File hadoopConfDir = tempFolder.newFolder();
-
-        final File hadoopHome = tempFolder.newFolder();
 
         final File hadoopHomeConf = new File(hadoopHome, "conf");
         final File hadoopHomeEtc = new File(hadoopHome, "etc/hadoop");
@@ -179,7 +171,12 @@ public class HadoopConfigLoadingTest {
     }
 
     @Test
-    public void loadOverlappingConfig() throws Exception {
+    void loadOverlappingConfig(
+            @TempDir File hadoopConfDir,
+            @TempDir File hadoopConfEntryDir,
+            @TempDir File legacyConfDir,
+            @TempDir File hadoopHome)
+            throws Exception {
         final String k1 = "key1";
         final String k2 = "key2";
         final String k3 = "key3";
@@ -192,12 +189,8 @@ public class HadoopConfigLoadingTest {
         final String v4 = "from HADOOP_HOME/etc/hadoop";
         final String v5 = "from HADOOP_HOME/conf";
 
-        final File hadoopConfDir = tempFolder.newFolder("hadoopConfDir");
-        final File hadoopConfEntryDir = tempFolder.newFolder("hadoopConfEntryDir");
-        final File legacyConfDir = tempFolder.newFolder("legacyConfDir");
-        final File hadoopHome = tempFolder.newFolder("hadoopHome");
-
         final File hadoopHomeConf = new File(hadoopHome, "conf");
+
         final File hadoopHomeEtc = new File(hadoopHome, "etc/hadoop");
 
         assertTrue(hadoopHomeConf.mkdirs());
@@ -266,7 +259,7 @@ public class HadoopConfigLoadingTest {
     }
 
     @Test
-    public void loadFromFlinkConfEntry() throws Exception {
+    void loadFromFlinkConfEntry() throws Exception {
         final String prefix = "flink.hadoop.";
 
         final String k1 = "brooklyn";

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
@@ -33,8 +33,7 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests that validate the loading of the Hadoop configuration, relative to entries in the Flink
@@ -51,7 +50,7 @@ class HadoopConfigLoadingTest {
         org.apache.hadoop.conf.Configuration hadoopConf =
                 HadoopUtils.getHadoopConfiguration(new Configuration());
 
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     @Test
@@ -75,11 +74,11 @@ class HadoopConfigLoadingTest {
         org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
 
         // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
+        assertThat(hadoopConf.get(k1, null)).isEqualTo(v1);
+        assertThat(hadoopConf.get(k2, null)).isEqualTo(v2);
 
         // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     @Test
@@ -102,11 +101,11 @@ class HadoopConfigLoadingTest {
         org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
 
         // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
+        assertThat(hadoopConf.get(k1, null)).isEqualTo(v1);
+        assertThat(hadoopConf.get(k2, null)).isEqualTo(v2);
 
         // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     @Test
@@ -128,8 +127,8 @@ class HadoopConfigLoadingTest {
         final File hadoopHomeConf = new File(hadoopHome, "conf");
         final File hadoopHomeEtc = new File(hadoopHome, "etc/hadoop");
 
-        assertTrue(hadoopHomeConf.mkdirs());
-        assertTrue(hadoopHomeEtc.mkdirs());
+        assertThat(hadoopHomeConf.mkdirs()).isTrue();
+        assertThat(hadoopHomeEtc.mkdirs()).isTrue();
 
         final File file1 = new File(hadoopConfDir, "core-site.xml");
         final File file2 = new File(hadoopConfDir, "hdfs-site.xml");
@@ -159,15 +158,15 @@ class HadoopConfigLoadingTest {
         }
 
         // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
-        assertEquals(v3, hadoopConf.get(k3, null));
-        assertEquals(v4, hadoopConf.get(k4, null));
-        assertEquals(v5, hadoopConf.get(k5, null));
-        assertEquals(v6, hadoopConf.get(k6, null));
+        assertThat(hadoopConf.get(k1, null)).isEqualTo(v1);
+        assertThat(hadoopConf.get(k2, null)).isEqualTo(v2);
+        assertThat(hadoopConf.get(k3, null)).isEqualTo(v3);
+        assertThat(hadoopConf.get(k4, null)).isEqualTo(v4);
+        assertThat(hadoopConf.get(k5, null)).isEqualTo(v5);
+        assertThat(hadoopConf.get(k6, null)).isEqualTo(v6);
 
         // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     @Test
@@ -193,8 +192,8 @@ class HadoopConfigLoadingTest {
 
         final File hadoopHomeEtc = new File(hadoopHome, "etc/hadoop");
 
-        assertTrue(hadoopHomeConf.mkdirs());
-        assertTrue(hadoopHomeEtc.mkdirs());
+        assertThat(hadoopHomeConf.mkdirs()).isTrue();
+        assertThat(hadoopHomeEtc.mkdirs()).isTrue();
 
         final File file1 = new File(hadoopConfDir, "core-site.xml");
         final File file2 = new File(hadoopConfEntryDir, "core-site.xml");
@@ -248,14 +247,14 @@ class HadoopConfigLoadingTest {
         }
 
         // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
-        assertEquals(v3, hadoopConf.get(k3, null));
-        assertEquals(v4, hadoopConf.get(k4, null));
-        assertEquals(v5, hadoopConf.get(k5, null));
+        assertThat(hadoopConf.get(k1, null)).isEqualTo(v1);
+        assertThat(hadoopConf.get(k2, null)).isEqualTo(v2);
+        assertThat(hadoopConf.get(k3, null)).isEqualTo(v3);
+        assertThat(hadoopConf.get(k4, null)).isEqualTo(v4);
+        assertThat(hadoopConf.get(k5, null)).isEqualTo(v5);
 
         // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     @Test
@@ -287,14 +286,14 @@ class HadoopConfigLoadingTest {
         org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
 
         // contains extra entries
-        assertEquals(v1, hadoopConf.get(k1, null));
-        assertEquals(v2, hadoopConf.get(k2, null));
-        assertEquals(v3, hadoopConf.get(k3, null));
-        assertEquals(v4, hadoopConf.get(k4, null));
-        assertTrue(hadoopConf.get(k5) == null);
+        assertThat(hadoopConf.get(k1, null)).isEqualTo(v1);
+        assertThat(hadoopConf.get(k2, null)).isEqualTo(v2);
+        assertThat(hadoopConf.get(k3, null)).isEqualTo(v3);
+        assertThat(hadoopConf.get(k4, null)).isEqualTo(v4);
+        assertThat(hadoopConf.get(k5)).isNull();
 
         // also contains classpath defaults
-        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+        assertThat(hadoopConf.get(IN_CP_CONFIG_KEY, null)).isEqualTo(IN_CP_CONFIG_VALUE);
     }
 
     private static void printConfig(File file, String key, String value) throws IOException {

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStreamTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStreamTest.java
@@ -23,11 +23,12 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
@@ -59,21 +60,14 @@ class HadoopDataInputStreamTest {
         seekAndAssert(testInputStream.getPos() + HadoopDataInputStream.MIN_SKIP_BYTES);
         seekAndAssert(testInputStream.getPos() + HadoopDataInputStream.MIN_SKIP_BYTES - 1);
 
-        try {
-            seekAndAssert(-1);
-            Assertions.fail();
-        } catch (Exception ignore) {
-        }
+        assertThatThrownBy(() -> seekAndAssert(-1)).isInstanceOf(Exception.class);
 
-        try {
-            seekAndAssert(-HadoopDataInputStream.MIN_SKIP_BYTES - 1);
-            Assertions.fail();
-        } catch (Exception ignore) {
-        }
+        assertThatThrownBy(() -> seekAndAssert(-HadoopDataInputStream.MIN_SKIP_BYTES - 1))
+                .isInstanceOf(Exception.class);
     }
 
     private void seekAndAssert(long seekPos) throws IOException {
-        Assertions.assertEquals(verifyInputStream.getPos(), testInputStream.getPos());
+        assertThat(testInputStream.getPos()).isEqualTo(verifyInputStream.getPos());
         long delta = seekPos - testInputStream.getPos();
         testInputStream.seek(seekPos);
 
@@ -88,7 +82,8 @@ class HadoopDataInputStreamTest {
             verify(verifyInputStream, never()).skip(anyLong());
         }
 
-        Assertions.assertEquals(seekPos, verifyInputStream.getPos());
+        assertThat(verifyInputStream.getPos()).isEqualTo(seekPos);
+
         reset(verifyInputStream);
     }
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStreamTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStreamTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -36,13 +36,13 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 /** Tests for the {@link HadoopDataInputStream}. */
-public class HadoopDataInputStreamTest {
+class HadoopDataInputStreamTest {
 
     private FSDataInputStream verifyInputStream;
     private HadoopDataInputStream testInputStream;
 
     @Test
-    public void testSeekSkip() throws IOException {
+    void testSeekSkip() throws IOException {
         verifyInputStream =
                 spy(
                         new FSDataInputStream(
@@ -61,19 +61,19 @@ public class HadoopDataInputStreamTest {
 
         try {
             seekAndAssert(-1);
-            Assert.fail();
+            Assertions.fail();
         } catch (Exception ignore) {
         }
 
         try {
             seekAndAssert(-HadoopDataInputStream.MIN_SKIP_BYTES - 1);
-            Assert.fail();
+            Assertions.fail();
         } catch (Exception ignore) {
         }
     }
 
     private void seekAndAssert(long seekPos) throws IOException {
-        Assert.assertEquals(verifyInputStream.getPos(), testInputStream.getPos());
+        Assertions.assertEquals(verifyInputStream.getPos(), testInputStream.getPos());
         long delta = seekPos - testInputStream.getPos();
         testInputStream.seek(seekPos);
 
@@ -88,7 +88,7 @@ public class HadoopDataInputStreamTest {
             verify(verifyInputStream, never()).skip(anyLong());
         }
 
-        Assert.assertEquals(seekPos, verifyInputStream.getPos());
+        Assertions.assertEquals(seekPos, verifyInputStream.getPos());
         reset(verifyInputStream);
     }
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeFsFactoryTest.java
@@ -20,9 +20,8 @@ package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.testutils.ClassLoaderUtils;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,14 +29,14 @@ import java.net.URL;
 import java.net.URLClassLoader;
 
 /** Tests that validate the behavior of the Hadoop File System Factory. */
-public class HadoopFreeFsFactoryTest extends TestLogger {
+class HadoopFreeFsFactoryTest {
 
     /**
      * This test validates that the factory can be instantiated and configured even when Hadoop
      * classes are missing from the classpath.
      */
     @Test
-    public void testHadoopFactoryInstantiationWithoutHadoop() throws Exception {
+    void testHadoopFactoryInstantiationWithoutHadoop() throws Exception {
         // we do reflection magic here to instantiate the test in another class
         // loader, to make sure no hadoop classes are in the classpath
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeTests.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeTests.java
@@ -23,7 +23,7 @@ import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
 
 import java.net.URI;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * A class with tests that require to be run in a Hadoop-free environment, to test proper error
@@ -37,17 +37,13 @@ public class HadoopFreeTests {
 
     public static void test() throws Exception {
         // make sure no Hadoop FS classes are in the classpath
-        try {
-            Class.forName("org.apache.hadoop.fs.FileSystem");
-            fail("Cannot run test when Hadoop classes are in the classpath");
-        } catch (ClassNotFoundException ignored) {
-        }
+        assertThatThrownBy(() -> Class.forName("org.apache.hadoop.fs.FileSystem"))
+                .describedAs("Cannot run test when Hadoop classes are in the classpath")
+                .isInstanceOf(ClassNotFoundException.class);
 
-        try {
-            Class.forName("org.apache.hadoop.conf.Configuration");
-            fail("Cannot run test when Hadoop classes are in the classpath");
-        } catch (ClassNotFoundException ignored) {
-        }
+        assertThatThrownBy(() -> Class.forName("org.apache.hadoop.conf.Configuration"))
+                .describedAs("Cannot run test when Hadoop classes are in the classpath")
+                .isInstanceOf(ClassNotFoundException.class);
 
         // this method should complete without a linkage error
         final HadoopFsFactory factory = new HadoopFsFactory();
@@ -55,11 +51,7 @@ public class HadoopFreeTests {
         // this method should also complete without a linkage error
         factory.configure(new Configuration());
 
-        try {
-            factory.create(new URI("hdfs://somehost:9000/root/dir"));
-            fail("This statement should fail with an exception");
-        } catch (UnsupportedFileSystemSchemeException e) {
-            // expected
-        }
+        assertThatThrownBy(() -> factory.create(new URI("hdfs://somehost:9000/root/dir")))
+                .isInstanceOf(UnsupportedFileSystemSchemeException.class);
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeTests.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFreeTests.java
@@ -23,7 +23,7 @@ import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
 
 import java.net.URI;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A class with tests that require to be run in a Hadoop-free environment, to test proper error

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
@@ -20,14 +20,13 @@ package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.core.fs.FileSystem;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests that validate the behavior of the Hadoop File System Factory. */
 class HadoopFsFactoryTest {
@@ -39,22 +38,19 @@ class HadoopFsFactoryTest {
         HadoopFsFactory factory = new HadoopFsFactory();
         FileSystem fs = factory.create(uri);
 
-        assertEquals(uri.getScheme(), fs.getUri().getScheme());
-        assertEquals(uri.getAuthority(), fs.getUri().getAuthority());
-        assertEquals(uri.getPort(), fs.getUri().getPort());
+        assertThat(fs.getUri().getScheme()).isEqualTo(uri.getScheme());
+        assertThat(fs.getUri().getAuthority()).isEqualTo(uri.getAuthority());
+        assertThat(fs.getUri().getPort()).isEqualTo(uri.getPort());
     }
 
     @Test
-    void testCreateHadoopFsWithMissingAuthority() throws Exception {
+    void testCreateHadoopFsWithMissingAuthority() {
         final URI uri = URI.create("hdfs:///my/path");
 
         HadoopFsFactory factory = new HadoopFsFactory();
 
-        try {
-            factory.create(uri);
-            Assertions.fail("should have failed with an exception");
-        } catch (IOException e) {
-            assertTrue(e.getMessage().contains("authority"));
-        }
+        assertThatThrownBy(() -> factory.create(uri))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("authority");
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactoryTest.java
@@ -19,22 +19,21 @@
 package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests that validate the behavior of the Hadoop File System Factory. */
-public class HadoopFsFactoryTest extends TestLogger {
+class HadoopFsFactoryTest {
 
     @Test
-    public void testCreateHadoopFsWithoutConfig() throws Exception {
+    void testCreateHadoopFsWithoutConfig() throws Exception {
         final URI uri = URI.create("hdfs://localhost:12345/");
 
         HadoopFsFactory factory = new HadoopFsFactory();
@@ -46,14 +45,14 @@ public class HadoopFsFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testCreateHadoopFsWithMissingAuthority() throws Exception {
+    void testCreateHadoopFsWithMissingAuthority() throws Exception {
         final URI uri = URI.create("hdfs:///my/path");
 
         HadoopFsFactory factory = new HadoopFsFactory();
 
         try {
             factory.create(uri);
-            fail("should have failed with an exception");
+            Assertions.fail("should have failed with an exception");
         } catch (IOException e) {
             assertTrue(e.getMessage().contains("authority"));
         }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
@@ -28,9 +28,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.jupiter.api.AfterAll;
-
 import org.junit.jupiter.api.Assumptions;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -41,7 +39,6 @@ class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
     @TempDir private static java.nio.file.Path tempFolder;
 
-
     private static MiniDFSCluster hdfsCluster;
 
     /** The cached file system instance. */
@@ -51,7 +48,7 @@ class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
     @BeforeAll
     static void testHadoopVersion() {
-        Assumptions.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 6));
+        Assumptions.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
     }
 
     @BeforeAll
@@ -59,7 +56,6 @@ class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
         Assumptions.assumeFalse(
                 OperatingSystem.isWindows(),
                 "HDFS cluster cannot be started on Windows without extensions.");
-
     }
 
     @BeforeAll

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
@@ -28,11 +28,12 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for the {@link HadoopRecoverableWriter}. */
 class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
@@ -48,14 +49,12 @@ class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
     @BeforeAll
     static void testHadoopVersion() {
-        Assumptions.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
+        assumeThat(HadoopUtils.isMinHadoopVersion(2, 6)).isTrue();
     }
 
     @BeforeAll
     static void verifyOS() {
-        Assumptions.assumeFalse(
-                OperatingSystem.isWindows(),
-                "HDFS cluster cannot be started on Windows without extensions.");
+        assumeThat(OperatingSystem.isWindows()).isFalse();
     }
 
     @BeforeAll

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
@@ -28,17 +28,19 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.jupiter.api.AfterAll;
+
+import org.junit.jupiter.api.Assumptions;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
-
 /** Tests for the {@link HadoopRecoverableWriter}. */
 class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
     @TempDir private static java.nio.file.Path tempFolder;
+
 
     private static MiniDFSCluster hdfsCluster;
 
@@ -49,12 +51,15 @@ class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
     @BeforeAll
     static void testHadoopVersion() {
-        assumeThat(HadoopUtils.isMinHadoopVersion(2, 6)).isTrue();
+        Assumptions.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 6));
     }
 
     @BeforeAll
     static void verifyOS() {
-        assumeThat(OperatingSystem.isWindows()).isFalse();
+        Assumptions.assumeFalse(
+                OperatingSystem.isWindows(),
+                "HDFS cluster cannot be started on Windows without extensions.");
+
     }
 
     @BeforeAll

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopViewFileSystemTruncateTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopViewFileSystemTruncateTest.java
@@ -34,14 +34,12 @@ import org.apache.hadoop.fs.viewfs.ConfigUtil;
 import org.apache.hadoop.fs.viewfs.ViewFileSystemTestSetup;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.hdfs.MiniDFSNNTopology;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -49,12 +47,13 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Test for {@link org.apache.hadoop.fs.viewfs.ViewFileSystem} support. */
-public class HadoopViewFileSystemTruncateTest {
+class HadoopViewFileSystemTruncateTest {
 
-    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+    @TempDir static File tempFolder;
 
     private final FileSystemTestHelper fileSystemTestHelper = new FileSystemTestHelper("/tests");
 
@@ -66,21 +65,21 @@ public class HadoopViewFileSystemTruncateTest {
     private FileSystem fsTarget;
     private Path targetTestRoot;
 
-    @BeforeClass
-    public static void testHadoopVersion() {
-        Assume.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
+    @BeforeAll
+    static void testHadoopVersion() {
+        assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
     }
 
-    @BeforeClass
-    public static void verifyOS() {
-        Assume.assumeTrue(
-                "HDFS cluster cannot be started on Windows without extensions.",
-                !OperatingSystem.isWindows());
+    @BeforeAll
+    static void verifyOS() {
+        assumeTrue(
+                !OperatingSystem.isWindows(),
+                "HDFS cluster cannot be started on Windows without extensions.");
     }
 
-    @BeforeClass
-    public static void createHDFS() throws Exception {
-        final File baseDir = TEMP_FOLDER.newFolder();
+    @BeforeAll
+    static void createHDFS() throws Exception {
+        final File baseDir = tempFolder;
 
         final Configuration hdConf = new Configuration();
         hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
@@ -94,8 +93,8 @@ public class HadoopViewFileSystemTruncateTest {
         fHdfs = hdfsCluster.getFileSystem(0);
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         fsTarget = fHdfs;
         targetTestRoot = fileSystemTestHelper.getAbsoluteTestRootPath(fsTarget);
 
@@ -113,18 +112,18 @@ public class HadoopViewFileSystemTruncateTest {
         ConfigUtil.addLink(fsViewConf, mountOnNn1.toString(), targetTestRoot.toUri());
     }
 
-    @AfterClass
-    public static void shutdownCluster() {
+    @AfterAll
+    static void shutdownCluster() {
         hdfsCluster.shutdown();
     }
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         fsTarget.delete(fileSystemTestHelper.getTestRootPath(fsTarget), true);
     }
 
     @Test
-    public void testViewFileSystemRecoverWorks() throws IOException {
+    void testViewFileSystemRecoverWorks() throws IOException {
 
         final org.apache.flink.core.fs.Path testPath =
                 new org.apache.flink.core.fs.Path(fSystem.getUri() + "mountOnNn1/test-1");

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopViewFileSystemTruncateTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopViewFileSystemTruncateTest.java
@@ -47,8 +47,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Test for {@link org.apache.hadoop.fs.viewfs.ViewFileSystem} support. */
 class HadoopViewFileSystemTruncateTest {
@@ -67,14 +67,14 @@ class HadoopViewFileSystemTruncateTest {
 
     @BeforeAll
     static void testHadoopVersion() {
-        assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
+        assumeThat(HadoopUtils.isMinHadoopVersion(2, 7)).isTrue();
     }
 
     @BeforeAll
     static void verifyOS() {
-        assumeTrue(
-                !OperatingSystem.isWindows(),
-                "HDFS cluster cannot be started on Windows without extensions.");
+        assumeThat(OperatingSystem.isWindows())
+                .describedAs("HDFS cluster cannot be started on Windows without extensions.")
+                .isFalse();
     }
 
     @BeforeAll
@@ -165,7 +165,7 @@ class HadoopViewFileSystemTruncateTest {
                 InputStreamReader ir = new InputStreamReader(in, UTF_8);
                 BufferedReader reader = new BufferedReader(ir)) {
             final String line = reader.readLine();
-            assertEquals(expectedContent, line);
+            assertThat(line).isEqualTo(expectedContent);
         }
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for extracting the {@link FileSystemKind} from file systems that Flink accesses through
@@ -40,19 +40,21 @@ class HdfsKindTest {
     @Test
     void testHdfsKind() throws IOException {
         final FileSystem fs = new Path("hdfs://localhost:55445/my/file").getFileSystem();
-        assertEquals(FileSystemKind.FILE_SYSTEM, fs.getKind());
+        assertThat(fs.getKind()).isEqualTo(FileSystemKind.FILE_SYSTEM);
     }
 
     @Test
     void testS3fileSystemSchemes() {
-        assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3"));
-        assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3n"));
-        assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3a"));
-        assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("EMRFS"));
+        assertThat(HadoopFileSystem.getKindForScheme("s3")).isEqualTo(FileSystemKind.OBJECT_STORE);
+        assertThat(HadoopFileSystem.getKindForScheme("s3n")).isEqualTo(FileSystemKind.OBJECT_STORE);
+        assertThat(HadoopFileSystem.getKindForScheme("s3a")).isEqualTo(FileSystemKind.OBJECT_STORE);
+        assertThat(HadoopFileSystem.getKindForScheme("EMRFS"))
+                .isEqualTo(FileSystemKind.OBJECT_STORE);
     }
 
     @Test
     void testViewFs() {
-        assertEquals(FileSystemKind.FILE_SYSTEM, HadoopFileSystem.getKindForScheme("viewfs"));
+        assertThat(HadoopFileSystem.getKindForScheme("viewfs"))
+                .isEqualTo(FileSystemKind.FILE_SYSTEM);
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
@@ -21,13 +21,12 @@ package org.apache.flink.runtime.fs.hdfs;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for extracting the {@link FileSystemKind} from file systems that Flink accesses through
@@ -36,16 +35,16 @@ import static org.junit.Assert.assertEquals;
  * <p>This class needs to be in this package, because it accesses package private methods from the
  * HDFS file system wrapper class.
  */
-public class HdfsKindTest extends TestLogger {
+class HdfsKindTest {
 
     @Test
-    public void testHdfsKind() throws IOException {
+    void testHdfsKind() throws IOException {
         final FileSystem fs = new Path("hdfs://localhost:55445/my/file").getFileSystem();
         assertEquals(FileSystemKind.FILE_SYSTEM, fs.getKind());
     }
 
     @Test
-    public void testS3fileSystemSchemes() {
+    void testS3fileSystemSchemes() {
         assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3"));
         assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3n"));
         assertEquals(FileSystemKind.OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3a"));
@@ -53,7 +52,7 @@ public class HdfsKindTest extends TestLogger {
     }
 
     @Test
-    public void testViewFs() {
+    void testViewFs() {
         assertEquals(FileSystemKind.FILE_SYSTEM, HadoopFileSystem.getKindForScheme("viewfs"));
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/LimitedConnectionsConfigurationTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/LimitedConnectionsConfigurationTest.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test that the Hadoop file system wrapper correctly picks up connection limiting settings for the
@@ -43,8 +41,8 @@ class LimitedConnectionsConfigurationTest {
         FileSystem hdfs = FileSystem.get(URI.create("hdfs://localhost:12345/a/b/c"));
         FileSystem ftpfs = FileSystem.get(URI.create("ftp://localhost:12345/a/b/c"));
 
-        assertFalse(hdfs instanceof LimitedConnectionsFileSystem);
-        assertFalse(ftpfs instanceof LimitedConnectionsFileSystem);
+        assertThat(hdfs).isNotInstanceOf(LimitedConnectionsFileSystem.class);
+        assertThat(ftpfs).isNotInstanceOf(LimitedConnectionsFileSystem.class);
 
         // configure some limits, which should cause "fsScheme" to be limited
 
@@ -61,15 +59,15 @@ class LimitedConnectionsConfigurationTest {
             hdfs = FileSystem.get(URI.create("hdfs://localhost:12345/a/b/c"));
             ftpfs = FileSystem.get(URI.create("ftp://localhost:12345/a/b/c"));
 
-            assertTrue(hdfs instanceof LimitedConnectionsFileSystem);
-            assertFalse(ftpfs instanceof LimitedConnectionsFileSystem);
+            assertThat(hdfs).isInstanceOf(LimitedConnectionsFileSystem.class);
+            assertThat(ftpfs).isNotInstanceOf(LimitedConnectionsFileSystem.class);
 
             LimitedConnectionsFileSystem limitedFs = (LimitedConnectionsFileSystem) hdfs;
-            assertEquals(40, limitedFs.getMaxNumOpenStreamsTotal());
-            assertEquals(39, limitedFs.getMaxNumOpenInputStreams());
-            assertEquals(38, limitedFs.getMaxNumOpenOutputStreams());
-            assertEquals(23456, limitedFs.getStreamOpenTimeout());
-            assertEquals(34567, limitedFs.getStreamInactivityTimeout());
+            assertThat(limitedFs.getMaxNumOpenStreamsTotal()).isEqualTo(40);
+            assertThat(limitedFs.getMaxNumOpenInputStreams()).isEqualTo(39);
+            assertThat(limitedFs.getMaxNumOpenOutputStreams()).isEqualTo(38);
+            assertThat(limitedFs.getStreamOpenTimeout()).isEqualTo(23456);
+            assertThat(limitedFs.getStreamInactivityTimeout()).isEqualTo(34567);
         } finally {
             // clear all settings
             FileSystem.initialize(new Configuration());

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/LimitedConnectionsConfigurationTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/LimitedConnectionsConfigurationTest.java
@@ -22,26 +22,22 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.LimitedConnectionsFileSystem;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test that the Hadoop file system wrapper correctly picks up connection limiting settings for the
  * correct file systems.
  */
-public class LimitedConnectionsConfigurationTest {
-
-    @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
+class LimitedConnectionsConfigurationTest {
 
     @Test
-    public void testConfiguration() throws Exception {
+    void testConfiguration() throws Exception {
 
         // nothing configured, we should get a regular file system
         FileSystem hdfs = FileSystem.get(URI.create("hdfs://localhost:12345/a/b/c"));

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
@@ -30,10 +30,8 @@ import org.mockito.Mockito;
 import sun.security.krb5.KrbException;
 
 import static org.apache.flink.runtime.util.HadoopUtils.HDFS_DELEGATION_TOKEN_KIND;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Unit tests for Hadoop utils. */
 class HadoopUtilsTest {
@@ -57,15 +55,15 @@ class HadoopUtilsTest {
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
         UserGroupInformation userWithoutCredentialsOrTokens =
                 createTestUser(AuthenticationMethod.KERBEROS);
-        assumeFalse(userWithoutCredentialsOrTokens.hasKerberosCredentials());
+        assumeThat(userWithoutCredentialsOrTokens.hasKerberosCredentials()).isFalse();
 
         boolean isKerberosEnabled =
                 HadoopUtils.isKerberosSecurityEnabled(userWithoutCredentialsOrTokens);
         boolean result =
                 HadoopUtils.areKerberosCredentialsValid(userWithoutCredentialsOrTokens, true);
 
-        assertTrue(isKerberosEnabled);
-        assertFalse(result);
+        assertThat(isKerberosEnabled).isTrue();
+        assertThat(result).isFalse();
     }
 
     @Test
@@ -75,12 +73,12 @@ class HadoopUtilsTest {
         UserGroupInformation userWithoutCredentialsButHavingToken =
                 createTestUser(AuthenticationMethod.KERBEROS);
         userWithoutCredentialsButHavingToken.addToken(getHDFSDelegationToken());
-        assumeFalse(userWithoutCredentialsButHavingToken.hasKerberosCredentials());
+        assumeThat(userWithoutCredentialsButHavingToken.hasKerberosCredentials()).isFalse();
 
         boolean result =
                 HadoopUtils.areKerberosCredentialsValid(userWithoutCredentialsButHavingToken, true);
 
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
@@ -94,7 +92,7 @@ class HadoopUtilsTest {
 
         boolean result = HadoopUtils.areKerberosCredentialsValid(userWithCredentials, true);
 
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
@@ -106,7 +104,7 @@ class HadoopUtilsTest {
 
         boolean result = HadoopUtils.isKerberosSecurityEnabled(userWithAuthMethodOtherThanKerberos);
 
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     @Test
@@ -117,7 +115,7 @@ class HadoopUtilsTest {
 
         boolean result = HadoopUtils.areKerberosCredentialsValid(user, false);
 
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
@@ -127,17 +125,17 @@ class HadoopUtilsTest {
 
         boolean result = HadoopUtils.hasHDFSDelegationToken(userWithToken);
 
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
     void testShouldReturnFalseIfTheUserHasNoHDFSDelegationToken() {
         UserGroupInformation userWithoutToken = createTestUser(AuthenticationMethod.KERBEROS);
-        assumeTrue(userWithoutToken.getTokens().isEmpty());
+        assumeThat(userWithoutToken.getTokens().isEmpty()).isTrue();
 
         boolean result = HadoopUtils.hasHDFSDelegationToken(userWithoutToken);
 
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
     private static Configuration getHadoopConfigWithAuthMethod(

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/HadoopUtilsTest.java
@@ -18,43 +18,41 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.util.TestLogger;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.token.Token;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import sun.security.krb5.KrbException;
 
 import static org.apache.flink.runtime.util.HadoopUtils.HDFS_DELEGATION_TOKEN_KIND;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Unit tests for Hadoop utils. */
-public class HadoopUtilsTest extends TestLogger {
+class HadoopUtilsTest {
 
-    @BeforeClass
-    public static void setPropertiesToEnableKerberosConfigInit() throws KrbException {
+    @BeforeAll
+    static void setPropertiesToEnableKerberosConfigInit() throws KrbException {
         System.setProperty("java.security.krb5.realm", "EXAMPLE.COM");
         System.setProperty("java.security.krb5.kdc", "kdc");
         System.setProperty("java.security.krb5.conf", "/dev/null");
         sun.security.krb5.Config.refresh();
     }
 
-    @AfterClass
-    public static void cleanupHadoopConfigs() {
+    @AfterAll
+    static void cleanupHadoopConfigs() {
         UserGroupInformation.setConfiguration(new Configuration());
     }
 
     @Test
-    public void testShouldReturnFalseWhenNoKerberosCredentialsOrDelegationTokens() {
+    void testShouldReturnFalseWhenNoKerberosCredentialsOrDelegationTokens() {
         UserGroupInformation.setConfiguration(
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
         UserGroupInformation userWithoutCredentialsOrTokens =
@@ -71,7 +69,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testShouldReturnTrueWhenDelegationTokenIsPresent() {
+    void testShouldReturnTrueWhenDelegationTokenIsPresent() {
         UserGroupInformation.setConfiguration(
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
         UserGroupInformation userWithoutCredentialsButHavingToken =
@@ -86,7 +84,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testShouldReturnTrueWhenKerberosCredentialsArePresent() {
+    void testShouldReturnTrueWhenKerberosCredentialsArePresent() {
         UserGroupInformation.setConfiguration(
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
         UserGroupInformation userWithCredentials = Mockito.mock(UserGroupInformation.class);
@@ -100,7 +98,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void isKerberosSecurityEnabled_NoKerberos_ReturnsFalse() {
+    void isKerberosSecurityEnabled_NoKerberos_ReturnsFalse() {
         UserGroupInformation.setConfiguration(
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.PROXY));
         UserGroupInformation userWithAuthMethodOtherThanKerberos =
@@ -112,7 +110,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testShouldReturnTrueIfTicketCacheIsNotUsed() {
+    void testShouldReturnTrueIfTicketCacheIsNotUsed() {
         UserGroupInformation.setConfiguration(
                 getHadoopConfigWithAuthMethod(AuthenticationMethod.KERBEROS));
         UserGroupInformation user = createTestUser(AuthenticationMethod.KERBEROS);
@@ -123,7 +121,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testShouldCheckIfTheUserHasHDFSDelegationToken() {
+    void testShouldCheckIfTheUserHasHDFSDelegationToken() {
         UserGroupInformation userWithToken = createTestUser(AuthenticationMethod.KERBEROS);
         userWithToken.addToken(getHDFSDelegationToken());
 
@@ -133,7 +131,7 @@ public class HadoopUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testShouldReturnFalseIfTheUserHasNoHDFSDelegationToken() {
+    void testShouldReturnFalseIfTheUserHasNoHDFSDelegationToken() {
         UserGroupInformation userWithoutToken = createTestUser(AuthenticationMethod.KERBEROS);
         assumeTrue(userWithoutToken.getTokens().isEmpty());
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
@@ -24,8 +24,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopFileSystemITTest;
 import org.apache.flink.testutils.oss.OSSTestCredentials;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -36,12 +36,12 @@ import static junit.framework.TestCase.assertEquals;
  * Unit tests for the OSS file system support via AliyunOSSFileSystem. These tests do actually read
  * from or write to OSS.
  */
-public class HadoopOSSFileSystemITCase extends AbstractHadoopFileSystemITTest {
+class HadoopOSSFileSystemITCase extends AbstractHadoopFileSystemITTest {
 
     private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         OSSTestCredentials.assumeCredentialsAvailable();
 
         final Configuration conf = new Configuration();
@@ -55,7 +55,7 @@ public class HadoopOSSFileSystemITCase extends AbstractHadoopFileSystemITTest {
     }
 
     @Test
-    public void testShadedConfigurations() {
+    void testShadedConfigurations() {
         final Configuration conf = new Configuration();
         conf.setString("fs.oss.endpoint", OSSTestCredentials.getOSSEndpoint());
         conf.setString("fs.oss.accessKeyId", OSSTestCredentials.getOSSAccessKey());

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSFileSystemITCase.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.UUID;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the OSS file system support via AliyunOSSFileSystem. These tests do actually read
@@ -68,13 +68,15 @@ class HadoopOSSFileSystemITCase extends AbstractHadoopFileSystemITTest {
         ossfsFactory.configure(conf);
         org.apache.hadoop.conf.Configuration configuration = ossfsFactory.getHadoopConfiguration();
         // shaded
-        assertEquals(
-                "org.apache.flink.fs.osshadoop.shaded.org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider",
-                configuration.get("fs.oss.credentials.provider"));
+        assertThat(configuration.get("fs.oss.credentials.provider"))
+                .isEqualTo(
+                        "org.apache.flink.fs.osshadoop.shaded.org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider");
         // should not shaded
-        assertEquals(OSSTestCredentials.getOSSEndpoint(), configuration.get("fs.oss.endpoint"));
-        assertEquals(OSSTestCredentials.getOSSAccessKey(), configuration.get("fs.oss.accessKeyId"));
-        assertEquals(
-                OSSTestCredentials.getOSSSecretKey(), configuration.get("fs.oss.accessKeySecret"));
+        assertThat(configuration.get("fs.oss.endpoint"))
+                .isEqualTo(OSSTestCredentials.getOSSEndpoint());
+        assertThat(configuration.get("fs.oss.accessKeyId"))
+                .isEqualTo(OSSTestCredentials.getOSSAccessKey());
+        assertThat(configuration.get("fs.oss.accessKeySecret"))
+                .isEqualTo(OSSTestCredentials.getOSSSecretKey());
     }
 }

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
@@ -44,7 +44,7 @@ class HadoopOSSRecoverableWriterExceptionITCase
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
     @BeforeAll
-    public static void checkCredentialsAndSetup() throws IOException {
+    static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         OSSTestCredentials.assumeCredentialsAvailable();
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
@@ -36,7 +36,7 @@ import static org.apache.flink.fs.osshadoop.OSSFileSystemFactory.MAX_CONCURRENT_
  * Tests for exception throwing in the {@link
  * org.apache.flink.fs.osshadoop.writer.OSSRecoverableWriter OSSRecoverableWriter}.
  */
-public class HadoopOSSRecoverableWriterExceptionITCase
+class HadoopOSSRecoverableWriterExceptionITCase
         extends AbstractHadoopRecoverableWriterExceptionITCase {
 
     // ----------------------- OSS general configuration -----------------------

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopRecoverableWriterExceptionITCase;
 import org.apache.flink.testutils.oss.OSSTestCredentials;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -43,7 +43,7 @@ public class HadoopOSSRecoverableWriterExceptionITCase
 
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
-    @BeforeClass
+    @BeforeAll
     public static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         OSSTestCredentials.assumeCredentialsAvailable();
@@ -58,7 +58,7 @@ public class HadoopOSSRecoverableWriterExceptionITCase
 
         conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
-        final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "/oss_tmp_dir";
+        final String defaultTmpDir = tempFolder.getAbsolutePath() + "/oss_tmp_dir";
         conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
@@ -39,7 +39,7 @@ import static org.apache.flink.fs.osshadoop.OSSFileSystemFactory.PART_UPLOAD_MIN
  * Tests for the {@link org.apache.flink.fs.osshadoop.writer.OSSRecoverableWriter
  * OSSRecoverableWriter}.
  */
-public class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableWriterITCase {
+class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableWriterITCase {
 
     // ----------------------- OSS general configuration -----------------------
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
@@ -27,7 +27,7 @@ import org.apache.flink.fs.osshadoop.writer.OSSRecoverable;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopRecoverableWriterITCase;
 import org.apache.flink.testutils.oss.OSSTestCredentials;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -45,7 +45,7 @@ public class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableW
 
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
-    @BeforeClass
+    @BeforeAll
     public static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         OSSTestCredentials.assumeCredentialsAvailable();
@@ -60,7 +60,7 @@ public class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableW
 
         conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
-        final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "/oss_tmp_dir";
+        final String defaultTmpDir = tempFolder.getAbsolutePath() + "/oss_tmp_dir";
         conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
@@ -46,7 +46,7 @@ class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableWriterIT
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
     @BeforeAll
-    public static void checkCredentialsAndSetup() throws IOException {
+    static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         OSSTestCredentials.assumeCredentialsAvailable();
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/OSSTestUtils.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/OSSTestUtils.java
@@ -25,8 +25,6 @@ import org.apache.flink.core.fs.RefCountedBufferingFileStream;
 import org.apache.flink.core.fs.RefCountedFileWithStream;
 import org.apache.flink.fs.osshadoop.writer.OSSRecoverableMultipartUpload;
 
-import org.junit.rules.TemporaryFolder;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +80,7 @@ public class OSSTestUtils {
 
     public static void uploadPart(
             OSSRecoverableMultipartUpload uploader,
-            final TemporaryFolder temporaryFolder,
+            final File temporaryFolder,
             final byte[] content)
             throws IOException {
         RefCountedBufferingFileStream partFile = writeData(temporaryFolder, content);
@@ -92,9 +90,9 @@ public class OSSTestUtils {
         uploader.uploadPart(partFile);
     }
 
-    public static RefCountedBufferingFileStream writeData(
-            TemporaryFolder temporaryFolder, byte[] content) throws IOException {
-        final File newFile = new File(temporaryFolder.getRoot(), ".tmp_" + UUID.randomUUID());
+    public static RefCountedBufferingFileStream writeData(File temporaryFolder, byte[] content)
+            throws IOException {
+        final File newFile = new File(temporaryFolder, ".tmp_" + UUID.randomUUID());
         final OutputStream out =
                 Files.newOutputStream(newFile.toPath(), StandardOpenOption.CREATE_NEW);
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/OSSTestUtils.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/OSSTestUtils.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.SplittableRandom;
 import java.util.UUID;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** OSS test utility class. */
 public class OSSTestUtils {
@@ -62,7 +62,7 @@ public class OSSTestUtils {
         for (byte[] bytes : expectContents) {
             out.write(bytes);
         }
-        assertEquals(out.toString(), actualContent);
+        assertThat(actualContent).isEqualTo(out.toString());
     }
 
     public static void objectContentEquals(FileSystem fs, Path objectPath, byte[]... expectContents)

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableFsDataOutputStreamTest.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
-import static junit.framework.TestCase.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link OSSRecoverableFsDataOutputStream}. */
@@ -95,7 +95,7 @@ class OSSRecoverableFsDataOutputStreamTest {
         committer.commit();
 
         // will not create empty object
-        assertFalse(fs.exists(objectPath));
+        assertThat(fs.exists(objectPath)).isFalse();
     }
 
     @Test
@@ -114,7 +114,7 @@ class OSSRecoverableFsDataOutputStreamTest {
         fsDataOutputStream.close();
 
         // close without commit will not upload current part
-        assertFalse(fs.exists(objectPath));
+        assertThat(fs.exists(objectPath)).isFalse();
     }
 
     @Test

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableFsDataOutputStreamTest.java
@@ -26,20 +26,21 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.fs.osshadoop.OSSTestUtils;
 import org.apache.flink.testutils.oss.OSSTestCredentials;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
 import static junit.framework.TestCase.assertFalse;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link OSSRecoverableFsDataOutputStream}. */
-public class OSSRecoverableFsDataOutputStreamTest {
+class OSSRecoverableFsDataOutputStreamTest {
 
     private static Path basePath;
 
@@ -55,10 +56,10 @@ public class OSSRecoverableFsDataOutputStreamTest {
 
     private RecoverableFsDataOutputStream fsDataOutputStream;
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir public static File temporaryFolder;
 
-    @Before
-    public void before() throws IOException {
+    @BeforeEach
+    void before() throws IOException {
         OSSTestCredentials.assumeCredentialsAvailable();
 
         final Configuration conf = new Configuration();
@@ -77,7 +78,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testRegularDataWritten() throws IOException {
+    void testRegularDataWritten() throws IOException {
         final byte[] part = OSSTestUtils.bytesOf("hello world", 1024 * 1024);
 
         fsDataOutputStream.write(part);
@@ -89,7 +90,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testNoDataWritten() throws IOException {
+    void testNoDataWritten() throws IOException {
         RecoverableFsDataOutputStream.Committer committer = fsDataOutputStream.closeForCommit();
         committer.commit();
 
@@ -97,14 +98,15 @@ public class OSSRecoverableFsDataOutputStreamTest {
         assertFalse(fs.exists(objectPath));
     }
 
-    @Test(expected = IOException.class)
-    public void testCloseForCommitOnClosedStreamShouldFail() throws IOException {
+    @Test
+    void testCloseForCommitOnClosedStreamShouldFail() throws IOException {
         fsDataOutputStream.closeForCommit().commit();
-        fsDataOutputStream.closeForCommit().commit();
+        assertThatThrownBy(() -> fsDataOutputStream.closeForCommit().commit())
+                .isInstanceOf(IOException.class);
     }
 
     @Test
-    public void testCloseWithoutCommit() throws IOException {
+    void testCloseWithoutCommit() throws IOException {
         final byte[] part = OSSTestUtils.bytesOf("hello world", 1024 * 1024);
 
         fsDataOutputStream.write(part);
@@ -116,7 +118,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testWriteLargeFile() throws IOException {
+    void testWriteLargeFile() throws IOException {
         List<byte[]> buffers = OSSTestUtils.generateRandomBuffer(50 * 1024 * 1024, 10 * 104 * 1024);
         for (byte[] buffer : buffers) {
             fsDataOutputStream.write(buffer);
@@ -129,7 +131,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testConcatWrites() throws IOException {
+    void testConcatWrites() throws IOException {
         fsDataOutputStream.write(OSSTestUtils.bytesOf("hello", 5));
         fsDataOutputStream.write(OSSTestUtils.bytesOf(" ", 1));
         fsDataOutputStream.write(OSSTestUtils.bytesOf("world", 5));
@@ -141,7 +143,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testRegularRecovery() throws IOException {
+    void testRegularRecovery() throws IOException {
         final byte[] part = OSSTestUtils.bytesOf("hello world", 1024 * 1024);
         fsDataOutputStream.write(part);
 
@@ -156,7 +158,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testContinuousPersistWithoutWrites() throws IOException {
+    void testContinuousPersistWithoutWrites() throws IOException {
         fsDataOutputStream.write(OSSTestUtils.bytesOf("hello", 5));
 
         fsDataOutputStream.persist();
@@ -174,7 +176,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testWriteSmallDataAndPersist() throws IOException {
+    void testWriteSmallDataAndPersist() throws IOException {
         fsDataOutputStream.write(OSSTestUtils.bytesOf("h", 1));
         fsDataOutputStream.persist();
 
@@ -201,7 +203,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testWriteBigDataAndPersist() throws IOException {
+    void testWriteBigDataAndPersist() throws IOException {
         List<byte[]> buffers = OSSTestUtils.generateRandomBuffer(50 * 1024 * 1024, 10 * 104 * 1024);
         for (byte[] buffer : buffers) {
             fsDataOutputStream.write(buffer);
@@ -215,7 +217,7 @@ public class OSSRecoverableFsDataOutputStreamTest {
     }
 
     @Test
-    public void testDataWrittenAfterRecovery() throws IOException {
+    void testDataWrittenAfterRecovery() throws IOException {
         final byte[] part = OSSTestUtils.bytesOf("hello world", 1024 * 1024);
         fsDataOutputStream.write(part);
 
@@ -236,8 +238,8 @@ public class OSSRecoverableFsDataOutputStreamTest {
         OSSTestUtils.objectContentEquals(fs, objectPath, buffers);
     }
 
-    @After
-    public void after() throws IOException {
+    @AfterEach
+    void after() throws IOException {
         try {
             if (fs != null) {
                 fs.delete(basePath, true);

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableMultipartUploadTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableMultipartUploadTest.java
@@ -145,7 +145,7 @@ class OSSRecoverableMultipartUploadTest {
 
         OSSRecoverable ossRecoverable = uploader.getRecoverable(partFile);
 
-        assertThat(ossRecoverable.getPartETags().size()).isEqualTo(2);
+        assertThat(ossRecoverable.getPartETags()).hasSize(2);
         assertThat(ossRecoverable.getLastPartObject()).isNotNull();
         assertThat(ossRecoverable.getLastPartObjectLength()).isEqualTo(1026);
         assertThat(ossRecoverable.getNumBytesInParts()).isEqualTo(2 * 1024 * 1024 + 20);

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableMultipartUploadTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableMultipartUploadTest.java
@@ -41,9 +41,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link OSSRecoverableMultipartUpload}. */
@@ -147,12 +145,12 @@ class OSSRecoverableMultipartUploadTest {
 
         OSSRecoverable ossRecoverable = uploader.getRecoverable(partFile);
 
-        assertEquals(ossRecoverable.getPartETags().size(), 2);
-        assertNotNull(ossRecoverable.getLastPartObject());
-        assertEquals(ossRecoverable.getLastPartObjectLength(), 1026);
-        assertEquals(ossRecoverable.getNumBytesInParts(), 2 * 1024 * 1024 + 20);
-        assertEquals(ossRecoverable.getUploadId(), uploadId);
-        assertEquals(ossRecoverable.getObjectName(), ossAccessor.pathToObject(objectPath));
+        assertThat(ossRecoverable.getPartETags().size()).isEqualTo(2);
+        assertThat(ossRecoverable.getLastPartObject()).isNotNull();
+        assertThat(ossRecoverable.getLastPartObjectLength()).isEqualTo(1026);
+        assertThat(ossRecoverable.getNumBytesInParts()).isEqualTo(2 * 1024 * 1024 + 20);
+        assertThat(ossRecoverable.getUploadId()).isEqualTo(uploadId);
+        assertThat(ossRecoverable.getObjectName()).isEqualTo(ossAccessor.pathToObject(objectPath));
 
         ossAccessor.completeMultipartUpload(
                 ossAccessor.pathToObject(objectPath), uploadId, completeParts);
@@ -180,7 +178,8 @@ class OSSRecoverableMultipartUploadTest {
         partFile.close();
         OSSRecoverable recoverableTwo = uploader.getRecoverable(partFile);
 
-        assertFalse(recoverableOne.getLastPartObject().equals(recoverableTwo.getLastPartObject()));
+        assertThat(recoverableOne.getLastPartObject())
+                .isNotEqualTo(recoverableTwo.getLastPartObject());
     }
 
     @Test

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.fs.osshadoop.writer;
 import com.aliyun.oss.model.PartETag;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import java.util.Objects;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Tests for the {@link OSSRecoverableSerializer}. */
-public class OSSRecoverableSerializerTest {
+class OSSRecoverableSerializerTest {
 
     private final OSSRecoverableSerializer serializer = OSSRecoverableSerializer.INSTANCE;
 
@@ -45,7 +45,7 @@ public class OSSRecoverableSerializerTest {
     private static final String ETAG_PREFIX = "TEST-ETAG-";
 
     @Test
-    public void testSerializeEmptyOSSRecoverable() throws IOException {
+    void testSerializeEmptyOSSRecoverable() throws IOException {
         OSSRecoverable originalEmptyRecoverable = createOSSRecoverable(false);
 
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
@@ -55,7 +55,7 @@ public class OSSRecoverableSerializerTest {
     }
 
     @Test
-    public void testSerializeOSSRecoverableOnlyWithIncompleteObject() throws IOException {
+    void testSerializeOSSRecoverableOnlyWithIncompleteObject() throws IOException {
         OSSRecoverable originalEmptyRecoverable = createOSSRecoverable(true);
 
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
@@ -65,7 +65,7 @@ public class OSSRecoverableSerializerTest {
     }
 
     @Test
-    public void testSerializeOSSRecoverableWithIncompleteObject() throws IOException {
+    void testSerializeOSSRecoverableWithIncompleteObject() throws IOException {
         OSSRecoverable originalEmptyRecoverable = createOSSRecoverable(true, 2, 4, 6);
 
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
@@ -75,7 +75,7 @@ public class OSSRecoverableSerializerTest {
     }
 
     @Test
-    public void testSerializeOSSRecoverableWithoutIncompleteObject() throws IOException {
+    void testSerializeOSSRecoverableWithoutIncompleteObject() throws IOException {
         OSSRecoverable originalEmptyRecoverable = createOSSRecoverable(false, 2, 4, 6);
 
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
@@ -19,12 +19,13 @@
 package org.apache.flink.fs.osshadoop.writer;
 
 import com.aliyun.oss.model.PartETag;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link OSSRecoverableSerializer}. */
 class OSSRecoverableSerializerTest {
@@ -102,13 +103,12 @@ class OSSRecoverableSerializerTest {
     }
 
     private static void assertIsEqualTo(OSSRecoverable actual, OSSRecoverable expected) {
-        Assertions.assertThat(actual.getObjectName()).isEqualTo(expected.getObjectName());
-        Assertions.assertThat(actual.getUploadId()).isEqualTo(expected.getUploadId());
-        Assertions.assertThat(actual.getNumBytesInParts()).isEqualTo(expected.getNumBytesInParts());
-        Assertions.assertThat(actual.getLastPartObject()).isEqualTo(expected.getLastPartObject());
-        Assertions.assertThat(actual.getLastPartObjectLength())
-                .isEqualTo(expected.getLastPartObjectLength());
-        Assertions.assertThat(actual.getPartETags().stream().map(PartETag::getETag).toArray())
+        assertThat(actual.getObjectName()).isEqualTo(expected.getObjectName());
+        assertThat(actual.getUploadId()).isEqualTo(expected.getUploadId());
+        assertThat(actual.getNumBytesInParts()).isEqualTo(expected.getNumBytesInParts());
+        assertThat(actual.getLastPartObject()).isEqualTo(expected.getLastPartObject());
+        assertThat(actual.getLastPartObjectLength()).isEqualTo(expected.getLastPartObjectLength());
+        assertThat(actual.getPartETags().stream().map(PartETag::getETag).toArray())
                 .isEqualTo(expected.getPartETags().stream().map(PartETag::getETag).toArray());
     }
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/writer/OSSRecoverableSerializerTest.java
@@ -19,17 +19,12 @@
 package org.apache.flink.fs.osshadoop.writer;
 
 import com.aliyun.oss.model.PartETag;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Tests for the {@link OSSRecoverableSerializer}. */
 class OSSRecoverableSerializerTest {
@@ -51,7 +46,7 @@ class OSSRecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
         OSSRecoverable copiedEmptyRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalEmptyRecoverable, isEqualTo(copiedEmptyRecoverable));
+        assertIsEqualTo(originalEmptyRecoverable, copiedEmptyRecoverable);
     }
 
     @Test
@@ -61,7 +56,7 @@ class OSSRecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
         OSSRecoverable copiedEmptyRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalEmptyRecoverable, isEqualTo(copiedEmptyRecoverable));
+        assertIsEqualTo(originalEmptyRecoverable, copiedEmptyRecoverable);
     }
 
     @Test
@@ -71,7 +66,7 @@ class OSSRecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
         OSSRecoverable copiedEmptyRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalEmptyRecoverable, isEqualTo(copiedEmptyRecoverable));
+        assertIsEqualTo(originalEmptyRecoverable, copiedEmptyRecoverable);
     }
 
     @Test
@@ -81,46 +76,7 @@ class OSSRecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
         OSSRecoverable copiedEmptyRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalEmptyRecoverable, isEqualTo(copiedEmptyRecoverable));
-    }
-
-    // --------------------------------- Matchers ---------------------------------
-
-    private static TypeSafeMatcher<OSSRecoverable> isEqualTo(OSSRecoverable expectedRecoverable) {
-        return new TypeSafeMatcher<OSSRecoverable>() {
-
-            @Override
-            protected boolean matchesSafely(OSSRecoverable actualRecoverable) {
-
-                return Objects.equals(
-                                expectedRecoverable.getObjectName(),
-                                actualRecoverable.getObjectName())
-                        && Objects.equals(
-                                expectedRecoverable.getUploadId(), actualRecoverable.getUploadId())
-                        && expectedRecoverable.getNumBytesInParts()
-                                == actualRecoverable.getNumBytesInParts()
-                        && Objects.equals(
-                                expectedRecoverable.getLastPartObject(),
-                                actualRecoverable.getLastPartObject())
-                        && expectedRecoverable.getLastPartObjectLength()
-                                == actualRecoverable.getLastPartObjectLength()
-                        && compareLists(
-                                expectedRecoverable.getPartETags(),
-                                actualRecoverable.getPartETags());
-            }
-
-            private boolean compareLists(final List<PartETag> first, final List<PartETag> second) {
-                return Arrays.equals(
-                        first.stream().map(PartETag::getETag).toArray(),
-                        second.stream().map(PartETag::getETag).toArray());
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText(
-                        expectedRecoverable + " with ignored LAST_PART_OBJECT_NAME.");
-            }
-        };
+        assertIsEqualTo(originalEmptyRecoverable, copiedEmptyRecoverable);
     }
 
     // --------------------------------- Test Utils ---------------------------------
@@ -143,6 +99,17 @@ class OSSRecoverableSerializerTest {
         } else {
             return new OSSRecoverable(TEST_UPLOAD_ID, TEST_OBJECT_NAME, etags, null, 12345L, 0L);
         }
+    }
+
+    private static void assertIsEqualTo(OSSRecoverable actual, OSSRecoverable expected) {
+        Assertions.assertThat(actual.getObjectName()).isEqualTo(expected.getObjectName());
+        Assertions.assertThat(actual.getUploadId()).isEqualTo(expected.getUploadId());
+        Assertions.assertThat(actual.getNumBytesInParts()).isEqualTo(expected.getNumBytesInParts());
+        Assertions.assertThat(actual.getLastPartObject()).isEqualTo(expected.getLastPartObject());
+        Assertions.assertThat(actual.getLastPartObjectLength())
+                .isEqualTo(expected.getLastPartObjectLength());
+        Assertions.assertThat(actual.getPartETags().stream().map(PartETag::getETag).toArray())
+                .isEqualTo(expected.getPartETags().stream().map(PartETag::getETag).toArray());
     }
 
     private static PartETag createEtag(int partNumber) {

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainer.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainer.java
@@ -40,7 +40,7 @@ import java.time.Duration;
 import java.util.Locale;
 
 /** {@code MinioTestContainer} provides a {@code Minio} test instance. */
-public class MinioTestContainer extends GenericContainer<MinioTestContainer> {
+class MinioTestContainer extends GenericContainer<MinioTestContainer> {
 
     private static final int DEFAULT_PORT = 9000;
 

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
@@ -58,7 +58,7 @@ class MinioTestContainerTest {
     }
 
     @Test
-    public void testBucketCreation() {
+    void testBucketCreation() {
         final String bucketName = "other-bucket";
         final Bucket otherBucket = getClient().createBucket(bucketName);
 
@@ -71,7 +71,7 @@ class MinioTestContainerTest {
     }
 
     @Test
-    public void testPutObject() throws IOException {
+    void testPutObject() throws IOException {
         final String bucketName = "other-bucket";
 
         getClient().createBucket(bucketName);
@@ -87,7 +87,7 @@ class MinioTestContainerTest {
     }
 
     @Test
-    public void testSetS3ConfigOptions() {
+    void testSetS3ConfigOptions() {
         final Configuration config = new Configuration();
         getTestContainer().setS3ConfigOptions(config);
 
@@ -98,12 +98,12 @@ class MinioTestContainerTest {
     }
 
     @Test
-    public void testGetDefaultBucketName() {
+    void testGetDefaultBucketName() {
         assertThat(getTestContainer().getDefaultBucketName()).isEqualTo(DEFAULT_BUCKET_NAME);
     }
 
     @Test
-    public void testDefaultBucketCreation() {
+    void testDefaultBucketCreation() {
         assertThat(getClient().listBuckets())
                 .singleElement()
                 .extracting(Bucket::getName)
@@ -111,7 +111,7 @@ class MinioTestContainerTest {
     }
 
     @Test
-    public void testS3EndpointNeedsToBeSpecifiedBeforeInitializingFileSyste() {
+    void testS3EndpointNeedsToBeSpecifiedBeforeInitializingFileSyste() {
         assertThatThrownBy(() -> getTestContainer().initializeFileSystem(new Configuration()))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/MinioTestContainerTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * {@code MinioTestContainerTest} tests some basic functionality provided by {@link
  * MinioTestContainer}.
  */
-public class MinioTestContainerTest {
+class MinioTestContainerTest {
 
     private static final String DEFAULT_BUCKET_NAME = "test-bucket";
 

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests that the file system factory picks up the entropy configuration properly. */
 class S3EntropyFsFactoryTest {
@@ -46,8 +46,8 @@ class S3EntropyFsFactoryTest {
         factory.configure(conf);
 
         FlinkS3FileSystem fs = (FlinkS3FileSystem) factory.create(new URI("s3://test"));
-        assertEquals("__entropy__", fs.getEntropyInjectionKey());
-        assertEquals(7, fs.generateEntropy().length());
+        assertThat(fs.getEntropyInjectionKey()).isEqualTo("__entropy__");
+        assertThat(fs.generateEntropy().length()).isEqualTo(7);
     }
 
     /**
@@ -65,7 +65,7 @@ class S3EntropyFsFactoryTest {
         factory.configure(conf);
 
         FlinkS3FileSystem fs = (FlinkS3FileSystem) factory.create(new URI("s3://test"));
-        assertEquals(fs.getLocalTmpDir(), dir1);
+        assertThat(fs.getLocalTmpDir()).isEqualTo(dir1);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S3EntropyFsFactoryTest.java
@@ -21,10 +21,9 @@ package org.apache.flink.fs.s3.common;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fs.s3.common.writer.S3AccessHelper;
 import org.apache.flink.runtime.util.HadoopConfigLoader;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
@@ -32,13 +31,13 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests that the file system factory picks up the entropy configuration properly. */
-public class S3EntropyFsFactoryTest extends TestLogger {
+class S3EntropyFsFactoryTest {
 
     @Test
-    public void testEntropyInjectionConfig() throws Exception {
+    void testEntropyInjectionConfig() throws Exception {
         final Configuration conf = new Configuration();
         conf.setString("s3.entropy.key", "__entropy__");
         conf.setInteger("s3.entropy.length", 7);
@@ -56,7 +55,7 @@ public class S3EntropyFsFactoryTest extends TestLogger {
      * first path from multiple paths in config.
      */
     @Test
-    public void testMultipleTempDirsConfig() throws Exception {
+    void testMultipleTempDirsConfig() throws Exception {
         final Configuration conf = new Configuration();
         String dir1 = "/tmp/dir1";
         String dir2 = "/tmp/dir2";

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
@@ -137,7 +137,7 @@ public abstract class S5CmdOnMinioITCase {
     }
 
     @BeforeAll
-    public static void prepareS5Cmd() throws Exception {
+    static void prepareS5Cmd() throws Exception {
         Path s5CmdTgz = Paths.get(temporaryDirectory.getPath(), "s5cmd.tar.gz");
         MessageDigest md = MessageDigest.getInstance("MD5");
 

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
@@ -186,12 +186,12 @@ public abstract class S5CmdOnMinioITCase {
     }
 
     @AfterAll
-    public static void unsetFileSystem() {
+    static void unsetFileSystem() {
         FileSystem.initialize(new Configuration(), null);
     }
 
     @Test
-    public void testS5CmdConfigurationIsUsed(@InjectMiniCluster MiniCluster flinkCluster)
+    void testS5CmdConfigurationIsUsed(@InjectMiniCluster MiniCluster flinkCluster)
             throws Exception {
         String moveFrom = getS5CmdPath();
         String moveTo = moveFrom + "-moved";
@@ -208,8 +208,7 @@ public abstract class S5CmdOnMinioITCase {
     }
 
     @Test
-    public void testRecoveryWithS5Cmd(@InjectMiniCluster MiniCluster flinkCluster)
-            throws Exception {
+    void testRecoveryWithS5Cmd(@InjectMiniCluster MiniCluster flinkCluster) throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(2);
         env.enableCheckpointing(CHECKPOINT_INTERVAL);

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
@@ -48,13 +48,13 @@ public class AbstractS3DelegationTokenProviderTest {
     }
 
     @Test
-    public void delegationTokensRequiredShouldReturnFalseWithoutCredentials() {
+    void delegationTokensRequiredShouldReturnFalseWithoutCredentials() {
         provider.init(new Configuration());
         assertFalse(provider.delegationTokensRequired());
     }
 
     @Test
-    public void delegationTokensRequiredShouldReturnTrueWithCredentials() {
+    void delegationTokensRequiredShouldReturnTrueWithCredentials() {
         Configuration configuration = new Configuration();
         configuration.setString(CONFIG_PREFIX + ".s3.region", REGION);
         configuration.setString(CONFIG_PREFIX + ".s3.access-key", ACCESS_KEY_ID);

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
@@ -36,7 +36,7 @@ class AbstractS3DelegationTokenProviderTest {
     private AbstractS3DelegationTokenProvider provider;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         provider =
                 new AbstractS3DelegationTokenProvider() {
                     @Override

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFIG_PREFIX;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AbstractS3DelegationTokenProvider}. */
 public class AbstractS3DelegationTokenProviderTest {
@@ -50,7 +49,7 @@ public class AbstractS3DelegationTokenProviderTest {
     @Test
     void delegationTokensRequiredShouldReturnFalseWithoutCredentials() {
         provider.init(new Configuration());
-        assertFalse(provider.delegationTokensRequired());
+        assertThat(provider.delegationTokensRequired()).isFalse();
     }
 
     @Test
@@ -61,6 +60,6 @@ public class AbstractS3DelegationTokenProviderTest {
         configuration.setString(CONFIG_PREFIX + ".s3.secret-key", SECRET_ACCESS_KEY);
         provider.init(configuration);
 
-        assertTrue(provider.delegationTokensRequired());
+        assertThat(provider.delegationTokensRequired()).isTrue();
     }
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenProviderTest.java
@@ -27,7 +27,7 @@ import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFI
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AbstractS3DelegationTokenProvider}. */
-public class AbstractS3DelegationTokenProviderTest {
+class AbstractS3DelegationTokenProviderTest {
 
     private static final String REGION = "testRegion";
     private static final String ACCESS_KEY_ID = "testAccessKeyId";

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFIG_PREFIX;
 import static org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenReceiver.PROVIDER_CONFIG_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AbstractS3DelegationTokenReceiver}. */
 public class AbstractS3DelegationTokenReceiverTest {
@@ -51,9 +50,8 @@ public class AbstractS3DelegationTokenReceiverTest {
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, "");
         AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
-        assertEquals(
-                DynamicTemporaryAWSCredentialsProvider.NAME,
-                hadoopConfiguration.get(PROVIDER_CONFIG_NAME));
+        assertThat(hadoopConfiguration.get(PROVIDER_CONFIG_NAME))
+                .isEqualTo(DynamicTemporaryAWSCredentialsProvider.NAME);
     }
 
     @Test
@@ -63,9 +61,9 @@ public class AbstractS3DelegationTokenReceiverTest {
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, PROVIDER_CLASS_NAME);
         AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
         String[] providers = hadoopConfiguration.get(PROVIDER_CONFIG_NAME).split(",");
-        assertEquals(2, providers.length);
-        assertEquals(DynamicTemporaryAWSCredentialsProvider.NAME, providers[0]);
-        assertEquals(PROVIDER_CLASS_NAME, providers[1]);
+        assertThat(providers.length).isEqualTo(2);
+        assertThat(providers[0]).isEqualTo(DynamicTemporaryAWSCredentialsProvider.NAME);
+        assertThat(providers[1]).isEqualTo(PROVIDER_CLASS_NAME);
     }
 
     @Test
@@ -74,9 +72,8 @@ public class AbstractS3DelegationTokenReceiverTest {
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, DynamicTemporaryAWSCredentialsProvider.NAME);
         AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
-        assertEquals(
-                DynamicTemporaryAWSCredentialsProvider.NAME,
-                hadoopConfiguration.get(PROVIDER_CONFIG_NAME));
+        assertThat(hadoopConfiguration.get(PROVIDER_CONFIG_NAME))
+                .isEqualTo(DynamicTemporaryAWSCredentialsProvider.NAME);
     }
 
     @Test
@@ -87,7 +84,7 @@ public class AbstractS3DelegationTokenReceiverTest {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
-        assertNull(hadoopConfiguration.get("fs.s3a.endpoint.region"));
+        assertThat(hadoopConfiguration.get("fs.s3a.endpoint.region")).isNull();
     }
 
     @Test
@@ -100,7 +97,7 @@ public class AbstractS3DelegationTokenReceiverTest {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         AbstractS3DelegationTokenReceiver.updateHadoopConfig(hadoopConfiguration);
-        assertEquals(REGION, hadoopConfiguration.get("fs.s3a.endpoint.region"));
+        assertThat(hadoopConfiguration.get("fs.s3a.endpoint.region")).isEqualTo(REGION);
     }
 
     private AbstractS3DelegationTokenReceiver createReceiver() {

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
@@ -29,7 +29,7 @@ import static org.apache.flink.fs.s3.common.token.AbstractS3DelegationTokenRecei
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AbstractS3DelegationTokenReceiver}. */
-public class AbstractS3DelegationTokenReceiverTest {
+class AbstractS3DelegationTokenReceiverTest {
 
     private static final String PROVIDER_CLASS_NAME = "TestProvider";
     private static final String REGION = "testRegion";

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/AbstractS3DelegationTokenReceiverTest.java
@@ -46,7 +46,7 @@ public class AbstractS3DelegationTokenReceiverTest {
     }
 
     @Test
-    public void updateHadoopConfigShouldSetProviderWhenEmpty() {
+    void updateHadoopConfigShouldSetProviderWhenEmpty() {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, "");
@@ -57,7 +57,7 @@ public class AbstractS3DelegationTokenReceiverTest {
     }
 
     @Test
-    public void updateHadoopConfigShouldPrependProviderWhenNotEmpty() {
+    void updateHadoopConfigShouldPrependProviderWhenNotEmpty() {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, PROVIDER_CLASS_NAME);
@@ -69,7 +69,7 @@ public class AbstractS3DelegationTokenReceiverTest {
     }
 
     @Test
-    public void updateHadoopConfigShouldNotAddProviderWhenAlreadyExists() {
+    void updateHadoopConfigShouldNotAddProviderWhenAlreadyExists() {
         org.apache.hadoop.conf.Configuration hadoopConfiguration =
                 new org.apache.hadoop.conf.Configuration();
         hadoopConfiguration.set(PROVIDER_CONFIG_NAME, DynamicTemporaryAWSCredentialsProvider.NAME);
@@ -80,7 +80,7 @@ public class AbstractS3DelegationTokenReceiverTest {
     }
 
     @Test
-    public void updateHadoopConfigShouldNotUpdateRegionWhenNotConfigured() {
+    void updateHadoopConfigShouldNotUpdateRegionWhenNotConfigured() {
         AbstractS3DelegationTokenReceiver receiver = createReceiver();
         receiver.init(new Configuration());
 
@@ -91,7 +91,7 @@ public class AbstractS3DelegationTokenReceiverTest {
     }
 
     @Test
-    public void updateHadoopConfigShouldUpdateRegionWhenConfigured() {
+    void updateHadoopConfigShouldUpdateRegionWhenConfigured() {
         AbstractS3DelegationTokenReceiver receiver = createReceiver();
         Configuration configuration = new Configuration();
         configuration.setString(CONFIG_PREFIX + ".s3.region", REGION);

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DynamicTemporaryAWSCredentialsProvider}. */
 class DynamicTemporaryAWSCredentialsProviderTest {
@@ -52,7 +52,7 @@ class DynamicTemporaryAWSCredentialsProviderTest {
         DynamicTemporaryAWSCredentialsProvider provider =
                 new DynamicTemporaryAWSCredentialsProvider();
 
-        assertThrows(NoAwsCredentialsException.class, provider::getCredentials);
+        assertThatThrownBy(provider::getCredentials).isInstanceOf(NoAwsCredentialsException.class);
     }
 
     @Test
@@ -72,8 +72,9 @@ class DynamicTemporaryAWSCredentialsProviderTest {
         receiver.onNewTokensObtained(InstantiationUtil.serializeObject(credentials));
         BasicSessionCredentials returnedCredentials =
                 (BasicSessionCredentials) provider.getCredentials();
-        assertEquals(returnedCredentials.getAWSAccessKeyId(), credentials.getAccessKeyId());
-        assertEquals(returnedCredentials.getAWSSecretKey(), credentials.getSecretAccessKey());
-        assertEquals(returnedCredentials.getSessionToken(), credentials.getSessionToken());
+        assertThat(returnedCredentials.getAWSAccessKeyId()).isEqualTo(credentials.getAccessKeyId());
+        assertThat(returnedCredentials.getAWSSecretKey())
+                .isEqualTo(credentials.getSecretAccessKey());
+        assertThat(returnedCredentials.getSessionToken()).isEqualTo(credentials.getSessionToken());
     }
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/token/DynamicTemporaryAWSCredentialsProviderTest.java
@@ -23,15 +23,15 @@ import org.apache.flink.util.InstantiationUtil;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
-import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link DynamicTemporaryAWSCredentialsProvider}. */
-public class DynamicTemporaryAWSCredentialsProviderTest {
+class DynamicTemporaryAWSCredentialsProviderTest {
 
     private static final String ACCESS_KEY_ID = "testAccessKeyId";
     private static final String SECRET_ACCESS_KEY = "testSecretAccessKey";
@@ -48,7 +48,7 @@ public class DynamicTemporaryAWSCredentialsProviderTest {
     }
 
     @Test
-    public void getCredentialsShouldThrowExceptionWhenNoCredentials() {
+    void getCredentialsShouldThrowExceptionWhenNoCredentials() {
         DynamicTemporaryAWSCredentialsProvider provider =
                 new DynamicTemporaryAWSCredentialsProvider();
 
@@ -56,7 +56,7 @@ public class DynamicTemporaryAWSCredentialsProviderTest {
     }
 
     @Test
-    public void getCredentialsShouldStoreCredentialsWhenCredentialsProvided() throws Exception {
+    void getCredentialsShouldStoreCredentialsWhenCredentialsProvided() throws Exception {
         DynamicTemporaryAWSCredentialsProvider provider =
                 new DynamicTemporaryAWSCredentialsProvider();
         Credentials credentials =

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
@@ -18,47 +18,53 @@
 
 package org.apache.flink.fs.s3.common.writer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for the {@link
  * RecoverableMultiPartUploadImpl#createIncompletePartObjectNamePrefix(String)}.
  */
-public class IncompletePartPrefixTest {
+class IncompletePartPrefixTest {
 
-    @Test(expected = NullPointerException.class)
-    public void nullObjectNameShouldThroughException() {
-        RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(null);
+    @Test
+    void nullObjectNameShouldThroughException() {
+        assertThatThrownBy(
+                        () ->
+                                RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(
+                                        null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void emptyInitialNameShouldSucceed() {
+    void emptyInitialNameShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("");
-        Assert.assertEquals("_tmp_", objectNamePrefix);
+        Assertions.assertEquals("_tmp_", objectNamePrefix);
     }
 
     @Test
-    public void nameWithoutSlashShouldSucceed() {
+    void nameWithoutSlashShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(
                         "no_slash_path");
-        Assert.assertEquals("_no_slash_path_tmp_", objectNamePrefix);
+        Assertions.assertEquals("_no_slash_path_tmp_", objectNamePrefix);
     }
 
     @Test
-    public void nameWithOnlySlashShouldSucceed() {
+    void nameWithOnlySlashShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/");
-        Assert.assertEquals("/_tmp_", objectNamePrefix);
+        Assertions.assertEquals("/_tmp_", objectNamePrefix);
     }
 
     @Test
-    public void normalPathShouldSucceed() {
+    void normalPathShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(
                         "/root/home/test-file");
-        Assert.assertEquals("/root/home/_test-file_tmp_", objectNamePrefix);
+        Assertions.assertEquals("/root/home/_test-file_tmp_", objectNamePrefix);
     }
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/IncompletePartPrefixTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.fs.s3.common.writer;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -42,7 +42,8 @@ class IncompletePartPrefixTest {
     void emptyInitialNameShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("");
-        Assertions.assertEquals("_tmp_", objectNamePrefix);
+
+        assertThat(objectNamePrefix).isEqualTo("_tmp_");
     }
 
     @Test
@@ -50,14 +51,16 @@ class IncompletePartPrefixTest {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(
                         "no_slash_path");
-        Assertions.assertEquals("_no_slash_path_tmp_", objectNamePrefix);
+
+        assertThat(objectNamePrefix).isEqualTo("_no_slash_path_tmp_");
     }
 
     @Test
     void nameWithOnlySlashShouldSucceed() {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix("/");
-        Assertions.assertEquals("/_tmp_", objectNamePrefix);
+
+        assertThat(objectNamePrefix).isEqualTo("/_tmp_");
     }
 
     @Test
@@ -65,6 +68,7 @@ class IncompletePartPrefixTest {
         String objectNamePrefix =
                 RecoverableMultiPartUploadImpl.createIncompletePartObjectNamePrefix(
                         "/root/home/test-file");
-        Assertions.assertEquals("/root/home/_test-file_tmp_", objectNamePrefix);
+
+        assertThat(objectNamePrefix).isEqualTo("/root/home/_test-file_tmp_");
     }
 }

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/RecoverableMultiPartUploadImplTest.java
@@ -28,7 +28,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.UploadPartResult;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -147,35 +146,14 @@ class RecoverableMultiPartUploadImplTest {
         TestUploadPartResult expectedCompletePart =
                 createUploadPartResult(TEST_OBJECT_NAME, partNo, content);
 
-        final List<TestUploadPartResult> actualCompleteParts = actual.getCompletePartsUploaded();
-
-        for (TestUploadPartResult result : actualCompleteParts) {
-            if (result.equals(expectedCompletePart)) {
-                return;
-            }
-        }
-
-        Assertions.fail(
-                "Expected multipart upload with part number "
-                        + partNo
-                        + " and specific content to be present, but it was not found among the uploaded parts.");
+        assertThat(actual.getCompletePartsUploaded()).contains(expectedCompletePart);
     }
 
     private static void assertThatHasUploadedObject(StubMultiPartUploader actual, byte[] content) {
         TestPutObjectResult expectedIncompletePart =
                 createPutObjectResult(TEST_OBJECT_NAME, content);
 
-        final List<TestPutObjectResult> actualIncompleteParts = actual.getIncompletePartsUploaded();
-
-        for (TestPutObjectResult result : actualIncompleteParts) {
-            if (result.equals(expectedIncompletePart)) {
-                return;
-            }
-        }
-
-        Assertions.fail(
-                "Expected multipart upload with specific content to be present, "
-                        + "but it was not found among the uploaded parts.");
+        assertThat(actual.getIncompletePartsUploaded()).contains(expectedIncompletePart);
     }
 
     private static void assertThatIsEqualTo(

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.FunctionWithException;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,6 +51,7 @@ import java.util.SplittableRandom;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link S3RecoverableFsDataOutputStream}. */
 class S3RecoverableFsDataOutputStreamTest {
@@ -254,7 +254,7 @@ class S3RecoverableFsDataOutputStreamTest {
     @Test
     void closeForCommitOnClosedStreamShouldFail() throws IOException {
         streamUnderTest.closeForCommit().commit();
-        Assertions.assertThatThrownBy(() -> streamUnderTest.closeForCommit().commit())
+        assertThatThrownBy(() -> streamUnderTest.closeForCommit().commit())
                 .isInstanceOf(IOException.class);
     }
 
@@ -267,7 +267,7 @@ class S3RecoverableFsDataOutputStreamTest {
         assertThat(multipartUploadUnderTest.getPublishedContents())
                 .isEqualTo(bytesOf("hello world"));
 
-        Assertions.assertThatThrownBy(
+        assertThatThrownBy(
                         () ->
                                 streamUnderTest.write(
                                         randomBuffer(

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableSerializerTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableSerializerTest.java
@@ -19,17 +19,13 @@
 package org.apache.flink.fs.s3.common.writer;
 
 import com.amazonaws.services.s3.model.PartETag;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link S3RecoverableSerializer}. */
 class S3RecoverableSerializerTest {
@@ -51,7 +47,7 @@ class S3RecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
         S3Recoverable copiedEmptyRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalEmptyRecoverable, isEqualTo(copiedEmptyRecoverable));
+        assertThatIsEqualTo(originalEmptyRecoverable, copiedEmptyRecoverable);
     }
 
     @Test
@@ -62,8 +58,7 @@ class S3RecoverableSerializerTest {
         S3Recoverable copiedNoIncompletePartRecoverable =
                 serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(
-                originalNoIncompletePartRecoverable, isEqualTo(copiedNoIncompletePartRecoverable));
+        assertThatIsEqualTo(originalNoIncompletePartRecoverable, copiedNoIncompletePartRecoverable);
     }
 
     @Test
@@ -74,9 +69,8 @@ class S3RecoverableSerializerTest {
         S3Recoverable copiedOnlyIncompletePartRecoverable =
                 serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(
-                originalOnlyIncompletePartRecoverable,
-                isEqualTo(copiedOnlyIncompletePartRecoverable));
+        assertThatIsEqualTo(
+                originalOnlyIncompletePartRecoverable, copiedOnlyIncompletePartRecoverable);
     }
 
     @Test
@@ -86,44 +80,22 @@ class S3RecoverableSerializerTest {
         byte[] serializedRecoverable = serializer.serialize(originalFullRecoverable);
         S3Recoverable copiedFullRecoverable = serializer.deserialize(1, serializedRecoverable);
 
-        assertThat(originalFullRecoverable, isEqualTo(copiedFullRecoverable));
+        assertThatIsEqualTo(originalFullRecoverable, copiedFullRecoverable);
     }
 
-    // --------------------------------- Matchers ---------------------------------
-
-    private static TypeSafeMatcher<S3Recoverable> isEqualTo(S3Recoverable expectedRecoverable) {
-        return new TypeSafeMatcher<S3Recoverable>() {
-
-            @Override
-            protected boolean matchesSafely(S3Recoverable actualRecoverable) {
-
-                return Objects.equals(
-                                expectedRecoverable.getObjectName(),
-                                actualRecoverable.getObjectName())
-                        && Objects.equals(
-                                expectedRecoverable.uploadId(), actualRecoverable.uploadId())
-                        && expectedRecoverable.numBytesInParts()
-                                == actualRecoverable.numBytesInParts()
-                        && Objects.equals(
-                                expectedRecoverable.incompleteObjectName(),
-                                actualRecoverable.incompleteObjectName())
-                        && expectedRecoverable.incompleteObjectLength()
-                                == actualRecoverable.incompleteObjectLength()
-                        && compareLists(expectedRecoverable.parts(), actualRecoverable.parts());
-            }
-
-            private boolean compareLists(final List<PartETag> first, final List<PartETag> second) {
-                return Arrays.equals(
-                        first.stream().map(PartETag::getETag).toArray(),
-                        second.stream().map(PartETag::getETag).toArray());
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText(
-                        expectedRecoverable + " with ignored LAST_PART_OBJECT_NAME.");
-            }
-        };
+    private static void assertThatIsEqualTo(
+            S3Recoverable actualRecoverable, S3Recoverable expectedRecoverable) {
+        assertThat(actualRecoverable.getObjectName())
+                .isEqualTo(expectedRecoverable.getObjectName());
+        assertThat(actualRecoverable.uploadId()).isEqualTo(expectedRecoverable.uploadId());
+        assertThat(actualRecoverable.numBytesInParts())
+                .isEqualTo(expectedRecoverable.numBytesInParts());
+        assertThat(actualRecoverable.incompleteObjectName())
+                .isEqualTo(expectedRecoverable.incompleteObjectName());
+        assertThat(actualRecoverable.incompleteObjectLength())
+                .isEqualTo(expectedRecoverable.incompleteObjectLength());
+        assertThat(actualRecoverable.parts().stream().map(PartETag::getETag).toArray())
+                .isEqualTo(expectedRecoverable.parts().stream().map(PartETag::getETag).toArray());
     }
 
     // --------------------------------- Test Utils ---------------------------------

--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableSerializerTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableSerializerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.fs.s3.common.writer;
 import com.amazonaws.services.s3.model.PartETag;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import java.util.Objects;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /** Tests for the {@link S3RecoverableSerializer}. */
-public class S3RecoverableSerializerTest {
+class S3RecoverableSerializerTest {
 
     private final S3RecoverableSerializer serializer = S3RecoverableSerializer.INSTANCE;
 
@@ -45,7 +45,7 @@ public class S3RecoverableSerializerTest {
     private static final String ETAG_PREFIX = "TEST-ETAG-";
 
     @Test
-    public void serializeEmptyS3Recoverable() throws IOException {
+    void serializeEmptyS3Recoverable() throws IOException {
         S3Recoverable originalEmptyRecoverable = createTestS3Recoverable(false);
 
         byte[] serializedRecoverable = serializer.serialize(originalEmptyRecoverable);
@@ -55,7 +55,7 @@ public class S3RecoverableSerializerTest {
     }
 
     @Test
-    public void serializeS3RecoverableWithoutIncompleteObject() throws IOException {
+    void serializeS3RecoverableWithoutIncompleteObject() throws IOException {
         S3Recoverable originalNoIncompletePartRecoverable = createTestS3Recoverable(false, 1, 5, 9);
 
         byte[] serializedRecoverable = serializer.serialize(originalNoIncompletePartRecoverable);
@@ -67,7 +67,7 @@ public class S3RecoverableSerializerTest {
     }
 
     @Test
-    public void serializeS3RecoverableOnlyWithIncompleteObject() throws IOException {
+    void serializeS3RecoverableOnlyWithIncompleteObject() throws IOException {
         S3Recoverable originalOnlyIncompletePartRecoverable = createTestS3Recoverable(true);
 
         byte[] serializedRecoverable = serializer.serialize(originalOnlyIncompletePartRecoverable);
@@ -80,7 +80,7 @@ public class S3RecoverableSerializerTest {
     }
 
     @Test
-    public void serializeS3RecoverableWithCompleteAndIncompleteParts() throws IOException {
+    void serializeS3RecoverableWithCompleteAndIncompleteParts() throws IOException {
         S3Recoverable originalFullRecoverable = createTestS3Recoverable(true, 1, 5, 9);
 
         byte[] serializedRecoverable = serializer.serialize(originalFullRecoverable);

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HAJobRunOnHadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HAJobRunOnHadoopS3FileSystemITCase.java
@@ -21,4 +21,4 @@ package org.apache.flink.fs.s3hadoop;
 import org.apache.flink.fs.s3.common.HAJobRunOnMinioS3StoreITCase;
 
 /** Runs the {@link HAJobRunOnMinioS3StoreITCase} on the Hadoop S3 file system. */
-public class HAJobRunOnHadoopS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}
+class HAJobRunOnHadoopS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
@@ -24,12 +24,12 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopFileSystemITTest;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Unit tests for the S3 file system support via Hadoop's {@link
@@ -39,10 +39,10 @@ import static org.junit.Assert.assertFalse;
  * href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel">consistency
  * guarantees</a> and what the {@link org.apache.hadoop.fs.s3a.S3AFileSystem} offers.
  */
-public class HadoopS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
+class HadoopS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         // check whether credentials exist
         S3TestCredentials.assumeCredentialsAvailable();
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import java.io.IOException;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the S3 file system support via Hadoop's {@link
@@ -58,6 +58,6 @@ class HadoopS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
 
         // check for uniqueness of the test directory
         // directory must not yet exist
-        assertFalse(fs.exists(basePath));
+        assertThat(fs.exists(basePath)).isFalse();
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.util.HadoopConfigLoader;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the S3 file system support via Hadoop's {@link
@@ -42,9 +42,8 @@ class HadoopS3FileSystemTest {
         configLoader.setFlinkConfig(conf);
 
         org.apache.hadoop.conf.Configuration hadoopConfig = configLoader.getOrLoadHadoopConfig();
-        assertEquals(
-                "com.amazonaws.auth.ContainerCredentialsProvider",
-                hadoopConfig.get("fs.s3a.aws.credentials.provider"));
+        assertThat(hadoopConfig.get("fs.s3a.aws.credentials.provider"))
+                .isEqualTo("com.amazonaws.auth.ContainerCredentialsProvider");
     }
 
     // ------------------------------------------------------------------------
@@ -88,7 +87,7 @@ class HadoopS3FileSystemTest {
 
         org.apache.hadoop.conf.Configuration hadoopConf = configLoader.getOrLoadHadoopConfig();
 
-        assertEquals(accessKey, hadoopConf.get("fs.s3a.access.key", null));
-        assertEquals(secretKey, hadoopConf.get("fs.s3a.secret.key", null));
+        assertThat(hadoopConf.get("fs.s3a.access.key", null)).isEqualTo(accessKey);
+        assertThat(hadoopConf.get("fs.s3a.secret.key", null)).isEqualTo(secretKey);
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemTest.java
@@ -21,18 +21,18 @@ package org.apache.flink.fs.s3hadoop;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.util.HadoopConfigLoader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for the S3 file system support via Hadoop's {@link
  * org.apache.hadoop.fs.s3a.S3AFileSystem}.
  */
-public class HadoopS3FileSystemTest {
+class HadoopS3FileSystemTest {
 
     @Test
-    public void testShadingOfAwsCredProviderConfig() {
+    void testShadingOfAwsCredProviderConfig() {
         final Configuration conf = new Configuration();
         conf.setString(
                 "fs.s3a.aws.credentials.provider",
@@ -54,7 +54,7 @@ public class HadoopS3FileSystemTest {
 
     /** Test forwarding of standard Hadoop-style credential keys. */
     @Test
-    public void testConfigKeysForwardingHadoopStyle() {
+    void testConfigKeysForwardingHadoopStyle() {
         Configuration conf = new Configuration();
         conf.setString("fs.s3a.access.key", "test_access_key");
         conf.setString("fs.s3a.secret.key", "test_secret_key");
@@ -64,7 +64,7 @@ public class HadoopS3FileSystemTest {
 
     /** Test forwarding of shortened Hadoop-style credential keys. */
     @Test
-    public void testConfigKeysForwardingShortHadoopStyle() {
+    void testConfigKeysForwardingShortHadoopStyle() {
         Configuration conf = new Configuration();
         conf.setString("s3.access.key", "my_key_a");
         conf.setString("s3.secret.key", "my_key_b");
@@ -74,7 +74,7 @@ public class HadoopS3FileSystemTest {
 
     /** Test forwarding of shortened Presto-style credential keys. */
     @Test
-    public void testConfigKeysForwardingPrestoStyle() {
+    void testConfigKeysForwardingPrestoStyle() {
         Configuration conf = new Configuration();
         conf.setString("s3.access-key", "clé d'accès");
         conf.setString("s3.secret-key", "clef secrète");

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemsSchemesTest.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemsSchemesTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ServiceLoader;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 /** This test validates that the S3 file system registers both under s3:// and s3a://. */
 class HadoopS3FileSystemsSchemesTest {

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemsSchemesTest.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemsSchemesTest.java
@@ -20,22 +20,22 @@ package org.apache.flink.fs.s3hadoop;
 
 import org.apache.flink.core.fs.FileSystemFactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ServiceLoader;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** This test validates that the S3 file system registers both under s3:// and s3a://. */
-public class HadoopS3FileSystemsSchemesTest {
+class HadoopS3FileSystemsSchemesTest {
 
     @Test
-    public void testS3Factory() {
+    void testS3Factory() {
         testFactory("s3");
     }
 
     @Test
-    public void testS3AFactory() {
+    void testS3AFactory() {
         testFactory("s3a");
     }
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterExceptionITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.fs.s3.common.FlinkS3FileSystem;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopRecoverableWriterExceptionITCase;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -38,7 +38,7 @@ import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.PART_UPL
  * Tests for exception throwing in the {@link
  * org.apache.flink.fs.s3.common.writer.S3RecoverableWriter S3RecoverableWriter}.
  */
-public class HadoopS3RecoverableWriterExceptionITCase
+class HadoopS3RecoverableWriterExceptionITCase
         extends AbstractHadoopRecoverableWriterExceptionITCase {
 
     // ----------------------- S3 general configuration -----------------------
@@ -46,8 +46,8 @@ public class HadoopS3RecoverableWriterExceptionITCase
     private static final long PART_UPLOAD_MIN_SIZE_VALUE = 7L << 20;
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
-    @BeforeClass
-    public static void checkCredentialsAndSetup() throws IOException {
+    @BeforeAll
+    static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         S3TestCredentials.assumeCredentialsAvailable();
 
@@ -61,7 +61,7 @@ public class HadoopS3RecoverableWriterExceptionITCase
         conf.set(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
         conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
-        final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "s3_tmp_dir";
+        final String defaultTmpDir = tempFolder.getAbsolutePath() + "s3_tmp_dir";
         conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterITCase.java
@@ -28,7 +28,7 @@ import org.apache.flink.fs.s3.common.writer.S3Recoverable;
 import org.apache.flink.runtime.fs.hdfs.AbstractHadoopRecoverableWriterITCase;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -40,15 +40,15 @@ import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.PART_UPL
  * Tests for the {@link org.apache.flink.fs.s3.common.writer.S3RecoverableWriter
  * S3RecoverableWriter}.
  */
-public class HadoopS3RecoverableWriterITCase extends AbstractHadoopRecoverableWriterITCase {
+class HadoopS3RecoverableWriterITCase extends AbstractHadoopRecoverableWriterITCase {
 
     // ----------------------- S3 general configuration -----------------------
 
     private static final long PART_UPLOAD_MIN_SIZE_VALUE = 7L << 20;
     private static final int MAX_CONCURRENT_UPLOADS_VALUE = 2;
 
-    @BeforeClass
-    public static void checkCredentialsAndSetup() throws IOException {
+    @BeforeAll
+    static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         S3TestCredentials.assumeCredentialsAvailable();
 
@@ -62,7 +62,7 @@ public class HadoopS3RecoverableWriterITCase extends AbstractHadoopRecoverableWr
         conf.set(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
         conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
-        final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "s3_tmp_dir";
+        final String defaultTmpDir = tempFolder.getAbsolutePath() + "s3_tmp_dir";
         conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/HAJobRunOnPrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/HAJobRunOnPrestoS3FileSystemITCase.java
@@ -21,4 +21,4 @@ package org.apache.flink.fs.s3presto;
 import org.apache.flink.fs.s3.common.HAJobRunOnMinioS3StoreITCase;
 
 /** Runs the {@link HAJobRunOnMinioS3StoreITCase} on the Presto S3 file system. */
-public class HAJobRunOnPrestoS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}
+class HAJobRunOnPrestoS3FileSystemITCase extends HAJobRunOnMinioS3StoreITCase {}

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_USE_INSTANCE_CREDENTIALS;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for the S3 file system support via Presto's {@link
@@ -63,7 +63,7 @@ class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
 
         // check for uniqueness of the test directory
         // directory must not yet exist
-        assertFalse(fs.exists(basePath));
+        assertThat(fs.exists(basePath)).isFalse();
     }
 
     @Test
@@ -77,11 +77,8 @@ class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
             conf.setString(S3_USE_INSTANCE_CREDENTIALS, "false");
             FileSystem.initialize(conf);
 
-            try {
-                path.getFileSystem().exists(path);
-                fail("should fail with an exception");
-            } catch (SdkClientException ignored) {
-            }
+            assertThatThrownBy(() -> path.getFileSystem().exists(path))
+                    .isInstanceOf(SdkClientException.class);
         }
 
         // standard Presto-style credential keys

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
@@ -26,19 +26,15 @@ import org.apache.flink.runtime.fs.hdfs.AbstractHadoopFileSystemITTest;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 
 import com.amazonaws.SdkClientException;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 
 import static com.facebook.presto.hive.s3.S3ConfigurationUpdater.S3_USE_INSTANCE_CREDENTIALS;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for the S3 file system support via Presto's {@link
@@ -48,20 +44,12 @@ import static org.junit.Assert.fail;
  * href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel">consistency
  * guarantees</a> and what the {@link com.facebook.presto.hive.s3.PrestoS3FileSystem} offers.
  */
-@RunWith(Parameterized.class)
-public class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
-
-    @Parameterized.Parameter public String scheme;
-
-    @Parameterized.Parameters(name = "Scheme = {0}")
-    public static List<String> parameters() {
-        return Arrays.asList("s3", "s3p");
-    }
+class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
 
     private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @BeforeAll
+    static void setup() throws IOException {
         S3TestCredentials.assumeCredentialsAvailable();
         // initialize configuration with valid credentials
         final Configuration conf = new Configuration();
@@ -79,7 +67,7 @@ public class PrestoS3FileSystemITCase extends AbstractHadoopFileSystemITTest {
     }
 
     @Test
-    public void testConfigKeysForwarding() throws Exception {
+    void testConfigKeysForwarding() throws Exception {
         final Path path = basePath;
 
         // access without credentials should fail

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -29,7 +29,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.facebook.presto.hive.s3.PrestoS3FileSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.net.URI;
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertTrue;
 public class PrestoS3FileSystemTest {
 
     @Test
-    public void testConfigPropagation() throws Exception {
+    void testConfigPropagation() throws Exception {
         final Configuration conf = new Configuration();
 
         conf.set(AbstractS3FileSystemFactory.ACCESS_KEY, "test_access_key_id");
@@ -58,7 +58,7 @@ public class PrestoS3FileSystemTest {
     }
 
     @Test
-    public void testDynamicConfigProvider() throws Exception {
+    void testDynamicConfigProvider() throws Exception {
         final Configuration conf = new Configuration();
 
         conf.setString(
@@ -73,7 +73,7 @@ public class PrestoS3FileSystemTest {
     }
 
     @Test
-    public void testConfigPropagationWithPrestoPrefix() throws Exception {
+    void testConfigPropagationWithPrestoPrefix() throws Exception {
         final Configuration conf = new Configuration();
         conf.setString("presto.s3.access-key", "test_access_key_id");
         conf.setString("presto.s3.secret-key", "test_secret_access_key");
@@ -85,7 +85,7 @@ public class PrestoS3FileSystemTest {
     }
 
     @Test
-    public void testConfigPropagationAlternateStyle() throws Exception {
+    void testConfigPropagationAlternateStyle() throws Exception {
         final Configuration conf = new Configuration();
         conf.setString("s3.access.key", "test_access_key_id");
         conf.setString("s3.secret.key", "test_secret_access_key");
@@ -97,7 +97,7 @@ public class PrestoS3FileSystemTest {
     }
 
     @Test
-    public void testShadingOfAwsCredProviderConfig() {
+    void testShadingOfAwsCredProviderConfig() {
         final Configuration conf = new Configuration();
         conf.setString(
                 "presto.s3.credentials-provider",

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -35,8 +35,6 @@ import java.lang.reflect.Field;
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the S3 file system support via Presto's PrestoS3FileSystem. These tests do not
@@ -107,9 +105,8 @@ public class PrestoS3FileSystemTest {
         configLoader.setFlinkConfig(conf);
 
         org.apache.hadoop.conf.Configuration hadoopConfig = configLoader.getOrLoadHadoopConfig();
-        assertEquals(
-                "com.amazonaws.auth.ContainerCredentialsProvider",
-                hadoopConfig.get("presto.s3.credentials-provider"));
+        assertThat(hadoopConfig.get("presto.s3.credentials-provider"))
+                .isEqualTo("com.amazonaws.auth.ContainerCredentialsProvider");
     }
 
     // ------------------------------------------------------------------------
@@ -119,15 +116,14 @@ public class PrestoS3FileSystemTest {
     private static void validateBasicCredentials(FileSystem fs) throws Exception {
         try (PrestoS3FileSystem prestoFs = getPrestoFileSystem(fs)) {
             AWSCredentialsProvider provider = getAwsCredentialsProvider(prestoFs);
-            assertTrue(provider instanceof AWSStaticCredentialsProvider);
+            assertThat(provider).isInstanceOf(AWSStaticCredentialsProvider.class);
         }
     }
 
     private static PrestoS3FileSystem getPrestoFileSystem(FileSystem fs) {
-        assertTrue(fs instanceof FlinkS3FileSystem);
-
+        assertThat(fs).isInstanceOf(FlinkS3FileSystem.class);
         org.apache.hadoop.fs.FileSystem hadoopFs = ((FlinkS3FileSystem) fs).getHadoopFileSystem();
-        assertTrue(hadoopFs instanceof PrestoS3FileSystem);
+        assertThat(hadoopFs).isInstanceOf(PrestoS3FileSystem.class);
         return (PrestoS3FileSystem) hadoopFs;
     }
 

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for the S3 file system support via Presto's PrestoS3FileSystem. These tests do not
  * actually read from or write to S3.
  */
-public class PrestoS3FileSystemTest {
+class PrestoS3FileSystemTest {
 
     @Test
     void testConfigPropagation() throws Exception {

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3RecoverableWriterTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3RecoverableWriterTest.java
@@ -24,9 +24,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.fs.s3.common.FlinkS3FileSystem;
 import org.apache.flink.testutils.s3.S3TestCredentials;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,9 +34,10 @@ import java.util.UUID;
 
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.MAX_CONCURRENT_UPLOADS;
 import static org.apache.flink.fs.s3.common.AbstractS3FileSystemFactory.PART_UPLOAD_MIN_SIZE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link org.apache.flink.core.fs.RecoverableWriter} of the Presto S3 FS. */
-public class PrestoS3RecoverableWriterTest {
+class PrestoS3RecoverableWriterTest {
 
     // ----------------------- S3 general configuration -----------------------
 
@@ -49,8 +50,8 @@ public class PrestoS3RecoverableWriterTest {
 
     // ----------------------- Test Lifecycle -----------------------
 
-    @BeforeClass
-    public static void checkCredentialsAndSetup() throws IOException {
+    @BeforeAll
+    static void checkCredentialsAndSetup() throws IOException {
         // check whether credentials exist
         S3TestCredentials.assumeCredentialsAvailable();
 
@@ -68,17 +69,18 @@ public class PrestoS3RecoverableWriterTest {
         FileSystem.initialize(conf);
     }
 
-    @AfterClass
-    public static void cleanUp() throws IOException {
+    @AfterAll
+    static void cleanUp() throws IOException {
         FileSystem.initialize(new Configuration());
     }
 
     // ----------------------- Tests -----------------------
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void requestingRecoverableWriterShouldThroughException() throws Exception {
+    @Test
+    void requestingRecoverableWriterShouldThroughException() throws Exception {
         URI s3Uri = URI.create(S3TestCredentials.getTestBucketUri());
         FlinkS3FileSystem fileSystem = (FlinkS3FileSystem) FileSystem.get(s3Uri);
-        fileSystem.createRecoverableWriter();
+        assertThatThrownBy(() -> fileSystem.createRecoverableWriter())
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

This migrates the Filesystem test code to use Junit5 and Assertj. 

## Brief change log

- Migrated the test code to use Junit5 according to the migration documentation
- Also migrated to Assertj (this is in a separate commit and could be dropped or resubmitted in a separate PR)

## Verifying this change

This change will not have any impact on non-test code since only test code was changed. The  change can potentially break tests, but the majority of changes are simple and don't touch the logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
