### PR TITLE
[FLINK-32205][rest] Add the option "rest.url-prefix" to support connecting to the server through a proxy.

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_configuration.html
+++ b/docs/layouts/shortcodes/generated/rest_configuration.html
@@ -128,5 +128,11 @@
             <td>Integer</td>
             <td>Thread priority of the REST server's executor for processing asynchronous requests. Lowering the thread priority will give Flink's main components more CPU time whereas increasing will allocate more time for the REST server's processing.</td>
         </tr>
+        <tr>
+            <td><h5>rest.url-prefix</h5></td>
+            <td style="word-wrap: break-word;">"/"</td>
+            <td>String</td>
+            <td>The url prefix that should be used by clients to construct the full target url, must start and end with '/'. This will be added between the address and version prefix. For example, if the option is set to '/foo/', the overview query URL will be transformed to 'localhost:8081/foo/v1/overview'. Attention: This option is respected only if the high-availability configuration is NONE.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -58,6 +58,17 @@ public class RestOptions {
                                     + " (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid"
                                     + " collisions when multiple Rest servers are running on the same machine.");
 
+    /** The url prefix that should be used by clients to construct the full target url. */
+    public static final ConfigOption<String> URL_PREFIX =
+            key("rest.url-prefix")
+                    .stringType()
+                    .defaultValue("/")
+                    .withDescription(
+                            "The url prefix that should be used by clients to construct the full target url, must start and end with '/'."
+                                    + " This will be added between the address and version prefix. For example, if the option is set to '/foo/',"
+                                    + " the overview query URL will be transformed to 'localhost:8081/foo/v1/overview'."
+                                    + " Attention: This option is respected only if the high-availability configuration is NONE.");
+
     /** The address that should be used by clients to connect to the server. */
     @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> ADDRESS =


### PR DESCRIPTION
## What is the purpose of the change
Introduce an option named "rest.url-prefix" to allow Flink clients to connect to the server behind Kubernetes ingress.


## Brief change log
  - Add the specified URL-prefix in front of the Flink origin URL.

## Verifying this change
  - Manually verified that Flink client in the Kubernetes cluster could submit jobs without the "rest.url-prefix". 
    * specified rest.address to JobManager Rest Service Name
  - Manually verified that Flink client could submit jobs with the "rest.url-prefix" through an ingress proxy.
    * specified rest.address to ingress host and rest.url-prefix to ingress path

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
