### PR TITLE
[FLINK-32388]Add the ability to pass parameters to CUSTOM PartitionCommitPolicy

### DIFF
--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -452,6 +452,13 @@ public class HourPartTimeExtractor implements PartitionTimeExtractor {
         <td> 实现 PartitionCommitPolicy 接口的分区提交策略类。只有在 custom 提交策略下才使用该类。</td>
     </tr>
     <tr>
+        <td><h5>sink.partition-commit.policy.class.parameters</h5></td>
+        <td style="word-wrap: break-word;">(无)</td>
+        <td>String</td>
+        <td> 传入 custom 提交策略类的字符串参数, 要求多个参数之间用分号分隔, 比如 'param1;param2',
+        该字符串将被切分为列表(['param1','param2'])并传给 custom 提交策略类的构造器。该项为可选项。</td>
+    </tr>
+    <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>
         <td style="word-wrap: break-word;">_SUCCESS</td>
         <td>String</td>

--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -455,8 +455,8 @@ public class HourPartTimeExtractor implements PartitionTimeExtractor {
         <td><h5>sink.partition-commit.policy.class.parameters</h5></td>
         <td style="word-wrap: break-word;">(无)</td>
         <td>String</td>
-        <td> 传入 custom 提交策略类的字符串参数, 要求多个参数之间用分号分隔, 比如 'param1;param2',
-        该字符串将被切分为列表(['param1','param2'])并传给 custom 提交策略类的构造器。该项为可选项。</td>
+        <td> 传入 custom 提交策略类的字符串参数, 多个参数之间用分号分隔, 比如 'param1;param2',
+        该字符串将被切分为列表(['param1','param2'])并传给 custom 提交策略类的构造器。该项为可选项，不配置的话将使用类的默认构造方法。</td>
     </tr>
     <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -476,7 +476,7 @@ The partition commit policy defines what action is taken when partitions are com
         <td>yes</td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>
-        <td>The custom commit policy class can accept a string argument, which can include multiple arguments separated by semicolons. For example, 'param1;param2'. The string argument will be split into a list (['param1', 'param2']) and passed as constructor parameters to the custom commit policy class.</td>
+        <td>The parameters passed to the constructor of the custom commit policy, with multiple parameters separated by semicolons, such as 'param1;param2'. For example, 'param1;param2'. The configuration value will be split into a list (['param1', 'param2']) and passed to the constructor of the custom commit policy class. This option is optional, if not configured, the default constructor will be used.</td>
     </tr>
     <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -476,7 +476,7 @@ The partition commit policy defines what action is taken when partitions are com
         <td>yes</td>
         <td style="word-wrap: break-word;">(none)</td>
         <td>String</td>
-        <td>The parameters passed to the constructor of the custom commit policy, with multiple parameters separated by semicolons, such as 'param1;param2'. For example, 'param1;param2'. The configuration value will be split into a list (['param1', 'param2']) and passed to the constructor of the custom commit policy class. This option is optional, if not configured, the default constructor will be used.</td>
+        <td>The parameters passed to the constructor of the custom commit policy, with multiple parameters separated by semicolons, such as 'param1;param2'. The configuration value will be split into a list (['param1', 'param2']) and passed to the constructor of the custom commit policy class. This option is optional, if not configured, the default constructor will be used.</td>
     </tr>
     <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -471,6 +471,14 @@ The partition commit policy defines what action is taken when partitions are com
         <td>The partition commit policy class for implement PartitionCommitPolicy interface. Only work in custom commit policy.</td>
     </tr>
     <tr>
+        <td><h5>sink.partition-commit.policy.class.parameters</h5></td>
+        <td>optional</td>
+        <td>yes</td>
+        <td style="word-wrap: break-word;">(none)</td>
+        <td>String</td>
+        <td>The custom commit policy class can accept a string argument, which can include multiple arguments separated by semicolons. For example, 'param1;param2'. The string argument will be split into a list (['param1', 'param2']) and passed as constructor parameters to the custom commit policy class.</td>
+    </tr>
+    <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>
         <td>optional</td>
         <td>yes</td>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -225,10 +225,10 @@ public class FileSystemConnectorOptions {
             key("sink.partition-commit.policy.class.parameters")
                     .stringType()
                     .asList()
-                    .defaultValues()
+                    .noDefaultValue()
                     .withDescription(
-                            "The parameters list for custom policy class"
-                                    + " A (semicolon-separated) list of patterns");
+                            "A (semicolon-separated) list of patterns that for custom policy class"
+                                    + "PartitionCommitPolicy interface. Only work in custom commit policy");
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             key("sink.partition-commit.success-file.name")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -227,8 +227,12 @@ public class FileSystemConnectorOptions {
                     .asList()
                     .noDefaultValue()
                     .withDescription(
-                            "A semicolon-separated string of parameters for the custom commit policy class"
-                                    + " PartitionCommitPolicy interface. All parameters should be of type string.");
+                            "The parameters passed to the constructor of the custom commit policy, "
+                                    + " with multiple parameters separated by semicolons, such as 'param1;param2'."
+                                    + " For example, 'param1;param2'. The configuration value will be split"
+                                    + " into a list (['param1', 'param2']) and passed to the constructor"
+                                    + " of the custom commit policy class."
+                                    + " This option is optional, if not configured, default constructor will be used.");
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             key("sink.partition-commit.success-file.name")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -229,9 +229,8 @@ public class FileSystemConnectorOptions {
                     .withDescription(
                             "The parameters passed to the constructor of the custom commit policy, "
                                     + " with multiple parameters separated by semicolons, such as 'param1;param2'."
-                                    + " For example, 'param1;param2'. The configuration value will be split"
-                                    + " into a list (['param1', 'param2']) and passed to the constructor"
-                                    + " of the custom commit policy class."
+                                    + " The configuration value will be split into a list (['param1', 'param2'])"
+                                    + " and passed to the constructor of the custom commit policy class."
                                     + " This option is optional, if not configured, default constructor will be used.");
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.table.factories.FactoryUtil;
 
 import java.time.Duration;
+import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -219,6 +220,15 @@ public class FileSystemConnectorOptions {
                     .withDescription(
                             "The partition commit policy class for implement"
                                     + " PartitionCommitPolicy interface. Only work in custom commit policy");
+
+    public static final ConfigOption<List<String>> SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS =
+            key("sink.partition-commit.policy.class.parameters")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            "The parameters list for custom policy class"
+                                    + " A (semicolon-separated) list of patterns");
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             key("sink.partition-commit.success-file.name")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -227,8 +227,8 @@ public class FileSystemConnectorOptions {
                     .asList()
                     .noDefaultValue()
                     .withDescription(
-                            "A (semicolon-separated) list of patterns that for custom policy class"
-                                    + "PartitionCommitPolicy interface. Only work in custom commit policy");
+                            "A semicolon-separated string of parameters for the custom commit policy class"
+                                    + " PartitionCommitPolicy interface. All parameters should be of type string.");
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             key("sink.partition-commit.success-file.name")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -121,6 +121,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE);
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS);
+        options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS);
         options.add(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
         options.add(FileSystemConnectorOptions.AUTO_COMPACTION);
         options.add(FileSystemConnectorOptions.COMPACTION_FILE_SIZE);
@@ -141,6 +142,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
                         FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE,
                         FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND,
                         FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS,
+                        FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS,
                         FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME,
                         FileSystemConnectorOptions.COMPACTION_FILE_SIZE)
                 .collect(Collectors.toSet());

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
@@ -199,7 +199,10 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                                                 .SINK_PARTITION_COMMIT_POLICY_CLASS),
                                 tableOptions.get(
                                         FileSystemConnectorOptions
-                                                .SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME)));
+                                                .SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                                tableOptions.get(
+                                        FileSystemConnectorOptions
+                                                .SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
 
         DataStreamSink<RowData> sink = inputStream.writeUsingOutputFormat(builder.build());
         sink.getTransformation().setParallelism(parallelism, parallelismConfigured);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.util.CollectionUtil;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -70,7 +70,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                             successFileName, fsSupplier.get());
                                 case PartitionCommitPolicy.CUSTOM:
                                     try {
-                                        if (!CollectionUtil.isNullOrEmpty(parameters)) {
+                                        if (parameters != null && !parameters.isEmpty()) {
                                             String[] paramStrings =
                                                     parameters.toArray(new String[0]);
                                             Class<?>[] classes = new Class<?>[parameters.size()];

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
@@ -69,7 +70,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                             successFileName, fsSupplier.get());
                                 case PartitionCommitPolicy.CUSTOM:
                                     try {
-                                        if (parameters != null && !parameters.isEmpty()) {
+                                        if (!CollectionUtil.isNullOrEmpty(parameters)) {
                                             String[] paramStrings =
                                                     parameters.toArray(
                                                             new String[parameters.size()]);
@@ -80,7 +81,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                             return (PartitionCommitPolicy)
                                                     cl.loadClass(customClass)
                                                             .getConstructor(classes)
-                                                            .newInstance(paramStrings);
+                                                            .newInstance((Object[]) paramStrings);
                                         } else {
                                             return (PartitionCommitPolicy)
                                                     cl.loadClass(customClass).newInstance();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.core.fs.FileSystem;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,7 +41,10 @@ public class PartitionCommitPolicyFactory implements Serializable {
     private final List<String> parameters;
 
     public PartitionCommitPolicyFactory(
-            String policyKind, String customClass, String successFileName, List<String> parameters) {
+            String policyKind,
+            String customClass,
+            String successFileName,
+            List<String> parameters) {
         this.policyKind = policyKind;
         this.customClass = customClass;
         this.successFileName = successFileName;
@@ -68,7 +70,9 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                 case PartitionCommitPolicy.CUSTOM:
                                     try {
                                         if (parameters != null && !parameters.isEmpty()) {
-                                            String[] paramStrings = parameters.toArray(new String[parameters.size()]);
+                                            String[] paramStrings =
+                                                    parameters.toArray(
+                                                            new String[parameters.size()]);
                                             Class<?>[] classes = new Class<?>[parameters.size()];
                                             for (int i = 0; i < parameters.size(); i++) {
                                                 classes[i] = String.class;
@@ -78,12 +82,14 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                                             .getConstructor(classes)
                                                             .newInstance(paramStrings);
                                         } else {
-                                                return (PartitionCommitPolicy)
-                                                        cl.loadClass(customClass).newInstance();
+                                            return (PartitionCommitPolicy)
+                                                    cl.loadClass(customClass).newInstance();
                                         }
-                                    } catch (ClassNotFoundException | IllegalAccessException |
-                                             InstantiationException | NoSuchMethodException |
-                                             InvocationTargetException e) {
+                                    } catch (ClassNotFoundException
+                                            | IllegalAccessException
+                                            | InstantiationException
+                                            | NoSuchMethodException
+                                            | InvocationTargetException e) {
                                         throw new RuntimeException(
                                                 "Can not create new instance for custom class from "
                                                         + customClass,

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -72,8 +72,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                     try {
                                         if (!CollectionUtil.isNullOrEmpty(parameters)) {
                                             String[] paramStrings =
-                                                    parameters.toArray(
-                                                            new String[0]);
+                                                    parameters.toArray(new String[0]);
                                             Class<?>[] classes = new Class<?>[parameters.size()];
                                             for (int i = 0; i < parameters.size(); i++) {
                                                 classes[i] = String.class;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -42,14 +42,6 @@ public class PartitionCommitPolicyFactory implements Serializable {
     private final List<String> parameters;
 
     public PartitionCommitPolicyFactory(
-            String policyKind, String customClass, String successFileName) {
-        this.policyKind = policyKind;
-        this.customClass = customClass;
-        this.successFileName = successFileName;
-        this.parameters = null;
-    }
-
-    public PartitionCommitPolicyFactory(
             String policyKind, String customClass, String successFileName, List<String> parameters) {
         this.policyKind = policyKind;
         this.customClass = customClass;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -46,7 +46,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
         this.policyKind = policyKind;
         this.customClass = customClass;
         this.successFileName = successFileName;
-        this.parameters = Arrays.asList();
+        this.parameters = null;
     }
 
     public PartitionCommitPolicyFactory(
@@ -64,11 +64,6 @@ public class PartitionCommitPolicyFactory implements Serializable {
             return Collections.emptyList();
         }
         String[] policyStrings = policyKind.split(",");
-        String[] paramStrings = parameters.toArray(new String[parameters.size()]);
-        Class<?>[] classes = new Class<?>[parameters.size()];
-        for (int i = 0; i < parameters.size(); i++) {
-            classes[i] = String.class;
-        }
         return Arrays.stream(policyStrings)
                 .map(
                         name -> {
@@ -80,7 +75,12 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                             successFileName, fsSupplier.get());
                                 case PartitionCommitPolicy.CUSTOM:
                                     try {
-                                        if (classes.length != 0) {
+                                        if (parameters != null && !parameters.isEmpty()) {
+                                            String[] paramStrings = parameters.toArray(new String[parameters.size()]);
+                                            Class<?>[] classes = new Class<?>[parameters.size()];
+                                            for (int i = 0; i < parameters.size(); i++) {
+                                                classes[i] = String.class;
+                                            }
                                             return (PartitionCommitPolicy)
                                                     cl.loadClass(customClass)
                                                             .getConstructor(classes)

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -73,7 +73,7 @@ public class PartitionCommitPolicyFactory implements Serializable {
                                         if (!CollectionUtil.isNullOrEmpty(parameters)) {
                                             String[] paramStrings =
                                                     parameters.toArray(
-                                                            new String[parameters.size()]);
+                                                            new String[0]);
                                             Class<?>[] classes = new Class<?>[parameters.size()];
                                             for (int i = 0; i < parameters.size(); i++) {
                                                 classes[i] = String.class;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionCommitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionCommitter.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
 import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
 import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionSpecFromPath;
@@ -120,7 +121,8 @@ public class PartitionCommitter extends AbstractStreamOperator<Void>
                 new PartitionCommitPolicyFactory(
                         conf.get(SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
+                        conf.get(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
         this.policies =
                 partitionCommitPolicyFactory.createPolicyChain(
                         getUserCodeClassloader(),

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -31,14 +31,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link FileSystemCommitter}. */
 public class FileSystemCommitterTest {
@@ -49,7 +46,6 @@ public class FileSystemCommitterTest {
 
     private TableMetaStoreFactory metaStoreFactory;
     private List<PartitionCommitPolicy> policies;
-    private List<PartitionCommitPolicy> customPolicies;
     private ObjectIdentifier identifier;
     @TempDir private java.nio.file.Path outputPath;
     @TempDir private java.nio.file.Path path;
@@ -261,38 +257,6 @@ public class FileSystemCommitterTest {
                         policies);
         committer.commitPartitions();
         assertThat(outputPath.toFile().list()).isEqualTo(new String[0]);
-    }
-
-    @Test
-    void testCustomCommitPolicyWithParameters() {
-        List<String> paramsList = Arrays.asList("param1", "param2");
-        customPolicies =
-                new PartitionCommitPolicyFactory(
-                        "custom", TestCustomCommitPolicy.class.getName(), null, paramsList)
-                        .createPolicyChain(
-                                Thread.currentThread().getContextClassLoader(),
-                                LocalFileSystem::getSharedInstance);
-        PartitionCommitPolicy customPolicy = customPolicies.get(0);
-        assertTrue(customPolicy instanceof TestCustomCommitPolicy);
-        TestCustomCommitPolicy myPolicy = (TestCustomCommitPolicy) customPolicy;
-        assertThat(myPolicy.getParam1()).isEqualTo("param1");
-        assertThat(myPolicy.getParam2()).isEqualTo("param2");
-    }
-
-    @Test
-    void testCustomCommitPolicyWithoutParameters() {
-        List<String> nullParamsList = new ArrayList<>();
-        customPolicies =
-                new PartitionCommitPolicyFactory(
-                        "custom", TestCustomCommitPolicy.class.getName(), null, nullParamsList)
-                        .createPolicyChain(
-                                Thread.currentThread().getContextClassLoader(),
-                                LocalFileSystem::getSharedInstance);
-        PartitionCommitPolicy customPolicy = customPolicies.get(0);
-        assertTrue(customPolicy instanceof TestCustomCommitPolicy);
-        TestCustomCommitPolicy myPolicy = (TestCustomCommitPolicy) customPolicy;
-        assertThat(myPolicy.getParam1()).isEqualTo(null);
-        assertThat(myPolicy.getParam2()).isEqualTo(null);
     }
 
     /** A {@link TableMetaStoreFactory} for test purpose. */

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -55,7 +55,7 @@ public class FileSystemCommitterTest {
         metaStoreFactory = new TestMetaStoreFactory(new Path(outputPath.toString()));
         policies =
                 new PartitionCommitPolicyFactory(
-                        "metastore,success-file", null, SUCCESS_FILE_NAME, null)
+                                "metastore,success-file", null, SUCCESS_FILE_NAME, null)
                         .createPolicyChain(
                                 Thread.currentThread().getContextClassLoader(),
                                 LocalFileSystem::getSharedInstance);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -31,11 +31,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link FileSystemCommitter}. */
 public class FileSystemCommitterTest {
@@ -46,6 +49,7 @@ public class FileSystemCommitterTest {
 
     private TableMetaStoreFactory metaStoreFactory;
     private List<PartitionCommitPolicy> policies;
+    private List<PartitionCommitPolicy> customPolicies;
     private ObjectIdentifier identifier;
     @TempDir private java.nio.file.Path outputPath;
     @TempDir private java.nio.file.Path path;
@@ -54,7 +58,8 @@ public class FileSystemCommitterTest {
     public void before() throws IOException {
         metaStoreFactory = new TestMetaStoreFactory(new Path(outputPath.toString()));
         policies =
-                new PartitionCommitPolicyFactory("metastore,success-file", null, SUCCESS_FILE_NAME)
+                new PartitionCommitPolicyFactory(
+                        "metastore,success-file", null, SUCCESS_FILE_NAME, null)
                         .createPolicyChain(
                                 Thread.currentThread().getContextClassLoader(),
                                 LocalFileSystem::getSharedInstance);
@@ -256,6 +261,38 @@ public class FileSystemCommitterTest {
                         policies);
         committer.commitPartitions();
         assertThat(outputPath.toFile().list()).isEqualTo(new String[0]);
+    }
+
+    @Test
+    void testCustomCommitPolicyWithParameters() {
+        List<String> paramsList = Arrays.asList("param1", "param2");
+        customPolicies =
+                new PartitionCommitPolicyFactory(
+                        "custom", TestCustomCommitPolicy.class.getName(), null, paramsList)
+                        .createPolicyChain(
+                                Thread.currentThread().getContextClassLoader(),
+                                LocalFileSystem::getSharedInstance);
+        PartitionCommitPolicy customPolicy = customPolicies.get(0);
+        assertTrue(customPolicy instanceof TestCustomCommitPolicy);
+        TestCustomCommitPolicy myPolicy = (TestCustomCommitPolicy) customPolicy;
+        assertThat(myPolicy.getParam1()).isEqualTo("param1");
+        assertThat(myPolicy.getParam2()).isEqualTo("param2");
+    }
+
+    @Test
+    void testCustomCommitPolicyWithoutParameters() {
+        List<String> nullParamsList = new ArrayList<>();
+        customPolicies =
+                new PartitionCommitPolicyFactory(
+                        "custom", TestCustomCommitPolicy.class.getName(), null, nullParamsList)
+                        .createPolicyChain(
+                                Thread.currentThread().getContextClassLoader(),
+                                LocalFileSystem::getSharedInstance);
+        PartitionCommitPolicy customPolicy = customPolicies.get(0);
+        assertTrue(customPolicy instanceof TestCustomCommitPolicy);
+        TestCustomCommitPolicy myPolicy = (TestCustomCommitPolicy) customPolicy;
+        assertThat(myPolicy.getParam1()).isEqualTo(null);
+        assertThat(myPolicy.getParam2()).isEqualTo(null);
     }
 
     /** A {@link TableMetaStoreFactory} for test purpose. */

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/TestCustomCommitPolicy.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/TestCustomCommitPolicy.java
@@ -1,0 +1,57 @@
+package org.apache.flink.connector.file.table;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** A custom PartitionCommitPolicy for test. */
+public class TestCustomCommitPolicy implements PartitionCommitPolicy {
+
+    private String param1;
+    private String param2;
+
+    public TestCustomCommitPolicy() {}
+
+    public TestCustomCommitPolicy(String param1, String param2) {
+        this.param1 = param1;
+        this.param2 = param2;
+    }
+
+    public String getParam1() {
+        return param1;
+    }
+
+    public String getParam2() {
+        return param2;
+    }
+
+    private static Set<String> committedPartitionPaths = new HashSet<>();
+
+    @Override
+    public void commit(PartitionCommitPolicy.Context context) throws Exception {
+        TestCustomCommitPolicy.committedPartitionPaths.add(context.partitionPath().getPath());
+    }
+
+    static Set<String> getCommittedPartitionPathsAndReset() {
+        Set<String> paths = TestCustomCommitPolicy.committedPartitionPaths;
+        TestCustomCommitPolicy.committedPartitionPaths = new HashSet<>();
+        return paths;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/batch/compact/BatchPartitionCommitterSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/batch/compact/BatchPartitionCommitterSinkTest.java
@@ -76,7 +76,7 @@ public class BatchPartitionCommitterSinkTest {
                         new String[] {"p1", "p2"},
                         new LinkedHashMap<>(),
                         identifier,
-                        new PartitionCommitPolicyFactory(null, null, null));
+                        new PartitionCommitPolicyFactory(null, null, null, null));
         committerSink.open(new Configuration());
 
         List<Path> pathList1 = createFiles(path, "task-1/p1=0/p2=0/", "f1", "f2");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 
 import java.time.Duration;
-import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -134,15 +133,6 @@ public class HiveOptions {
                                     + " Both can be configured at the same time: 'metastore,success-file'."
                                     + " custom: use policy class to create a commit policy."
                                     + " Support to configure multiple policies: 'metastore,success-file'.");
-
-    public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_CLASS =
-            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS;
-
-    public static final ConfigOption<List<String>> SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS =
-            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS;
-
-    public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
-            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
 
     public static final ConfigOption<MemorySize> COMPACT_SMALL_FILES_AVG_SIZE =
             key("compaction.small-files.avg-size")

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 
 import java.time.Duration;
+import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -136,6 +137,9 @@ public class HiveOptions {
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_CLASS =
             FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS;
+
+    public static final ConfigOption<List<String>> SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS =
+            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS;
 
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -223,7 +223,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                                                     HiveOptions
                                                             .TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE
                                                             .key(),
-                                                    HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS,
+                                                    FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS,
                                                     identifier,
                                                     PartitionCommitPolicy.METASTORE)));
         }
@@ -455,9 +455,9 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         PartitionCommitPolicyFactory partitionCommitPolicyFactory =
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
 
         org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(sd.getLocation());
         BucketsBuilder<RowData, String, ? extends BucketsBuilder<RowData, ?, ?>> builder =
@@ -610,9 +610,9 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         builder.setPartitionCommitPolicyFactory(
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
         return BatchSink.createBatchNoCompactSink(
                 dataStream, converter, builder.build(), sinkParallelism, sinkParallelismConfigured);
     }
@@ -718,7 +718,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 identifier.getDatabaseName(),
                 identifier.getObjectName(),
                 org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions())
-                        .get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        .get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
                 autoGatherStatistic,
                 gatherStatsThreadNum);
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -456,7 +456,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
+                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
 
         org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(sd.getLocation());
         BucketsBuilder<RowData, String, ? extends BucketsBuilder<RowData, ?, ?>> builder =
@@ -610,7 +611,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME)));
+                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
         return BatchSink.createBatchNoCompactSink(
                 dataStream, converter, builder.build(), sinkParallelism, sinkParallelismConfigured);
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -223,7 +223,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                                                     HiveOptions
                                                             .TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE
                                                             .key(),
-                                                    FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS,
+                                                    FileSystemConnectorOptions
+                                                            .SINK_PARTITION_COMMIT_POLICY_CLASS,
                                                     identifier,
                                                     PartitionCommitPolicy.METASTORE)));
         }
@@ -456,8 +457,11 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
-                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
+                        conf.get(
+                                FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(
+                                FileSystemConnectorOptions
+                                        .SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS));
 
         org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(sd.getLocation());
         BucketsBuilder<RowData, String, ? extends BucketsBuilder<RowData, ?, ?>> builder =
@@ -611,8 +615,11 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new PartitionCommitPolicyFactory(
                         conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
-                        conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
+                        conf.get(
+                                FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(
+                                FileSystemConnectorOptions
+                                        .SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS)));
         return BatchSink.createBatchNoCompactSink(
                 dataStream, converter, builder.build(), sinkParallelism, sinkParallelismConfigured);
     }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connectors.hive;
 
 import org.apache.flink.configuration.BatchExecutionOptions;
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
@@ -528,7 +529,7 @@ public class HiveDialectQueryITCase {
      */
     private boolean isDataFile(Path path) {
         String successFileName =
-                tableEnv.getConfig().get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
+                tableEnv.getConfig().get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
         return !path.toFile().isHidden() && !path.toFile().getName().equals(successFileName);
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -529,7 +529,8 @@ public class HiveDialectQueryITCase {
      */
     private boolean isDataFile(Path path) {
         String successFileName =
-                tableEnv.getConfig().get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
+                tableEnv.getConfig()
+                        .get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
         return !path.toFile().isHidden() && !path.toFile().getName().equals(successFileName);
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
@@ -196,7 +197,7 @@ class HiveTableCompactSinkITCase {
 
     private List<Path> listDataFiles(Path path) throws Exception {
         String defaultSuccessFileName =
-                HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.defaultValue();
+                FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.defaultValue();
         return Files.list(path)
                 .filter(
                         p ->

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -728,7 +729,7 @@ class HiveTableSinkITCase {
 
     private long getPathSize(java.nio.file.Path path) throws IOException {
         String defaultSuccessFileName =
-                HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.defaultValue();
+                FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.defaultValue();
         return Files.list(path)
                 .filter(
                         p ->

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkTest.java
@@ -169,30 +169,28 @@ public class FileSystemTableSinkTest {
         final String inputTable = "inputTable";
         final String outputTable = "outputTable";
         final String customPartitionCommitPolicyClassName = TestCustomCommitPolicy.class.getName();
-        EnvironmentSettings settings = EnvironmentSettings.newInstance()
-                .inStreamingMode()
-                .build();
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(100);
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
 
         String ddl =
-                "CREATE TABLE %s (" +
-                        "  a INT," +
-                        "  b STRING," +
-                        "  c STRING," +
-                        "  d STRING," +
-                        "  e STRING" +
-                        ") PARTITIONED BY (d, e) WITH (" +
-                        "'connector'='filesystem'," +
-                        "'path'='/tmp'," +
-                        "'format'='testcsv'," +
-                        "'sink.partition-commit.delay'='0s'," +
-                        "'sink.partition-commit.policy.kind'='custom'," +
-                        "'sink.partition-commit.policy.class'='%s'," +
-                        "'sink.partition-commit.policy.class.parameters'='test1;test2'" +
-                        ")";
+                "CREATE TABLE %s ("
+                        + "  a INT,"
+                        + "  b STRING,"
+                        + "  c STRING,"
+                        + "  d STRING,"
+                        + "  e STRING"
+                        + ") PARTITIONED BY (d, e) WITH ("
+                        + "'connector'='filesystem',"
+                        + "'path'='/tmp',"
+                        + "'format'='testcsv',"
+                        + "'sink.partition-commit.delay'='0s',"
+                        + "'sink.partition-commit.policy.kind'='custom',"
+                        + "'sink.partition-commit.policy.class'='%s',"
+                        + "'sink.partition-commit.policy.class.parameters'='test1;test2'"
+                        + ")";
         ddl = String.format(ddl, outputTable, customPartitionCommitPolicyClassName);
 
         List<Row> data =
@@ -203,17 +201,16 @@ public class FileSystemTableSinkTest {
                 env.addSource(
                         new FiniteTestSource<>(data),
                         new RowTypeInfo(
-                                Types.INT,
-                                Types.STRING,
-                                Types.STRING,
-                                Types.STRING,
-                                Types.STRING));
+                                Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING));
         Table t = tableEnv.fromDataStream(stream, Schema.newBuilder().build());
         tableEnv.createTemporaryView(inputTable, t);
         tableEnv.executeSql(ddl);
         tableEnv.sqlQuery("select * from inputTable").executeInsert("outputTable").await();
         Set<String> committedPaths = TestCustomCommitPolicy.getCommittedPartitionPathsAndReset();
-        Set<String> validationSet = new HashSet<>(Arrays.asList("test1test2", "/tmp/d=2020-05-03/e=3", "/tmp/d=2020-05-03/e=4"));
+        Set<String> validationSet =
+                new HashSet<>(
+                        Arrays.asList(
+                                "test1test2", "/tmp/d=2020-05-03/e=3", "/tmp/d=2020-05-03/e=4"));
         assertEquals(validationSet, committedPaths);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableSinkTest.java
@@ -18,26 +18,16 @@
 
 package org.apache.flink.connector.file.table;
 
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
-import org.apache.flink.table.api.Schema;
-import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
-import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/TestCustomCommitPolicy.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/TestCustomCommitPolicy.java
@@ -47,6 +47,7 @@ public class TestCustomCommitPolicy implements PartitionCommitPolicy {
     @Override
     public void commit(PartitionCommitPolicy.Context context) throws Exception {
         TestCustomCommitPolicy.committedPartitionPaths.add(context.partitionPath().getPath());
+        TestCustomCommitPolicy.committedPartitionPaths.add(param1 + param2);
     }
 
     static Set<String> getCommittedPartitionPathsAndReset() {


### PR DESCRIPTION
## What is the purpose of the change

By allowing the passing of parameters, the custom PartitionCommitPolicy becomes more flexible and customizable. This enables user to enhance their custom PartitionCommitPolicy by including additional functionality, such as passing monitoring parameters to track the files associated with each commit.

## Brief change log

- `SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS` parameter added
- To create a custom commit policy through the PartitionCommitPolicyFactory, you have the option to include `SINK_PARTITION_COMMIT_POLICY_CLASS_PARAMETERS` as a parameter.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature?  (yes)
- If yes, how is the feature documented?  (docs)

Key: **sink.partition-commit.policy.class.parameters** 
Default: (none) 
Type: String 
Description: A (semicolon-separated) list of patterns that for custom policy class. Only work in custom commit policy