### PR TITLE
[FLINK-32414][connectors/common] Don't emitLatestWatermark when lastEmittedWatermark is UNINITIALIZED

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -503,6 +503,9 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     private void emitLatestWatermark(long time) {
         checkState(currentMainOutput != null);
+        if (lastEmittedWatermark == Watermark.UNINITIALIZED.getTimestamp()) {
+            return;
+        }
         operatorEventGateway.sendEventToCoordinator(
                 new ReportedWatermarkEvent(lastEmittedWatermark));
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -193,6 +193,39 @@ class SourceOperatorAlignmentTest {
     }
 
     @Test
+    void testWatermarkAlignmentWithoutSplit() throws Exception {
+        operator.initializeState(context.createStateContext());
+        operator.open();
+
+        CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.NOTHING_AVAILABLE);
+
+        // Don't report any ReportedWatermarkEvent
+        context.getTimeService().advance(1);
+        assertNoReportedWatermarkEvent(context);
+
+        context.getTimeService().advance(1);
+        assertNoReportedWatermarkEvent(context);
+
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.NOTHING_AVAILABLE);
+
+        MockSourceSplit newSplit = new MockSourceSplit(2);
+        int record = 10;
+        newSplit.addRecord(record);
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
+
+        List<Integer> expectedOutput = new ArrayList<>();
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
+        expectedOutput.add(record);
+
+        context.getTimeService().advance(1);
+        assertLatestReportedWatermarkEvent(record);
+        assertOutput(actualOutput, expectedOutput);
+    }
+
+    @Test
     void testStopWhileWaitingForWatermarkAlignment() throws Exception {
         testWatermarkAlignment();
 
@@ -258,6 +291,14 @@ class SourceOperatorAlignmentTest {
         assertThat(events).isNotEmpty();
         assertThat(events.get(events.size() - 1))
                 .isEqualTo(new ReportedWatermarkEvent(expectedWatermark));
+    }
+
+    private void assertNoReportedWatermarkEvent(SourceOperatorTestContext context) {
+        List<OperatorEvent> events =
+                context.getGateway().getEventsSent().stream()
+                        .filter(event -> event instanceof ReportedWatermarkEvent)
+                        .collect(Collectors.toList());
+        assertThat(events).isEmpty();
     }
 
     private static class PunctuatedGenerator implements WatermarkGenerator<Integer> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -46,22 +46,17 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link SourceOperator} watermark alignment. */
 @SuppressWarnings("serial")
-public class SourceOperatorAlignmentTest {
+class SourceOperatorAlignmentTest {
 
     @Nullable private SourceOperatorTestContext context;
     @Nullable private SourceOperator<Integer, MockSourceSplit> operator;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         context =
                 new SourceOperatorTestContext(
                         false,
@@ -73,14 +68,14 @@ public class SourceOperatorAlignmentTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         context.close();
         context = null;
         operator = null;
     }
 
     @Test
-    public void testWatermarkAlignment() throws Exception {
+    void testWatermarkAlignment() throws Exception {
         operator.initializeState(context.createStateContext());
         operator.open();
         MockSourceSplit newSplit = new MockSourceSplit(2);
@@ -98,39 +93,39 @@ public class SourceOperatorAlignmentTest {
         CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
         List<Integer> expectedOutput = new ArrayList<>();
 
-        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.MORE_AVAILABLE));
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
         expectedOutput.add(record1);
         context.getTimeService().advance(1);
         assertLatestReportedWatermarkEvent(record1);
         assertOutput(actualOutput, expectedOutput);
-        assertTrue(operator.isAvailable());
+        assertThat(operator.isAvailable()).isTrue();
 
         operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 - 1));
 
-        assertFalse(operator.isAvailable());
-        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
+        assertThat(operator.isAvailable()).isFalse();
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.NOTHING_AVAILABLE);
         assertLatestReportedWatermarkEvent(record1);
         assertOutput(actualOutput, expectedOutput);
-        assertFalse(operator.isAvailable());
+        assertThat(operator.isAvailable()).isFalse();
 
         operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 1));
 
-        assertTrue(operator.isAvailable());
+        assertThat(operator.isAvailable()).isTrue();
         operator.emitNext(actualOutput);
         // Try to poll a record second time. Technically speaking previous emitNext call could have
         // already switch the operator status to unavailable, but that's an implementation detail.
         // However, this second call can not emit anything and should after that second call
         // operator must be unavailable.
-        assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.NOTHING_AVAILABLE);
         expectedOutput.add(record2);
         context.getTimeService().advance(1);
         assertLatestReportedWatermarkEvent(record2);
         assertOutput(actualOutput, expectedOutput);
-        assertFalse(operator.isAvailable());
+        assertThat(operator.isAvailable()).isFalse();
     }
 
     @Test
