### PR TITLE
[FLINK-25000][build] Java 17 uses Scala 2.12.15 

### DIFF
--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -330,6 +330,9 @@ under the License.
 		</profile>
 		<profile>
 			<id>java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -328,5 +328,20 @@ under the License.
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>java17</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.github.zentol.japicmp</groupId>
+						<artifactId>japicmp-maven-plugin</artifactId>
+						<configuration>
+							<!-- version bump broke the checks -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -292,6 +292,9 @@ under the License.
 	<profiles>
 		<profile>
 			<id>java17</id>
+			<activation>
+				<jdk>[17,)</jdk>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -289,4 +289,22 @@ under the License.
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>java17</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.github.zentol.japicmp</groupId>
+						<artifactId>japicmp-maven-plugin</artifactId>
+						<configuration>
+							<!-- version bump broke the checks -->
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/ScalaSerializersMigrationTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/ScalaSerializersMigrationTest.scala
@@ -20,11 +20,14 @@ package org.apache.flink.api.scala.migration
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.typeutils._
+import org.apache.flink.testutils.junit.FailsOnJava17
 
 import org.junit.{Assert, Test}
+import org.junit.experimental.categories.Category
 
 import scala.util.Try
 
+@Category(Array(classOf[FailsOnJava17]))
 class ScalaSerializersMigrationTest {
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -1074,6 +1074,11 @@ under the License.
 				<jdk>[17,)</jdk>
 			</activation>
 
+			<properties>
+				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
+				<scala.version>2.12.15</scala.version>
+			</properties>
+
 			<build>
 				<pluginManagement>
 					<plugins>


### PR DESCRIPTION
Based on #22780.

Since Scala 2.12.7 doesn't compile on Java 17 we will run the build with a later version of Scala when running on Java 17. This breaks various compatibility tests which are now disable in Java 17 builds, and I don't see a way around that.

Note that compiled 2.12.7 Scala code does appear to run on Java 17, so this really just about making CI work.