### PR TITLE
[FLINK-32008][protobuf] Ensure bulk persistence is not supported

### DIFF
--- a/flink-formats/flink-protobuf/pom.xml
+++ b/flink-formats/flink-protobuf/pom.xml
@@ -56,6 +56,16 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Filesystem connector is only present to ensure bulk files are not supported -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFileFormatFactory.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFileFormatFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.BulkWriter.Factory;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.file.table.factories.BulkReaderFormatFactory;
+import org.apache.flink.connector.file.table.factories.BulkWriterFormatFactory;
+import org.apache.flink.connector.file.table.format.BulkDecodingFormat;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Throw a {@link ValidationException} when using Protobuf format factory for file system.
+ *
+ * <p>In practice, there is <a href="https://protobuf.dev/programming-guides/techniques/#streaming">
+ * no standard</a> for storing bulk protobuf messages. This factory is present to prevent falling
+ * back to the {@link org.apache.flink.connector.file.table.DeserializationSchemaAdapter}, a
+ * line-based format which could silently succeed but write unrecoverable data to disk.
+ *
+ * <p>If your use case requires storing bulk protobuf messages on disk, the parquet file format
+ * might be the appropriate container and has an API for mapping records to protobuf messages.
+ */
+@Internal
+public class PbFileFormatFactory implements BulkReaderFormatFactory, BulkWriterFormatFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return PbFormatFactory.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public BulkDecodingFormat<RowData> createDecodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        throw new ValidationException(
+                "The 'protobuf' format is not supported for the 'filesystem' connector.");
+    }
+
+    @Override
+    public EncodingFormat<Factory<RowData>> createEncodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        throw new ValidationException(
+                "The 'protobuf' format is not supported for the 'filesystem' connector.");
+    }
+}

--- a/flink-formats/flink-protobuf/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-formats/flink-protobuf/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,3 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 org.apache.flink.formats.protobuf.PbFormatFactory
+org.apache.flink.formats.protobuf.PbFileFormatFactory


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

It's currently possible to use protobuf as a format to read/write files that store bulk records.  This is not actually supported by the [protobuf format](https://protobuf.dev/programming-guides/techniques/#streaming) itself.  Some techniques can be used to frame the data, but from the discussion on the [mailing list](https://lists.apache.org/thread/z9tqdqrhj12c17wqsdbm5fhzonqq5kp0), this doesn't seem like a useful thing to do.

The protobuf format is apt for serializing individual records framed inside other containers (like a Kafka message).  For bulk persistence, the parquet format using the protobuf-oriented API is a better standard than rolling our own.

The current state falls back to writing individual records as binaries delimited by newlines `0x0a`, and this may silently succeed but the resulting files are very unlikely to be successfully read (or even readable, since a newline can be indistinguishable from a real tag).

## Brief change log

  -  Add a separate `PbFileFormatFactory` that throws a ValidationException when attempting to create a `BulkEncodingFormat` or `BulkDecodingFormat`.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added a test to `ProtobufSQLITCaseTest` when attempting to write with the `filesystem` connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** (Except for a provided/optional flink jar)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no** (except indirectly)

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs** and a meaningful ValidationException message
