### PR TITLE
[FLINK-32316] [connectors/common] Scheduling announceCombinedWatermark period task during SourceCoordinator::start not in construct function to avoid duplicated task be scheduled

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -19,7 +19,10 @@
 package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.common.eventtime.WatermarkAlignmentParams;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.core.fs.AutoCloseableRegistry;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.ReportedWatermarkEvent;
 import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
@@ -27,6 +30,9 @@ import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -129,6 +135,67 @@ class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
             assertLatestWatermarkAlignmentEvent(subtask0, 6000);
             assertLatestWatermarkAlignmentEvent(subtask1, 1044);
         }
+    }
+
+    /**
+     * When JobManager failover and auto recover job, SourceCoordinator will reset twice: 1. Create
+     * JobMaster --> Create Scheduler --> Create DefaultExecutionGraph --> Init
+     * SourceCoordinator(but will not start it) 2. JobMaster call
+     * restoreLatestCheckpointedStateInternal, which will call {@link
+     * org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator#resetToCheckpoint(long,byte[])}
+     * and reset SourceCoordinator. Because the first SourceCoordinator is not be started, so the
+     * period task can't be stopped.
+     */
+    @Test
+    void testAnnounceCombinedWatermarkWithoutStart() throws Exception {
+        long maxDrift = 1000L;
+        WatermarkAlignmentParams params =
+                new WatermarkAlignmentParams(maxDrift, "group1", maxDrift);
+
+        final Source<Integer, MockSourceSplit, Set<MockSourceSplit>> mockSource =
+                createMockSource();
+
+        // First to init a SourceCoordinator to simulate JobMaster init SourceCoordinator
+        AtomicInteger counter1 = new AtomicInteger(0);
+        sourceCoordinator =
+                new SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>>(
+                        OPERATOR_NAME,
+                        mockSource,
+                        getNewSourceCoordinatorContext(),
+                        new CoordinatorStoreImpl(),
+                        params,
+                        null) {
+                    @Override
+                    void announceCombinedWatermark() {
+                        counter1.incrementAndGet();
+                    }
+                };
+
+        // Second we call SourceCoordinator::close and re-init SourceCoordinator to simulate
+        // RecreateOnResetOperatorCoordinator::resetToCheckpoint
+        sourceCoordinator.close();
+        CountDownLatch latch = new CountDownLatch(2);
+        sourceCoordinator =
+                new SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>>(
+                        OPERATOR_NAME,
+                        mockSource,
+                        getNewSourceCoordinatorContext(),
+                        new CoordinatorStoreImpl(),
+                        params,
+                        null) {
+                    @Override
+                    void announceCombinedWatermark() {
+                        latch.countDown();
+                    }
+                };
+
+        sourceCoordinator.start();
+        setReaderTaskReady(sourceCoordinator, 0, 0);
+
+        latch.await();
+        assertThat(counter1.get()).isZero();
+
+        sourceCoordinator.close();
     }
 
     private SourceCoordinator<?, ?> getAndStartNewSourceCoordinator(


### PR DESCRIPTION
see [FLINK-32316](https://issues.apache.org/jira/browse/FLINK-32316)

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
