### PR TITLE
[FLINK-31784][runtime] Adds multi-component support to DefaultLeaderElectionService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
@@ -34,7 +34,11 @@ import java.util.UUID;
  *
  * <p>The order of events matters. Therefore, calling event processing functions of this interface
  * should happen in a single-thread environment.
+ *
+ * @deprecated {@link LeaderElectionEventHandler} will be replaced by {@link
+ *     MultipleComponentLeaderElectionDriver.Listener}.
  */
+@Deprecated
 @NotThreadSafe
 public interface LeaderElectionEventHandler {
 
@@ -43,12 +47,14 @@ public interface LeaderElectionEventHandler {
      *
      * @param newLeaderSessionId the valid leader session id
      */
+    @Deprecated
     void onGrantLeadership(UUID newLeaderSessionId);
 
     /**
      * Called by specific {@link LeaderElectionDriver} when the leadership is revoked. Updating the
      * LeaderElection data at this point doesn't have any effect anymore.
      */
+    @Deprecated
     void onRevokeLeadership();
 
     /**
@@ -61,5 +67,6 @@ public interface LeaderElectionEventHandler {
      * @param leaderInformation leader information which contains leader session id and leader
      *     address.
      */
+    @Deprecated
     void onLeaderInformationChange(LeaderInformation leaderInformation);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegister.java
@@ -111,7 +111,7 @@ public class LeaderInformationRegister {
      * Returns a {@link LeaderInformation} which is empty if no {@code LeaderInformation} is stored
      * for the passed {@code contenderID}.
      */
-    public LeaderInformation forContenderIDOrEmpty(String contenderID) {
+    public LeaderInformation forContenderIdOrEmpty(String contenderID) {
         return forContenderID(contenderID).orElse(LeaderInformation.empty());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -931,13 +931,13 @@ class DefaultLeaderElectionServiceTest {
 
         void runTest(RunnableWithException testMethod, ExecutorService leaderEventOperationExecutor)
                 throws Exception {
-            try {
-                leaderElectionService =
+            try (final DefaultLeaderElectionService localLeaderElectionService =
                         new DefaultLeaderElectionService(
                                 driverFactory,
                                 DefaultLeaderElectionServiceTest.this.fatalErrorHandlerExtension
                                         .getTestingFatalErrorHandler(),
-                                leaderEventOperationExecutor);
+                                leaderEventOperationExecutor)) {
+                leaderElectionService = localLeaderElectionService;
                 leaderElectionService.startLeaderElectionBackend();
                 testingLeaderElectionDriver = driverFactory.assertAndGetOnlyCreatedDriver();
 
@@ -949,10 +949,6 @@ class DefaultLeaderElectionServiceTest {
             } finally {
                 if (leaderElection != null) {
                     leaderElection.close();
-                }
-
-                if (leaderElectionService != null) {
-                    leaderElectionService.close();
                 }
 
                 if (testingContender != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
@@ -113,6 +113,25 @@ class LeaderInformationRegisterTest {
     }
 
     @Test
+    void testMergeKnownLeaderInformationForExistingContenderID() {
+        final String contenderID = "contender-id";
+        final LeaderInformation oldLeaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "old-address");
+
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(contenderID, oldLeaderInformation);
+
+        final LeaderInformation newLeaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "new-address");
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.merge(initialRegister, contenderID, newLeaderInformation);
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
+        assertThat(newRegister.forContenderID(contenderID)).hasValue(newLeaderInformation);
+    }
+
+    @Test
     void testClear() {
         final String contenderID = "contender-id";
         final LeaderInformation leaderInformation =
@@ -184,7 +203,7 @@ class LeaderInformationRegisterTest {
                 LeaderInformation.known(UUID.randomUUID(), "address");
         assertThat(
                         LeaderInformationRegister.of(contenderID, leaderInformation)
-                                .forContenderIDOrEmpty(contenderID))
+                                .forContenderIdOrEmpty(contenderID))
                 .isEqualTo(leaderInformation);
     }
 
@@ -202,7 +221,7 @@ class LeaderInformationRegisterTest {
         final String contenderID = "contender-id";
         assertThat(
                         LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
-                                .forContenderIDOrEmpty(contenderID))
+                                .forContenderIdOrEmpty(contenderID))
                 .isEqualTo(LeaderInformation.empty());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeaderInformationRegisterTest {
+
+    @Test
+    void testOfWithKnownLeaderInformation() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final LeaderInformationRegister testInstance =
+                LeaderInformationRegister.of(contenderID, leaderInformation);
+        assertThat(testInstance.getRegisteredContenderIDs()).containsExactly(contenderID);
+        assertThat(testInstance.forContenderID(contenderID)).hasValue(leaderInformation);
+    }
+
+    @Test
+    void testOfWithEmptyLeaderInformation() {
+        final String contenderID = "contender-id";
+        final LeaderInformationRegister testInstance =
+                LeaderInformationRegister.of(contenderID, LeaderInformation.empty());
+
+        assertThat(testInstance.getRegisteredContenderIDs()).isEmpty();
+        assertThat(testInstance.forContenderID(contenderID)).isNotPresent();
+    }
+
+    @Test
+    void testMerge() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final String newContenderID = "new-contender-id";
+        final LeaderInformation newLeaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "new-address");
+
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(contenderID, leaderInformation);
+
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.merge(
+                        initialRegister, newContenderID, newLeaderInformation);
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs())
+                .containsExactlyInAnyOrder(contenderID, newContenderID);
+        assertThat(newRegister.forContenderID(contenderID)).hasValue(leaderInformation);
+        assertThat(newRegister.forContenderID(newContenderID)).hasValue(newLeaderInformation);
+    }
+
+    @Test
+    void testMergeEmptyLeaderInformation() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final String newContenderID = "new-contender-id";
+
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(contenderID, leaderInformation);
+
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.merge(
+                        initialRegister, newContenderID, LeaderInformation.empty());
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
+        assertThat(newRegister.forContenderID(newContenderID)).isNotPresent();
+    }
+
+    @Test
+    void testMergeEmptyLeaderInformationForExistingContenderID() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(contenderID, leaderInformation);
+
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.merge(
+                        initialRegister, contenderID, LeaderInformation.empty());
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs()).isEmpty();
+        assertThat(newRegister.forContenderID(contenderID)).isNotPresent();
+    }
+
+    @Test
+    void testClear() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(contenderID, leaderInformation);
+
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.clear(initialRegister, contenderID);
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs()).isEmpty();
+        assertThat(newRegister.forContenderID(contenderID)).isNotPresent();
+    }
+
+    @Test
+    void testClearNotRegisteredContenderID() {
+        final String contenderID = "contender-id";
+        final LeaderInformationRegister initialRegister =
+                LeaderInformationRegister.of(
+                        contenderID, LeaderInformation.known(UUID.randomUUID(), "address"));
+
+        final LeaderInformationRegister newRegister =
+                LeaderInformationRegister.clear(initialRegister, "another-contender-id");
+
+        assertThat(newRegister).isNotSameAs(initialRegister);
+        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
+    }
+
+    @Test
+    void testEmptyLeaderInformationFiltering() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+
+        final String contenderIDWithEmptyLeaderInformation = "new-contender-id";
+
+        final Map<String, LeaderInformation> records = new HashMap<>();
+        records.put(contenderID, leaderInformation);
+        records.put(contenderIDWithEmptyLeaderInformation, LeaderInformation.empty());
+
+        final LeaderInformationRegister testInstance = new LeaderInformationRegister(records);
+        assertThat(testInstance.getRegisteredContenderIDs()).containsExactly(contenderID);
+        assertThat(testInstance.forContenderID(contenderIDWithEmptyLeaderInformation))
+                .isNotPresent();
+    }
+
+    @Test
+    void testEmptyInstance() {
+        assertThat(LeaderInformationRegister.empty().getRegisteredContenderIDs()).isEmpty();
+    }
+
+    @Test
+    void testForContenderID() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, leaderInformation)
+                                .forContenderID(contenderID))
+                .hasValue(leaderInformation);
+    }
+
+    @Test
+    void testForContenderIDOrEmpty() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, leaderInformation)
+                                .forContenderIDOrEmpty(contenderID))
+                .isEqualTo(leaderInformation);
+    }
+
+    @Test
+    void testForContenderIDWithEmptyLeaderInformation() {
+        final String contenderID = "contender-id";
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
+                                .forContenderID(contenderID))
+                .isNotPresent();
+    }
+
+    @Test
+    void testForContenderIDOrEmptyWithEmptyLeaderInformation() {
+        final String contenderID = "contender-id";
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
+                                .forContenderIDOrEmpty(contenderID))
+                .isEqualTo(LeaderInformation.empty());
+    }
+
+    @Test
+    void testHasLeaderInformation() {
+        final String contenderID = "contender-id";
+        final LeaderInformation leaderInformation =
+                LeaderInformation.known(UUID.randomUUID(), "address");
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, leaderInformation)
+                                .hasLeaderInformation(contenderID))
+                .isTrue();
+    }
+
+    @Test
+    void testHasLeaderInformationWithEmptyLeaderInformation() {
+        final String contenderID = "contender-id";
+        assertThat(
+                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
+                                .hasLeaderInformation(contenderID))
+                .isFalse();
+    }
+
+    @Test
+    void hasNoLeaderInformation() {
+        LeaderInformationRegister register = LeaderInformationRegister.empty();
+        assertThat(register.hasNoLeaderInformation()).isTrue();
+
+        register = LeaderInformationRegister.of("contender-id", LeaderInformation.empty());
+        assertThat(register.hasNoLeaderInformation()).isTrue();
+
+        register =
+                LeaderInformationRegister.merge(
+                        register,
+                        "other-contender-id",
+                        LeaderInformation.known(UUID.randomUUID(), "address"));
+        assertThat(register.hasNoLeaderInformation()).isFalse();
+    }
+}


