### PR TITLE
[FLINK-32373][sql-client] Support passing headers with SQL Client gateway requests

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1756,6 +1756,12 @@ public final class ConfigConstants {
     /** The user lib directory name. */
     public static final String DEFAULT_FLINK_USR_LIB_DIR = "usrlib";
 
+    /**
+     * The environment variable name which contains a list of newline-separated HTTP headers for
+     * Flink's REST client.
+     */
+    public static final String FLINK_REST_CLIENT_HEADERS = "FLINK_REST_CLIENT_HEADERS";
+
     // ---------------------------- Encoding ------------------------------
 
     public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/HttpHeader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/HttpHeader.java
@@ -64,14 +64,14 @@ public class HttpHeader {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        HttpHeader that = (HttpHeader) o;
+        HttpHeader that = (HttpHeader) other;
         return Objects.equals(getName(), that.getName())
                 && Objects.equals(getValue(), that.getValue());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/HttpHeader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/HttpHeader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import java.util.Objects;
+
+/** Represents an HTTP header with a name and a value. */
+public class HttpHeader {
+
+    /** The name of the HTTP header. */
+    private final String name;
+
+    /** The value of the HTTP header. */
+    private final String value;
+
+    /**
+     * Constructs an {@code HttpHeader} object with the specified name and value.
+     *
+     * @param name the name of the HTTP header
+     * @param value the value of the HTTP header
+     */
+    public HttpHeader(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    /**
+     * Returns the name of this HTTP header.
+     *
+     * @return the name of this HTTP header
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the value of this HTTP header.
+     *
+     * @return the value of this HTTP header
+     */
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpHeader{" + "name='" + name + '\'' + ", value='" + value + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HttpHeader that = (HttpHeader) o;
+        return Objects.equals(getName(), that.getName())
+                && Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getValue());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -69,6 +69,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRespon
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpClientCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderValues;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectAggregator;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
@@ -376,7 +377,8 @@ public class RestClient implements AutoCloseableAsync {
                         targetUrl,
                         messageHeaders.getHttpMethod().getNettyHttpMethod(),
                         payload,
-                        fileUploads);
+                        fileUploads,
+                        messageHeaders.getCustomHeaders());
 
         final JavaType responseType;
 
@@ -411,7 +413,8 @@ public class RestClient implements AutoCloseableAsync {
             String targetUrl,
             HttpMethod httpMethod,
             ByteBuf jsonPayload,
-            Collection<FileUpload> fileUploads)
+            Collection<FileUpload> fileUploads,
+            Collection<HttpHeader> customHeaders)
             throws IOException {
         if (fileUploads.isEmpty()) {
 
@@ -419,22 +422,22 @@ public class RestClient implements AutoCloseableAsync {
                     new DefaultFullHttpRequest(
                             HttpVersion.HTTP_1_1, httpMethod, targetUrl, jsonPayload);
 
-            httpRequest
-                    .headers()
-                    .set(HttpHeaderNames.HOST, targetAddress)
+            HttpHeaders headers = httpRequest.headers();
+            headers.set(HttpHeaderNames.HOST, targetAddress)
                     .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE)
                     .add(HttpHeaderNames.CONTENT_LENGTH, jsonPayload.capacity())
                     .add(HttpHeaderNames.CONTENT_TYPE, RestConstants.REST_CONTENT_TYPE);
+            customHeaders.forEach(ch -> headers.add(ch.getName(), ch.getValue()));
 
             return new SimpleRequest(httpRequest);
         } else {
             HttpRequest httpRequest =
                     new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, targetUrl);
 
-            httpRequest
-                    .headers()
-                    .set(HttpHeaderNames.HOST, targetAddress)
+            HttpHeaders headers = httpRequest.headers();
+            headers.set(HttpHeaderNames.HOST, targetAddress)
                     .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+            customHeaders.forEach(ch -> headers.set(ch.getName(), ch.getValue()));
 
             // takes care of splitting the request into multiple parts
             HttpPostRequestEncoder bodyRequestEncoder;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -427,7 +427,7 @@ public class RestClient implements AutoCloseableAsync {
                     .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE)
                     .add(HttpHeaderNames.CONTENT_LENGTH, jsonPayload.capacity())
                     .add(HttpHeaderNames.CONTENT_TYPE, RestConstants.REST_CONTENT_TYPE);
-            customHeaders.forEach(ch -> headers.add(ch.getName(), ch.getValue()));
+            customHeaders.forEach(ch -> headers.set(ch.getName(), ch.getValue()));
 
             return new SimpleRequest(httpRequest);
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/CustomHeadersDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/CustomHeadersDecorator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpHeader;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Decorator class for {@link MessageHeaders} that adds the ability to include custom HTTP headers.
+ */
+public class CustomHeadersDecorator<
+                R extends RequestBody, P extends ResponseBody, M extends MessageParameters>
+        implements MessageHeaders<R, P, M> {
+
+    private final MessageHeaders<R, P, M> decorated;
+    private Collection<HttpHeader> customHeaders;
+
+    /**
+     * Creates a new {@code CustomHeadersDecorator} for a given {@link MessageHeaders} object.
+     *
+     * @param decorated The MessageHeaders to decorate.
+     */
+    public CustomHeadersDecorator(MessageHeaders<R, P, M> decorated) {
+        this.decorated = decorated;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return decorated.getHttpMethod();
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return decorated.getTargetRestEndpointURL();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return decorated.getSupportedAPIVersions();
+    }
+
+    @Override
+    public Class<P> getResponseClass() {
+        return decorated.getResponseClass();
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return decorated.getResponseStatusCode();
+    }
+
+    @Override
+    public String getDescription() {
+        return decorated.getDescription();
+    }
+
+    @Override
+    public Class<R> getRequestClass() {
+        return decorated.getRequestClass();
+    }
+
+    @Override
+    public M getUnresolvedMessageParameters() {
+        return decorated.getUnresolvedMessageParameters();
+    }
+
+    /**
+     * Returns the custom headers added to the message.
+     *
+     * @return The custom headers as a collection of {@link HttpHeader}.
+     */
+    @Override
+    public Collection<HttpHeader> getCustomHeaders() {
+        return customHeaders;
+    }
+
+    /**
+     * Sets the custom headers for the message.
+     *
+     * @param customHeaders A collection of custom headers.
+     */
+    public void setCustomHeaders(Collection<HttpHeader> customHeaders) {
+        this.customHeaders = customHeaders;
+    }
+
+    /**
+     * Adds a custom header to the message. Initializes the custom headers collection if it hasn't
+     * been initialized yet.
+     *
+     * @param httpHeader The header to add.
+     */
+    public void addCustomHeader(HttpHeader httpHeader) {
+        if (customHeaders == null) {
+            customHeaders = new ArrayList<>();
+        }
+        customHeaders.add(httpHeader);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.runtime.rest.HttpHeader;
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.Collection;
@@ -92,5 +94,17 @@ public interface MessageHeaders<
 
         return getHttpMethod().name().toLowerCase(Locale.ROOT)
                 + className.substring(0, headersSuffixStart);
+    }
+
+    /**
+     * Returns a collection of custom HTTP headers.
+     *
+     * <p>This default implementation returns an empty list. Override this method to provide custom
+     * headers if needed.
+     *
+     * @return a collection of custom {@link HttpHeaders}, empty by default.
+     */
+    default Collection<HttpHeader> getCustomHeaders() {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-32030](https://issues.apache.org/jira/browse/FLINK-32030) and [FLINK-32035](https://issues.apache.org/jira/browse/FLINK-32035) enable communication from the SQL Client to the SQL Gateway placed behind a proxy (i.e. a K8S ingress). Such use cases typically require authentication. This PR enables authentication by adding the ability to supply custom headers to the underlying RestClient.

## Verifying this change

  - Added a test that verifies that custom headers are read and parsed correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - A follow up docs PR will be created to document URLs support in SQL Client gateway mode, including the custom headers feature
