### PR TITLE
[FLINK-32358][rpc] Add rpc system loading priority

### DIFF
--- a/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
@@ -44,11 +44,18 @@ import java.util.UUID;
  */
 public class AkkaRpcSystemLoader implements RpcSystemLoader {
 
+    static final int LOAD_PRIORITY = 0;
+
     /** The name of the akka dependency jar, bundled with flink-rpc-akka-loader module artifact. */
     private static final String FLINK_RPC_AKKA_FAT_JAR = "flink-rpc-akka.jar";
 
     static final String HINT_USAGE =
             "mvn clean package -pl flink-rpc/flink-rpc-akka,flink-rpc/flink-rpc-akka-loader -DskipTests";
+
+    @Override
+    public int getLoadPriority() {
+        return LOAD_PRIORITY;
+    }
 
     @Override
     public RpcSystem loadRpcSystem(Configuration config) {

--- a/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/FallbackAkkaRpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/test/java/org/apache/flink/runtime/rpc/akka/FallbackAkkaRpcSystemLoader.java
@@ -51,6 +51,11 @@ public class FallbackAkkaRpcSystemLoader implements RpcSystemLoader {
     private static final String MODULE_FLINK_RPC_AKKA = "flink-rpc-akka";
 
     @Override
+    public int getLoadPriority() {
+        return AkkaRpcSystemLoader.LOAD_PRIORITY + 1;
+    }
+
+    @Override
     public RpcSystem loadRpcSystem(Configuration config) {
         try {
             LOG.debug(

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -23,7 +23,9 @@ import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.PriorityQueue;
 import java.util.ServiceLoader;
 
 /**
@@ -91,8 +93,11 @@ public interface RpcSystem extends RpcSystemUtils, AutoCloseable {
      * @return loaded RpcSystem
      */
     static RpcSystem load(Configuration config) {
-        final Iterator<RpcSystemLoader> iterator =
-                ServiceLoader.load(RpcSystemLoader.class).iterator();
+        final PriorityQueue<RpcSystemLoader> rpcSystemLoaders =
+                new PriorityQueue<>(Comparator.comparingInt(RpcSystemLoader::getLoadPriority));
+        ServiceLoader.load(RpcSystemLoader.class).forEach(rpcSystemLoaders::add);
+
+        final Iterator<RpcSystemLoader> iterator = rpcSystemLoaders.iterator();
 
         Exception loadError = null;
         while (iterator.hasNext()) {

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystemLoader.java
@@ -21,5 +21,11 @@ import org.apache.flink.configuration.Configuration;
 
 /** A loader for an {@link RpcSystem}. */
 public interface RpcSystemLoader {
+    /**
+     * Returns the loading priority for this loader, for a deterministic loading order if multiple
+     * rpc system loaders are present on the classpath. {@code 0} designates the highest priority.
+     */
+    int getLoadPriority();
+
     RpcSystem loadRpcSystem(Configuration config);
 }

--- a/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcSystemTest.java
+++ b/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcSystemTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.testutils.junit.extensions.ContextClassLoaderExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RpcSystemTest {
+
+    @RegisterExtension
+    static final ContextClassLoaderExtension classLoaderExtension =
+            ContextClassLoaderExtension.builder()
+                    .withServiceEntry(
+                            RpcSystemLoader.class,
+                            // usually loader 2 would be loaded first
+                            TestRpcSystemLoader2.class.getName(),
+                            TestRpcSystemLoader1.class.getName())
+                    .build();
+
+    @Test
+    void testRpcSystemPrioritization() {
+        assertThat(RpcSystem.load()).isNotNull();
+    }
+
+    /** Test {@link RpcSystemLoader} with a high priority. */
+    public static final class TestRpcSystemLoader1 implements RpcSystemLoader {
+
+        @Override
+        public int getLoadPriority() {
+            return 0;
+        }
+
+        @Override
+        public RpcSystem loadRpcSystem(Configuration config) {
+            return new DummyTestRpcSystem();
+        }
+    }
+
+    /** Test {@link RpcSystemLoader} with a low priority. */
+    public static final class TestRpcSystemLoader2 implements RpcSystemLoader {
+
+        @Override
+        public int getLoadPriority() {
+            return 4;
+        }
+
+        @Override
+        public RpcSystem loadRpcSystem(Configuration config) {
+            return null;
+        }
+    }
+
+    private static class DummyTestRpcSystem implements RpcSystem {
+
+        @Override
+        public RpcServiceBuilder localServiceBuilder(Configuration configuration) {
+            return null;
+        }
+
+        @Override
+        public RpcServiceBuilder remoteServiceBuilder(
+                Configuration configuration,
+                @Nullable String externalAddress,
+                String externalPortRange) {
+            return null;
+        }
+
+        @Override
+        public String getRpcUrl(
+                String hostname,
+                int port,
+                String endpointName,
+                AddressResolution addressResolution,
+                Configuration config)
+                throws UnknownHostException {
+            return null;
+        }
+
+        @Override
+        public InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception {
+            return null;
+        }
+
+        @Override
+        public long getMaximumMessageSizeInBytes(Configuration config) {
+            return 0;
+        }
+    }
+}

--- a/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcSystemTest.java
+++ b/flink-rpc/flink-rpc-core/src/test/java/org/apache/flink/runtime/rpc/RpcSystemTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RpcSystemTest {
 
     @RegisterExtension
-    static final ContextClassLoaderExtension classLoaderExtension =
+    static final ContextClassLoaderExtension CLASS_LOADER_EXTENSION =
             ContextClassLoaderExtension.builder()
                     .withServiceEntry(
                             RpcSystemLoader.class,


### PR DESCRIPTION
This PR ensures that, if the main and fallback akka rpc system loaders are both on the classpath, the main loader gets priority. This avoids cases on CI where the fallback loader was used just because it appeared first on the classpath.