### PR TITLE
[FLINK-32410] Allocate hash-based collections with sufficient capacity for expected size

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/PartitionWriterTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,7 +103,8 @@ class PartitionWriterTest {
 
                 @Override
                 public LinkedHashMap<String, String> generatePartValues(Row in) {
-                    LinkedHashMap<String, String> ret = new LinkedHashMap<>(1);
+                    LinkedHashMap<String, String> ret =
+                            CollectionUtil.newLinkedHashMapWithExpectedSize(1);
                     ret.put("p", in.getField(0).toString());
                     return ret;
                 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -226,7 +227,7 @@ public class HivePartitionUtils {
     public static CatalogPartitionSpec createPartitionSpec(
             String hivePartitionName, String defaultPartitionName) {
         String[] partKeyVals = hivePartitionName.split("/");
-        Map<String, String> spec = new HashMap<>(partKeyVals.length);
+        Map<String, String> spec = CollectionUtil.newHashMapWithExpectedSize(partKeyVals.length);
         for (String keyVal : partKeyVals) {
             String[] kv = keyVal.split("=");
             String partitionValue = unescapePathName(kv[1]);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -110,7 +111,6 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Period;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -296,7 +296,7 @@ public class HiveInspectors {
                     return null;
                 }
                 Map<Object, Object> map = (Map) o;
-                Map<Object, Object> result = new HashMap<>(map.size());
+                Map<Object, Object> result = CollectionUtil.newHashMapWithExpectedSize(map.size());
 
                 for (Map.Entry<Object, Object> entry : map.entrySet()) {
                     result.put(
@@ -418,7 +418,7 @@ public class HiveInspectors {
                 return null;
             }
 
-            Map<Object, Object> result = new HashMap<>(map.size());
+            Map<Object, Object> result = CollectionUtil.newHashMapWithExpectedSize(map.size());
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 result.put(
                         toFlinkObject(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.planner.delegation.hive.parse.HiveParserCreateView
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserErrorMsg;
 import org.apache.flink.table.planner.plan.nodes.hive.LogicalDistribution;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
@@ -1150,7 +1151,7 @@ public class HiveParserCalcitePlanner {
         // Grouping sets: we need to transform them into ImmutableBitSet objects for Calcite
         List<ImmutableBitSet> transformedGroupSets = null;
         if (hasGroupSets) {
-            Set<ImmutableBitSet> set = new HashSet<>(groupSets.size());
+            Set<ImmutableBitSet> set = CollectionUtil.newHashSetWithExpectedSize(groupSets.size());
             for (int val : groupSets) {
                 set.add(convert(val, groupSet.cardinality()));
             }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.planner.delegation.hive.parse.HiveASTParser;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserDDLSemanticAnalyzer;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserErrorMsg;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.runtime.tree.Tree;
@@ -1997,7 +1998,8 @@ public class HiveParserBaseSemanticAnalyzer {
         }
 
         List<String> parts = resolvedCatalogTable.getPartitionKeys();
-        Map<String, TypeInfo> partColsTypes = new HashMap<>(parts.size());
+        Map<String, TypeInfo> partColsTypes =
+                CollectionUtil.newHashMapWithExpectedSize(parts.size());
         for (String col : parts) {
             Optional<DataType> dataType =
                     resolvedCatalogTable
@@ -2155,7 +2157,8 @@ public class HiveParserBaseSemanticAnalyzer {
                 childIndex = 1;
                 HiveParserASTNode partspec = (HiveParserASTNode) ast.getChild(1);
                 // partSpec is a mapping from partition column name to its value.
-                Map<String, String> tmpPartSpec = new HashMap<>(partspec.getChildCount());
+                Map<String, String> tmpPartSpec =
+                        CollectionUtil.newHashMapWithExpectedSize(partspec.getChildCount());
                 for (int i = 0; i < partspec.getChildCount(); ++i) {
                     HiveParserASTNode partspecVal = (HiveParserASTNode) partspec.getChild(i);
                     String val = null;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -123,7 +123,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -2188,7 +2187,8 @@ public class HiveParserBaseSemanticAnalyzer {
                         cluster);
 
                 List<String> parts = ((CatalogTable) table).getPartitionKeys();
-                partSpec = new LinkedHashMap<>(partspec.getChildCount());
+                partSpec =
+                        CollectionUtil.newLinkedHashMapWithExpectedSize(partspec.getChildCount());
                 for (String part : parts) {
                     partSpec.put(part, tmpPartSpec.get(part));
                 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.accumulators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
@@ -198,7 +199,7 @@ public class AccumulatorHelper {
         }
 
         Map<String, OptionalFailure<Object>> accumulators =
-                new HashMap<>(serializedAccumulators.size());
+                CollectionUtil.newHashMapWithExpectedSize(serializedAccumulators.size());
 
         for (Map.Entry<String, SerializedValue<OptionalFailure<Object>>> entry :
                 serializedAccumulators.entrySet()) {
@@ -234,7 +235,8 @@ public class AccumulatorHelper {
             return Collections.emptyMap();
         }
 
-        Map<String, Object> accumulators = new HashMap<>(serializedAccumulators.size());
+        Map<String, Object> accumulators =
+                CollectionUtil.newHashMapWithExpectedSize(serializedAccumulators.size());
 
         for (Map.Entry<String, OptionalFailure<Object>> entry :
                 deserializedAccumulators.entrySet()) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -104,7 +105,7 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 
     @Override
     public Map<K, V> copy(Map<K, V> from) {
-        Map<K, V> newMap = new HashMap<>(from.size());
+        Map<K, V> newMap = CollectionUtil.newHashMapWithExpectedSize(from.size());
 
         for (Map.Entry<K, V> entry : from.entrySet()) {
             K newKey = keySerializer.copy(entry.getKey());
@@ -147,7 +148,7 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
     public Map<K, V> deserialize(DataInputView source) throws IOException {
         final int size = source.readInt();
 
-        final Map<K, V> map = new HashMap<>(size);
+        final Map<K, V> map = CollectionUtil.newHashMapWithExpectedSize(size);
         for (int i = 0; i < size; ++i) {
             K key = keySerializer.deserialize(source);
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -31,11 +31,11 @@ import org.apache.flink.api.java.typeutils.runtime.Tuple0Serializer;
 import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.types.Value;
+import org.apache.flink.util.CollectionUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -164,7 +164,7 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 
     @Override
     public Map<String, TypeInformation<?>> getGenericParameters() {
-        Map<String, TypeInformation<?>> m = new HashMap<>(types.length);
+        Map<String, TypeInformation<?>> m = CollectionUtil.newHashMapWithExpectedSize(types.length);
         for (int i = 0; i < types.length; i++) {
             m.put("T" + i, types[i]);
         }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -657,7 +657,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 
     LinkedHashMap<Class<?>, TypeSerializer<?>> getBundledSubclassSerializerRegistry() {
         final LinkedHashMap<Class<?>, TypeSerializer<?>> result =
-                new LinkedHashMap<>(registeredClasses.size());
+                CollectionUtil.newLinkedHashMapWithExpectedSize(registeredClasses.size());
         registeredClasses.forEach(
                 (registeredClass, id) -> result.put(registeredClass, registeredSerializers[id]));
         return result;
@@ -790,7 +790,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
             Map<Class<?>, TypeSerializer<?>> nonRegisteredSubclassSerializerCache) {
 
         final LinkedHashMap<Class<?>, TypeSerializer<?>> subclassRegistry =
-                new LinkedHashMap<>(registeredSubclassesToTags.size());
+                CollectionUtil.newLinkedHashMapWithExpectedSize(registeredSubclassesToTags.size());
 
         for (Map.Entry<Class<?>, Integer> entry : registeredSubclassesToTags.entrySet()) {
             subclassRegistry.put(entry.getKey(), registeredSubclassSerializers[entry.getValue()]);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -675,7 +676,8 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
             Class<?> basePojoClass, ExecutionConfig executionConfig) {
 
         LinkedHashSet<Class<?>> subclassesInRegistrationOrder =
-                new LinkedHashSet<>(executionConfig.getRegisteredPojoTypes().size());
+                CollectionUtil.newLinkedHashSetWithExpectedSize(
+                        executionConfig.getRegisteredPojoTypes().size());
         for (Class<?> registeredClass : executionConfig.getRegisteredPojoTypes()) {
             if (registeredClass.equals(basePojoClass)) {
                 continue;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
@@ -28,13 +28,13 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.LinkedOptionalMap;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -340,7 +340,8 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
         checkState(newFields.length == newFieldSerializers.length);
 
         int numFields = newFields.length;
-        final Map<Field, TypeSerializer<?>> index = new HashMap<>(numFields);
+        final Map<Field, TypeSerializer<?>> index =
+                CollectionUtil.newHashMapWithExpectedSize(numFields);
         for (int i = 0; i < numFields; i++) {
             index.put(newFields[i], newFieldSerializers[i]);
         }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
@@ -256,7 +256,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     private static <K> LinkedHashMap<K, TypeSerializer<?>> restoreSerializers(
             LinkedHashMap<K, TypeSerializerSnapshot<?>> snapshotsMap) {
         final LinkedHashMap<K, TypeSerializer<?>> restoredSerializersMap =
-                new LinkedHashMap<>(snapshotsMap.size());
+                CollectionUtil.newLinkedHashMapWithExpectedSize(snapshotsMap.size());
         snapshotsMap.forEach(
                 (key, snapshot) -> restoredSerializersMap.put(key, snapshot.restoreSerializer()));
         return restoredSerializersMap;
@@ -274,7 +274,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
                     LinkedHashMap<Class<?>, TypeSerializer<?>> subclassSerializerRegistry) {
 
         final LinkedHashMap<Class<?>, Integer> subclassIds =
-                new LinkedHashMap<>(subclassSerializerRegistry.size());
+                CollectionUtil.newLinkedHashMapWithExpectedSize(subclassSerializerRegistry.size());
         final TypeSerializer[] subclassSerializers =
                 new TypeSerializer[subclassSerializerRegistry.size()];
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotData.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotData.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.LinkedOptionalMap;
 import org.apache.flink.util.function.BiConsumerWithException;
@@ -33,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -105,7 +105,7 @@ final class PojoSerializerSnapshotData<T> {
                 (k, v) -> registeredSubclassSerializerSnapshots.put(k, v.snapshotConfiguration()));
 
         Map<Class<?>, TypeSerializerSnapshot<?>> nonRegisteredSubclassSerializerSnapshots =
-                new HashMap<>(nonRegisteredSubclassSerializers.size());
+                CollectionUtil.newHashMapWithExpectedSize(nonRegisteredSubclassSerializers.size());
         nonRegisteredSubclassSerializers.forEach(
                 (k, v) ->
                         nonRegisteredSubclassSerializerSnapshots.put(k, v.snapshotConfiguration()));

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotData.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotData.java
@@ -100,7 +100,8 @@ final class PojoSerializerSnapshotData<T> {
         }
 
         LinkedHashMap<Class<?>, TypeSerializerSnapshot<?>> registeredSubclassSerializerSnapshots =
-                new LinkedHashMap<>(registeredSubclassSerializers.size());
+                CollectionUtil.newLinkedHashMapWithExpectedSize(
+                        registeredSubclassSerializers.size());
         registeredSubclassSerializers.forEach(
                 (k, v) -> registeredSubclassSerializerSnapshots.put(k, v.snapshotConfiguration()));
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/ValueSerializer.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Value;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.InstantiationUtil;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -223,7 +224,8 @@ public final class ValueSerializer<T extends Value> extends TypeSerializer<T> {
     private static LinkedHashMap<String, KryoRegistration> asKryoRegistrations(Class<?> type) {
         checkNotNull(type);
 
-        LinkedHashMap<String, KryoRegistration> registration = new LinkedHashMap<>(1);
+        LinkedHashMap<String, KryoRegistration> registration =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(1);
         registration.put(type.getClass().getName(), new KryoRegistration(type));
 
         return registration;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.java.typeutils.runtime.KryoUtils;
 import org.apache.flink.api.java.typeutils.runtime.NoFetchingInput;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.InstantiationUtil;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -195,8 +196,10 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 
         this.type = checkNotNull(toCopy.type, "Type class cannot be null.");
         this.defaultSerializerClasses = toCopy.defaultSerializerClasses;
-        this.defaultSerializers = new LinkedHashMap<>(toCopy.defaultSerializers.size());
-        this.kryoRegistrations = new LinkedHashMap<>(toCopy.kryoRegistrations.size());
+        this.defaultSerializers =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(toCopy.defaultSerializers.size());
+        this.kryoRegistrations =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(toCopy.kryoRegistrations.size());
 
         // deep copy the serializer instances in defaultSerializers
         for (Map.Entry<Class<?>, ExecutionConfig.SerializableSerializer<?>> entry :

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.CollectionUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -751,7 +752,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     @Override
     public Map<String, String> toMap() {
         synchronized (this.confData) {
-            Map<String, String> ret = new HashMap<>(this.confData.size());
+            Map<String, String> ret =
+                    CollectionUtil.newHashMapWithExpectedSize(this.confData.size());
             for (Map.Entry<String, Object> entry : confData.entrySet()) {
                 ret.put(entry.getKey(), ConfigurationUtils.convertToString(entry.getValue()));
             }

--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -77,7 +77,7 @@ public final class CollectionUtil {
 
     /** Partition a collection into approximately n buckets. */
     public static <T> Collection<List<T>> partition(Collection<T> elements, int numBuckets) {
-        Map<Integer, List<T>> buckets = new HashMap<>(numBuckets);
+        Map<Integer, List<T>> buckets = newHashMapWithExpectedSize(numBuckets);
 
         int initialCapacity = elements.size() / numBuckets;
 
@@ -211,7 +211,7 @@ public final class CollectionUtil {
             return expectedSize + 1;
         }
         return expectedSize < (Integer.MAX_VALUE / 2 + 1)
-                ? (int) ((float) expectedSize / loadFactor + 1.0f)
+                ? (int) Math.ceil(expectedSize / loadFactor)
                 : Integer.MAX_VALUE;
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -129,7 +129,8 @@ public final class InstantiationUtil {
 
         // ------------------------------------------------
 
-        private static final HashMap<String, Class<?>> primitiveClasses = new HashMap<>(9);
+        private static final HashMap<String, Class<?>> primitiveClasses =
+                CollectionUtil.newHashMapWithExpectedSize(9);
 
         static {
             primitiveClasses.put("boolean", boolean.class);
@@ -273,7 +274,8 @@ public final class InstantiationUtil {
         }
 
         private static Map<String, ObjectStreamClass> initMap() {
-            final Map<String, ObjectStreamClass> init = new HashMap<>(4);
+            final Map<String, ObjectStreamClass> init =
+                    CollectionUtil.newHashMapWithExpectedSize(4);
             for (MigrationUtil m : MigrationUtil.values()) {
                 init.put(m.oldSerializerName, m.newSerializerStreamClass);
             }

--- a/flink-core/src/main/java/org/apache/flink/util/LinkedOptionalMap.java
+++ b/flink-core/src/main/java/org/apache/flink/util/LinkedOptionalMap.java
@@ -63,7 +63,8 @@ public final class LinkedOptionalMap<K, V> {
     public static <K, V> LinkedOptionalMap<K, V> optionalMapOf(
             Map<K, V> sourceMap, Function<K, String> keyNameGetter) {
 
-        LinkedHashMap<String, KeyValue<K, V>> underlyingMap = new LinkedHashMap<>(sourceMap.size());
+        LinkedHashMap<String, KeyValue<K, V>> underlyingMap =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(sourceMap.size());
 
         sourceMap.forEach(
                 (k, v) -> {
@@ -94,7 +95,7 @@ public final class LinkedOptionalMap<K, V> {
     }
 
     public LinkedOptionalMap(int initialSize) {
-        this(new LinkedHashMap<>(initialSize));
+        this(CollectionUtil.newLinkedHashMapWithExpectedSize(initialSize));
     }
 
     @SuppressWarnings("CopyConstructorMissesField")
@@ -174,7 +175,8 @@ public final class LinkedOptionalMap<K, V> {
      * IllegalStateException}.
      */
     public LinkedHashMap<K, V> unwrapOptionals() {
-        final LinkedHashMap<K, V> unwrapped = new LinkedHashMap<>(underlyingMap.size());
+        final LinkedHashMap<K, V> unwrapped =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(underlyingMap.size());
 
         for (Entry<String, KeyValue<K, V>> entry : underlyingMap.entrySet()) {
             String namedKey = entry.getKey();

--- a/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
@@ -64,9 +64,17 @@ public class CollectionUtilTest {
         Assertions.assertEquals(
                 3, CollectionUtil.computeRequiredCapacity(2, HASH_MAP_DEFAULT_LOAD_FACTOR));
         Assertions.assertEquals(
-                5, CollectionUtil.computeRequiredCapacity(3, HASH_MAP_DEFAULT_LOAD_FACTOR));
+                4, CollectionUtil.computeRequiredCapacity(3, HASH_MAP_DEFAULT_LOAD_FACTOR));
         Assertions.assertEquals(
                 6, CollectionUtil.computeRequiredCapacity(4, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                7, CollectionUtil.computeRequiredCapacity(5, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                8, CollectionUtil.computeRequiredCapacity(6, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                10, CollectionUtil.computeRequiredCapacity(7, HASH_MAP_DEFAULT_LOAD_FACTOR));
+        Assertions.assertEquals(
+                11, CollectionUtil.computeRequiredCapacity(8, HASH_MAP_DEFAULT_LOAD_FACTOR));
         Assertions.assertEquals(
                 134, CollectionUtil.computeRequiredCapacity(100, HASH_MAP_DEFAULT_LOAD_FACTOR));
         Assertions.assertEquals(
@@ -74,9 +82,9 @@ public class CollectionUtilTest {
         Assertions.assertEquals(
                 13334, CollectionUtil.computeRequiredCapacity(10000, HASH_MAP_DEFAULT_LOAD_FACTOR));
 
-        Assertions.assertEquals(20001, CollectionUtil.computeRequiredCapacity(10000, 0.5f));
+        Assertions.assertEquals(20000, CollectionUtil.computeRequiredCapacity(10000, 0.5f));
 
-        Assertions.assertEquals(100001, CollectionUtil.computeRequiredCapacity(10000, 0.1f));
+        Assertions.assertEquals(100000, CollectionUtil.computeRequiredCapacity(10000, 0.1f));
 
         Assertions.assertEquals(
                 1431655808,

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.configuration.description.TextElement;
 import org.apache.flink.docs.util.ConfigurationOptionLocator;
 import org.apache.flink.docs.util.OptionWithMetaInfo;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TimeUtils;
 
@@ -51,7 +52,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -602,7 +602,7 @@ public class ConfigOptionsDocGenerator {
 
         private static class Node {
             private final List<OptionWithMetaInfo> configOptions = new ArrayList<>(8);
-            private final Map<String, Node> children = new HashMap<>(8);
+            private final Map<String, Node> children = CollectionUtil.newHashMapWithExpectedSize(8);
             private boolean isGroupRoot = false;
 
             private Node addChild(String keyComponent) {

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/ArtificialKeyedStateMapper.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/ArtificialKeyedStateMapper.java
@@ -24,9 +24,9 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.tests.artificialstate.builder.ArtificialStateBuilder;
+import org.apache.flink.util.CollectionUtil;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -53,7 +53,8 @@ public class ArtificialKeyedStateMapper<IN, OUT> extends RichMapFunction<IN, OUT
 
         this.mapFunction = mapFunction;
         this.artificialStateBuilders = artificialStateBuilders;
-        Set<String> stateNames = new HashSet<>(this.artificialStateBuilders.size());
+        Set<String> stateNames =
+                CollectionUtil.newHashSetWithExpectedSize(this.artificialStateBuilders.size());
         for (ArtificialStateBuilder<IN> stateBuilder : this.artificialStateBuilders) {
             if (!stateNames.add(stateBuilder.getStateName())) {
                 throw new IllegalArgumentException(

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/schema/TpcdsSchemaProvider.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/schema/TpcdsSchemaProvider.java
@@ -20,10 +20,10 @@ package org.apache.flink.table.tpcds.schema;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.CollectionUtil;
 
 import java.sql.Date;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -36,7 +36,8 @@ public class TpcdsSchemaProvider {
     private static final Map<String, TpcdsSchema> schemaMap = createTableSchemas();
 
     private static Map<String, TpcdsSchema> createTableSchemas() {
-        final Map<String, TpcdsSchema> schemaMap = new HashMap<>(tpcdsTableNums);
+        final Map<String, TpcdsSchema> schemaMap =
+                CollectionUtil.newHashMapWithExpectedSize(tpcdsTableNums);
         schemaMap.put(
                 "catalog_sales",
                 new TpcdsSchema(

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -36,7 +37,6 @@ import org.apache.avro.util.Utf8;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -296,7 +296,8 @@ public class RowDataToAvroConverters {
                 final MapData mapData = (MapData) object;
                 final ArrayData keyArray = mapData.keyArray();
                 final ArrayData valueArray = mapData.valueArray();
-                final Map<Object, Object> map = new HashMap<>(mapData.size());
+                final Map<Object, Object> map =
+                        CollectionUtil.newHashMapWithExpectedSize(mapData.size());
                 for (int i = 0; i < mapData.size(); ++i) {
                     final String key = keyArray.getString(i).toString();
                     final Object value =

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/MultipleParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/MultipleParameterTool.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.utils;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.java.Utils;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -60,7 +61,8 @@ public class MultipleParameterTool extends AbstractParameterTool {
      * @return A {@link MultipleParameterTool}
      */
     public static MultipleParameterTool fromArgs(String[] args) {
-        final Map<String, Collection<String>> map = new HashMap<>(args.length / 2);
+        final Map<String, Collection<String>> map =
+                CollectionUtil.newHashMapWithExpectedSize(args.length / 2);
 
         int i = 0;
         while (i < args.length) {
@@ -214,7 +216,7 @@ public class MultipleParameterTool extends AbstractParameterTool {
      */
     public MultipleParameterTool mergeWith(MultipleParameterTool other) {
         final Map<String, Collection<String>> resultData =
-                new HashMap<>(data.size() + other.data.size());
+                CollectionUtil.newHashMapWithExpectedSize(data.size() + other.data.size());
         resultData.putAll(data);
         other.data.forEach(
                 (key, value) -> {

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.utils;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -62,7 +63,7 @@ public class ParameterTool extends AbstractParameterTool {
      * @return A {@link ParameterTool}
      */
     public static ParameterTool fromArgs(String[] args) {
-        final Map<String, String> map = new HashMap<>(args.length / 2);
+        final Map<String, String> map = CollectionUtil.newHashMapWithExpectedSize(args.length / 2);
 
         int i = 0;
         while (i < args.length) {
@@ -296,7 +297,8 @@ public class ParameterTool extends AbstractParameterTool {
      * @return The Merged {@link ParameterTool}
      */
     public ParameterTool mergeWith(ParameterTool other) {
-        final Map<String, String> resultData = new HashMap<>(data.size() + other.data.size());
+        final Map<String, String> resultData =
+                CollectionUtil.newHashMapWithExpectedSize(data.size() + other.data.size());
         resultData.putAll(data);
         resultData.putAll(other.data);
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -38,6 +38,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
@@ -119,7 +120,7 @@ public class NFA<T> {
     }
 
     private Map<String, State<T>> loadStates(final Collection<State<T>> validStates) {
-        Map<String, State<T>> tmp = new HashMap<>(4);
+        Map<String, State<T>> tmp = CollectionUtil.newHashMapWithExpectedSize(4);
         for (State<T> state : validStates) {
             tmp.put(state.getName(), state);
         }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferAccessor.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferAccessor.java
@@ -20,6 +20,7 @@ package org.apache.flink.cep.nfa.sharedbuffer;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.DeweyNumber;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -204,7 +205,8 @@ public class SharedBufferAccessor<V> implements AutoCloseable {
      * @return the event associated with the eventId.
      */
     public Map<String, List<V>> materializeMatch(Map<String, List<EventId>> match) {
-        Map<String, List<V>> materializedMatch = new LinkedHashMap<>(match.size());
+        Map<String, List<V>> materializedMatch =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(match.size());
 
         for (Map.Entry<String, List<EventId>> pattern : match.entrySet()) {
             List<V> events = new ArrayList<>(pattern.getValue().size());

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadata.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadata.java
@@ -25,11 +25,11 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.state.api.BootstrapTransformation;
 import org.apache.flink.state.api.runtime.BootstrapTransformationWithID;
 import org.apache.flink.state.api.runtime.OperatorIDGenerator;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +61,7 @@ public class SavepointMetadata {
 
         this.masterStates = Preconditions.checkNotNull(masterStates);
 
-        this.operatorStateIndex = new HashMap<>(initialStates.size());
+        this.operatorStateIndex = CollectionUtil.newHashMapWithExpectedSize(initialStates.size());
         initialStates.forEach(
                 existingState ->
                         operatorStateIndex.put(

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/metadata/SavepointMetadataV2.java
@@ -25,12 +25,12 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.state.api.OperatorIdentifier;
 import org.apache.flink.state.api.StateBootstrapTransformation;
 import org.apache.flink.state.api.runtime.StateBootstrapTransformationWithID;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +61,7 @@ public class SavepointMetadataV2 {
 
         this.maxParallelism = maxParallelism;
         this.masterStates = new ArrayList<>(masterStates);
-        this.operatorStateIndex = new HashMap<>(initialStates.size());
+        this.operatorStateIndex = CollectionUtil.newHashMapWithExpectedSize(initialStates.size());
 
         initialStates.forEach(
                 existingState ->

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.runtime.rpc.messages.HandshakeSuccessMessage;
 import org.apache.flink.runtime.rpc.messages.RemoteHandshakeMessage;
 import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -59,7 +60,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -98,7 +98,7 @@ public class AkkaRpcService implements RpcService {
     private final ClassLoader flinkClassLoader;
 
     @GuardedBy("lock")
-    private final Map<ActorRef, RpcEndpoint> actors = new HashMap<>(4);
+    private final Map<ActorRef, RpcEndpoint> actors = CollectionUtil.newHashMapWithExpectedSize(4);
 
     private final String address;
     private final int port;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsHistory.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.util.CollectionUtil;
+
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +172,7 @@ public class CheckpointStatsHistory implements Serializable {
         List<AbstractCheckpointStats> checkpointsHistory;
         Map<Long, AbstractCheckpointStats> checkpointsById;
 
-        checkpointsById = new HashMap<>(checkpointsArray.length);
+        checkpointsById = CollectionUtil.newHashMapWithExpectedSize(checkpointsArray.length);
 
         if (maxSize == 0) {
             checkpointsHistory = Collections.emptyList();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -162,7 +163,8 @@ public class Checkpoints {
 
         // (2) validate it (parallelism, etc)
         HashMap<OperatorID, OperatorState> operatorStates =
-                new HashMap<>(checkpointMetadata.getOperatorStates().size());
+                CollectionUtil.newHashMapWithExpectedSize(
+                        checkpointMetadata.getOperatorStates().size());
         for (OperatorState operatorState : checkpointMetadata.getOperatorStates()) {
 
             ExecutionJobVertex executionJobVertex =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -22,13 +22,13 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,7 +71,7 @@ public class OperatorState implements CompositeStateHandle {
 
         this.operatorID = operatorID;
 
-        this.operatorSubtaskStates = new HashMap<>(parallelism);
+        this.operatorSubtaskStates = CollectionUtil.newHashMapWithExpectedSize(parallelism);
 
         this.parallelism = parallelism;
         this.maxParallelism = maxParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -152,7 +153,9 @@ public class PendingCheckpoint implements Checkpoint {
         this.checkpointTimestamp = checkpointTimestamp;
         this.checkpointPlan = checkNotNull(checkpointPlan);
 
-        this.notYetAcknowledgedTasks = new HashMap<>(checkpointPlan.getTasksToWaitFor().size());
+        this.notYetAcknowledgedTasks =
+                CollectionUtil.newHashMapWithExpectedSize(
+                        checkpointPlan.getTasksToWaitFor().size());
         for (Execution execution : checkpointPlan.getTasksToWaitFor()) {
             notYetAcknowledgedTasks.put(execution.getAttemptId(), execution.getVertex());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -172,7 +172,9 @@ public class PendingCheckpoint implements Checkpoint {
                 operatorCoordinatorsToConfirm.isEmpty()
                         ? Collections.emptySet()
                         : new HashSet<>(operatorCoordinatorsToConfirm);
-        this.acknowledgedTasks = new HashSet<>(checkpointPlan.getTasksToWaitFor().size());
+        this.acknowledgedTasks =
+                CollectionUtil.newHashSetWithExpectedSize(
+                        checkpointPlan.getTasksToWaitFor().size());
         this.onCompletionPromise = checkNotNull(onCompletionPromise);
         this.pendingCheckpointStats = pendingCheckpointStats;
         this.masterTriggerCompletionPromise = checkNotNull(masterTriggerCompletionPromise);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RescaleMappings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RescaleMappings.java
@@ -19,12 +19,12 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.util.IntArrayList;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -115,7 +115,8 @@ public class RescaleMappings implements Serializable {
     }
 
     public Set<Integer> getAmbiguousTargets() {
-        final Set<Integer> ambiguousTargets = new HashSet<>(numberOfTargets);
+        final Set<Integer> ambiguousTargets =
+                CollectionUtil.newHashSetWithExpectedSize(numberOfTargets);
         final BitSet usedTargets = new BitSet(numberOfTargets);
 
         for (int[] targets : mappings) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
@@ -153,7 +154,8 @@ public class RoundRobinOperatorStateRepartitioner
     private Map<String, StateEntry> collectStates(
             List<List<OperatorStateHandle>> parallelSubtaskStates, OperatorStateHandle.Mode mode) {
 
-        Map<String, StateEntry> states = new HashMap<>(parallelSubtaskStates.size());
+        Map<String, StateEntry> states =
+                CollectionUtil.newHashMapWithExpectedSize(parallelSubtaskStates.size());
 
         for (int i = 0; i < parallelSubtaskStates.size(); ++i) {
             final int subtaskIndex = i;
@@ -370,7 +372,8 @@ public class RoundRobinOperatorStateRepartitioner
                     if (operatorStateHandle == null) {
                         operatorStateHandle =
                                 new OperatorStreamStateHandle(
-                                        new HashMap<>(nameToDistributeState.size()),
+                                        CollectionUtil.newHashMapWithExpectedSize(
+                                                nameToDistributeState.size()),
                                         handleWithOffsets.f0);
                         mergeMap.put(handleWithOffsets.f0, operatorStateHandle);
                     }
@@ -405,7 +408,9 @@ public class RoundRobinOperatorStateRepartitioner
                     if (operatorStateHandle == null) {
                         operatorStateHandle =
                                 new OperatorStreamStateHandle(
-                                        new HashMap<>(unionState.size()), handleWithMetaInfo.f0);
+                                        CollectionUtil.newHashMapWithExpectedSize(
+                                                unionState.size()),
+                                        handleWithMetaInfo.f0);
                         mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
                     }
                     operatorStateHandle
@@ -442,7 +447,9 @@ public class RoundRobinOperatorStateRepartitioner
                 if (operatorStateHandle == null) {
                     operatorStateHandle =
                             new OperatorStreamStateHandle(
-                                    new HashMap<>(broadcastState.size()), handleWithMetaInfo.f0);
+                                    CollectionUtil.newHashMapWithExpectedSize(
+                                            broadcastState.size()),
+                                    handleWithMetaInfo.f0);
                     mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
                 }
                 operatorStateHandle

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -91,7 +92,7 @@ public class StateAssignmentOperation {
         this.tasks = Preconditions.checkNotNull(tasks);
         this.operatorStates = Preconditions.checkNotNull(operatorStates);
         this.allowNonRestoredState = allowNonRestoredState;
-        this.vertexAssignments = new HashMap<>(tasks.size());
+        this.vertexAssignments = CollectionUtil.newHashMapWithExpectedSize(tasks.size());
     }
 
     public void assignStates() {
@@ -103,7 +104,8 @@ public class StateAssignmentOperation {
         // information in first pass
         for (ExecutionJobVertex executionJobVertex : tasks) {
             List<OperatorIDPair> operatorIDPairs = executionJobVertex.getOperatorIDs();
-            Map<OperatorID, OperatorState> operatorStates = new HashMap<>(operatorIDPairs.size());
+            Map<OperatorID, OperatorState> operatorStates =
+                    CollectionUtil.newHashMapWithExpectedSize(operatorIDPairs.size());
             for (OperatorIDPair operatorIDPair : operatorIDPairs) {
                 OperatorID operatorID =
                         operatorIDPair
@@ -763,7 +765,8 @@ public class StateAssignmentOperation {
 
     private static <T> Map<OperatorInstanceID, List<T>> toInstanceMap(
             OperatorID operatorID, List<List<T>> states) {
-        Map<OperatorInstanceID, List<T>> result = new HashMap<>(states.size());
+        Map<OperatorInstanceID, List<T>> result =
+                CollectionUtil.newHashMapWithExpectedSize(states.size());
 
         for (int subtaskIndex = 0; subtaskIndex < states.size(); subtaskIndex++) {
             checkNotNull(states.get(subtaskIndex) != null, "states.get(subtaskIndex) is null");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskState.java
@@ -21,11 +21,11 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,7 +71,7 @@ public class TaskState implements CompositeStateHandle {
 
         this.jobVertexID = jobVertexID;
 
-        this.subtaskStates = new HashMap<>(parallelism);
+        this.subtaskStates = CollectionUtil.newHashMapWithExpectedSize(parallelism);
 
         this.parallelism = parallelism;
         this.maxParallelism = maxParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.CollectionUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,12 +114,14 @@ class TaskStateAssignment {
         this.vertexAssignments = checkNotNull(vertexAssignments);
         final int expectedNumberOfSubtasks = newParallelism * oldState.size();
 
-        subManagedOperatorState = new HashMap<>(expectedNumberOfSubtasks);
-        subRawOperatorState = new HashMap<>(expectedNumberOfSubtasks);
-        inputChannelStates = new HashMap<>(expectedNumberOfSubtasks);
-        resultSubpartitionStates = new HashMap<>(expectedNumberOfSubtasks);
-        subManagedKeyedState = new HashMap<>(expectedNumberOfSubtasks);
-        subRawKeyedState = new HashMap<>(expectedNumberOfSubtasks);
+        subManagedOperatorState =
+                CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
+        subRawOperatorState = CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
+        inputChannelStates = CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
+        resultSubpartitionStates =
+                CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
+        subManagedKeyedState = CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
+        subRawKeyedState = CollectionUtil.newHashMapWithExpectedSize(expectedNumberOfSubtasks);
 
         final List<OperatorIDPair> operatorIDs = executionJobVertex.getOperatorIDs();
         outputOperatorID = operatorIDs.get(0).getGeneratedOperatorID();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -75,7 +76,7 @@ public class TaskStateSnapshot implements CompositeStateHandle {
     }
 
     public TaskStateSnapshot(int size, boolean isTaskFinished) {
-        this(new HashMap<>(size), false, isTaskFinished);
+        this(CollectionUtil.newHashMapWithExpectedSize(size), false, isTaskFinished);
     }
 
     public TaskStateSnapshot(Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint.metadata;
 
-import java.util.HashMap;
+import org.apache.flink.util.CollectionUtil;
+
 import java.util.Map;
 
 /**
@@ -28,7 +29,8 @@ import java.util.Map;
  */
 public class MetadataSerializers {
 
-    private static final Map<Integer, MetadataSerializer> SERIALIZERS = new HashMap<>(4);
+    private static final Map<Integer, MetadataSerializer> SERIALIZERS =
+            CollectionUtil.newHashMapWithExpectedSize(4);
 
     static {
         registerSerializer(MetadataV1Serializer.INSTANCE);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAcce
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.BiFunctionWithException;
@@ -68,7 +69,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -616,7 +616,8 @@ public abstract class MetadataV2V3SerializerBase {
             return null;
         } else if (PARTITIONABLE_OPERATOR_STATE_HANDLE == type) {
             int mapSize = dis.readInt();
-            Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>(mapSize);
+            Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap =
+                    CollectionUtil.newHashMapWithExpectedSize(mapSize);
             for (int i = 0; i < mapSize; ++i) {
                 String key = dis.readUTF();
 
@@ -823,7 +824,8 @@ public abstract class MetadataV2V3SerializerBase {
             DataInputStream dis, @Nullable DeserializationContext context) throws IOException {
 
         final int size = dis.readInt();
-        Map<StateHandleID, StreamStateHandle> result = new HashMap<>(size);
+        Map<StateHandleID, StreamStateHandle> result =
+                CollectionUtil.newHashMapWithExpectedSize(size);
 
         for (int i = 0; i < size; ++i) {
             StateHandleID stateHandleID = new StateHandleID(dis.readUTF());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -21,12 +21,12 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -44,7 +44,7 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
 
     public DefaultJobManagerRunnerRegistry(int initialCapacity) {
         Preconditions.checkArgument(initialCapacity > 0);
-        jobManagerRunners = new HashMap<>(initialCapacity);
+        jobManagerRunners = CollectionUtil.newHashMapWithExpectedSize(initialCapacity);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -91,6 +91,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -293,7 +294,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         this.cleanupRunnerFactory = dispatcherServices.getCleanupRunnerFactory();
 
         this.jobManagerRunnerTerminationFutures =
-                new HashMap<>(INITIAL_JOB_MANAGER_RUNNER_REGISTRY_CAPACITY);
+                CollectionUtil.newHashMapWithExpectedSize(
+                        INITIAL_JOB_MANAGER_RUNNER_REGISTRY_CAPACITY);
         this.submittedAndWaitingTerminationJobIDs = new HashSet<>();
 
         this.shutDownFuture = new CompletableFuture<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkUserCodeClassLoader;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
@@ -402,7 +403,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
             // NOTE: do not store the class paths, i.e. URLs, into a set for performance reasons
             //       see http://findbugs.sourceforge.net/bugDescriptions.html#DMI_COLLECTION_OF_URLS
             //       -> alternatively, compare their string representation
-            this.classPaths = new HashSet<>(requiredClassPaths.size());
+            this.classPaths = CollectionUtil.newHashSetWithExpectedSize(requiredClassPaths.size());
             for (URL url : requiredClassPaths) {
                 classPaths.add(url.toString());
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -80,6 +80,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.IterableUtils;
@@ -331,10 +332,10 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
         this.userClassLoader = checkNotNull(userClassLoader, "userClassLoader");
 
-        this.tasks = new HashMap<>(16);
-        this.intermediateResults = new HashMap<>(16);
+        this.tasks = CollectionUtil.newHashMapWithExpectedSize(16);
+        this.intermediateResults = CollectionUtil.newHashMapWithExpectedSize(16);
         this.verticesInCreationOrder = new ArrayList<>(16);
-        this.currentExecutions = new HashMap<>(16);
+        this.currentExecutions = CollectionUtil.newHashMapWithExpectedSize(16);
 
         this.jobStatusListeners = new ArrayList<>();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
@@ -66,7 +67,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -490,7 +490,9 @@ public class Execution
                 .thenApply(
                         rpdds -> {
                             Map<IntermediateResultPartitionID, ResultPartitionDeploymentDescriptor>
-                                    producedPartitions = new LinkedHashMap<>(partitions.size());
+                                    producedPartitions =
+                                            CollectionUtil.newLinkedHashMapWithExpectedSize(
+                                                    partitions.size());
                             rpdds.forEach(
                                     rpdd -> producedPartitions.put(rpdd.getPartitionId(), rpdd));
                             return producedPartitions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionManager.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.util.CollectionUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -36,7 +37,8 @@ public class ResultPartitionManager implements ResultPartitionProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResultPartitionManager.class);
 
-    private final Map<ResultPartitionID, ResultPartition> registeredPartitions = new HashMap<>(16);
+    private final Map<ResultPartitionID, ResultPartition> registeredPartitions =
+            CollectionUtil.newHashMapWithExpectedSize(16);
 
     private boolean isShutdown;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.throughput.BufferDebloater;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -65,7 +66,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -255,7 +255,7 @@ public class SingleInputGate extends IndexedInputGate {
         checkArgument(numberOfInputChannels > 0);
         this.numberOfInputChannels = numberOfInputChannels;
 
-        this.inputChannels = new HashMap<>(numberOfInputChannels);
+        this.inputChannels = CollectionUtil.newHashMapWithExpectedSize(numberOfInputChannels);
         this.channels = new InputChannel[numberOfInputChannels];
         this.channelsWithEndOfPartitionEvents = new BitSet(numberOfInputChannels);
         this.channelsWithEndOfUserRecords = new BitSet(numberOfInputChannels);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LocationPreferenceSlotSelectionStrategy.java
@@ -23,11 +23,11 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -68,8 +68,9 @@ public abstract class LocationPreferenceSlotSelectionStrategy implements SlotSel
         // we build up two indexes, one for resource id and one for host names of the preferred
         // locations.
         final Map<ResourceID, Integer> preferredResourceIDs =
-                new HashMap<>(locationPreferences.size());
-        final Map<String, Integer> preferredFQHostNames = new HashMap<>(locationPreferences.size());
+                CollectionUtil.newHashMapWithExpectedSize(locationPreferences.size());
+        final Map<String, Integer> preferredFQHostNames =
+                CollectionUtil.newHashMapWithExpectedSize(locationPreferences.size());
 
         for (TaskManagerLocation locationPreference : locationPreferences) {
             preferredResourceIDs.merge(locationPreference.getResourceID(), 1, Integer::sum);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.memory;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.LongFunctionWithException;
@@ -34,7 +35,6 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -238,7 +238,7 @@ public class MemoryManager {
                 (o, currentSegmentsForOwner) -> {
                     Set<MemorySegment> segmentsForOwner =
                             currentSegmentsForOwner == null
-                                    ? new HashSet<>(numberOfPages)
+                                    ? CollectionUtil.newHashSetWithExpectedSize(numberOfPages)
                                     : currentSegmentsForOwner;
                     for (long i = numberOfPages; i > 0; i--) {
                         MemorySegment segment =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.metrics.filter.DefaultMetricFilter;
 import org.apache.flink.runtime.metrics.filter.MetricFilter;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterators;
 
@@ -41,7 +42,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -264,7 +264,8 @@ public final class ReporterSetup {
 
     private static Map<String, MetricReporterFactory> loadAvailableReporterFactories(
             @Nullable PluginManager pluginManager) {
-        final Map<String, MetricReporterFactory> reporterFactories = new HashMap<>(2);
+        final Map<String, MetricReporterFactory> reporterFactories =
+                CollectionUtil.newHashMapWithExpectedSize(2);
         final Iterator<MetricReporterFactory> factoryIterator =
                 getAllReporterFactories(pluginManager);
         // do not use streams or for-each loops here because they do not allow catching individual

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.scope;
 
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.util.CollectionUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -226,7 +227,7 @@ public abstract class ScopeFormat {
     }
 
     protected static HashMap<String, Integer> arrayToMap(String[] array) {
-        HashMap<String, Integer> map = new HashMap<>(array.length);
+        HashMap<String, Integer> map = CollectionUtil.newHashMapWithExpectedSize(array.length);
         for (int i = 0; i < array.length; i++) {
             map.put(array[i], i);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/SpillChannelManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/SpillChannelManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.sort;
 
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.File;
 import java.util.HashSet;
@@ -36,8 +37,8 @@ final class SpillChannelManager implements AutoCloseable {
     private volatile boolean closed;
 
     public SpillChannelManager() {
-        this.channelsToDeleteAtShutdown = new HashSet<>(64);
-        this.openChannels = new HashSet<>(64);
+        this.channelsToDeleteAtShutdown = CollectionUtil.newHashSetWithExpectedSize(64);
+        this.openChannels = CollectionUtil.newHashSetWithExpectedSize(64);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/DefaultJobLeaderIdService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/DefaultJobLeaderIdService.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -33,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -74,7 +74,7 @@ public class DefaultJobLeaderIdService implements JobLeaderIdService {
         this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor, "scheduledExecutor");
         this.jobTimeout = Preconditions.checkNotNull(jobTimeout, "jobTimeout");
 
-        jobLeaderIdListeners = new HashMap<>(4);
+        jobLeaderIdListeners = CollectionUtil.newHashMapWithExpectedSize(4);
 
         jobLeaderIdActions = null;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -80,6 +80,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationRejection;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorThreadInfoGateway;
 import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkExpectedException;
@@ -89,7 +90,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -201,10 +201,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
         this.resourceManagerMetricGroup = checkNotNull(resourceManagerMetricGroup);
 
-        this.jobManagerRegistrations = new HashMap<>(4);
-        this.jmResourceIdRegistrations = new HashMap<>(4);
-        this.taskExecutors = new HashMap<>(8);
-        this.taskExecutorGatewayFutures = new HashMap<>(8);
+        this.jobManagerRegistrations = CollectionUtil.newHashMapWithExpectedSize(4);
+        this.jmResourceIdRegistrations = CollectionUtil.newHashMapWithExpectedSize(4);
+        this.taskExecutors = CollectionUtil.newHashMapWithExpectedSize(8);
+        this.taskExecutorGatewayFutures = CollectionUtil.newHashMapWithExpectedSize(8);
         this.blocklistHandler =
                 blocklistHandlerFactory.create(
                         new ResourceManagerBlocklistContext(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.runtime.util.ResourceCounter;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -122,7 +123,7 @@ public class DeclarativeSlotManager implements SlotManager {
         this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
         this.requirementsCheckDelay = slotManagerConfiguration.getRequirementCheckDelay();
 
-        pendingSlotAllocations = new HashMap<>(16);
+        pendingSlotAllocations = CollectionUtil.newHashMapWithExpectedSize(16);
 
         this.slotTracker = Preconditions.checkNotNull(slotTracker);
         slotTracker.registerSlotStatusUpdateListener(createSlotStatusUpdateListener());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -31,7 +32,6 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -209,7 +209,8 @@ public class HandlerRequest<R extends RequestBody> {
 
     private static <P extends MessageParameter<?>> Map<Class<? extends P>, P> mapParameters(
             Collection<P> parameters) {
-        final Map<Class<? extends P>, P> mappedParameters = new HashMap<>(2);
+        final Map<Class<? extends P>, P> mappedParameters =
+                CollectionUtil.newHashMapWithExpectedSize(2);
 
         for (P parameter : parameters) {
             if (parameter.isResolved()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -51,7 +52,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -109,7 +109,8 @@ public class JobDetailsHandler
                         : -1L;
         final long duration = (endTime > 0L ? endTime : now) - startTime;
 
-        final Map<JobStatus, Long> timestamps = new HashMap<>(JobStatus.values().length);
+        final Map<JobStatus, Long> timestamps =
+                CollectionUtil.newHashMapWithExpectedSize(JobStatus.values().length);
 
         for (JobStatus jobStatus : JobStatus.values()) {
             timestamps.put(jobStatus, executionGraph.getStatusTimestamp(jobStatus));
@@ -133,7 +134,7 @@ public class JobDetailsHandler
         }
 
         Map<ExecutionState, Integer> jobVerticesPerStateMap =
-                new HashMap<>(ExecutionState.values().length);
+                CollectionUtil.newHashMapWithExpectedSize(ExecutionState.values().length);
 
         for (ExecutionState executionState : ExecutionState.values()) {
             jobVerticesPerStateMap.put(
@@ -194,7 +195,8 @@ public class JobDetailsHandler
         ExecutionState jobVertexState =
                 ExecutionJobVertex.getAggregateJobVertexState(tasksPerState, ejv.getParallelism());
 
-        Map<ExecutionState, Integer> tasksPerStateMap = new HashMap<>(tasksPerState.length);
+        Map<ExecutionState, Integer> tasksPerStateMap =
+                CollectionUtil.newHashMapWithExpectedSize(tasksPerState.length);
 
         for (ExecutionState executionState : ExecutionState.values()) {
             tasksPerStateMap.put(executionState, tasksPerState[executionState.ordinal()]);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -258,7 +259,7 @@ public class JobVertexTaskManagersHandler
                             counts.getAccumulateBusyTime());
 
             Map<ExecutionState, Integer> statusCounts =
-                    new HashMap<>(ExecutionState.values().length);
+                    CollectionUtil.newHashMapWithExpectedSize(ExecutionState.values().length);
             for (ExecutionState state : ExecutionState.values()) {
                 statusCounts.put(state, executionsPerState[state.ordinal()]);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
@@ -37,11 +37,11 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -115,7 +115,8 @@ public class SubtasksTimesHandler
             TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
             String locationString = location == null ? "(unassigned)" : location.getHostname();
 
-            Map<ExecutionState, Long> timestampMap = new HashMap<>(ExecutionState.values().length);
+            Map<ExecutionState, Long> timestampMap =
+                    CollectionUtil.newHashMapWithExpectedSize(ExecutionState.values().length);
             for (ExecutionState state : ExecutionState.values()) {
                 timestampMap.put(state, timestamps[state.ordinal()]);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractAggregatingMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractAggregatingMetricsHandler.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.MetricsAggregationPara
 import org.apache.flink.runtime.rest.messages.job.metrics.MetricsFilterParameter;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -43,7 +44,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +182,7 @@ public abstract class AbstractAggregatingMetricsHandler<
      */
     private static Collection<String> getAvailableMetrics(
             Collection<? extends MetricStore.ComponentMetricStore> stores) {
-        Set<String> uniqueMetrics = new HashSet<>(32);
+        Set<String> uniqueMetrics = CollectionUtil.newHashSetWithExpectedSize(32);
         for (MetricStore.ComponentMetricStore store : stores) {
             uniqueMetrics.addAll(store.metrics.keySet());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails.CurrentAttempts;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.util.CollectionUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,10 @@ public class MetricStore {
                     job.getCurrentExecutionAttempts();
             Map<String, Map<Integer, Integer>> jobRepresentativeAttempts =
                     representativeAttempts.compute(
-                            jobId, (k, overwritten) -> new HashMap<>(currentAttempts.size()));
+                            jobId,
+                            (k, overwritten) ->
+                                    CollectionUtil.newHashMapWithExpectedSize(
+                                            currentAttempts.size()));
             currentAttempts.forEach(
                     (vertexId, subtaskAttempts) -> {
                         Map<Integer, Integer> vertexAttempts =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDKeyDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDKeySerializer;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,7 +45,6 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -300,7 +300,8 @@ public class CheckpointStatistics implements ResponseBody {
         if (includeTaskCheckpointStatistics) {
             Collection<TaskStateStats> taskStateStats = checkpointStats.getAllTaskStateStats();
 
-            checkpointStatisticsPerTask = new HashMap<>(taskStateStats.size());
+            checkpointStatisticsPerTask =
+                    CollectionUtil.newHashMapWithExpectedSize(taskStateStats.size());
 
             for (TaskStateStats taskStateStat : taskStateStats) {
                 checkpointStatisticsPerTask.put(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -22,13 +22,13 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -67,9 +67,9 @@ class DefaultOperatorStateBackendSnapshotStrategy
         }
 
         final Map<String, PartitionableListState<?>> registeredOperatorStatesDeepCopies =
-                new HashMap<>(registeredOperatorStates.size());
+                CollectionUtil.newHashMapWithExpectedSize(registeredOperatorStates.size());
         final Map<String, BackendWritableBroadcastState<?, ?>> registeredBroadcastStatesDeepCopies =
-                new HashMap<>(registeredBroadcastStates.size());
+                CollectionUtil.newHashMapWithExpectedSize(registeredBroadcastStates.size());
 
         ClassLoader snapshotClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(userClassLoader);
@@ -168,7 +168,7 @@ class DefaultOperatorStateBackendSnapshotStrategy
                     registeredOperatorStatesDeepCopies.size()
                             + registeredBroadcastStatesDeepCopies.size();
             final Map<String, OperatorStateHandle.StateMetaInfo> writtenStatesMetaData =
-                    new HashMap<>(initialMapCapacity);
+                    CollectionUtil.newHashMapWithExpectedSize(initialMapCapacity);
 
             for (Map.Entry<String, PartitionableListState<?>> entry :
                     registeredOperatorStatesDeepCopies.entrySet()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateCheckpointOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateCheckpointOutputStream.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.runtime.util.LongArrayList;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /** Checkpoint output stream that allows to write raw operator state in a partitioned way. */
@@ -63,7 +63,8 @@ public final class OperatorStateCheckpointOutputStream
             startNewPartition();
         }
 
-        Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>(1);
+        Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap =
+                CollectionUtil.newHashMapWithExpectedSize(1);
 
         OperatorStateHandle.StateMetaInfo metaInfo =
                 new OperatorStateHandle.StateMetaInfo(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastStateBackendMetaInfo.java
@@ -22,13 +22,13 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -208,8 +208,9 @@ public class RegisteredBroadcastStateBackendMetaInfo<K, V> extends RegisteredSta
                         StateMetaInfoSnapshot.CommonOptionsKeys.OPERATOR_STATE_DISTRIBUTION_MODE
                                 .toString(),
                         assignmentMode.toString());
-        Map<String, TypeSerializer<?>> serializerMap = new HashMap<>(2);
-        Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap = new HashMap<>(2);
+        Map<String, TypeSerializer<?>> serializerMap = CollectionUtil.newHashMapWithExpectedSize(2);
+        Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap =
+                CollectionUtil.newHashMapWithExpectedSize(2);
         String keySerializerKey =
                 StateMetaInfoSnapshot.CommonSerializerKeys.KEY_SERIALIZER.toString();
         String valueSerializerKey =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -24,13 +24,13 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -262,8 +262,9 @@ public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStat
                 Collections.singletonMap(
                         StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE.toString(),
                         stateType.toString());
-        Map<String, TypeSerializer<?>> serializerMap = new HashMap<>(2);
-        Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap = new HashMap<>(2);
+        Map<String, TypeSerializer<?>> serializerMap = CollectionUtil.newHashMapWithExpectedSize(2);
+        Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap =
+                CollectionUtil.newHashMapWithExpectedSize(2);
         String namespaceSerializerKey =
                 StateMetaInfoSnapshot.CommonSerializerKeys.NAMESPACE_SERIALIZER.toString();
         String valueSerializerKey =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapPriorityQueueSet.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -95,7 +96,8 @@ public class HeapPriorityQueueSet<T extends HeapPriorityQueueElement> extends He
         final int deduplicationSetSize = 1 + minimumCapacity / keyGroupsInLocalRange;
         this.deduplicationMapsByKeyGroup = new HashMap[keyGroupsInLocalRange];
         for (int i = 0; i < keyGroupsInLocalRange; ++i) {
-            deduplicationMapsByKeyGroup[i] = new HashMap<>(deduplicationSetSize);
+            deduplicationMapsByKeyGroup[i] =
+                    CollectionUtil.newHashMapWithExpectedSize(deduplicationSetSize);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
@@ -27,12 +27,12 @@ import org.apache.flink.runtime.state.StateSnapshot;
 import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,8 +97,10 @@ final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
                         + " states are supported");
 
         final List<StateMetaInfoSnapshot> metaInfoSnapshots = new ArrayList<>(numStates);
-        final Map<StateUID, Integer> stateNamesToId = new HashMap<>(numStates);
-        final Map<StateUID, StateSnapshot> cowStateStableSnapshots = new HashMap<>(numStates);
+        final Map<StateUID, Integer> stateNamesToId =
+                CollectionUtil.newHashMapWithExpectedSize(numStates);
+        final Map<StateUID, StateSnapshot> cowStateStableSnapshots =
+                CollectionUtil.newHashMapWithExpectedSize(numStates);
 
         processSnapshotMetaInfoForAllStates(
                 metaInfoSnapshots,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotReadersWriters.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshotSerializationUtil;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nonnull;
 
@@ -143,7 +144,8 @@ public class StateMetaInfoSnapshotReadersWriters {
             final StateMetaInfoSnapshot.BackendStateType stateType =
                     StateMetaInfoSnapshot.BackendStateType.values()[inputView.readInt()];
             final int numOptions = inputView.readInt();
-            HashMap<String, String> optionsMap = new HashMap<>(numOptions);
+            HashMap<String, String> optionsMap =
+                    CollectionUtil.newHashMapWithExpectedSize(numOptions);
             for (int i = 0; i < numOptions; ++i) {
                 String key = inputView.readUTF();
                 String value = inputView.readUTF();
@@ -152,7 +154,7 @@ public class StateMetaInfoSnapshotReadersWriters {
 
             final int numSerializerConfigSnapshots = inputView.readInt();
             final HashMap<String, TypeSerializerSnapshot<?>> serializerConfigsMap =
-                    new HashMap<>(numSerializerConfigSnapshots);
+                    CollectionUtil.newHashMapWithExpectedSize(numSerializerConfigSnapshots);
 
             for (int i = 0; i < numSerializerConfigSnapshots; ++i) {
                 serializerConfigsMap.put(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.ttl;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nonnull;
@@ -76,7 +77,7 @@ class TtlMapState<K, N, UK, UV>
         if (map == null) {
             return;
         }
-        Map<UK, TtlValue<UV>> ttlMap = new HashMap<>(map.size());
+        Map<UK, TtlValue<UV>> ttlMap = CollectionUtil.newHashMapWithExpectedSize(map.size());
         long currentTimestamp = timeProvider.currentTimestamp();
         for (Map.Entry<UK, UV> entry : map.entrySet()) {
             UK key = entry.getKey();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1578,7 +1578,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     taskSlotTable.getAllocatedSlots(jobId);
             final JobMasterId jobMasterId = jobManagerConnection.getJobMasterId();
 
-            final Collection<SlotOffer> reservedSlots = new HashSet<>(2);
+            final Collection<SlotOffer> reservedSlots =
+                    CollectionUtil.newHashSetWithExpectedSize(2);
 
             while (reservedSlotsIterator.hasNext()) {
                 SlotOffer offer = reservedSlotsIterator.next().generateSlotOffer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -131,6 +131,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkExpectedException;
@@ -284,7 +285,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     @Nullable private UUID currentRegistrationTimeoutId;
 
     private final Map<JobID, Collection<CompletableFuture<ExecutionState>>>
-            taskResultPartitionCleanupFuturesPerJob = new HashMap<>(8);
+            taskResultPartitionCleanupFuturesPerJob = CollectionUtil.newHashMapWithExpectedSize(8);
 
     private final ThreadInfoSampleService threadInfoSampleService;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ThreadInfoSampleService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ThreadInfoSampleService.java
@@ -23,13 +23,13 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.util.JvmUtils;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -72,7 +72,7 @@ class ThreadInfoSampleService implements Closeable {
                                 requestParams.getNumSamples(),
                                 requestParams.getDelayBetweenSamples(),
                                 requestParams.getMaxStackTraceDepth(),
-                                new HashMap<>(threads.size()),
+                                CollectionUtil.newHashMapWithExpectedSize(threads.size()),
                                 resultFuture));
         return resultFuture;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/PartitionTable.java
@@ -18,13 +18,13 @@
 package org.apache.flink.runtime.taskexecutor.partition;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +54,7 @@ public class PartitionTable<K> {
                 key,
                 (ignored, partitionIds) -> {
                     if (partitionIds == null) {
-                        partitionIds = new HashSet<>(8);
+                        partitionIds = CollectionUtil.newHashSetWithExpectedSize(8);
                     }
                     partitionIds.addAll(newPartitionIds);
                     return partitionIds;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/DefaultTimerService.java
@@ -19,10 +19,10 @@
 package org.apache.flink.runtime.taskexecutor.slot;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.Preconditions;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
@@ -58,7 +58,7 @@ public class DefaultTimerService<K> implements TimerService<K> {
                 "The shut down timeout must be larger than or equal than 0.");
         this.shutdownTimeout = shutdownTimeout;
 
-        this.timeouts = new HashMap<>(16);
+        this.timeouts = CollectionUtil.newHashMapWithExpectedSize(16);
         this.timeoutListener = null;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.AutoCloseableAsync;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -31,7 +32,6 @@ import org.apache.flink.util.concurrent.FutureUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -102,7 +102,7 @@ public class TaskSlot<T extends TaskSlotPayload> implements AutoCloseableAsync {
         this.resourceProfile = Preconditions.checkNotNull(resourceProfile);
         this.asyncExecutor = Preconditions.checkNotNull(asyncExecutor);
 
-        this.tasks = new HashMap<>(4);
+        this.tasks = CollectionUtil.newHashMapWithExpectedSize(4);
         this.state = TaskSlotState.ALLOCATED;
 
         this.jobId = jobId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -44,7 +45,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -127,7 +127,7 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
         this.defaultSlotResourceProfile = Preconditions.checkNotNull(defaultSlotResourceProfile);
         this.memoryPageSize = memoryPageSize;
 
-        this.taskSlots = new HashMap<>(numberSlots);
+        this.taskSlots = CollectionUtil.newHashMapWithExpectedSize(numberSlots);
 
         this.timerService = Preconditions.checkNotNull(timerService);
 
@@ -135,11 +135,11 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
                 new ResourceBudgetManager(
                         Preconditions.checkNotNull(totalAvailableResourceProfile));
 
-        allocatedSlots = new HashMap<>(numberSlots);
+        allocatedSlots = CollectionUtil.newHashMapWithExpectedSize(numberSlots);
 
-        taskSlotMappings = new HashMap<>(4 * numberSlots);
+        taskSlotMappings = CollectionUtil.newHashMapWithExpectedSize(4 * numberSlots);
 
-        slotsPerJob = new HashMap<>(4);
+        slotsPerJob = CollectionUtil.newHashMapWithExpectedSize(4);
 
         slotActions = null;
         state = State.CREATED;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -338,7 +338,7 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
         Set<AllocationID> slots = slotsPerJob.get(jobId);
 
         if (slots == null) {
-            slots = new HashSet<>(4);
+            slots = CollectionUtil.newHashSetWithExpectedSize(4);
             slotsPerJob.put(jobId, slots);
         }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.util.CollectionUtil;
 
 import org.rocksdb.CompactionStyle;
 
@@ -163,7 +164,7 @@ public enum PredefinedOptions {
     private final Map<String, Object> options;
 
     PredefinedOptions(Map<ConfigOption<?>, Object> initMap) {
-        options = new HashMap<>(initMap.size());
+        options = CollectionUtil.newHashMapWithExpectedSize(initMap.size());
         for (Map.Entry<ConfigOption<?>, Object> entry : initMap.entrySet()) {
             options.put(entry.getKey().key(), entry.getValue());
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -104,7 +105,7 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
             CloseableRegistry closeableRegistry,
             CloseableRegistry tmpResourcesRegistry) {
         Map<StateHandleID, CompletableFuture<StreamStateHandle>> futures =
-                new HashMap<>(files.size());
+                CollectionUtil.newHashMapWithExpectedSize(files.size());
 
         for (Map.Entry<StateHandleID, Path> entry : files.entrySet()) {
             final Supplier<StreamStateHandle> supplier =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketStateSerializer.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -160,7 +161,8 @@ class BucketStateSerializer<BucketID> implements SimpleVersionedSerializer<Bucke
         final int committableVersion = in.readInt();
         final int numCheckpoints = in.readInt();
         final HashMap<Long, List<InProgressFileWriter.PendingFileRecoverable>>
-                pendingFileRecoverablePerCheckpoint = new HashMap<>(numCheckpoints);
+                pendingFileRecoverablePerCheckpoint =
+                        CollectionUtil.newHashMapWithExpectedSize(numCheckpoints);
 
         for (int i = 0; i < numCheckpoints; i++) {
             final long checkpointId = in.readLong();
@@ -204,7 +206,8 @@ class BucketStateSerializer<BucketID> implements SimpleVersionedSerializer<Bucke
         final int pendingFileRecoverableSerializerVersion = dataInputView.readInt();
         final int numCheckpoints = dataInputView.readInt();
         final HashMap<Long, List<InProgressFileWriter.PendingFileRecoverable>>
-                pendingFileRecoverablesPerCheckpoint = new HashMap<>(numCheckpoints);
+                pendingFileRecoverablesPerCheckpoint =
+                        CollectionUtil.newHashMapWithExpectedSize(numCheckpoints);
 
         for (int i = 0; i < numCheckpoints; i++) {
             final long checkpointId = dataInputView.readLong();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.JavaSerializer;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -155,7 +156,7 @@ public abstract class MessageAcknowledgingSourceBase<Type, UId> extends RichSour
                                         "message-acknowledging-source-state",
                                         new JavaSerializer<>()));
 
-        this.idsForCurrentCheckpoint = new HashSet<>(64);
+        this.idsForCurrentCheckpoint = CollectionUtil.newHashSetWithExpectedSize(64);
         this.pendingCheckpoints = new ArrayDeque<>();
         this.idsProcessedButNotAcknowledged = new HashSet<>();
 
@@ -235,7 +236,7 @@ public abstract class MessageAcknowledgingSourceBase<Type, UId> extends RichSour
 
         pendingCheckpoints.addLast(
                 new Tuple2<>(context.getCheckpointId(), idsForCurrentCheckpoint));
-        idsForCurrentCheckpoint = new HashSet<>(64);
+        idsForCurrentCheckpoint = CollectionUtil.newHashSetWithExpectedSize(64);
 
         this.checkpointedState.clear();
         this.checkpointedState.add(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SerializedCheckpointData.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SerializedCheckpointData.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.HashSet;
 import java.util.Set;
 
 /** This class represents serialized checkpoint data for a collection of elements. */
@@ -165,7 +165,7 @@ class SerializedCheckpointData implements java.io.Serializable {
                 deser.setBuffer(serializedData);
             }
 
-            final Set<T> ids = new HashSet<>(checkpoint.getNumIds());
+            final Set<T> ids = CollectionUtil.newHashSetWithExpectedSize(checkpoint.getNumIds());
             final int numIds = checkpoint.getNumIds();
 
             for (int i = 0; i < numIds; i++) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
@@ -21,10 +21,10 @@ package org.apache.flink.streaming.api.functions.source.datagen;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.commons.math3.random.RandomDataGenerator;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
@@ -174,7 +174,7 @@ public abstract class RandomGenerator<T> implements DataGenerator<T> {
 
             @Override
             public Map<K, V> next() {
-                Map<K, V> map = new HashMap<>(size);
+                Map<K, V> map = CollectionUtil.newHashMapWithExpectedSize(size);
                 for (int i = 0; i < size; i++) {
                     map.put(key.next(), value.next());
                 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -225,7 +225,7 @@ public class InternalTimersSnapshotReaderWriters {
             // read the event time timers
             int sizeOfEventTimeTimers = in.readInt();
             Set<TimerHeapInternalTimer<K, N>> restoredEventTimers =
-                    new HashSet<>(sizeOfEventTimeTimers);
+                    CollectionUtil.newHashSetWithExpectedSize(sizeOfEventTimeTimers);
             if (sizeOfEventTimeTimers > 0) {
                 for (int i = 0; i < sizeOfEventTimeTimers; i++) {
                     TimerHeapInternalTimer<K, N> timer = timerSerializer.deserialize(in);
@@ -237,7 +237,7 @@ public class InternalTimersSnapshotReaderWriters {
             // read the processing time timers
             int sizeOfProcessingTimeTimers = in.readInt();
             Set<TimerHeapInternalTimer<K, N>> restoredProcessingTimers =
-                    new HashSet<>(sizeOfProcessingTimeTimers);
+                    CollectionUtil.newHashSetWithExpectedSize(sizeOfProcessingTimeTimers);
             if (sizeOfProcessingTimeTimers > 0) {
                 for (int i = 0; i < sizeOfProcessingTimeTimers; i++) {
                     TimerHeapInternalTimer<K, N> timer = timerSerializer.deserialize(in);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -33,7 +34,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -214,7 +214,7 @@ public final class UnorderedStreamElementQueue<OUT> implements StreamElementQueu
         private final Queue<StreamElementQueueEntry<OUT>> completedElements;
 
         Segment(int initialCapacity) {
-            incompleteElements = new HashSet<>(initialCapacity);
+            incompleteElements = CollectionUtil.newHashSetWithExpectedSize(initialCapacity);
             completedElements = new ArrayDeque<>(initialCapacity);
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
@@ -41,10 +41,10 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +97,8 @@ public class CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
 
         collector = new TimestampedCollector<>(output);
 
-        this.broadcastStates = new HashMap<>(broadcastStateDescriptors.size());
+        this.broadcastStates =
+                CollectionUtil.newHashMapWithExpectedSize(broadcastStateDescriptors.size());
         for (MapStateDescriptor<?, ?> descriptor : broadcastStateDescriptors) {
             broadcastStates.put(
                     descriptor, getOperatorStateBackend().getBroadcastState(descriptor));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperator.java
@@ -32,10 +32,10 @@ import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +83,8 @@ public class CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT>
 
         collector = new TimestampedCollector<>(output);
 
-        this.broadcastStates = new HashMap<>(broadcastStateDescriptors.size());
+        this.broadcastStates =
+                CollectionUtil.newHashMapWithExpectedSize(broadcastStateDescriptors.size());
         for (MapStateDescriptor<?, ?> descriptor : broadcastStateDescriptors) {
             broadcastStates.put(
                     descriptor, getOperatorStateBackend().getBroadcastState(descriptor));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
@@ -43,6 +43,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
 
@@ -50,7 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -203,7 +203,8 @@ public final class RescalingStreamTaskNetworkInput<T>
      */
     static class RecordFilterFactory<T>
             implements Function<InputChannelInfo, Predicate<StreamRecord<T>>> {
-        private final Map<Integer, StreamPartitioner<T>> partitionerCache = new HashMap<>(1);
+        private final Map<Integer, StreamPartitioner<T>> partitionerCache =
+                CollectionUtil.newHashMapWithExpectedSize(1);
         private final Function<Integer, StreamPartitioner<?>> gatePartitioners;
         private final TypeSerializer<T> inputSerializer;
         private final int numberOfChannels;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
@@ -25,12 +25,12 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -154,7 +154,7 @@ public final class CommittableCollectorSerializer<CommT>
                             new SubtaskSimpleVersionedSerializer(checkpointId), in);
 
             Map<Integer, SubtaskCommittableManager<CommT>> subtasksCommittableManagers =
-                    new HashMap<>(subtaskCommittableManagers.size());
+                    CollectionUtil.newHashMapWithExpectedSize(subtaskCommittableManagers.size());
 
             for (SubtaskCommittableManager<CommT> subtaskCommittableManager :
                     subtaskCommittableManagers) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -66,6 +66,7 @@ import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorFactory;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.SerializedValue;
@@ -176,7 +177,7 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         List<NonChainedOutput> outputsInOrder =
                 configuration.getVertexNonChainedOutputs(userCodeClassloader);
         Map<IntermediateDataSetID, RecordWriterOutput<?>> recordWriterOutputs =
-                new HashMap<>(outputsInOrder.size());
+                CollectionUtil.newHashMapWithExpectedSize(outputsInOrder.size());
         this.streamOutputs = new RecordWriterOutput<?>[outputsInOrder.size()];
         this.finishedOnRestoreInput =
                 this.isTaskDeployedAsFinished()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.runtime.io.checkpointing.BarrierAlignmentUtil;
 import org.apache.flink.streaming.runtime.io.checkpointing.BarrierAlignmentUtil.Cancellable;
 import org.apache.flink.streaming.runtime.io.checkpointing.BarrierAlignmentUtil.DelayableTimer;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -345,7 +346,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
         // streaming topology
 
         Map<OperatorID, OperatorSnapshotFutures> snapshotFutures =
-                new HashMap<>(operatorChain.getNumberOfOperators());
+                CollectionUtil.newHashMapWithExpectedSize(operatorChain.getNumberOfOperators());
         try {
             if (takeSnapshotSync(
                     snapshotFutures, metadata, metrics, options, operatorChain, isRunning)) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/result/MaterializedCollectStreamResult.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.client.gateway.StatementResult;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CollectionUtil;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /** Collects results and returns them as table snapshots. */
@@ -43,7 +43,7 @@ public class MaterializedCollectStreamResult extends MaterializedCollectResultBa
 
         final int initialCapacity =
                 computeMaterializedTableCapacity(maxRowCount); // avoid frequent resizing
-        rowPositionCache = new HashMap<>(initialCapacity);
+        rowPositionCache = CollectionUtil.newHashMapWithExpectedSize(initialCapacity);
         // start listener thread
         retrievalThread.start();
     }

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementGrouper.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementGrouper.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.codesplit;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.codesplit.JavaParser.BlockStatementContext;
 import org.apache.flink.table.codesplit.JavaParser.StatementContext;
+import org.apache.flink.util.CollectionUtil;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -147,7 +148,8 @@ public class BlockStatementGrouper {
         visitor.rewrite();
         Map<String, Pair<TokenStreamRewriter, List<LocalGroupElement>>> groups = visitor.groups;
 
-        Map<String, List<String>> groupStrings = new HashMap<>(groups.size());
+        Map<String, List<String>> groupStrings =
+                CollectionUtil.newHashMapWithExpectedSize(groups.size());
         for (Entry<String, Pair<TokenStreamRewriter, List<LocalGroupElement>>> group :
                 groups.entrySet()) {
             List<String> collectedStringGroups =

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementSplitter.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.codesplit;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.codesplit.JavaParser.BlockStatementContext;
 import org.apache.flink.table.codesplit.JavaParser.StatementContext;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.v4.runtime.CharStreams;
@@ -145,7 +146,8 @@ public class BlockStatementSplitter {
      */
     public Map<String, List<String>> extractBlocks() {
 
-        Map<String, List<String>> allBlocks = new HashMap<>(visitor.blocks.size());
+        Map<String, List<String>> allBlocks =
+                CollectionUtil.newHashMapWithExpectedSize(visitor.blocks.size());
 
         for (Entry<String, List<ParserRuleContext>> entry : visitor.blocks.entrySet()) {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatistics.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatistics.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.catalog.stats;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.CollectionUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,7 +68,7 @@ public class CatalogColumnStatistics {
      */
     public CatalogColumnStatistics copy() {
         Map<String, CatalogColumnStatisticsDataBase> copy =
-                new HashMap<>(columnStatisticsData.size());
+                CollectionUtil.newHashMapWithExpectedSize(columnStatisticsData.size());
         for (Map.Entry<String, CatalogColumnStatisticsDataBase> entry :
                 columnStatisticsData.entrySet()) {
             copy.put(entry.getKey(), entry.getValue().copy());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/NullAwareMapSerializer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/NullAwareMapSerializer.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -74,7 +75,7 @@ public class NullAwareMapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 
     @Override
     public Map<K, V> copy(Map<K, V> from) {
-        Map<K, V> newMap = new HashMap<>(from.size());
+        Map<K, V> newMap = CollectionUtil.newHashMapWithExpectedSize(from.size());
 
         for (Map.Entry<K, V> entry : from.entrySet()) {
             K newKey = entry.getKey() == null ? null : keySerializer.copy(entry.getKey());
@@ -122,7 +123,7 @@ public class NullAwareMapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
     public Map<K, V> deserialize(DataInputView source) throws IOException {
         final int size = source.readInt();
 
-        final Map<K, V> map = new HashMap<>(size);
+        final Map<K, V> map = CollectionUtil.newHashMapWithExpectedSize(size);
         for (int i = 0; i < size; ++i) {
             boolean keyIsNull = source.readBoolean();
             K key = keyIsNull ? null : keySerializer.deserialize(source);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/connector/sink/TestManagedSinkCommittableSerializer.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/connector/sink/TestManagedSinkCommittableSerializer.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,7 +120,8 @@ public class TestManagedSinkCommittableSerializer
     private CatalogPartitionSpec deserializePartitionSpec(DataInputDeserializer in)
             throws IOException {
         int size = in.readInt();
-        LinkedHashMap<String, String> partitionKVs = new LinkedHashMap<>(size);
+        LinkedHashMap<String, String> partitionKVs =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(size);
         for (int i = 0; i < size; i++) {
             String partitionKey = in.readUTF();
             String partitionValue = in.readUTF();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.data.binary.BinaryStringDataUtil;
 import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.table.utils.ThreadLocalCache;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -812,7 +813,7 @@ public class SqlFunctionUtils {
         }
 
         String[] keyValuePairs = text.split(listDelimiter);
-        Map<String, String> ret = new HashMap<>(keyValuePairs.length);
+        Map<String, String> ret = CollectionUtil.newHashMapWithExpectedSize(keyValuePairs.length);
         for (String keyValuePair : keyValuePairs) {
             String[] keyValue = keyValuePair.split(keyValueDelimiter, 2);
             if (keyValue.length < 2) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/SpillChannelManager.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/SpillChannelManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.sort;
 
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.Closeable;
 import java.io.File;
@@ -37,8 +38,8 @@ public class SpillChannelManager implements Closeable {
     private volatile boolean closed;
 
     public SpillChannelManager() {
-        this.channels = new HashSet<>(64);
-        this.openChannels = new HashSet<>(64);
+        this.channels = CollectionUtil.newHashSetWithExpectedSize(64);
+        this.openChannels = CollectionUtil.newHashSetWithExpectedSize(64);
     }
 
     /** Add a new File channel. */

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/sink/UpsertTestFileUtil.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/sink/UpsertTestFileUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.upserttest.sink;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.util.CollectionUtil;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -110,7 +111,7 @@ public class UpsertTestFileUtil {
             throws IOException {
         checkNotNull(bis);
         Map<ImmutableByteArrayWrapper, ImmutableByteArrayWrapper> bytesMap = readRecords(bis);
-        Map<K, V> typedMap = new HashMap<>(bytesMap.size());
+        Map<K, V> typedMap = CollectionUtil.newHashMapWithExpectedSize(bytesMap.size());
 
         Iterator<Map.Entry<ImmutableByteArrayWrapper, ImmutableByteArrayWrapper>> it =
                 bytesMap.entrySet().iterator();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -834,7 +834,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                         getFileReplication());
 
         // The files need to be shipped and added to classpath.
-        Set<File> systemShipFiles = new HashSet<>(shipFiles.size());
+        Set<File> systemShipFiles = CollectionUtil.newHashSetWithExpectedSize(shipFiles.size());
         for (File file : shipFiles) {
             systemShipFiles.add(file.getAbsoluteFile());
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The JDK API to create hash-based collections for a certain capacity is arguably misleading because it doesn't size the collections to "hold a specific number of items" like you'd expect it would. Instead it sizes it to hold "load-factor%" of the specified number.

For the common pattern to allocate a hash-based collection with the size of expected elements to avoid rehashes, this means that a rehash is essentially guaranteed.

This PR replaces constructor calls for allocations for expected size with helper methods (similar to Guava's `Maps.newHashMapWithExpectedSize(int)`) .

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