-    public void testWatermarkAlignmentWithIdleness() throws Exception {
+    void testWatermarkAlignmentWithIdleness() throws Exception {
         // we use a separate context, because we need to enable idleness
         try (SourceOperatorTestContext context =
                 new SourceOperatorTestContext(
@@ -156,17 +151,18 @@ public class SourceOperatorAlignmentTest {
             CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
             List<Integer> expectedOutput = new ArrayList<>();
 
-            assertThat(operator.emitNext(actualOutput), is(DataInputStatus.MORE_AVAILABLE));
+            assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
             expectedOutput.add(record1);
             context.getTimeService().advance(1);
             assertLatestReportedWatermarkEvent(context, record1);
             // mock WatermarkAlignmentEvent from SourceCoordinator
             operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 100));
             assertOutput(actualOutput, expectedOutput);
-            assertTrue(operator.isAvailable());
+            assertThat(operator.isAvailable()).isTrue();
 
             // source becomes idle, it should report Long.MAX_VALUE as the watermark
-            assertThat(operator.emitNext(actualOutput), is(DataInputStatus.NOTHING_AVAILABLE));
+            assertThat(operator.emitNext(actualOutput))
+                    .isEqualTo(DataInputStatus.NOTHING_AVAILABLE);
             context.getTimeService().advance(1);
             assertLatestReportedWatermarkEvent(context, Long.MAX_VALUE);
             // If all source subtasks of the watermark group are idle,
@@ -184,7 +180,7 @@ public class SourceOperatorAlignmentTest {
                     new AddSplitEvent<>(
                             Collections.singletonList(newSplit), new MockSourceSplitSerializer()));
 
-            assertThat(operator.emitNext(actualOutput), is(DataInputStatus.MORE_AVAILABLE));
+            assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
             expectedOutput.add(record2);
             context.getTimeService().advance(1);
             // becomes active again, should go back to the previously emitted
@@ -192,23 +188,23 @@ public class SourceOperatorAlignmentTest {
             assertLatestReportedWatermarkEvent(context, record1);
             operator.handleOperatorEvent(new WatermarkAlignmentEvent(record1 + 100));
             assertOutput(actualOutput, expectedOutput);
-            assertTrue(operator.isAvailable());
+            assertThat(operator.isAvailable()).isTrue();
         }
     }
 
     @Test
-    public void testStopWhileWaitingForWatermarkAlignment() throws Exception {
+    void testStopWhileWaitingForWatermarkAlignment() throws Exception {
         testWatermarkAlignment();
 
         CompletableFuture<?> availableFuture = operator.getAvailableFuture();
-        assertFalse(availableFuture.isDone());
+        assertThat(availableFuture).isNotDone();
         operator.stop(StopMode.NO_DRAIN);
-        assertTrue(availableFuture.isDone());
-        assertTrue(operator.isAvailable());
+        assertThat(availableFuture).isDone();
+        assertThat(operator.isAvailable()).isTrue();
     }
 
     @Test
-    public void testReportedWatermarkDoNotDecrease() throws Exception {
+    void testReportedWatermarkDoNotDecrease() throws Exception {
         operator.initializeState(context.createStateContext());
         operator.open();
         MockSourceSplit split1 = new MockSourceSplit(2);
@@ -240,12 +236,12 @@ public class SourceOperatorAlignmentTest {
     private void assertOutput(
             CollectingDataOutput<Integer> actualOutput, List<Integer> expectedOutput) {
         assertThat(
-                actualOutput.getEvents().stream()
-                        .filter(o -> o instanceof StreamRecord)
-                        .mapToInt(object -> ((StreamRecord<Integer>) object).getValue())
-                        .boxed()
-                        .collect(Collectors.toList()),
-                contains(expectedOutput.toArray()));
+                        actualOutput.getEvents().stream()
+                                .filter(o -> o instanceof StreamRecord)
+                                .mapToInt(object -> ((StreamRecord<Integer>) object).getValue())
+                                .boxed()
+                                .collect(Collectors.toList()))
+                .containsExactly(expectedOutput.toArray(new Integer[0]));
     }
 
     private void assertLatestReportedWatermarkEvent(long expectedWatermark) {
@@ -259,8 +255,9 @@ public class SourceOperatorAlignmentTest {
                         .filter(event -> event instanceof ReportedWatermarkEvent)
                         .collect(Collectors.toList());
 
-        assertFalse(events.isEmpty());
-        assertEquals(new ReportedWatermarkEvent(expectedWatermark), events.get(events.size() - 1));
+        assertThat(events).isNotEmpty();
+        assertThat(events.get(events.size() - 1))
+                .isEqualTo(new ReportedWatermarkEvent(expectedWatermark));
     }
 
     private static class PunctuatedGenerator implements WatermarkGenerator<Integer> {


### PR DESCRIPTION
## What is the purpose of the change

Watermark alignment will cause flink jobs to hang forever when any source subtask has no SourceSplit. You can get more background from FLINK-32414.

## Brief change log

Don't emitLatestWatermark when lastEmittedWatermark is UNINITIALIZED


## Verifying this change

This change added tests and can be verified as follows:

  - *Added SourceOperatorAlignmentTest#testWatermarkAlignmentWithoutSplit*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no