### PR TITLE
[FLINK-31645][network] Introduce the PartitionFileReader and  DiskIOSchduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReader.java
@@ -18,14 +18,30 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.positionToNextBuffer;
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.readFromByteChannel;
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.ProducerMergedPartitionFileIndex.Region;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The implementation of {@link PartitionFileReader} with producer-merge mode. In this mode, the
@@ -36,9 +52,51 @@ import java.nio.file.Path;
  */
 public class ProducerMergedPartitionFileReader implements PartitionFileReader {
 
+    /**
+     * Max number of caches.
+     *
+     * <p>The constant defines the maximum number of caches that can be created. Its value is set to
+     * 10000, which is considered sufficient for most parallel jobs. Each cache only contains
+     * references and numerical variables and occupies a minimal amount of memory so the value is
+     * not excessively large.
+     */
+    private static final int DEFAULT_MAX_CACHE_NUM = 10000;
+
+    /**
+     * Buffer offset caches stored in map.
+     *
+     * <p>The key is the combination of {@link TieredStorageSubpartitionId} and buffer index. The
+     * value is the buffer offset cache, which includes file offset of the buffer index, the region
+     * containing the buffer index and next buffer index to consume.
+     */
+    private final Map<Tuple2<TieredStorageSubpartitionId, Integer>, BufferOffsetCache>
+            bufferOffsetCaches;
+
+    private final ByteBuffer reusedHeaderBuffer = BufferReaderWriterUtil.allocatedHeaderBuffer();
+
+    private final Path dataFilePath;
+
+    private final ProducerMergedPartitionFileIndex dataIndex;
+
+    private final int maxCacheNumber;
+
+    private volatile FileChannel fileChannel;
+
+    /** The current number of caches. */
+    private int numCaches;
+
     ProducerMergedPartitionFileReader(
-            Path dataFilePath, ProducerMergedPartitionFileIndex partitionFileIndex) {
-        // TODO, implement the ProducerMergePartitionFileReader
+            Path dataFilePath, ProducerMergedPartitionFileIndex dataIndex) {
+        this(dataFilePath, dataIndex, DEFAULT_MAX_CACHE_NUM);
+    }
+
+    @VisibleForTesting
+    ProducerMergedPartitionFileReader(
+            Path dataFilePath, ProducerMergedPartitionFileIndex dataIndex, int maxCacheNumber) {
+        this.dataFilePath = dataFilePath;
+        this.dataIndex = dataIndex;
+        this.bufferOffsetCaches = new HashMap<>();
+        this.maxCacheNumber = maxCacheNumber;
     }
 
     @Override
@@ -50,8 +108,32 @@ public class ProducerMergedPartitionFileReader implements PartitionFileReader {
             MemorySegment memorySegment,
             BufferRecycler recycler)
             throws IOException {
-        // TODO, implement the ProducerMergePartitionFileReader
-        return null;
+
+        lazyInitializeFileChannel();
+        Tuple2<TieredStorageSubpartitionId, Integer> cacheKey =
+                Tuple2.of(subpartitionId, bufferIndex);
+        Optional<BufferOffsetCache> cache = tryGetCache(cacheKey, true);
+        if (!cache.isPresent()) {
+            return null;
+        }
+        fileChannel.position(cache.get().getFileOffset());
+        Buffer buffer =
+                readFromByteChannel(fileChannel, reusedHeaderBuffer, memorySegment, recycler);
+        boolean hasNextBuffer =
+                cache.get()
+                        .advance(
+                                checkNotNull(buffer).readableBytes()
+                                        + BufferReaderWriterUtil.HEADER_LENGTH);
+        if (hasNextBuffer) {
+            int nextBufferIndex = bufferIndex + 1;
+            // TODO: introduce the LRU cache strategy in the future to restrict the total
+            // cache number. Testing to prevent cache leaks has been implemented.
+            if (numCaches < maxCacheNumber) {
+                bufferOffsetCaches.put(Tuple2.of(subpartitionId, nextBufferIndex), cache.get());
+                numCaches++;
+            }
+        }
+        return buffer;
     }
 
     @Override
@@ -60,9 +142,124 @@ public class ProducerMergedPartitionFileReader implements PartitionFileReader {
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
             int bufferIndex) {
-        return 0;
+        lazyInitializeFileChannel();
+        Tuple2<TieredStorageSubpartitionId, Integer> cacheKey =
+                Tuple2.of(subpartitionId, bufferIndex);
+        return tryGetCache(cacheKey, false)
+                .map(BufferOffsetCache::getFileOffset)
+                .orElse(Long.MAX_VALUE);
     }
 
     @Override
-    public void release() {}
+    public void release() {
+        if (fileChannel != null) {
+            try {
+                fileChannel.close();
+            } catch (IOException e) {
+                ExceptionUtils.rethrow(e, "Failed to close file channel.");
+            }
+        }
+        IOUtils.deleteFileQuietly(dataFilePath);
+    }
+
+    /**
+     * Initialize the file channel in a lazy manner, which can reduce usage of the file descriptor
+     * resource.
+     */
+    private void lazyInitializeFileChannel() {
+        if (fileChannel == null) {
+            try {
+                fileChannel = FileChannel.open(dataFilePath, StandardOpenOption.READ);
+            } catch (IOException e) {
+                ExceptionUtils.rethrow(e, "Failed to open file channel.");
+            }
+        }
+    }
+
+    /**
+     * Try to get the cache according to the key.
+     *
+     * <p>If the relevant buffer offset cache exists, it will be returned and subsequently removed.
+     * However, if the buffer offset cache does not exist, a new cache will be created using the
+     * data index and returned.
+     *
+     * @param cacheKey the key of cache.
+     * @param removeKey boolean decides whether to remove key.
+     * @return returns the relevant buffer offset cache if it exists, otherwise return {@link
+     *     Optional#empty()}.
+     */
+    private Optional<BufferOffsetCache> tryGetCache(
+            Tuple2<TieredStorageSubpartitionId, Integer> cacheKey, boolean removeKey) {
+        BufferOffsetCache bufferOffsetCache = bufferOffsetCaches.remove(cacheKey);
+        if (bufferOffsetCache == null) {
+            Optional<Region> regionOpt = dataIndex.getRegion(cacheKey.f0, cacheKey.f1);
+            return regionOpt.map(region -> new BufferOffsetCache(cacheKey.f1, region));
+        } else {
+            if (removeKey) {
+                numCaches--;
+            } else {
+                bufferOffsetCaches.put(cacheKey, bufferOffsetCache);
+            }
+            return Optional.of(bufferOffsetCache);
+        }
+    }
+
+    /**
+     * The {@link BufferOffsetCache} represents the file offset cache for a buffer index. Each cache
+     * includes file offset of the buffer index, the region containing the buffer index and next
+     * buffer index to consume.
+     */
+    private class BufferOffsetCache {
+
+        private final Region region;
+
+        private long fileOffset;
+
+        private int nextBufferIndex;
+
+        private BufferOffsetCache(int bufferIndex, Region region) {
+            this.nextBufferIndex = bufferIndex;
+            this.region = region;
+            moveFileOffsetToBuffer(bufferIndex);
+        }
+
+        /**
+         * Get the file offset.
+         *
+         * @return the file offset.
+         */
+        private long getFileOffset() {
+            return fileOffset;
+        }
+
+        /**
+         * Updates the {@link BufferOffsetCache} upon the retrieval of a buffer from the file using
+         * the file offset in the {@link BufferOffsetCache}.
+         *
+         * @param bufferSize denotes the size of the buffer.
+         * @return return true if there are remaining buffers in the region, otherwise return false.
+         */
+        private boolean advance(long bufferSize) {
+            nextBufferIndex++;
+            fileOffset += bufferSize;
+            return nextBufferIndex < (region.getFirstBufferIndex() + region.getNumBuffers());
+        }
+
+        /**
+         * Relocates the file channel offset to the position of the specified buffer index.
+         *
+         * @param bufferIndex denotes the index of the buffer.
+         */
+        private void moveFileOffsetToBuffer(int bufferIndex) {
+            try {
+                checkNotNull(fileChannel).position(region.getRegionFileOffset());
+                for (int i = 0; i < (bufferIndex - region.getFirstBufferIndex()); ++i) {
+                    positionToNextBuffer(fileChannel, reusedHeaderBuffer);
+                }
+                fileOffset = fileChannel.position();
+            } catch (IOException e) {
+                ExceptionUtils.rethrow(e, "Failed to move file offset");
+            }
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageNettyServiceImpl.java
@@ -176,10 +176,14 @@ public class TieredStorageNettyServiceImpl implements TieredStorageNettyService 
             NettyConnectionReaderAvailabilityAndPriorityHelper helper) {
         List<NettyConnectionReaderRegistration> registrations =
                 getReaderRegistration(partitionId, subpartitionId);
+        boolean hasSetChannel = false;
         for (NettyConnectionReaderRegistration registration : registrations) {
             if (registration.trySetChannel(index, inputChannelProvider, helper)) {
-                return;
+                hasSetChannel = true;
             }
+        }
+        if (hasSetChannel) {
+            return;
         }
 
         NettyConnectionReaderRegistration registration = new NettyConnectionReaderRegistration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageResultSubpartitionView.java
@@ -108,9 +108,11 @@ public class TieredStorageResultSubpartitionView implements ResultSubpartitionVi
 
     @Override
     public void notifyRequiredSegmentId(int segmentId) {
-        requiredSegmentId = segmentId;
-        stopSendingData = false;
-        availabilityListener.notifyDataAvailable();
+        if (segmentId > requiredSegmentId) {
+            requiredSegmentId = segmentId;
+            stopSendingData = false;
+            availabilityListener.notifyDataAvailable();
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
 
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
@@ -26,7 +27,9 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.Tiere
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMemoryManager;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** A factory that creates all the components of a tier. */
 public interface TierFactory {
@@ -44,7 +47,12 @@ public interface TierFactory {
             PartitionFileReader partitionFileReader,
             TieredStorageMemoryManager storageMemoryManager,
             TieredStorageNettyService nettyService,
-            TieredStorageResourceRegistry resourceRegistry);
+            TieredStorageResourceRegistry resourceRegistry,
+            BatchShuffleReadBufferPool bufferPool,
+            ScheduledExecutorService ioExecutor,
+            int maxRequestedBuffers,
+            Duration bufferRequestTimeout,
+            int maxBufferReadAhead);
 
     /** Creates the consumer-side agent of a Tier. */
     TierConsumerAgent createConsumerAgent(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk;
+
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionWriter;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyPayload;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyServiceProducer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyServiceImpl;
+import org.apache.flink.util.FatalExitExceptionHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The {@link DiskIOScheduler} is a scheduler that controls the reading of data from shuffle files.
+ * It ensures the correct order of buffers in each subpartition during file reading. The scheduler
+ * implements the {@link NettyServiceProducer} interface to send the buffers to the Netty server
+ * through the {@link NettyConnectionWriter}.
+ */
+public class DiskIOScheduler implements Runnable, BufferRecycler, NettyServiceProducer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DiskIOScheduler.class);
+
+    private final Object lock = new Object();
+
+    /** The partition id. */
+    private final TieredStoragePartitionId partitionId;
+
+    /** The executor is responsible for scheduling the disk read process. */
+    private final ScheduledExecutorService ioExecutor;
+
+    /**
+     * The buffer pool is specifically designed for reading from disk and shared in the TaskManager.
+     */
+    private final BatchShuffleReadBufferPool bufferPool;
+
+    /**
+     * The maximum number of buffers that can be allocated and still not recycled for a
+     * subpartition, which ensures that each subpartition can be consumed evenly.
+     */
+    private final int maxBufferReadAhead;
+
+    /**
+     * The maximum number of buffers that can be allocated and still not recycled by a single {@link
+     * DiskIOScheduler} for all subpartitions. This ensures that different {@link DiskIOScheduler}s
+     * in the TaskManager can evenly use the buffer pool.
+     */
+    private final int maxRequestedBuffers;
+
+    /**
+     * The maximum time to wait when requesting read buffers from the buffer pool before throwing an
+     * exception.
+     */
+    private final Duration bufferRequestTimeout;
+
+    private final TieredStorageNettyService nettyService;
+
+    /**
+     * Retrieve the segment id if the buffer index represents the first buffer. The first integer is
+     * the id of subpartition, and the second integer is buffer index and the value is segment id.
+     */
+    private final BiFunction<Integer, Integer, Integer> firstBufferIndexInSegmentRetriever;
+
+    private final PartitionFileReader partitionFileReader;
+
+    @GuardedBy("lock")
+    private final Map<NettyConnectionId, ScheduledSubpartitionReader> allScheduledReaders =
+            new HashMap<>();
+
+    @GuardedBy("lock")
+    private boolean isRunning;
+
+    @GuardedBy("lock")
+    private int numRequestedBuffers;
+
+    @GuardedBy("lock")
+    private boolean isReleased;
+
+    public DiskIOScheduler(
+            TieredStoragePartitionId partitionId,
+            BatchShuffleReadBufferPool bufferPool,
+            ScheduledExecutorService ioExecutor,
+            int maxRequestedBuffers,
+            Duration bufferRequestTimeout,
+            int maxBufferReadAhead,
+            TieredStorageNettyService nettyService,
+            BiFunction<Integer, Integer, Integer> firstBufferIndexInSegmentRetriever,
+            PartitionFileReader partitionFileReader) {
+        this.partitionId = partitionId;
+        this.bufferPool = checkNotNull(bufferPool);
+        this.ioExecutor = checkNotNull(ioExecutor);
+        this.maxRequestedBuffers = maxRequestedBuffers;
+        this.bufferRequestTimeout = checkNotNull(bufferRequestTimeout);
+        this.maxBufferReadAhead = maxBufferReadAhead;
+        this.nettyService = nettyService;
+        this.firstBufferIndexInSegmentRetriever = firstBufferIndexInSegmentRetriever;
+        this.partitionFileReader = partitionFileReader;
+        bufferPool.registerRequester(this);
+    }
+
+    @Override
+    public synchronized void run() {
+        int numBuffersRead = readBuffersFromFile();
+        synchronized (lock) {
+            numRequestedBuffers += numBuffersRead;
+            isRunning = false;
+        }
+        if (numBuffersRead == 0) {
+            ioExecutor.schedule(this::triggerScheduling, 5, TimeUnit.MILLISECONDS);
+        } else {
+            triggerScheduling();
+        }
+    }
+
+    @Override
+    public void connectionEstablished(
+            TieredStorageSubpartitionId subpartitionId,
+            NettyConnectionWriter nettyConnectionWriter) {
+        synchronized (lock) {
+            checkState(!isReleased, "DiskIOScheduler is already released.");
+            ScheduledSubpartitionReader scheduledSubpartitionReader =
+                    new ScheduledSubpartitionReader(subpartitionId, nettyConnectionWriter);
+            allScheduledReaders.put(
+                    nettyConnectionWriter.getNettyConnectionId(), scheduledSubpartitionReader);
+            triggerScheduling();
+        }
+    }
+
+    @Override
+    public void connectionBroken(NettyConnectionId id) {
+        synchronized (lock) {
+            allScheduledReaders.remove(id);
+        }
+    }
+
+    @Override
+    public void recycle(MemorySegment segment) {
+        synchronized (lock) {
+            bufferPool.recycle(segment);
+            --numRequestedBuffers;
+            triggerScheduling();
+        }
+    }
+
+    public void release() {
+        synchronized (lock) {
+            if (isReleased) {
+                return;
+            }
+            isReleased = true;
+            failScheduledReaders(
+                    new ArrayList<>(allScheduledReaders.values()),
+                    new RuntimeException("Disk readers are released unexpectedly."));
+            partitionFileReader.release();
+            bufferPool.unregisterRequester(this);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Internal Methods
+    // ------------------------------------------------------------------------
+
+    private int readBuffersFromFile() {
+        List<ScheduledSubpartitionReader> scheduledReaders = sortScheduledReaders();
+        if (scheduledReaders.isEmpty()) {
+            return 0;
+        }
+        Queue<MemorySegment> buffers;
+        try {
+            buffers = allocateBuffers();
+        } catch (Exception exception) {
+            failScheduledReaders(scheduledReaders, exception);
+            LOG.error("Failed to request buffers for data reading.", exception);
+            return 0;
+        }
+
+        int numBuffersAllocated = buffers.size();
+        if (numBuffersAllocated <= 0) {
+            return 0;
+        }
+
+        for (ScheduledSubpartitionReader scheduledReader : scheduledReaders) {
+            if (buffers.isEmpty()) {
+                break;
+            }
+            try {
+                scheduledReader.loadDiskDataToBuffers(buffers, this);
+            } catch (Exception throwable) {
+                failScheduledReaders(Collections.singletonList(scheduledReader), throwable);
+                LOG.debug("Failed to read shuffle data.", throwable);
+            }
+        }
+        int numBuffersRead = numBuffersAllocated - buffers.size();
+        releaseBuffers(buffers);
+        return numBuffersRead;
+    }
+
+    private List<ScheduledSubpartitionReader> sortScheduledReaders() {
+        synchronized (lock) {
+            if (isReleased) {
+                return new ArrayList<>();
+            }
+            List<ScheduledSubpartitionReader> scheduledReaders = new ArrayList<>();
+            for (ScheduledSubpartitionReader reader : allScheduledReaders.values()) {
+                reader.prepareForScheduling();
+                scheduledReaders.add(reader);
+            }
+            Collections.sort(scheduledReaders);
+            return scheduledReaders;
+        }
+    }
+
+    private Queue<MemorySegment> allocateBuffers() throws Exception {
+        long timeoutTime = getBufferRequestTimeoutTime();
+        do {
+            List<MemorySegment> buffers = bufferPool.requestBuffers();
+            if (!buffers.isEmpty()) {
+                return new ArrayDeque<>(buffers);
+            }
+            synchronized (lock) {
+                if (isReleased) {
+                    return new ArrayDeque<>();
+                }
+            }
+        } while (System.currentTimeMillis() < timeoutTime
+                || System.currentTimeMillis() < (timeoutTime = getBufferRequestTimeoutTime()));
+        throw new TimeoutException(
+                String.format(
+                        "Buffer request timeout, this means there is a fierce contention of"
+                                + " the batch shuffle read memory, please increase '%s'.",
+                        TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
+    }
+
+    private void failScheduledReaders(
+            List<ScheduledSubpartitionReader> scheduledReaders, Throwable failureCause) {
+        for (ScheduledSubpartitionReader scheduledReader : scheduledReaders) {
+            synchronized (lock) {
+                allScheduledReaders.remove(scheduledReader.getId());
+            }
+            scheduledReader.failReader(failureCause);
+        }
+    }
+
+    private void releaseBuffers(Queue<MemorySegment> buffers) {
+        if (!buffers.isEmpty()) {
+            try {
+                bufferPool.recycle(buffers);
+                buffers.clear();
+            } catch (Throwable throwable) {
+                // this should never happen so just trigger fatal error
+                FatalExitExceptionHandler.INSTANCE.uncaughtException(
+                        Thread.currentThread(), throwable);
+            }
+        }
+    }
+
+    private void triggerScheduling() {
+        synchronized (lock) {
+            if (!isRunning
+                    && !allScheduledReaders.isEmpty()
+                    && numRequestedBuffers + bufferPool.getNumBuffersPerRequest()
+                            <= maxRequestedBuffers
+                    && numRequestedBuffers < bufferPool.getAverageBuffersPerRequester()) {
+                isRunning = true;
+                ioExecutor.execute(
+                        () -> {
+                            try {
+                                run();
+                            } catch (Throwable throwable) {
+                                LOG.error("Failed to read data.", throwable);
+                                // handle un-expected exception as unhandledExceptionHandler is not
+                                // worked for ScheduledExecutorService.
+                                FatalExitExceptionHandler.INSTANCE.uncaughtException(
+                                        Thread.currentThread(), throwable);
+                            }
+                        });
+            }
+        }
+    }
+
+    private long getBufferRequestTimeoutTime() {
+        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toMillis();
+    }
+
+    /**
+     * The {@link ScheduledSubpartitionReader} is responsible for reading a subpartition from disk,
+     * and is scheduled by the {@link DiskIOScheduler}.
+     */
+    private class ScheduledSubpartitionReader implements Comparable<ScheduledSubpartitionReader> {
+
+        private final TieredStorageSubpartitionId subpartitionId;
+
+        private final NettyConnectionWriter nettyConnectionWriter;
+
+        private int nextSegmentId = -1;
+
+        private int nextBufferIndex;
+
+        private long priority;
+
+        private boolean isFailed;
+
+        private ScheduledSubpartitionReader(
+                TieredStorageSubpartitionId subpartitionId,
+                NettyConnectionWriter nettyConnectionWriter) {
+            this.subpartitionId = subpartitionId;
+            this.nettyConnectionWriter = nettyConnectionWriter;
+        }
+
+        private void loadDiskDataToBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler)
+                throws IOException {
+
+            if (isFailed) {
+                throw new IOException(
+                        "The scheduled subpartition reader for "
+                                + subpartitionId
+                                + " has already been failed.");
+            }
+            while (!buffers.isEmpty()
+                    && nettyConnectionWriter.numQueuedBuffers() < maxBufferReadAhead
+                    && nextSegmentId >= 0) {
+                MemorySegment memorySegment = buffers.poll();
+                Buffer buffer;
+                try {
+                    if ((buffer =
+                                    partitionFileReader.readBuffer(
+                                            partitionId,
+                                            subpartitionId,
+                                            nextSegmentId,
+                                            nextBufferIndex,
+                                            memorySegment,
+                                            recycler))
+                            == null) {
+                        buffers.add(memorySegment);
+                        break;
+                    }
+                } catch (Throwable throwable) {
+                    buffers.add(memorySegment);
+                    throw throwable;
+                }
+                writeToNettyConnectionWriter(
+                        NettyPayload.newBuffer(
+                                buffer, nextBufferIndex++, subpartitionId.getSubpartitionId()));
+                if (buffer.getDataType() == Buffer.DataType.END_OF_SEGMENT) {
+                    nextSegmentId = -1;
+                    updateSegmentId();
+                }
+            }
+        }
+
+        @Override
+        public int compareTo(ScheduledSubpartitionReader reader) {
+            checkArgument(reader != null);
+            return Long.compare(getPriority(), reader.getPriority());
+        }
+
+        private void prepareForScheduling() {
+            if (nextSegmentId < 0) {
+                updateSegmentId();
+            }
+            priority =
+                    nextSegmentId < 0
+                            ? Long.MAX_VALUE
+                            : partitionFileReader.getPriority(
+                                    partitionId, subpartitionId, nextSegmentId, nextBufferIndex);
+        }
+
+        private void writeToNettyConnectionWriter(NettyPayload nettyPayload) {
+            nettyConnectionWriter.writeBuffer(nettyPayload);
+            if (nettyConnectionWriter.numQueuedBuffers() <= 1) {
+                notifyAvailable();
+            }
+        }
+
+        private long getPriority() {
+            return priority;
+        }
+
+        private void notifyAvailable() {
+            ((TieredStorageNettyServiceImpl) nettyService)
+                    .notifyResultSubpartitionViewSendBuffer(
+                            nettyConnectionWriter.getNettyConnectionId());
+        }
+
+        private void failReader(Throwable failureCause) {
+            if (isFailed) {
+                return;
+            }
+            isFailed = true;
+            nettyConnectionWriter.close(failureCause);
+            ((TieredStorageNettyServiceImpl) nettyService)
+                    .notifyResultSubpartitionViewSendBuffer(
+                            nettyConnectionWriter.getNettyConnectionId());
+        }
+
+        private void updateSegmentId() {
+            Integer segmentId =
+                    firstBufferIndexInSegmentRetriever.apply(
+                            subpartitionId.getSubpartitionId(), nextBufferIndex);
+            if (segmentId != null) {
+                nextSegmentId = segmentId;
+                writeToNettyConnectionWriter(NettyPayload.newSegment(segmentId));
+            }
+        }
+
+        private NettyConnectionId getId() {
+            return nettyConnectionWriter.getNettyConnectionId();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierConsumerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierConsumerAgent.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionReader;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/** The data client is used to fetch data from disk tier. */
+public class DiskTierConsumerAgent implements TierConsumerAgent {
+
+    private final Map<
+                    TieredStoragePartitionId,
+                    Map<TieredStorageSubpartitionId, CompletableFuture<NettyConnectionReader>>>
+            nettyConnectionReaders = new HashMap<>();
+
+    public DiskTierConsumerAgent(
+            List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
+            TieredStorageNettyService nettyService) {
+        for (TieredStorageConsumerSpec tieredStorageConsumerSpec : tieredStorageConsumerSpecs) {
+            TieredStoragePartitionId partitionId = tieredStorageConsumerSpec.getPartitionId();
+            TieredStorageSubpartitionId subpartitionId =
+                    tieredStorageConsumerSpec.getSubpartitionId();
+            nettyConnectionReaders
+                    .computeIfAbsent(partitionId, ignore -> new HashMap<>())
+                    .put(
+                            subpartitionId,
+                            nettyService.registerConsumer(partitionId, subpartitionId));
+        }
+    }
+
+    @Override
+    public void start() {
+        // noop
+    }
+
+    @Override
+    public Optional<Buffer> getNextBuffer(
+            TieredStoragePartitionId partitionId,
+            TieredStorageSubpartitionId subpartitionId,
+            int segmentId) {
+        try {
+            return nettyConnectionReaders
+                    .get(partitionId)
+                    .get(subpartitionId)
+                    .get()
+                    .readBuffer(segmentId);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to get next buffer.", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // noop
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk;
 
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
@@ -31,7 +32,9 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFact
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** The implementation of {@link TierFactory} for disk tier. */
 public class DiskTierFactory implements TierFactory {
@@ -64,7 +67,12 @@ public class DiskTierFactory implements TierFactory {
             PartitionFileReader partitionFileReader,
             TieredStorageMemoryManager storageMemoryManager,
             TieredStorageNettyService nettyService,
-            TieredStorageResourceRegistry resourceRegistry) {
+            TieredStorageResourceRegistry resourceRegistry,
+            BatchShuffleReadBufferPool bufferPool,
+            ScheduledExecutorService ioExecutor,
+            int maxRequestedBuffers,
+            Duration bufferRequestTimeout,
+            int maxBufferReadAhead) {
         return new DiskTierProducerAgent(
                 partitionId,
                 numSubpartitions,
@@ -74,16 +82,21 @@ public class DiskTierFactory implements TierFactory {
                 minReservedDiskSpaceFraction,
                 isBroadcastOnly,
                 partitionFileWriter,
+                partitionFileReader,
                 storageMemoryManager,
                 nettyService,
-                resourceRegistry);
+                resourceRegistry,
+                bufferPool,
+                ioExecutor,
+                maxRequestedBuffers,
+                bufferRequestTimeout,
+                maxBufferReadAhead);
     }
 
     @Override
     public TierConsumerAgent createConsumerAgent(
             List<TieredStorageConsumerSpec> tieredStorageConsumerSpecs,
             TieredStorageNettyService nettyService) {
-        // TODO, create the disk tier consumer agent.
-        return null;
+        return new DiskTierConsumerAgent(tieredStorageConsumerSpecs, nettyService);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.memory;
 
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
@@ -31,7 +32,9 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFact
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** The implementation of {@link TierFactory} for memory tier. */
 public class MemoryTierFactory implements TierFactory {
@@ -61,7 +64,12 @@ public class MemoryTierFactory implements TierFactory {
             PartitionFileReader partitionFileReader,
             TieredStorageMemoryManager memoryManager,
             TieredStorageNettyService nettyService,
-            TieredStorageResourceRegistry resourceRegistry) {
+            TieredStorageResourceRegistry resourceRegistry,
+            BatchShuffleReadBufferPool bufferPool,
+            ScheduledExecutorService ioExecutor,
+            int maxRequestedBuffers,
+            Duration bufferRequestTimeout,
+            int maxBufferReadAhead) {
         return new MemoryTierProducerAgent(
                 partitionID,
                 numSubpartitions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageTestUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Test utils for tiered storage. */
+public class TieredStorageTestUtils {
+
+    public static List<PartitionFileWriter.SubpartitionBufferContext> generateBuffersToWrite(
+            int numSubpartitions, int numSegments, int numBuffersPerSegment, int bufferSizeBytes) {
+        List<PartitionFileWriter.SubpartitionBufferContext> subpartitionBuffers = new ArrayList<>();
+        for (int i = 0; i < numSubpartitions; i++) {
+            List<PartitionFileWriter.SegmentBufferContext> segmentBufferContexts =
+                    new ArrayList<>();
+            for (int j = 0; j < numSegments; j++) {
+                List<Tuple2<Buffer, Integer>> bufferAndIndexes = new ArrayList<>();
+                for (int k = 0; k < numBuffersPerSegment; k++) {
+                    bufferAndIndexes.add(
+                            new Tuple2<>(
+                                    BufferBuilderTestUtils.buildSomeBuffer(bufferSizeBytes), k));
+                }
+                segmentBufferContexts.add(
+                        new PartitionFileWriter.SegmentBufferContext(j, bufferAndIndexes, false));
+            }
+
+            subpartitionBuffers.add(
+                    new PartitionFileWriter.SubpartitionBufferContext(i, segmentBufferContexts));
+        }
+        return subpartitionBuffers;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/DiskIOSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/DiskIOSchedulerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
+
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyConnectionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.NettyPayload;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TestingNettyConnectionWriter;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyServiceImpl;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk.DiskIOScheduler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link DiskIOScheduler}. */
+class DiskIOSchedulerTest {
+
+    private static final TieredStoragePartitionId DEFAULT_PARTITION_ID =
+            TieredStorageIdMappingUtils.convertId(new ResultPartitionID());
+
+    private static final TieredStorageSubpartitionId DEFAULT_SUBPARTITION_ID =
+            new TieredStorageSubpartitionId(0);
+
+    private static final int BUFFER_POOL_SIZE = 1;
+
+    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
+
+    private static final int DEFAULT_MAX_READ_AHEAD = 5;
+
+    private BatchShuffleReadBufferPool bufferPool;
+
+    private ManuallyTriggeredScheduledExecutorService ioExecutor;
+
+    private CompletableFuture<Integer> segmentIdFuture;
+
+    private CompletableFuture<Void> readerReleaseFuture;
+
+    private DiskIOScheduler diskIOScheduler;
+
+    private List<Map<Integer, Integer>> firstBufferIndexInSegment;
+
+    @BeforeEach
+    void before() {
+        this.ioExecutor = new ManuallyTriggeredScheduledExecutorService();
+        this.bufferPool = new BatchShuffleReadBufferPool(BUFFER_POOL_SIZE, BUFFER_POOL_SIZE);
+        this.bufferPool.initialize();
+        this.segmentIdFuture = new CompletableFuture<>();
+        this.readerReleaseFuture = new CompletableFuture<>();
+        this.firstBufferIndexInSegment = createFirstBufferIndexInSegment();
+        this.diskIOScheduler =
+                new DiskIOScheduler(
+                        DEFAULT_PARTITION_ID,
+                        bufferPool,
+                        ioExecutor,
+                        BUFFER_POOL_SIZE,
+                        DEFAULT_BUFFER_REQUEST_TIMEOUT,
+                        DEFAULT_MAX_READ_AHEAD,
+                        new TieredStorageNettyServiceImpl(),
+                        (subpartitionId, bufferIndex) ->
+                                firstBufferIndexInSegment.get(subpartitionId).get(bufferIndex),
+                        new TestingPartitionFileReader.Builder()
+                                .setReadBufferSupplier(
+                                        (bufferIndex, segmentId) -> {
+                                            segmentIdFuture.complete(segmentId);
+                                            return BufferBuilderTestUtils.buildSomeBuffer(0);
+                                        })
+                                .setReleaseNotifier(() -> readerReleaseFuture.complete(null))
+                                .setPrioritySupplier(subpartitionId -> (long) subpartitionId)
+                                .build());
+    }
+
+    @AfterEach
+    void after() {
+        bufferPool.destroy();
+    }
+
+    @Test
+    void testConnectionEstablished() {
+        CompletableFuture<NettyPayload> bufferWriteNotifier = new CompletableFuture<>();
+        TestingNettyConnectionWriter nettyConnectionWriter =
+                new TestingNettyConnectionWriter.Builder()
+                        .setWriteBufferFunction(
+                                nettyPayload -> {
+                                    if (nettyPayload.getSegmentId() == -1) {
+                                        bufferWriteNotifier.complete(nettyPayload);
+                                    }
+                                    return null;
+                                })
+                        .build();
+        diskIOScheduler.connectionEstablished(DEFAULT_SUBPARTITION_ID, nettyConnectionWriter);
+        assertThat(segmentIdFuture).isNotDone();
+        assertThat(bufferWriteNotifier).isNotDone();
+        ioExecutor.trigger();
+        assertThat(segmentIdFuture).isCompletedWithValue(0);
+        assertThat(bufferWriteNotifier).isDone();
+    }
+
+    @Test
+    void testSequenceReading() {
+        CompletableFuture<NettyPayload> bufferWriteNotifier1 = new CompletableFuture<>();
+        CompletableFuture<NettyPayload> bufferWriteNotifier2 = new CompletableFuture<>();
+        TestingNettyConnectionWriter nettyConnectionWriter1 =
+                new TestingNettyConnectionWriter.Builder()
+                        .setWriteBufferFunction(
+                                nettyPayload -> {
+                                    if (nettyPayload.getSegmentId() == -1) {
+                                        bufferWriteNotifier1.complete(nettyPayload);
+                                    }
+                                    return null;
+                                })
+                        .build();
+        TestingNettyConnectionWriter nettyConnectionWriter2 =
+                new TestingNettyConnectionWriter.Builder()
+                        .setWriteBufferFunction(
+                                nettyPayload -> {
+                                    if (nettyPayload.getSegmentId() == -1) {
+                                        bufferWriteNotifier1.complete(nettyPayload);
+                                    }
+                                    return null;
+                                })
+                        .build();
+        diskIOScheduler.connectionEstablished(
+                new TieredStorageSubpartitionId(1), nettyConnectionWriter2);
+        diskIOScheduler.connectionEstablished(
+                new TieredStorageSubpartitionId(0), nettyConnectionWriter1);
+        assertThat(bufferWriteNotifier1).isNotDone();
+        assertThat(bufferWriteNotifier2).isNotDone();
+        ioExecutor.trigger();
+        assertThat(bufferWriteNotifier1).isDone();
+        assertThat(bufferWriteNotifier2).isNotDone();
+    }
+
+    @Test
+    void testConnectionBroken() {
+        CompletableFuture<NettyPayload> bufferWriteNotifier = new CompletableFuture<>();
+        NettyConnectionId nettyConnectionId = NettyConnectionId.newId();
+        TestingNettyConnectionWriter nettyConnectionWriter =
+                new TestingNettyConnectionWriter.Builder()
+                        .setWriteBufferFunction(
+                                nettyPayload -> {
+                                    if (nettyPayload.getSegmentId() == -1) {
+                                        bufferWriteNotifier.complete(nettyPayload);
+                                    }
+                                    return null;
+                                })
+                        .setNettyConnectionIdSupplier(() -> nettyConnectionId)
+                        .build();
+        diskIOScheduler.connectionEstablished(DEFAULT_SUBPARTITION_ID, nettyConnectionWriter);
+        diskIOScheduler.connectionBroken(nettyConnectionId);
+        ioExecutor.trigger();
+        assertThat(segmentIdFuture).isNotDone();
+        assertThat(bufferWriteNotifier).isNotDone();
+    }
+
+    @Test
+    void testRelease() {
+        CompletableFuture<NettyPayload> bufferWriteNotifier = new CompletableFuture<>();
+        NettyConnectionId nettyConnectionId = NettyConnectionId.newId();
+        TestingNettyConnectionWriter nettyConnectionWriter =
+                new TestingNettyConnectionWriter.Builder()
+                        .setWriteBufferFunction(
+                                nettyPayload -> {
+                                    bufferWriteNotifier.complete(nettyPayload);
+                                    return null;
+                                })
+                        .setNettyConnectionIdSupplier(() -> nettyConnectionId)
+                        .build();
+        diskIOScheduler.connectionEstablished(DEFAULT_SUBPARTITION_ID, nettyConnectionWriter);
+        diskIOScheduler.release();
+        assertThat(readerReleaseFuture).isDone();
+        assertThatThrownBy(
+                        () ->
+                                diskIOScheduler.connectionEstablished(
+                                        DEFAULT_SUBPARTITION_ID, nettyConnectionWriter))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    private List<Map<Integer, Integer>> createFirstBufferIndexInSegment() {
+        Map<Integer, Integer> firstBufferIndexInSegment0 = new HashMap<>();
+        Map<Integer, Integer> firstBufferIndexInSegment1 = new HashMap<>();
+        firstBufferIndexInSegment0.put(0, 0);
+        firstBufferIndexInSegment1.put(0, 0);
+        List<Map<Integer, Integer>> list = new ArrayList<>();
+        list.add(firstBufferIndexInSegment0);
+        list.add(firstBufferIndexInSegment1);
+        return list;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.HEADER_LENGTH;
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageTestUtils.generateBuffersToWrite;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ProducerMergedPartitionFileReader}. */
+class ProducerMergedPartitionFileReaderTest {
+
+    private static final int DEFAULT_NUM_SUBPARTITION = 1;
+
+    private static final int DEFAULT_SEGMENT_NUM = 1;
+
+    private static final int DEFAULT_SEGMENT_ID = 0;
+
+    private static final int DEFAULT_BUFFER_NUMBER = 5;
+
+    private static final int DEFAULT_BUFFER_SIZE = 3;
+
+    private static final String DEFAULT_TEST_FILE_NAME = "testFile";
+
+    private static final TieredStoragePartitionId DEFAULT_PARTITION_ID =
+            TieredStorageIdMappingUtils.convertId(new ResultPartitionID());
+
+    private static final TieredStorageSubpartitionId DEFAULT_SUBPARTITION_ID =
+            new TieredStorageSubpartitionId(0);
+
+    @TempDir private Path tempFolder;
+
+    private Path testFilePath;
+
+    private ProducerMergedPartitionFileReader partitionFileReader;
+
+    @BeforeEach
+    void before() throws ExecutionException, InterruptedException {
+        ProducerMergedPartitionFileIndex partitionFileIndex =
+                new ProducerMergedPartitionFileIndex(DEFAULT_NUM_SUBPARTITION);
+        testFilePath = new File(tempFolder.toFile(), DEFAULT_TEST_FILE_NAME).toPath();
+        ProducerMergedPartitionFileWriter partitionFileWriter =
+                new ProducerMergedPartitionFileWriter(testFilePath, partitionFileIndex);
+        // Write buffers to disk by writer
+        List<PartitionFileWriter.SubpartitionBufferContext> subpartitionBuffers =
+                generateBuffersToWrite(
+                        DEFAULT_NUM_SUBPARTITION,
+                        DEFAULT_SEGMENT_NUM,
+                        DEFAULT_BUFFER_NUMBER,
+                        DEFAULT_BUFFER_SIZE);
+        partitionFileWriter.write(DEFAULT_PARTITION_ID, subpartitionBuffers).get();
+        partitionFileReader =
+                new ProducerMergedPartitionFileReader(testFilePath, partitionFileIndex);
+    }
+
+    @Test
+    void testReadBuffer() throws IOException {
+        for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ++bufferIndex) {
+            Buffer buffer = readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID);
+            assertThat(buffer).isNotNull();
+            buffer.recycleBuffer();
+        }
+        MemorySegment memorySegment =
+                MemorySegmentFactory.allocateUnpooledSegment(DEFAULT_BUFFER_SIZE);
+        assertThat(
+                        partitionFileReader.readBuffer(
+                                DEFAULT_PARTITION_ID,
+                                DEFAULT_SUBPARTITION_ID,
+                                DEFAULT_SEGMENT_ID,
+                                DEFAULT_BUFFER_NUMBER + 1,
+                                memorySegment,
+                                FreeingBufferRecycler.INSTANCE))
+                .isNull();
+    }
+
+    @Test
+    void testGetPriority() throws IOException {
+        int currentFileOffset = 0;
+        for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ++bufferIndex) {
+            Buffer buffer = readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID);
+            assertThat(buffer).isNotNull();
+            assertThat(
+                            partitionFileReader.getPriority(
+                                    DEFAULT_PARTITION_ID,
+                                    DEFAULT_SUBPARTITION_ID,
+                                    DEFAULT_SEGMENT_ID,
+                                    bufferIndex))
+                    .isEqualTo(currentFileOffset);
+            currentFileOffset += (HEADER_LENGTH + DEFAULT_BUFFER_SIZE);
+            buffer.recycleBuffer();
+        }
+    }
+
+    @Test
+    void testCacheExceedMaxNumber() throws IOException {
+        int cacheNumber = 3;
+        AtomicInteger indexQueryTime = new AtomicInteger(0);
+        TestingProducerMergedPartitionFileIndex partitionFileIndex =
+                new TestingProducerMergedPartitionFileIndex.Builder()
+                        .setGetRegionFunction(
+                                (subpartitionId, integer) -> {
+                                    indexQueryTime.incrementAndGet();
+                                    return Optional.of(
+                                            new ProducerMergedPartitionFileIndex.Region(0, 0, 2));
+                                })
+                        .build();
+        partitionFileReader =
+                new ProducerMergedPartitionFileReader(
+                        testFilePath, partitionFileIndex, cacheNumber);
+        // Read different subpartitions from the reader and make cache reach max number.
+        for (int subpartitionId = 0; subpartitionId < cacheNumber * 2; ++subpartitionId) {
+            assertThat(
+                            readBuffer(
+                                    subpartitionId < cacheNumber ? 0 : 1,
+                                    new TieredStorageSubpartitionId(subpartitionId % cacheNumber)))
+                    .isNotNull();
+        }
+        // The following buffer reading from other subpartitions can only query the index.
+        assertThat(readBuffer(0, new TieredStorageSubpartitionId(3))).isNotNull();
+        assertThat(readBuffer(0, new TieredStorageSubpartitionId(3))).isNotNull();
+        assertThat(indexQueryTime).hasValue(5);
+    }
+
+    @Test
+    void testRelease() {
+        assertThat(testFilePath.toFile().exists()).isTrue();
+        partitionFileReader.release();
+        assertThat(testFilePath.toFile().exists()).isFalse();
+    }
+
+    private Buffer readBuffer(int bufferIndex, TieredStorageSubpartitionId subpartitionId)
+            throws IOException {
+        MemorySegment memorySegment =
+                MemorySegmentFactory.allocateUnpooledSegment(DEFAULT_BUFFER_SIZE);
+        return partitionFileReader.readBuffer(
+                DEFAULT_PARTITION_ID,
+                subpartitionId,
+                DEFAULT_SEGMENT_ID,
+                bufferIndex,
+                memorySegment,
+                FreeingBufferRecycler.INSTANCE);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileWriterTest.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageIdMappingUtils;
@@ -32,11 +29,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageTestUtils.generateBuffersToWrite;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ProducerMergedPartitionFileWriter}. */
@@ -93,28 +90,5 @@ class ProducerMergedPartitionFileWriterTest {
                         new File(tempFolder.toFile(), "testFile1").toPath(), partitionFileIndex);
         partitionFileWriter.release();
         assertThat(isReleased).isTrue();
-    }
-
-    private static List<PartitionFileWriter.SubpartitionBufferContext> generateBuffersToWrite(
-            int numSubpartitions, int numSegments, int numBuffersPerSegment, int bufferSizeBytes) {
-        List<PartitionFileWriter.SubpartitionBufferContext> subpartitionBuffers = new ArrayList<>();
-        for (int i = 0; i < numSubpartitions; i++) {
-            List<PartitionFileWriter.SegmentBufferContext> segmentBufferContexts =
-                    new ArrayList<>();
-            for (int j = 0; j < numSegments; j++) {
-                List<Tuple2<Buffer, Integer>> bufferAndIndexes = new ArrayList<>();
-                for (int k = 0; k < numBuffersPerSegment; k++) {
-                    bufferAndIndexes.add(
-                            new Tuple2<>(
-                                    BufferBuilderTestUtils.buildSomeBuffer(bufferSizeBytes), k));
-                }
-                segmentBufferContexts.add(
-                        new PartitionFileWriter.SegmentBufferContext(j, bufferAndIndexes, false));
-            }
-
-            subpartitionBuffers.add(
-                    new PartitionFileWriter.SubpartitionBufferContext(i, segmentBufferContexts));
-        }
-        return subpartitionBuffers;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/** Testing implementation for {@link PartitionFileReader}. */
+public class TestingPartitionFileReader implements PartitionFileReader {
+
+    private final BiFunction<Integer, Integer, Buffer> readBufferFunction;
+
+    private final Function<Integer, Long> getPriorityFunction;
+
+    private final Runnable releaseRunnable;
+
+    private TestingPartitionFileReader(
+            BiFunction<Integer, Integer, Buffer> readBufferFunction,
+            Function<Integer, Long> getPriorityFunction,
+            Runnable releaseRunnable) {
+        this.readBufferFunction = readBufferFunction;
+        this.getPriorityFunction = getPriorityFunction;
+        this.releaseRunnable = releaseRunnable;
+    }
+
+    @Override
+    public Buffer readBuffer(
+            TieredStoragePartitionId partitionId,
+            TieredStorageSubpartitionId subpartitionId,
+            int segmentId,
+            int bufferIndex,
+            MemorySegment memorySegment,
+            BufferRecycler recycler)
+            throws IOException {
+        return readBufferFunction.apply(bufferIndex, segmentId);
+    }
+
+    @Override
+    public long getPriority(
+            TieredStoragePartitionId partitionId,
+            TieredStorageSubpartitionId subpartitionId,
+            int segmentId,
+            int bufferIndex) {
+        return getPriorityFunction.apply(subpartitionId.getSubpartitionId());
+    }
+
+    @Override
+    public void release() {
+        releaseRunnable.run();
+    }
+
+    /** Builder for {@link TestingPartitionFileReader}. */
+    public static class Builder {
+        private BiFunction<Integer, Integer, Buffer> readBufferSupplier =
+                (bufferIndex, segmentId) -> null;
+
+        private Function<Integer, Long> prioritySupplier = bufferIndex -> 0L;
+
+        private Runnable releaseNotifier = () -> {};
+
+        public Builder setReadBufferSupplier(
+                BiFunction<Integer, Integer, Buffer> readBufferSupplier) {
+            this.readBufferSupplier = readBufferSupplier;
+            return this;
+        }
+
+        public Builder setPrioritySupplier(Function<Integer, Long> prioritySupplier) {
+            this.prioritySupplier = prioritySupplier;
+            return this;
+        }
+
+        public Builder setReleaseNotifier(Runnable releaseNotifier) {
+            this.releaseNotifier = releaseNotifier;
+            return this;
+        }
+
+        public TestingPartitionFileReader build() {
+            return new TestingPartitionFileReader(
+                    readBufferSupplier, prioritySupplier, releaseNotifier);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
@@ -27,7 +28,9 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFact
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -71,7 +74,12 @@ public class TestingTierFactory implements TierFactory {
             PartitionFileReader partitionFileReader,
             TieredStorageMemoryManager storageMemoryManager,
             TieredStorageNettyService nettyService,
-            TieredStorageResourceRegistry resourceRegistry) {
+            TieredStorageResourceRegistry resourceRegistry,
+            BatchShuffleReadBufferPool bufferPool,
+            ScheduledExecutorService ioExecutor,
+            int maxRequestedBuffers,
+            Duration bufferRequestTimeout,
+            int maxBufferReadAhead) {
         return tierProducerAgentSupplier.get();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgentTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk;
 
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingTieredStorageMemoryManager;
@@ -26,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.Tiered
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageUtils;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.TestingPartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.TestingPartitionFileWriter;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TestingNettyServiceProducer;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TestingTieredStorageNettyService;
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -203,8 +207,14 @@ public class DiskTierProducerAgentTest {
                 minReservedDiskSpaceFraction,
                 isBroadcastOnly,
                 partitionFileWriter,
+                new TestingPartitionFileReader.Builder().build(),
                 memoryManager,
                 nettyService,
-                resourceRegistry);
+                resourceRegistry,
+                new BatchShuffleReadBufferPool(1, 1),
+                new ManuallyTriggeredScheduledExecutorService(),
+                0,
+                Duration.ofMinutes(5),
+                0);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

### Introduce Disk Tier reader

1. Introduce the ProducerMergePartitionFileReader
2. Introduce the DiskIOScheduler and ScheduledSubpartitionReader
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)