### PR TITLE
[FLINK-25002][build] Add java 17 add-opens/add-exports JVM arguments

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,7 @@
 -XX:+IgnoreUnrecognizedVMOptions
+--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -34,6 +34,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -33,6 +33,13 @@
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<!-- Allow users to pass custom connector versions -->
 	<dependencies>
 		<dependency>

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -34,6 +34,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -36,6 +36,12 @@ under the License.
 
 	<properties>
 		<kafka.version>3.2.3</kafka.version>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			Kryo
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -33,6 +33,24 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config> <!--
+			required by JmxServer
+			-->--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED <!--
+			PluginConfigTest (CommonTestUtils#setEnv)
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			ExceptionUtilsTest
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			StateDescriptorTest (Kryo serialization of File)
+			-->--add-opens=java.base/java.io=ALL-UNNAMED <!--
+			SerializersTest (Kryo serialization of Nested1->Path->URI)
+			-->--add-opens=java.base/java.net=ALL-UNNAMED <!--
+			InitOutputPathTest
+			-->--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED <!--
+			-->--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -16,6 +16,9 @@
 #  limitations under the License.
 ################################################################################
 
+# These parameters are required for Java 17 support.
+# They can be safely removed when using Java 8/11.
+env.java.opts.all: --add-exports=java.base/sun.net.util=ALL-UNNAMED --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
 
 #==============================================================================
 # Common

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -13,7 +13,7 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-# limitations under the License.
+#  limitations under the License.
 ################################################################################
 
 

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -107,6 +107,9 @@
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>org.apache.flink.streaming.tests.queryablestate.QsStateClient</mainClass>
+									<manifestEntries>
+										<Add-Opens>java.base/java.util</Add-Opens>
+									</manifestEntries>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -73,6 +73,8 @@ function run_local_recovery_test {
     TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
     # configure for HA
     create_ha_config
+    # required for PID business in StickyAllocationAndLocalRecoveryTestJob
+    set_config_key env.java.opts.taskmanager "--add-opens=java.management/sun.management=ALL-UNNAMED"
 
     # Enable debug logging
     sed -i -e 's/rootLogger.level = .*/rootLogger.level = DEBUG/' "$FLINK_DIR/conf/log4j.properties"

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -32,6 +32,13 @@ under the License.
 	<artifactId>flink-examples-table_${scala.binary.version}</artifactId>
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<!-- Flink core -->
 		<dependency>

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -31,6 +31,17 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			HadoopConfigLoadingTest
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			HadoopUtilsTest
+			-->--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED <!--
+			HadoopDataInputStreamTest
+			-->--add-opens=java.base/java.io=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -33,6 +33,19 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			Kryo ByteBuffer
+			-->--add-opens=java.base/java.nio=ALL-UNNAMED <!--
+			Kryo LocalDate
+			-->--add-opens=java.base/java.time=ALL-UNNAMED <!--
+			Kryo
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- Core -->

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -33,6 +33,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<dependency>

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -33,6 +33,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<dependency>

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -33,6 +33,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			Kryo buffer
+			-->--add-opens=java.base/java.nio=ALL-UNNAMED <!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- Core -->

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -33,6 +33,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- Core -->

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -31,6 +31,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<!--
 		This is a Hadoop2 only flink module.
 	-->

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -33,6 +33,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config> <!--
+			JoinOperatorTest / chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			CollectionInputFormatTest
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -32,6 +32,10 @@ under the License.
 
 	<properties>
 		<kubernetes.client.version>6.6.2</kubernetes.client.version>
+		<surefire.module.config><!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -33,6 +33,13 @@ under the License.
     <name>Flink : Libraries : CEP</name>
     <packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -34,6 +34,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			Kryo
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -31,6 +31,13 @@ under the License.
 	<artifactId>flink-metrics-jmx</artifactId>
 	<name>Flink : Metrics : JMX</name>
 
+	<properties>
+		<surefire.module.config> <!--
+			required by JmxServer
+			-->--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -35,6 +35,15 @@ under the License.
 
 	<properties>
 		<arrow.version>5.0.0</arrow.version>
+		<kafka.version>3.2.3</kafka.version>
+		<surefire.module.config><!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			Kryo AtomicBoolean
+			-->--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED <!--
+			Arrow MemoryUtil
+			-->--add-opens=java.base/java.nio=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -254,8 +254,10 @@ def launch_gateway_server_process(env, args):
             [construct_flink_classpath(env), construct_hadoop_classpath(env)])
         if "FLINK_TESTING" in env:
             classpath = os.pathsep.join([classpath, construct_test_classpath()])
-        command = [java_executable, jvm_args, "-XX:+IgnoreUnrecognizedVMOptions"] + jvm_opts \
-            + log_settings + ["-cp", classpath, program_args.main_class] + program_args.other_args
+        command = [java_executable, jvm_args, "-XX:+IgnoreUnrecognizedVMOptions",
+                   "--add-opens=jdk.proxy2/jdk.proxy2=ALL-UNNAMED"] \
+            + jvm_opts + log_settings \
+            + ["-cp", classpath, program_args.main_class] + program_args.other_args
     else:
         command = [os.path.join(env["FLINK_BIN_DIR"], "flink"), "run"] + program_args.other_args \
             + ["-c", program_args.main_class]

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -33,6 +33,13 @@ under the License.
 	<name>Flink : Queryable state : Runtime</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -33,6 +33,20 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			JobManagerProcessUtilsTest
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			ConnectionUtilsTest
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			-->--add-opens=java.base/java.net=ALL-UNNAMED <!--
+			OperatorStateBackendTest
+			-->--add-opens=java.base/java.io=ALL-UNNAMED <!--
+			AsynchronousFileIOChannelTest
+			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -60,6 +61,9 @@ public class BootstrapTools {
 
     private static final Escaper WINDOWS_DOUBLE_QUOTE_ESCAPER =
             Escapers.builder().addEscape('"', "\\\"").addEscape('^', "\"^^\"").build();
+
+    @VisibleForTesting
+    static final String IGNORE_UNRECOGNIZED_VM_OPTIONS = "-XX:+IgnoreUnrecognizedVMOptions";
 
     /**
      * Writes a Flink YAML config file from a Flink Configuration object.
@@ -191,6 +195,7 @@ public class BootstrapTools {
         if (flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS).length() > 0) {
             javaOpts += " " + flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS);
         }
+        javaOpts += " " + IGNORE_UNRECOGNIZED_VM_OPTIONS;
 
         // krb5.conf file will be available as local resource in JM/TM container
         if (hasKrb5) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -179,7 +179,15 @@ public class BootstrapToolsTest extends TestLogger {
         final String redirects = "1> ./logs/taskmanager.out 2> ./logs/taskmanager.err";
 
         assertEquals(
-                String.join(" ", java, jvmmem, mainClass, dynamicConfigs, basicArgs, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        mainClass,
+                        dynamicConfigs,
+                        basicArgs,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -192,7 +200,14 @@ public class BootstrapToolsTest extends TestLogger {
                         ""));
 
         assertEquals(
-                String.join(" ", java, jvmmem, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -206,7 +221,15 @@ public class BootstrapToolsTest extends TestLogger {
 
         final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
         assertEquals(
-                String.join(" ", java, jvmmem, krb5, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -220,7 +243,16 @@ public class BootstrapToolsTest extends TestLogger {
 
         // logback only, with/out krb5
         assertEquals(
-                String.join(" ", java, jvmmem, logfile, logback, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        logfile,
+                        logback,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -233,7 +265,17 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                String.join(" ", java, jvmmem, krb5, logfile, logback, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        logfile,
+                        logback,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -247,7 +289,16 @@ public class BootstrapToolsTest extends TestLogger {
 
         // log4j, with/out krb5
         assertEquals(
-                String.join(" ", java, jvmmem, logfile, log4j, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        logfile,
+                        log4j,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -260,7 +311,17 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                String.join(" ", java, jvmmem, krb5, logfile, log4j, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        logfile,
+                        log4j,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -274,7 +335,17 @@ public class BootstrapToolsTest extends TestLogger {
 
         // logback + log4j, with/out krb5
         assertEquals(
-                String.join(" ", java, jvmmem, logfile, logback, log4j, mainClass, args, redirects),
+                String.join(
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -288,7 +359,16 @@ public class BootstrapToolsTest extends TestLogger {
 
         assertEquals(
                 String.join(
-                        " ", java, jvmmem, krb5, logfile, logback, log4j, mainClass, args,
+                        " ",
+                        java,
+                        jvmmem,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
                         redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
@@ -305,7 +385,16 @@ public class BootstrapToolsTest extends TestLogger {
         cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
         assertEquals(
                 String.join(
-                        " ", java, jvmmem, jvmOpts, logfile, logback, log4j, mainClass, args,
+                        " ",
+                        java,
+                        jvmmem,
+                        jvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
                         redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
@@ -320,7 +409,17 @@ public class BootstrapToolsTest extends TestLogger {
 
         assertEquals(
                 String.join(
-                        " ", java, jvmmem, jvmOpts, krb5, logfile, logback, log4j, mainClass, args,
+                        " ",
+                        java,
+                        jvmmem,
+                        jvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
                         redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
@@ -337,8 +436,18 @@ public class BootstrapToolsTest extends TestLogger {
         cfg.setString(CoreOptions.FLINK_TM_JVM_OPTIONS, tmJvmOpts);
         assertEquals(
                 String.join(
-                        " ", java, jvmmem, jvmOpts, tmJvmOpts, logfile, logback, log4j, mainClass,
-                        args, redirects),
+                        " ",
+                        java,
+                        jvmmem,
+                        jvmOpts,
+                        tmJvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -352,8 +461,19 @@ public class BootstrapToolsTest extends TestLogger {
 
         assertEquals(
                 String.join(
-                        " ", java, jvmmem, jvmOpts, tmJvmOpts, krb5, logfile, logback, log4j,
-                        mainClass, args, redirects),
+                        " ",
+                        java,
+                        jvmmem,
+                        jvmOpts,
+                        tmJvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        logfile,
+                        logback,
+                        log4j,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -372,8 +492,25 @@ public class BootstrapToolsTest extends TestLogger {
                 "%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
         assertEquals(
                 String.join(
-                        " ", java, "1", jvmmem, "2", jvmOpts, tmJvmOpts, krb5, "3", logfile,
-                        logback, log4j, "4", mainClass, "5", args, "6", redirects),
+                        " ",
+                        java,
+                        "1",
+                        jvmmem,
+                        "2",
+                        jvmOpts,
+                        tmJvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        "3",
+                        logfile,
+                        logback,
+                        log4j,
+                        "4",
+                        mainClass,
+                        "5",
+                        args,
+                        "6",
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -390,8 +527,19 @@ public class BootstrapToolsTest extends TestLogger {
                 "%java% %logging% %jvmopts% %jvmmem% %class% %args% %redirects%");
         assertEquals(
                 String.join(
-                        " ", java, logfile, logback, log4j, jvmOpts, tmJvmOpts, krb5, jvmmem,
-                        mainClass, args, redirects),
+                        " ",
+                        java,
+                        logfile,
+                        logback,
+                        log4j,
+                        jvmOpts,
+                        tmJvmOpts,
+                        BootstrapTools.IGNORE_UNRECOGNIZED_VM_OPTIONS,
+                        krb5,
+                        jvmmem,
+                        mainClass,
+                        args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -179,21 +179,7 @@ public class BootstrapToolsTest extends TestLogger {
         final String redirects = "1> ./logs/taskmanager.out 2> ./logs/taskmanager.err";
 
         assertEquals(
-                java
-                        + " "
-                        + jvmmem
-                        + ""
-                        + // jvmOpts
-                        ""
-                        + // logging
-                        " "
-                        + mainClass
-                        + " "
-                        + dynamicConfigs
-                        + " "
-                        + basicArgs
-                        + " "
-                        + redirects,
+                String.join(" ", java, jvmmem, mainClass, dynamicConfigs, basicArgs, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -206,9 +192,7 @@ public class BootstrapToolsTest extends TestLogger {
                         ""));
 
         assertEquals(
-                java + " " + jvmmem + "" + // jvmOpts
-                        "" + // logging
-                        " " + mainClass + " " + args + " " + redirects,
+                String.join(" ", java, jvmmem, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -222,9 +206,7 @@ public class BootstrapToolsTest extends TestLogger {
 
         final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
         assertEquals(
-                java + " " + jvmmem + " " + krb5 + // jvmOpts
-                        "" + // logging
-                        " " + mainClass + " " + args + " " + redirects,
+                String.join(" ", java, jvmmem, krb5, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -238,9 +220,7 @@ public class BootstrapToolsTest extends TestLogger {
 
         // logback only, with/out krb5
         assertEquals(
-                java + " " + jvmmem + "" + // jvmOpts
-                        " " + logfile + " " + logback + " " + mainClass + " " + args + " "
-                        + redirects,
+                String.join(" ", java, jvmmem, logfile, logback, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -253,9 +233,7 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                java + " " + jvmmem + " " + krb5 + // jvmOpts
-                        " " + logfile + " " + logback + " " + mainClass + " " + args + " "
-                        + redirects,
+                String.join(" ", java, jvmmem, krb5, logfile, logback, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -269,9 +247,7 @@ public class BootstrapToolsTest extends TestLogger {
 
         // log4j, with/out krb5
         assertEquals(
-                java + " " + jvmmem + "" + // jvmOpts
-                        " " + logfile + " " + log4j + " " + mainClass + " " + args + " "
-                        + redirects,
+                String.join(" ", java, jvmmem, logfile, log4j, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -284,9 +260,7 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                java + " " + jvmmem + " " + krb5 + // jvmOpts
-                        " " + logfile + " " + log4j + " " + mainClass + " " + args + " "
-                        + redirects,
+                String.join(" ", java, jvmmem, krb5, logfile, log4j, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -300,9 +274,7 @@ public class BootstrapToolsTest extends TestLogger {
 
         // logback + log4j, with/out krb5
         assertEquals(
-                java + " " + jvmmem + "" + // jvmOpts
-                        " " + logfile + " " + logback + " " + log4j + " " + mainClass + " " + args
-                        + " " + redirects,
+                String.join(" ", java, jvmmem, logfile, logback, log4j, mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -315,9 +287,9 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                java + " " + jvmmem + " " + krb5 + // jvmOpts
-                        " " + logfile + " " + logback + " " + log4j + " " + mainClass + " " + args
-                        + " " + redirects,
+                String.join(
+                        " ", java, jvmmem, krb5, logfile, logback, log4j, mainClass, args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -332,8 +304,9 @@ public class BootstrapToolsTest extends TestLogger {
         // logback + log4j, with/out krb5, different JVM opts
         cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
         assertEquals(
-                java + " " + jvmmem + " " + jvmOpts + " " + logfile + " " + logback + " " + log4j
-                        + " " + mainClass + " " + args + " " + redirects,
+                String.join(
+                        " ", java, jvmmem, jvmOpts, logfile, logback, log4j, mainClass, args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -346,9 +319,9 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                java + " " + jvmmem + " " + jvmOpts + " " + krb5 + // jvmOpts
-                        " " + logfile + " " + logback + " " + log4j + " " + mainClass + " " + args
-                        + " " + redirects,
+                String.join(
+                        " ", java, jvmmem, jvmOpts, krb5, logfile, logback, log4j, mainClass, args,
+                        redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -363,8 +336,9 @@ public class BootstrapToolsTest extends TestLogger {
         // logback + log4j, with/out krb5, different JVM opts
         cfg.setString(CoreOptions.FLINK_TM_JVM_OPTIONS, tmJvmOpts);
         assertEquals(
-                java + " " + jvmmem + " " + jvmOpts + " " + tmJvmOpts + " " + logfile + " "
-                        + logback + " " + log4j + " " + mainClass + " " + args + " " + redirects,
+                String.join(
+                        " ", java, jvmmem, jvmOpts, tmJvmOpts, logfile, logback, log4j, mainClass,
+                        args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -377,9 +351,9 @@ public class BootstrapToolsTest extends TestLogger {
                         mainArgs));
 
         assertEquals(
-                java + " " + jvmmem + " " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
-                        " " + logfile + " " + logback + " " + log4j + " " + mainClass + " " + args
-                        + " " + redirects,
+                String.join(
+                        " ", java, jvmmem, jvmOpts, tmJvmOpts, krb5, logfile, logback, log4j,
+                        mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -397,9 +371,9 @@ public class BootstrapToolsTest extends TestLogger {
                 ConfigConstants.YARN_CONTAINER_START_COMMAND_TEMPLATE,
                 "%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
         assertEquals(
-                java + " 1 " + jvmmem + " 2 " + jvmOpts + " " + tmJvmOpts + " " + krb5 + // jvmOpts
-                        " 3 " + logfile + " " + logback + " " + log4j + " 4 " + mainClass + " 5 "
-                        + args + " 6 " + redirects,
+                String.join(
+                        " ", java, "1", jvmmem, "2", jvmOpts, tmJvmOpts, krb5, "3", logfile,
+                        logback, log4j, "4", mainClass, "5", args, "6", redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,
@@ -415,9 +389,9 @@ public class BootstrapToolsTest extends TestLogger {
                 ConfigConstants.YARN_CONTAINER_START_COMMAND_TEMPLATE,
                 "%java% %logging% %jvmopts% %jvmmem% %class% %args% %redirects%");
         assertEquals(
-                java + " " + logfile + " " + logback + " " + log4j + " " + jvmOpts + " " + tmJvmOpts
-                        + " " + krb5 + // jvmOpts
-                        " " + jvmmem + " " + mainClass + " " + args + " " + redirects,
+                String.join(
+                        " ", java, logfile, logback, log4j, jvmOpts, tmJvmOpts, krb5, jvmmem,
+                        mainClass, args, redirects),
                 BootstrapTools.getTaskManagerShellCommand(
                         cfg,
                         containeredParams,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -150,6 +150,11 @@ public abstract class TestJvmProcess {
             cmd = ArrayUtils.addAll(cmd, jvmArgs);
         }
 
+        final String moduleConfig = System.getProperty("surefire.module.config");
+        if (moduleConfig != null) {
+            cmd = ArrayUtils.addAll(cmd, moduleConfig.split(" "));
+        }
+
         synchronized (createDestroyLock) {
             checkState(process == null, "process already started");
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -31,6 +31,13 @@ under the License.
 	<name>Flink : Scala</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -35,6 +35,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<dependency>

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -35,6 +35,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -33,6 +33,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			FromElementsFunctionTest
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -31,6 +31,13 @@ under the License.
 	<name>Flink : Streaming Scala</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -35,6 +35,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			Hadoop StringInternUtils
+			-->--add-opens=java.base/java.net=ALL-UNNAMED <!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 
 		<!-- Flink client to submit jobs -->

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -34,6 +34,15 @@
 
     <packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			SqlGatewayTest/CommonTestUtils.setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			OperationManager#getThreadInFuture
+			-->--add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
     <dependencies>
         <!-- Flink client to submit jobs -->
         <dependency>

--- a/flink-table/flink-sql-jdbc-driver/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver/pom.xml
@@ -34,6 +34,13 @@
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -37,6 +37,23 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			HashAggCodeGeneratorTest / AggTestBase
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			kryo AtomicBoolean
+			-->--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED <!--
+			kryo LocalDate/ZoneOffset
+			-->--add-opens=java.base/java.time=ALL-UNNAMED <!--
+			kryo MathContext
+			-->--add-opens=java.base/java.math=ALL-UNNAMED <!--
+			kryo ByteBuffer
+			-->--add-opens=java.base/java.nio=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<!-- Mainly used for calcite-core, relocated in org.apache.flink.calcite.shaded by the shade plugin -->
 		<dependency>

--- a/flink-table/flink-table-runtime/pom.xml
+++ b/flink-table/flink-table-runtime/pom.xml
@@ -35,6 +35,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			kryo AtomicBoolean
+			-->--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 		<!-- Table dependencies -->
 		<dependency>

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
@@ -63,6 +63,13 @@ public class TestProcessBuilder {
         jvmArgs.add(getCurrentClasspath());
         jvmArgs.add("-XX:+IgnoreUnrecognizedVMOptions");
 
+        final String moduleConfig = System.getProperty("surefire.module.config");
+        if (moduleConfig != null) {
+            for (String moduleArg : moduleConfig.split(" ")) {
+                addJvmArg(moduleArg);
+            }
+        }
+
         this.mainClass = mainClass;
     }
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -34,6 +34,15 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			chill ArraysAsListSerializer
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			Kryo File (GroupReduceITCase)
+			-->--add-opens=java.base/java.io=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencies>
 	
 		<dependency>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -38,6 +38,14 @@ under the License.
 
 	<properties>
 		<japicmp.skip>true</japicmp.skip>
+		<surefire.module.config><!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--
+			MiniYARNCluster
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED <!--
+			YARNSessionFIFOSecuredITCase
+			-->--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -34,6 +34,10 @@ under the License.
 		<!-- for testing (will override Hadoop's default dependency on too low SDK versions that
 			do not work with our httpcomponents version) -->
 		<aws.sdk.version>1.12.319</aws.sdk.version>
+		<surefire.module.config><!--
+			CommonTestUtils#setEnv
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ under the License.
 		<flink.forkCountITCase>2</flink.forkCountITCase>
 		<flink.forkCountUnitTest>4</flink.forkCountUnitTest>
 		<flink.reuseForks>true</flink.reuseForks>
-		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions</flink.surefire.baseArgLine>
+		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
 		<flink.shaded.version>16.1</flink.shaded.version>
 		<flink.shaded.jackson.version>2.13.4</flink.shaded.jackson.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
@@ -195,6 +195,12 @@ under the License.
  * limitations under the License.
  */
 		</spotless.license.header>
+
+		<!-- This property should contain the add-opens/add-exports commands required for the tests
+		     in the given module to pass.
+		     It MUST be a space-separated list not containing any newlines,
+		     of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
+		<surefire.module.config/>
 
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
@@ -1647,6 +1653,8 @@ under the License.
 							unset: don't alter the configuration
 						-->
 						<checkpointing.changelog>random</checkpointing.changelog>
+						<!-- Expose as property so that test utils that spawn JVMs can pick it up. -->
+						<surefire.module.config>${surefire.module.config}</surefire.module.config>
 						<project.basedir>${project.basedir}</project.basedir>
 						<!--suppress MavenModelInspection -->
 						<test.randomization.seed>${test.randomization.seed}</test.randomization.seed>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ under the License.
 		<flink.forkCountITCase>2</flink.forkCountITCase>
 		<flink.forkCountUnitTest>4</flink.forkCountUnitTest>
 		<flink.reuseForks>true</flink.reuseForks>
-		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m</flink.surefire.baseArgLine>
+		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions</flink.surefire.baseArgLine>
 		<flink.shaded.version>16.1</flink.shaded.version>
 		<flink.shaded.jackson.version>2.13.4</flink.shaded.jackson.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>


### PR DESCRIPTION
This PR sets of all required add-opens/add-exports statements for Maven, surefire, test-internal JVMs and flink-dist.

If a module requires such a statement for surefire/testing then it must define a list of statements in the `surefire.module.config` property of the module's pom. This property is set on the test JVMs via surefire, but is also exposed as a system property to the test itself such that utils like the `TestJvmProcess` can forward them.
I documented a hint for each statement as to why it is required.

flink-dist is configured separately via `flink-conf.yaml`.

The required statements were purely determined by running tests and checking what fails.
"Completeness" was validated on my personal [CI](https://dev.azure.com/chesnay/flink/_build/results?buildId=3606&view=results); we may not be covering all tests since some only run on the apache branches. We'll just amend missing ones in the future if necessary.