### PR TITLE
[FLINK-30343][test] Migrates KubernetesLeaderElectionAndRetrievalITCase to use the MultipleComponentLeaderElectionDriver interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/MultipleComponentLeaderElectionDriver.java
@@ -21,14 +21,7 @@ package org.apache.flink.runtime.leaderelection;
 /**
  * A leader election driver that allows to write {@link LeaderInformation} for multiple components.
  */
-public interface MultipleComponentLeaderElectionDriver {
-
-    /**
-     * Closes the driver.
-     *
-     * @throws Exception if closing this driver fails
-     */
-    void close() throws Exception;
+public interface MultipleComponentLeaderElectionDriver extends AutoCloseable {
 
     /**
      * Returns whether the driver has currently leadership.


### PR DESCRIPTION
* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* https://github.com/apache/flink/pull/22390
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* https://github.com/apache/flink/pull/22828
* == THIS PR === FLINK-30343
* https://github.com/apache/flink/pull/22829
* https://github.com/apache/flink/pull/22661

## What is the purpose of the change

Migrating the `KubernetesLeaderElectionAndRetrievalITCase` tests that do not use the `DefaultLeaderElectionService` to the `MultipleComponentLeaderElection*` interfaces.

## Brief change log

Migrating the `KubernetesLeaderElectionAndRetrievalITCase` tests that do not use the `DefaultLeaderElectionService` to the `MultipleComponentLeaderElection*` interfaces.

## Verifying this change

* The existing tests should still pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable