### PR TITLE
[hotfix] Remove local timeout for Hybrid and Tiered result partition test.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/IgnoreShutdownRejectedExecutionHandler.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/IgnoreShutdownRejectedExecutionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.concurrent;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Rejected executions are ignored or logged in debug if the executor is {@link
+ * java.util.concurrent.ThreadPoolExecutor#isShutdown shutdown}. Otherwise, {@link
+ * RejectedExecutionException} is thrown.
+ */
+public class IgnoreShutdownRejectedExecutionHandler implements RejectedExecutionHandler {
+    @Nullable private final Logger logger;
+
+    public IgnoreShutdownRejectedExecutionHandler() {
+        this(null);
+    }
+
+    public IgnoreShutdownRejectedExecutionHandler(@Nullable Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        if (executor.isShutdown()) {
+            if (logger != null) {
+                logger.debug("Execution is rejected because shutdown is in progress");
+            }
+        } else {
+            throw new RejectedExecutionException();
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/SchedulerFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/SchedulerFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.util.concurrent.IgnoreShutdownRejectedExecutionHandler;
+
 import org.slf4j.Logger;
 
 import java.util.concurrent.RejectedExecutionException;
@@ -50,12 +52,6 @@ class SchedulerFactory {
                     thread.setUncaughtExceptionHandler(INSTANCE);
                     return thread;
                 },
-                (ignored, executor) -> {
-                    if (executor.isShutdown()) {
-                        log.debug("Execution rejected because shutdown is in progress");
-                    } else {
-                        throw new RejectedExecutionException();
-                    }
-                });
+                new IgnoreShutdownRejectedExecutionHandler(log));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -51,7 +51,6 @@ import org.apache.flink.util.concurrent.IgnoreShutdownRejectedExecutionHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -353,7 +352,6 @@ class HsResultPartitionTest {
     }
 
     @Test
-    @Timeout(30)
     void testRelease() throws Exception {
         final int numSubpartitions = 2;
         final int numBuffers = 10;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.concurrent.IgnoreShutdownRejectedExecutionHandler;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,13 +106,7 @@ class HsResultPartitionTest {
                 new ScheduledThreadPoolExecutor(
                         numThreads,
                         new ExecutorThreadFactory("test-io-scheduler-thread"),
-                        (ignored, executor) -> {
-                            if (executor.isShutdown()) {
-                                // ignore rejected as shutdown.
-                            } else {
-                                throw new RejectedExecutionException();
-                            }
-                        });
+                        new IgnoreShutdownRejectedExecutionHandler());
     }
 
     @AfterEach

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.Tiere
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.concurrent.IgnoreShutdownRejectedExecutionHandler;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -90,13 +90,7 @@ class TieredResultPartitionTest {
                 new ScheduledThreadPoolExecutor(
                         NUM_THREADS,
                         new ExecutorThreadFactory("test-io-scheduler-thread"),
-                        (ignored, executor) -> {
-                            if (executor.isShutdown()) {
-                                // ignore rejected as shutdown.
-                            } else {
-                                throw new RejectedExecutionException();
-                            }
-                        });
+                        new IgnoreShutdownRejectedExecutionHandler());
     }
 
     @AfterEach

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionTest.java
@@ -43,7 +43,6 @@ import org.apache.flink.util.concurrent.IgnoreShutdownRejectedExecutionHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
@@ -113,7 +112,6 @@ class TieredResultPartitionTest {
     }
 
     @Test
-    @Timeout(30)
     void testRelease() throws Exception {
         final int numSubpartitions = 2;
         final int numBuffers = 10;


### PR DESCRIPTION
## What is the purpose of the change

*`HsResultPartitionTest#testRelease` and `TieredResultPartitionTest#testRelease`  depend on local timeout, which will make the test unstable.*


## Brief change log

  - *Remove local timeout for Hybrid and Tiered result partition test.*


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
