### PR TITLE
[FLINK-32370][jdbc-driver] Debug error log for jdbc gateway e2e test

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.UnavailableDispatcherOperationException;
 import org.apache.flink.runtime.entrypoint.ClusterEntryPointExceptionUtils;
 import org.apache.flink.runtime.rest.FileUploadHandler;
 import org.apache.flink.runtime.rest.FlinkHttpObjectAggregator;
@@ -54,6 +55,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -266,7 +268,12 @@ public abstract class AbstractHandler<
                     HttpResponseStatus.SERVICE_UNAVAILABLE,
                     responseHeaders);
         } else {
-            log.error("Unhandled exception.", throwable);
+            if (throwable instanceof UnavailableDispatcherOperationException
+                    || throwable instanceof FileNotFoundException) {
+                log.debug("Job is not initialized or is finished: {}", throwable.getMessage());
+            } else {
+                log.error("Unhandled exception.", throwable);
+            }
             String stackTrace =
                     String.format(
                             "<Exception on server side:%n%s%nEnd of exception on server side>",


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to debug error log for jdbc gateway e2e test

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
