### PR TITLE
[FLINK-32411][connector/common] Fix the bug about SourceCoordinator thread leaks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -269,10 +269,10 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     @Override
     public void close() throws Exception {
         LOG.info("Closing SourceCoordinator for source {}.", operatorName);
-        closeQuietly(context);
         if (started) {
             closeQuietly(enumerator);
         }
+        closeQuietly(context);
         LOG.info("Source coordinator for source {} closed.", operatorName);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -63,11 +63,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Arrays.asList;
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readAndVerifyCoordinatorSerdeVersion;
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readBytes;
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.writeCoordinatorSerdeVersion;
-import static org.apache.flink.util.IOUtils.closeAll;
+import static org.apache.flink.util.IOUtils.closeQuietly;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -270,8 +269,9 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     @Override
     public void close() throws Exception {
         LOG.info("Closing SourceCoordinator for source {}.", operatorName);
+        closeQuietly(context);
         if (started) {
-            closeAll(asList(context, enumerator), Throwable.class);
+            closeQuietly(enumerator);
         }
         LOG.info("Source coordinator for source {} closed.", operatorName);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -340,6 +340,11 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         shutdownExecutorForcefully(coordinatorExecutor, Duration.ofNanos(Long.MAX_VALUE));
     }
 
+    @VisibleForTesting
+    boolean isClosed() {
+        return closed;
+    }
+
     // --------- Package private additional methods for the SourceCoordinator ------------
 
     void attemptReady(OperatorCoordinator.SubtaskGateway gateway) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -118,6 +118,13 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         sourceCoordinator.start();
         sourceCoordinator.close();
         assertThat(getEnumerator().isClosed()).isTrue();
+        assertThat(sourceCoordinator.getContext().isClosed()).isTrue();
+    }
+
+    @Test
+    void testClosedWithoutStart() throws Exception {
+        sourceCoordinator.close();
+        assertThat(sourceCoordinator.getContext().isClosed()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug about SourceCoordinator thread leaks. You can get more detailed background from FLINK-32411.

## Brief change log

Closing the SourceCoordinatorContext inside of the SourceCoordinator#close even if the SourceCoordinator isn't started.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added the SourceCoordinatorTest#testClosedWithoutStart*
  - *Improved the SourceCoordinatorTest#testClosed*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no