### PR TITLE
[FLINK-31731] Add backwards compatible constructor for DebeziumAvroSerializationSchema

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
@@ -66,6 +66,14 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
             RowType rowType,
             String schemaRegistryUrl,
             String schemaRegistrySubject,
+            @Nullable Map<String, ?> registryConfigs) {
+        this(rowType, schemaRegistryUrl, schemaRegistrySubject, null, registryConfigs);
+    }
+
+    public DebeziumAvroSerializationSchema(
+            RowType rowType,
+            String schemaRegistryUrl,
+            String schemaRegistrySubject,
             @Nullable String schemaString,
             @Nullable Map<String, ?> registryConfigs) {
         RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));


### PR DESCRIPTION
## What is the purpose of the change

Adds a backwards compatible constructor for `DebeziumAvroSerializationSchema` that doesn't require passing an arg for the schema string. This allows the code in `apache/flink-connector-kafka` to build against Flink 1.18.x.

The constructor args for `DebeziumAvroSerializationSchema` was modified in e818c11d to allow passing in a nullable schema string. There were test code in `apache/flink-connector-kafka` that used that constructor, and therefore broke with that change and could no longer simultaneously build against Flink 1.18.x and 1.17.x.

There's a bigger question of _why_ the `flink-connector-kafka` tests are using the constructor which is meant to be `@Internal`, but for now this should have the nightly tests passing again and unblock Flink 1.18.x.

## Brief change log

- Add back a constructor for `DebeziumAvroSerializationSchema` that doesn't require an arg for the schema string.

## Verifying this change

The nightly tests in `flink-connector-kafka` should be passing again: https://github.com/apache/flink-connector-kafka/actions/workflows/weekly.yml

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
