### PR TITLE
[FLINK-32374][table-planner] Fix the issue that ExecNodeGraphInternalPlan#writeToFile should support TRUNCATE_EXISTING for overwriting

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
@@ -79,6 +79,7 @@ public class ExecNodeGraphInternalPlan implements InternalPlan {
                     file.toPath(),
                     serializedPlan.getBytes(StandardCharsets.UTF_8),
                     StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
                     StandardOpenOption.WRITE);
         } catch (IOException e) {
             throw new TableException("Cannot write the compiled plan to file '" + file + "'.", e);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -258,7 +259,8 @@ public class CompiledPlanITCase extends JsonPlanTestBase {
         TableResult tableResult =
                 tableEnv.executeSql(
                         String.format(
-                                "COMPILE PLAN '%s' FOR INSERT INTO sink SELECT * FROM src",
+                                "COMPILE PLAN '%s' FOR INSERT INTO sink "
+                                        + "SELECT IF(a > b, a, b) AS a, b + 1 AS b, SUBSTR(c, 1, 4) AS c FROM src WHERE a > 10",
                                 planPath));
 
         assertThat(tableResult).isEqualTo(TableResultInternal.TABLE_RESULT_OK);
@@ -271,6 +273,11 @@ public class CompiledPlanITCase extends JsonPlanTestBase {
                                         "COMPILE PLAN '%s' FOR INSERT INTO sink SELECT a + 1, b + 1, CONCAT(c, '-something') FROM src",
                                         planPath)))
                 .isEqualTo(TableResultInternal.TABLE_RESULT_OK);
+        assertThat(
+                        TableTestUtil.isValidJson(
+                                FileUtils.readFileToString(
+                                        planPath.toFile(), StandardCharsets.UTF_8)))
+                .isTrue();
 
         tableEnv.executeSql(String.format("EXECUTE PLAN '%s'", planPath)).await();
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleType
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.configuration.BatchExecutionOptions
 import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode
 import org.apache.flink.streaming.api.{environment, TimeCharacteristic}
 import org.apache.flink.streaming.api.datastream.DataStream
@@ -1763,6 +1764,19 @@ object TableTestUtil {
     val parser = objectMapper.getFactory.createParser(json)
     val jsonNode: JsonNode = parser.readValueAsTree[JsonNode]
     jsonNode.toPrettyString
+  }
+
+  @throws[IOException]
+  def isValidJson(json: String): Boolean = {
+    try {
+      val parser = objectMapper.getFactory.createParser(json)
+      while (parser.nextToken() != null) {
+        // Do nothing, just parse the JSON string
+      }
+      true
+    } catch {
+      case _: JsonParseException => false
+    }
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

This pull request is cherry-picked from commit f69ed3454f2ab200310edee230da292ee2408503


## Brief change log

Please see #22820


## Verifying this change

Please see #22820

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? N.A.
