### PR TITLE
[FLINK-32376] Extend Sink#InitContext

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -17,9 +17,11 @@
 
 package org.apache.flink.connector.base.sink.writer;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -139,6 +141,21 @@ public class TestSinkInitContext implements Sink.InitContext {
 
     @Override
     public SerializationSchema.InitializationContext asSerializationSchemaInitializationContext() {
+        return null;
+    }
+
+    @Override
+    public boolean isObjectReuseEnabled() {
+        return false;
+    }
+
+    @Override
+    public <IN> TypeSerializer<IN> createInputSerializer() {
+        return null;
+    }
+
+    @Override
+    public JobID getJobId() {
         return null;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
@@ -20,9 +20,11 @@ package org.apache.flink.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.util.UserCodeClassLoader;
 
@@ -115,6 +117,18 @@ public interface Sink<InputT> extends Serializable {
          * Provides a view on this context as a {@link SerializationSchema.InitializationContext}.
          */
         SerializationSchema.InitializationContext asSerializationSchemaInitializationContext();
+
+        /** Returns whether object reuse has been enabled or disabled. */
+        boolean isObjectReuseEnabled();
+
+        /** Creates a serializer for the type of sink's input. */
+        <IN> TypeSerializer<IN> createInputSerializer();
+
+        /**
+         * The ID of the current job. Note that Job ID can change in particular upon manual restart.
+         * The returned ID should NOT be used for any job management tasks.
+         */
+        JobID getJobId();
 
         /**
          * Returns a metadata consumer, the {@link SinkWriter} can publish metadata events of type

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.flink.streaming.api.functions;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.metrics.MetricGroup;
@@ -215,6 +217,21 @@ class PrintSinkTest {
         public SerializationSchema.InitializationContext
                 asSerializationSchemaInitializationContext() {
             return this;
+        }
+
+        @Override
+        public boolean isObjectReuseEnabled() {
+            return false;
+        }
+
+        @Override
+        public <IN> TypeSerializer<IN> createInputSerializer() {
+            return null;
+        }
+
+        @Override
+        public JobID getJobId() {
+            return null;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Address the [FLIP-287 Extend Sink#InitContext to expose TypeSerializer, ObjectReuse and JobID](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240880853)

## Brief change log

Add three new methods to Sink#InitContext
  - isObjectReuseEnabled
  - createInputSerializer
  - getJobId


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( yes )
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( yes )
  - If yes, how is the feature documented? ( not applicable )