### PR DESCRIPTION
## PR Hierarchy

* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* https://github.com/apache/flink/pull/22390
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* https://github.com/apache/flink/pull/22828
* https://github.com/apache/flink/pull/22830
* https://github.com/apache/flink/pull/22829
* https://github.com/apache/flink/pull/22661
* === THIS PR === FLINK-31784
* https://github.com/apache/flink/pull/22848
* https://github.com/apache/flink/pull/22873
* https://github.com/apache/flink/pull/22935

## What is the purpose of the change

Replacing the `leaderContender` and `contenderID` fields in `DefaultLeaderElectionService` with a `leaderContenderRegistry` that allows adding multiple contenders.

## Brief change log

* Removes `DefaultLeaderElectionService` fields `leaderContender` and `contenderID`
* Adds `DefaultLeaderElectionService#leaderContenderRegistry`
* Makes `MultpleComponentLeaderElectionDriver.Listener` interface methods first-class citizens and let the `LeaderElectionEventHandler` interface call those
* Introduces `contenderID` in `EmbeddedLeaderElection` to allow logging
* Removes `LeaderContender#getDescription()`

## Verifying this change

* Added multi-component support test scenarios to `DefaultLeaderElectionServiceTest`
* Copied relevant tests over from `DefaultMultipleComponentLeaderElectionServiceTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable