### PR TITLE
[BP-1.17][FLINK-32368][test] Fixes wrong interface implementation in KubernetesTestFixture

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -159,7 +159,7 @@ class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilityTestBa
                                                     checkpointIDCounter
                                                             .shutdown(JobStatus.FINISHED)
                                                             .get())
-                                    .satisfies(anyCauseMatches(CompletionException.class));
+                                    .satisfies(anyCauseMatches(ExecutionException.class));
 
                             // fixing the internal issue should make the shutdown succeed again
                             KubernetesUtils.createConfigMapIfItDoesNotExist(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
+import org.apache.flink.runtime.leaderelection.LeaderElectionException;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.assertThatChainOfCauses;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
@@ -91,9 +92,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -136,9 +137,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                     "Could not write leader information since ConfigMap "
                                             + LEADER_CONFIGMAP_NAME
                                             + " does not exist.";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(KubernetesException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -199,9 +200,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " is deleted externally";
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };
@@ -223,9 +224,9 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             electionEventHandler.waitForError();
                             final String errorMsg =
                                     "Error while watching the ConfigMap " + LEADER_CONFIGMAP_NAME;
-                            assertThat(electionEventHandler.getError()).isNotNull();
-                            assertThatChainOfCauses(electionEventHandler.getError())
-                                    .anySatisfy(t -> assertThat(t).hasMessageContaining(errorMsg));
+                            assertThat(electionEventHandler.getError())
+                                    .isInstanceOf(LeaderElectionException.class)
+                                    .hasMessage(errorMsg);
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -561,9 +561,9 @@ class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTestBase 
                             final FlinkKubeClient anotherFlinkKubeClient =
                                     createFlinkKubeClientBuilder()
                                             .setCheckAndUpdateConfigMapFunction(
-                                                    (configMapName, function) -> {
-                                                        throw updateException;
-                                                    })
+                                                    (configMapName, function) ->
+                                                            FutureUtils.completedExceptionally(
+                                                                    updateException))
                                             .build();
                             final KubernetesStateHandleStore<
                                             TestingLongStateHandleHelper.LongStateHandle>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
@@ -167,10 +166,10 @@ class KubernetesTestFixture {
                                                     .orElse(false);
                                     return CompletableFuture.completedFuture(updated);
                                 } catch (Throwable throwable) {
-                                    throw new CompletionException(throwable);
+                                    return FutureUtils.completedExceptionally(throwable);
                                 }
                             }
-                            throw new CompletionException(
+                            return FutureUtils.completedExceptionally(
                                     new KubernetesException(
                                             "ConfigMap " + configMapName + " does not exist."));
                         })


### PR DESCRIPTION
1.17 backport PR for parent PR https://github.com/apache/flink/pull/22809