### PR TITLE
[FLINK-32368][test] Fixes wrong interface implementation in KubernetesTestFixture

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,7 +159,7 @@ class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilityTestBa
                                                     checkpointIDCounter
                                                             .shutdown(JobStatus.FINISHED)
                                                             .get())
-                                    .satisfies(anyCauseMatches(CompletionException.class));
+                                    .satisfies(anyCauseMatches(ExecutionException.class));
 
                             // fixing the internal issue should make the shutdown succeed again
                             KubernetesUtils.createConfigMapIfItDoesNotExist(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
+import org.apache.flink.runtime.leaderelection.LeaderElectionException;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.assertThatChainOfCauses;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
@@ -91,9 +92,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -136,9 +137,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                     "Could not write leader information since ConfigMap "
                                             + LEADER_CONFIGMAP_NAME
                                             + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -199,9 +200,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " is deleted externally";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -223,9 +224,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "Error while watching the ConfigMap " + LEADER_CONFIGMAP_NAME;
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -560,9 +560,9 @@ class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTestBase 
                             final FlinkKubeClient anotherFlinkKubeClient =
                                     createFlinkKubeClientBuilder()
                                             .setCheckAndUpdateConfigMapFunction(
-                                                    (configMapName, function) -> {
-                                                        throw updateException;
-                                                    })
+                                                    (configMapName, function) ->
+                                                            FutureUtils.completedExceptionally(
+                                                                    updateException))
                                             .build();
                             final KubernetesStateHandleStore<
                                             TestingLongStateHandleHelper.LongStateHandle>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
@@ -167,10 +166,10 @@ class KubernetesTestFixture {
                                                     .orElse(false);
                                     return CompletableFuture.completedFuture(updated);
                                 } catch (Throwable throwable) {
-                                    throw new CompletionException(throwable);
+                                    return FutureUtils.completedExceptionally(throwable);
                                 }
                             }
-                            throw new CompletionException(
+                            return FutureUtils.completedExceptionally(
                                     new KubernetesException(
                                             "ConfigMap " + configMapName + " does not exist."));
                         })


### PR DESCRIPTION
## What is the purpose of the change

[FlinkKubeClient.checkAndUpdateConfigMap](https://github.com/apache/flink/blob/ab3eb40d920fa609f49164a0bbb5fcbb3004a808/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java#L163) expects an error to be forwarded through the `CompletableFuture` instead of throwing a `RuntimeException`.

The actual implementation implements it accordingly in [Fabric8FlinkKubeClient:313](https://github.com/apache/flink/blob/025a95b627faf8ec8b725a7784d1279b41e10ba7/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java#L313) where a `CompletionException` is thrown within the `CompletableFuture`'s `supplyAsync` call resulting in the future to fail.

`KubernetesTestFixture` doesn't make the returned future complete exceptionally but throws a `CompletionException` (see [KubernetesTestFixture:172](https://github.com/apache/flink/blob/6fc5f789869433688eb5f62494f1a4404e0dd11b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java#L172)).

This results in inconsistent test behavior.

## Brief change log

* Updates the `KubernetesTestFixture`
* adapts related tests

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable