### PR TITLE
[FLINK-32288][runtime] Improve the scheduling performance of AdaptiveBatchScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/AllFinishedInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/AllFinishedInputConsumableDecider.java
@@ -37,14 +37,15 @@ public class AllFinishedInputConsumableDecider implements InputConsumableDecider
                 executionVertex.getConsumedPartitionGroups()) {
 
             if (!consumableStatusCache.computeIfAbsent(
-                    consumedPartitionGroup, this::isConsumedPartitionGroupConsumable)) {
+                    consumedPartitionGroup, this::isConsumableBasedOnFinishedProducers)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean isConsumedPartitionGroupConsumable(
+    @Override
+    public boolean isConsumableBasedOnFinishedProducers(
             final ConsumedPartitionGroup consumedPartitionGroup) {
         return consumedPartitionGroup.getNumberOfUnfinishedPartitions() == 0;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
@@ -65,6 +65,19 @@ public class DefaultInputConsumableDecider implements InputConsumableDecider {
         return true;
     }
 
+    @Override
+    public boolean isConsumableBasedOnFinishedProducers(
+            final ConsumedPartitionGroup consumedPartitionGroup) {
+        if (consumedPartitionGroup.getResultPartitionType().canBePipelinedConsumed()) {
+            // For canBePipelined consumed partition group, whether it is consumable does not depend
+            // on task finish. To optimize performance and avoid unnecessary computation, we simply
+            // return false.
+            return false;
+        } else {
+            return consumedPartitionGroup.areAllPartitionsFinished();
+        }
+    }
+
     private boolean isConsumedPartitionGroupConsumable(
             final ConsumedPartitionGroup consumedPartitionGroup,
             final Set<ExecutionVertexID> verticesToSchedule) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 
 /**
  * {@link InputConsumableDecider} is responsible for determining whether the input of an
- * executionVertex is consumable.
+ * executionVertex or a consumed partition group is consumable.
  */
 public interface InputConsumableDecider {
     /**
@@ -40,6 +40,14 @@ public interface InputConsumableDecider {
             SchedulingExecutionVertex executionVertex,
             Set<ExecutionVertexID> verticesToSchedule,
             Map<ConsumedPartitionGroup, Boolean> consumableStatusCache);
+
+    /**
+     * Determining whether the consumed partition group is consumable based on finished producers.
+     *
+     * @param consumedPartitionGroup to be determined whether it is consumable.
+     */
+    boolean isConsumableBasedOnFinishedProducers(
+            final ConsumedPartitionGroup consumedPartitionGroup);
 
     /** Factory for {@link InputConsumableDecider}. */
     interface Factory {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PartialFinishedInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PartialFinishedInputConsumableDecider.java
@@ -43,14 +43,15 @@ public class PartialFinishedInputConsumableDecider implements InputConsumableDec
                 executionVertex.getConsumedPartitionGroups()) {
 
             if (!consumableStatusCache.computeIfAbsent(
-                    consumedPartitionGroup, this::isConsumedPartitionGroupConsumable)) {
+                    consumedPartitionGroup, this::isConsumableBasedOnFinishedProducers)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean isConsumedPartitionGroupConsumable(
+    @Override
+    public boolean isConsumableBasedOnFinishedProducers(
             final ConsumedPartitionGroup consumedPartitionGroup) {
         if (consumedPartitionGroup
                 .getResultPartitionType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
@@ -103,6 +103,11 @@ public class VertexwiseSchedulingStrategy
                     IterableUtils.toStream(executionVertex.getProducedResults())
                             .map(SchedulingResultPartition::getConsumerVertexGroups)
                             .flatMap(Collection::stream)
+                            .filter(
+                                    group ->
+                                            inputConsumableDecider
+                                                    .isConsumableBasedOnFinishedProducers(
+                                                            group.getConsumedPartitionGroup()))
                             .flatMap(IterableUtils::toStream)
                             .collect(Collectors.toSet());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -135,6 +135,8 @@ public class SchedulerBenchmarkUtils {
         return schedulerBuilder
                 .setVertexParallelismAndInputInfosDecider(
                         createCustomParallelismDecider(jobConfiguration.getParallelism()))
+                .setHybridPartitionDataConsumeConstraint(
+                        jobConfiguration.getHybridPartitionDataConsumeConstraint())
                 .setInputConsumableDeciderFactory(
                         loadInputConsumableDeciderFactory(
                                 jobConfiguration.getHybridPartitionDataConsumeConstraint()))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
@@ -50,6 +50,17 @@ class DefaultInputConsumableDeciderTest {
         DefaultInputConsumableDecider inputConsumableDecider =
                 createDefaultInputConsumableDecider(Collections.emptySet(), topology);
 
+        consumer.forEach(
+                vertex ->
+                        vertex.getConsumedPartitionGroups()
+                                .forEach(
+                                        group ->
+                                                assertThat(
+                                                                inputConsumableDecider
+                                                                        .isConsumableBasedOnFinishedProducers(
+                                                                                group))
+                                                        .isFalse()));
+
         assertThat(
                         inputConsumableDecider.isInputConsumable(
                                 consumer.get(0), Collections.emptySet(), new HashMap<>()))
@@ -77,6 +88,17 @@ class DefaultInputConsumableDeciderTest {
 
         DefaultInputConsumableDecider inputConsumableDecider =
                 createDefaultInputConsumableDecider(Collections.emptySet(), topology);
+
+        consumer.forEach(
+                vertex ->
+                        vertex.getConsumedPartitionGroups()
+                                .forEach(
+                                        group ->
+                                                assertThat(
+                                                                inputConsumableDecider
+                                                                        .isConsumableBasedOnFinishedProducers(
+                                                                                group))
+                                                        .isTrue()));
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
@@ -42,6 +42,12 @@ public class TestingInputConsumableDecider implements InputConsumableDecider {
                 || inputConsumableExecutionVertices.contains(executionVertex);
     }
 
+    @Override
+    public boolean isConsumableBasedOnFinishedProducers(
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        return true;
+    }
+
     public void setInputConsumable(SchedulingExecutionVertex executionVertex) {
         inputConsumableExecutionVertices.add(executionVertex);
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

After adding the benchmark of AdaptiveBatchScheduler in [FLINK-30480](https://issues.apache.org/jira/browse/FLINK-30480), we noticed a regression in the performance of SchedulingDownstreamTasksInBatchJobBenchmark#SchedulingDownstreamTasks. When scheduling a batch job with a parallelism of 4000*4000, the time spent increased from 32ms to 1336ms on my local PC.

## Brief change log

  - *Enriching hybridPartitionDataConsumeConstraint when create AdaptiveBatchScheduler in scheduler benchmark utils.*
  - *The InputConsumableDecider interface adds an isConsumedPartitionGroupConsumable method, which is implemented in the DefaultInputConsumableDecider, AllFinishedInputConsumableDecider, and PartialFinishedInputConsumableDecider.*
  - *Adding filter logic for ConsumedPartitionGroup in VertexwiseSchedulingStrategy::onExecutionStateChange.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates that DefaultInputConsumableDecider::isConsumedPartitionGroupConsumable is worked.*
  - *Manually verified the change by running SchedulingDownstreamTasksInBatchJobBenchmarkTest, we can see that redundant loops have been pruned .*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
