### PR TITLE
[BP-1.16][FLINK-32371][build] Bump snappy-java to 1.1.10.1

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1
-- org.xerial.snappy:snappy-java:1.1.8.3
+- org.xerial.snappy:snappy-java:1.1.10.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -31,7 +31,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.3
+- org.xerial.snappy:snappy-java:1.1.10.1
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -41,7 +41,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.3
+- org.xerial.snappy:snappy-java:1.1.10.1
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -49,7 +49,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hudi:hudi-presto-bundle:0.10.1
 - org.weakref:jmxutils:1.19
 - software.amazon.ion:ion-java:1.0.2
-- org.xerial.snappy:snappy-java:1.1.8.3
+- org.xerial.snappy:snappy-java:1.1.10.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.kerby:kerb-core:1.0.1

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@ under the License.
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
-				<version>1.1.8.3</version>
+				<version>1.1.10.1</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
1.16 backport for parent PR #22815

The backport caused some conflicts which I resolved:
* Snappy was only added to `flink-formats/flink-sql-avro-confluent-registry` (FLINK-31485) ~and `flink-filesystems/flink-s3-fs-presto` (FLINK-29502)~ in 1.17.