### PR TITLE
[FLINK-32035][sql-client] Support HTTPS endpoints in SQL Client gateway mode

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-restclient/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-restclient/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<version>1.18-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- This module is designated to testing RestClient functionality that requires-->
+	<!-- internet access and is only supposed to run in the CI environment. -->
+	<artifactId>flink-end-to-end-tests-restclient</artifactId>
+	<name>Flink : E2E Tests : Rest Client</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/java/org/apache/flink/runtime/rest/RestClientITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/java/org/apache/flink/runtime/rest/RestClientITCase.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.concurrent.TimeUnit;
+
+/** Tests for {@link RestClient} that rely on external connections. */
+public class RestClientITCase extends TestLogger {
+
+    @Test
+    public void testHttpsConnectionWithDefaultCerts() throws Exception {
+        final Configuration config = new Configuration();
+        final URL httpsUrl = new URL("https://raw.githubusercontent.com");
+        TestUrlMessageHeaders testUrlMessageHeaders =
+                new TestUrlMessageHeaders(
+                        "apache/flink/master/flink-runtime-web/web-dashboard/package.json");
+        try (final RestClient restClient =
+                RestClient.forUrl(config, Executors.directExecutor(), httpsUrl)) {
+            restClient
+                    .sendRequest(
+                            httpsUrl.getHost(),
+                            443,
+                            testUrlMessageHeaders,
+                            EmptyMessageParameters.getInstance(),
+                            EmptyRequestBody.getInstance())
+                    .get(60, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class TestUrlMessageHeaders
+            implements RuntimeMessageHeaders<
+                    EmptyRequestBody, GenericResponseBody, EmptyMessageParameters> {
+
+        private final String endpointUrl;
+
+        private final Collection<RestAPIVersion<EmptyRestAPIVersion>> supportedVersions =
+                Collections.singleton(new EmptyRestAPIVersion());
+
+        TestUrlMessageHeaders(String endpointUrl) {
+            this.endpointUrl = endpointUrl;
+        }
+
+        @Override
+        public HttpMethodWrapper getHttpMethod() {
+            return HttpMethodWrapper.GET;
+        }
+
+        @Override
+        public String getTargetRestEndpointURL() {
+            return endpointUrl;
+        }
+
+        @Override
+        public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+            return supportedVersions;
+        }
+
+        @Override
+        public Class<GenericResponseBody> getResponseClass() {
+            return GenericResponseBody.class;
+        }
+
+        @Override
+        public HttpResponseStatus getResponseStatusCode() {
+            return HttpResponseStatus.OK;
+        }
+
+        @Override
+        public String getDescription() {
+            return "";
+        }
+
+        @Override
+        public Class<EmptyRequestBody> getRequestClass() {
+            return EmptyRequestBody.class;
+        }
+
+        @Override
+        public EmptyMessageParameters getUnresolvedMessageParameters() {
+            return EmptyMessageParameters.getInstance();
+        }
+
+        private static class EmptyRestAPIVersion implements RestAPIVersion<EmptyRestAPIVersion> {
+
+            @Override
+            public String getURLVersionPrefix() {
+                return "";
+            }
+
+            @Override
+            public boolean isDefaultVersion() {
+                return true;
+            }
+
+            @Override
+            public boolean isStableVersion() {
+                return true;
+            }
+
+            @Override
+            public int compareTo(EmptyRestAPIVersion o) {
+                return 0;
+            }
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static class GenericResponseBody extends LinkedHashMap implements ResponseBody {}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -78,6 +78,7 @@ under the License.
 		<module>flink-end-to-end-tests-sql</module>
 		<module>flink-end-to-end-tests-jdbc-driver</module>
 		<module>flink-end-to-end-tests-hive</module>
+		<module>flink-end-to-end-tests-restclient</module>
     </modules>
 
 	<dependencies>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -23,9 +23,7 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
-import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -45,10 +43,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.URL;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -86,26 +81,6 @@ public class RestClientTest extends TestLogger {
             final Throwable throwable = ExceptionUtils.stripExecutionException(e);
             assertThat(throwable, instanceOf(ConnectTimeoutException.class));
             assertThat(throwable.getMessage(), containsString(unroutableIp));
-        }
-    }
-
-    @Test
-    public void testHttpsConnectionWithDefaultCerts() throws Exception {
-        final Configuration config = new Configuration();
-        final URL httpsUrl = new URL("https://raw.githubusercontent.com");
-        TestUrlMessageHeaders testUrlMessageHeaders =
-                new TestUrlMessageHeaders(
-                        "apache/flink/master/flink-runtime-web/web-dashboard/package.json");
-        try (final RestClient restClient =
-                RestClient.forUrl(config, Executors.directExecutor(), httpsUrl)) {
-            restClient
-                    .sendRequest(
-                            httpsUrl.getHost(),
-                            443,
-                            testUrlMessageHeaders,
-                            EmptyMessageParameters.getInstance(),
-                            EmptyRequestBody.getInstance())
-                    .get(60, TimeUnit.SECONDS);
         }
     }
 
@@ -271,84 +246,4 @@ public class RestClientTest extends TestLogger {
             return "/";
         }
     }
-
-    private static class TestUrlMessageHeaders
-            implements RuntimeMessageHeaders<
-                    EmptyRequestBody, GenericResponseBody, EmptyMessageParameters> {
-
-        private final String endpointUrl;
-
-        private final Collection<RestAPIVersion<EmptyRestAPIVersion>> supportedVersions =
-                Collections.singleton(new EmptyRestAPIVersion());
-
-        TestUrlMessageHeaders(String endpointUrl) {
-            this.endpointUrl = endpointUrl;
-        }
-
-        @Override
-        public HttpMethodWrapper getHttpMethod() {
-            return HttpMethodWrapper.GET;
-        }
-
-        @Override
-        public String getTargetRestEndpointURL() {
-            return endpointUrl;
-        }
-
-        @Override
-        public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
-            return supportedVersions;
-        }
-
-        @Override
-        public Class<GenericResponseBody> getResponseClass() {
-            return GenericResponseBody.class;
-        }
-
-        @Override
-        public HttpResponseStatus getResponseStatusCode() {
-            return HttpResponseStatus.OK;
-        }
-
-        @Override
-        public String getDescription() {
-            return "";
-        }
-
-        @Override
-        public Class<EmptyRequestBody> getRequestClass() {
-            return EmptyRequestBody.class;
-        }
-
-        @Override
-        public EmptyMessageParameters getUnresolvedMessageParameters() {
-            return EmptyMessageParameters.getInstance();
-        }
-
-        private static class EmptyRestAPIVersion implements RestAPIVersion<EmptyRestAPIVersion> {
-
-            @Override
-            public String getURLVersionPrefix() {
-                return "";
-            }
-
-            @Override
-            public boolean isDefaultVersion() {
-                return true;
-            }
-
-            @Override
-            public boolean isStableVersion() {
-                return true;
-            }
-
-            @Override
-            public int compareTo(EmptyRestAPIVersion o) {
-                return 0;
-            }
-        }
-    }
-
-    @SuppressWarnings("rawtypes")
-    private static class GenericResponseBody extends LinkedHashMap implements ResponseBody {}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ExecutorImpl.java
@@ -174,7 +174,9 @@ public class ExecutorImpl implements Executor {
             // register required resource
             this.executorService = Executors.newCachedThreadPool();
             registry.registerCloseable(executorService::shutdownNow);
-            this.restClient = new RestClient(defaultContext.getFlinkConfig(), executorService);
+            Configuration flinkConfig = defaultContext.getFlinkConfig();
+
+            this.restClient = RestClient.forUrl(flinkConfig, executorService, gatewayUrl);
             registry.registerCloseable(restClient);
 
             // determine gateway rest api version
@@ -189,8 +191,7 @@ public class ExecutorImpl implements Executor {
                     sendRequest(
                                     OpenSessionHeaders.getInstance(),
                                     EmptyMessageParameters.getInstance(),
-                                    new OpenSessionRequestBody(
-                                            sessionId, defaultContext.getFlinkConfig().toMap()))
+                                    new OpenSessionRequestBody(sessionId, flinkConfig.toMap()))
                             .get();
             this.sessionHandle = new SessionHandle(UUID.fromString(response.getSessionHandle()));
             registry.registerCloseable(this::closeSession);


### PR DESCRIPTION
## What is the purpose of the change

SQL Client gateway mode allows to submit SQL queries to remote Flink clusters.The target clusters are often placed behind proxies, such as K8S ingresses. [FLINK-32030](https://issues.apache.org/jira/browse/FLINK-32030) expanded the capability to connect to SQL gateways using URLs. This PR addresses the limitation caused by the tight coupling between the underlying `RestClient` and internal cluster SSL configuration. It makes it possible to connect to HTTPS endpoints using built-in JDK keystores rather than forcing usage of user-supplied once. 

## Brief change log

- Makes  user-supplied `TrustManager` configuration optional when enabling SSL
- Automatically enables SSL in RestClient for `https://` URLs
- Makes use of encrypted endpoints in SQL Client

## Verifying this change
  - Added test to verify that a HTTPS connection using built-in JDK truststore works as expected

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - A follow up docs PR will be created to document URLs support in SQL Client gateway mode
