### PR TITLE
[FLINK-30344][test] Migrates KubernetesHighAvailabilityTestBase-related tests to use the MultipleComponentLeaderElectionDriver interface

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -143,7 +143,6 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
     protected LeaderRetrievalService createLeaderRetrievalService(String componentId) {
         return new DefaultLeaderRetrievalService(
                 new KubernetesMultipleComponentLeaderRetrievalDriverFactory(
-                        kubeClient,
                         configMapSharedWatcher,
                         watchExecutorService,
                         getClusterConfigMap(),

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderRetrievalDriverFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.kubernetes.highavailability;
 
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -39,8 +38,6 @@ import java.util.concurrent.Executor;
 public class KubernetesMultipleComponentLeaderRetrievalDriverFactory
         implements LeaderRetrievalDriverFactory {
 
-    private final FlinkKubeClient kubeClient;
-
     private final KubernetesConfigMapSharedWatcher configMapSharedWatcher;
 
     private final Executor watchExecutor;
@@ -50,12 +47,10 @@ public class KubernetesMultipleComponentLeaderRetrievalDriverFactory
     private final String componentId;
 
     public KubernetesMultipleComponentLeaderRetrievalDriverFactory(
-            FlinkKubeClient kubeClient,
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName,
             String componentId) {
-        this.kubeClient = Preconditions.checkNotNull(kubeClient);
         this.configMapSharedWatcher = Preconditions.checkNotNull(configMapSharedWatcher);
         this.watchExecutor = Preconditions.checkNotNull(watchExecutor);
         this.configMapName = Preconditions.checkNotNull(configMapName);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesCheckpointIDCounterTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.leaderelection.LeaderElectionEvent;
 
 import org.junit.jupiter.api.Test;
 
@@ -185,7 +186,8 @@ class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilityTestBa
 
                             // lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader();
+
+                            electionEventHandler.await(LeaderElectionEvent.NotLeaderEvent.class);
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);
@@ -260,7 +262,8 @@ class KubernetesCheckpointIDCounterTest extends KubernetesHighAvailabilityTestBa
 
                             // lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader();
+                            electionEventHandler.await(LeaderElectionEvent.NotLeaderEvent.class);
+
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
@@ -20,11 +20,11 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
-import org.apache.flink.kubernetes.utils.Constants;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatChainOfCauses;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,9 +67,8 @@ class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabilityTest
 
                             // Leader changed
                             final String newLeader = LEADER_ADDRESS + "_" + 2;
-                            getLeaderConfigMap()
-                                    .getData()
-                                    .put(Constants.LEADER_ADDRESS_KEY, newLeader);
+                            putLeaderInformationIntoConfigMap(UUID.randomUUID(), newLeader);
+
                             callbackHandler.onModified(
                                     Collections.singletonList(getLeaderConfigMap()));
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionDriverTest.java
@@ -101,7 +101,6 @@ class KubernetesMultipleComponentLeaderElectionDriverTest {
                             final DefaultLeaderRetrievalService leaderRetrievalService =
                                     new DefaultLeaderRetrievalService(
                                             new KubernetesMultipleComponentLeaderRetrievalDriverFactory(
-                                                    getFlinkKubeClient(),
                                                     getConfigMapSharedWatcher(),
                                                     testExecutorExtension.getExecutor(),
                                                     LEADER_CONFIGMAP_NAME,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.highavailability.KubernetesStateHandleStore.S
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
+import org.apache.flink.runtime.leaderelection.LeaderElectionEvent;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.persistence.StringResourceVersion;
@@ -511,7 +512,8 @@ class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTestBase 
                             store.addAndLock(key, state);
                             // Lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader();
+                            electionEventHandler.await(LeaderElectionEvent.NotLeaderEvent.class);
+
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);
@@ -921,7 +923,8 @@ class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTestBase 
                             store.addAndLock(key, state);
                             // Lost leadership
                             getLeaderCallback().notLeader();
-                            electionEventHandler.waitForRevokeLeader();
+                            electionEventHandler.await(LeaderElectionEvent.NotLeaderEvent.class);
+
                             getLeaderConfigMap()
                                     .getAnnotations()
                                     .remove(KubernetesLeaderElector.LEADER_ANNOTATION_KEY);


### PR DESCRIPTION
* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* https://github.com/apache/flink/pull/22390
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* == THIS PR === FLINK-30344
* https://github.com/apache/flink/pull/22830
* https://github.com/apache/flink/pull/22829
* https://github.com/apache/flink/pull/22661

## What is the purpose of the change

Migrating the k8s-related tests that do not use the `DefaultLeaderElectionService` to the `MultipleComponentLeaderElection*` interfaces.

## Brief change log

* Updates `Context` implementation in `KubernetesLeaderElectionDriverTest`
* Adapts implementing test classes

## Verifying this change

* The existing tests should still pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable