### PR TITLE
[FLINK-32413][runtime] Adds fallback error handler to DefaultLeaderElectionService

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -683,7 +683,8 @@ class JobMasterServiceLeadershipRunnerTest {
         // we need to use DefaultLeaderElectionService here because JobMasterServiceLeadershipRunner
         // in connection with the DefaultLeaderElectionService generates the nested locking
         final DefaultLeaderElectionService defaultLeaderElectionService =
-                new DefaultLeaderElectionService(testingLeaderElectionDriverFactory);
+                new DefaultLeaderElectionService(
+                        testingLeaderElectionDriverFactory, fatalErrorHandler);
         defaultLeaderElectionService.startLeaderElectionBackend();
 
         // latch to detect when we reached the first synchronized section having a lock on the

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -138,7 +138,9 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
         LeaderElectionDriverFactory leaderElectionDriverFactory =
                 new ZooKeeperLeaderElectionDriverFactory(client, PATH);
         DefaultLeaderElectionService leaderElectionService =
-                new DefaultLeaderElectionService(leaderElectionDriverFactory);
+                new DefaultLeaderElectionService(
+                        leaderElectionDriverFactory,
+                        testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
         leaderElectionService.startLeaderElectionBackend();
 
         final TestingConnectionStateListener connectionStateListener =


### PR DESCRIPTION
## What is the purpose of the change

In production we should be fine ignoring those errors as long as no contender is added. But the default behavior limits our ability to identify errors in some test scenarios (e.g. [DefaultLeaderElectionServiceTest.testDelayedGrantCallAfterContenderBeingDeregisteredAgain](https://github.com/apache/flink/blob/bc18b8b1e23c557c74d4330ccc42f276f1bb7581/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java#L242)). Adding a fallback error handler resolves this issue. 

## Brief change log

* Added new constructor allows the configuration of the fallback error handler.

## Verifying this change

* Added proper error handler in all affected test cases
* `DefaultLeaderElectionServiceTest.testErrorIsIgnoredAfterLeaderElectionBeingClosed` needed to be modified to succeed again (this one covers the new code path)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable