### PR TITLE
[FLINK-32370][client] Fix warn log in result fetcher when job is finished

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -128,12 +128,13 @@ public class CollectResultFetcher<T> {
                 try {
                     response = sendRequest(buffer.getVersion(), requestOffset);
                 } catch (Exception e) {
-                    if (ExceptionUtils.findThrowable(
-                                    e, UnavailableDispatcherOperationException.class)
+                    if (ExceptionUtils.findThrowableWithMessage(
+                                    e, UnavailableDispatcherOperationException.class.getName())
                             .isPresent()) {
                         LOG.debug(
                                 "The job execution has not started yet; cannot fetch results.", e);
-                    } else if (ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
+                    } else if (ExceptionUtils.findThrowableWithMessage(
+                                    e, FlinkJobNotFoundException.class.getName())
                             .isPresent()) {
                         LOG.debug(
                                 "The job cannot be found. It is very likely that the job is not in a RUNNING state.",


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix warn log in result fetcher when job is finished which should log debug log in fetcher. When the fetcher print warn information in log file, it may cause jdbc e2e test fail

## Brief change log
  - Use `ExceptionUtils.findThrowableWithMessage` to check exception in fetcher instead of `ExceptionUtils.findThrowable`

## Verifying this change

This change added tests and can be verified as follows:

  - Added `RestClusterClientTest.testSendCoordinationRequestException` to check exception message

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
