### PR TITLE
[FLINK-32264][table] Add-built-in FIELD-function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -670,6 +670,9 @@ collection:
   - sql: ARRAY_MIN(array)
     table: array.arrayMin()
     description: Returns the minimum value from the array, if array itself is null, the function returns null.
+  - sql: FIELD(value, ...)
+    table: value.field(...)
+    description: Returns the position of the given value in the list of arguments, where the position count starts from 1. If the value is not found in the list or if the value is null, the function returns 0. If the list is null or the list is empty, the function returns 0.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -238,6 +238,7 @@ advanced type helper functions
     Expression.array_min
     Expression.array_sort
     Expression.array_union
+    Expression.field
     Expression.map_entries
     Expression.map_keys
     Expression.map_values

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1609,6 +1609,15 @@ class Expression(Generic[T]):
         """
         return _unary_op("arrayMin")(self)
 
+    def field(self, *args) -> 'Expression':
+        """
+        Returns the position of the first argument within the list of the following arguments.
+        The position count starts from 1. If the value is not found in the list or the value is
+        null, the function returns 0. If the list is null or the list is empty, the function
+        returns 0.
+        """
+        return _binary_op("field")(self, *args)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -92,6 +92,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXTRACT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FIELD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FIRST_VALUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FLATTEN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.FLOOR;
@@ -1517,6 +1518,22 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayMin() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_MIN, toExpr()));
+    }
+
+    /**
+     * Returns the position of the given value in the list of arguments, where the position count
+     * starts from 1.
+     *
+     * <p>If the value is not found in the list or if the value is null, the function returns 0. If
+     * the list is null or the list is empty, the function returns 0.
+     */
+    public OutType field(InType... input) {
+        Expression[] args =
+                Stream.concat(
+                                Stream.of(toExpr()),
+                                Arrays.stream(input).map(ApiExpressionUtils::objectToExpression))
+                        .toArray(Expression[]::new);
+        return toApiSpecificExpression(unresolvedCall(FIELD, args));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.strategies.AnyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ArrayOfStringArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
 import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
@@ -407,6 +408,17 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(forceNullable(SpecificTypeStrategies.ARRAY_ELEMENT))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition FIELD =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("FIELD")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            varyingSequence(
+                                    new AnyArgumentTypeStrategy(), new AnyArgumentTypeStrategy()))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT())))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.FieldFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -54,7 +54,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayJoinTestCases(),
                         arraySliceTestCases(),
                         arrayMinTestCases(),
-                        arraySortTestCases())
+                        arraySortTestCases(),
+                        fieldTestCases())
                 .flatMap(s -> s);
     }
 
@@ -1595,5 +1596,82 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     LocalDate.of(2012, 5, 16)
                                 },
                                 DataTypes.ARRAY(DataTypes.DATE())));
+    }
+
+    private Stream<TestSetSpec> fieldTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.FIELD)
+                        .onFieldsWithData(
+                                new Integer[] {1, 2, 2, null},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                1,
+                                2.1,
+                                "3")
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.INT().notNull(),
+                                DataTypes.DOUBLE().notNull(),
+                                DataTypes.STRING().notNull())
+                        .testResult($("f0").field(), "FIELD(f0)", 0, DataTypes.INT().nullable())
+                        .testResult(
+                                $("f0").field(new Integer[] {1, 2, 2, null}, 1, 2.0, "3"),
+                                "FIELD(f0, ARRAY[1,2,2,null], 1, 2.0, '3')",
+                                1,
+                                DataTypes.INT().nullable())
+                        .testResult($("f0").field(), "FIELD(f0)", 0, DataTypes.INT())
+                        .testResult(
+                                $("f0").field((Integer) null),
+                                "FIELD(f0, null)",
+                                0,
+                                DataTypes.INT().nullable())
+                        .testResult(
+                                $("f1").field(new Integer[] {1, 2, 2, null}, 1, 2.0, "3"),
+                                "FIELD(f1, ARRAY[1,2,2,null], 1, 2.0, '3')",
+                                0,
+                                DataTypes.INT().nullable())
+                        .testResult(
+                                $("f2").field(new Integer[] {1, 2, 2, null}, 1, 2.0, "3"),
+                                "FIELD(f2, ARRAY[1,2,2,null], 1, 2.0, '3')",
+                                0,
+                                DataTypes.INT().nullable())
+                        .testResult(
+                                $("f2").field(
+                                                new Integer[] {1, 2, 2, null},
+                                                1,
+                                                2.0,
+                                                "3",
+                                                new Row[] {
+                                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                                    null
+                                                }),
+                                "FIELD(f2, ARRAY[1,2,2,null], 1, 2.0, '3', ARRAY[(TRUE, DATE '2022-4-20'), (TRUE, DATE '1990-10-14'), NULL])",
+                                5,
+                                DataTypes.INT())
+                        .testResult(
+                                $("f3").field(new Integer[] {1, 2, 2, null}, 1, 2.0, "3"),
+                                "FIELD(f3, ARRAY[1,2,2,null], 1, 2.0, '3')",
+                                2,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                $("f4").field(new Integer[] {1, 2, 2, null}, 1, 2.1, "3"),
+                                "FIELD(f4, ARRAY[1,2,2,null], 1, 2.1E0, '3')",
+                                3,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                $("f5").field(new Integer[] {1, 2, 2, null}, 1, 2.0, "3"),
+                                "FIELD(f5, ARRAY[1,2,2,null], 1, 2.0, '3')",
+                                4,
+                                DataTypes.INT().notNull())
+                        .testSqlValidationError(
+                                "FIELD()", "No match found for function signature FIELD()"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/FieldFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/FieldFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#FIELD}. */
+@Internal
+public class FieldFunction extends BuiltInScalarFunction {
+
+    private final SpecializedFunction.ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle equalityHandle;
+
+    private final List<DataType> dataTypeList;
+
+    public FieldFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.FIELD, context);
+        final List<DataType> argumentDataTypes = context.getCallContext().getArgumentDataTypes();
+        dataTypeList = ImmutableList.copyOf(argumentDataTypes);
+        final DataType dataType = context.getCallContext().getArgumentDataTypes().get(0);
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable Integer eval(Object value, Object... array) {
+        try {
+            if (value == null || array == null || array.length == 0) {
+                return 0;
+            }
+            LogicalTypeRoot dataType1 =
+                    dataTypeList.get(0).notNull().toInternal().getLogicalType().getTypeRoot();
+            if (dataType1.equals(LogicalTypeRoot.CHAR)
+                    || dataType1.equals(LogicalTypeRoot.VARBINARY)) {
+                dataType1 = LogicalTypeRoot.VARCHAR;
+            }
+            for (int i = 0; i < array.length; i++) {
+                final Object element = array[i];
+                if (element != null) {
+                    LogicalTypeRoot dataType2 =
+                            dataTypeList
+                                    .get(i + 1)
+                                    .notNull()
+                                    .toInternal()
+                                    .getLogicalType()
+                                    .getTypeRoot();
+                    if (dataType2.equals(LogicalTypeRoot.CHAR)
+                            || dataType2.equals(LogicalTypeRoot.VARBINARY)) {
+                        dataType2 = LogicalTypeRoot.VARCHAR;
+                    }
+                    if ((dataType1.equals(dataType2))
+                            && (boolean) equalityHandle.invoke(element, value)) {
+                        return i + 1;
+                    }
+                }
+            }
+            return 0;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of FIELD
The FIELD function returns the position of a value in a list of values (val...). 
The list support mixed data type.

## Brief change log
FIELD for Table API and SQL

Syntax:
`FIELD(value, val...)`

Arguments:
value: The value to find in the list.
val... : The list of values that is to be searched.

Returns:
If value is not found in the list of values (val...), the FIELD function will return 0.
If value is NULL, the FIELD function will return 0.
If list of values is NULL or EMPTY, return 0.

Examples:

```
SELECT FIELD('b', 'a', 'b', 'c', 'd', 'e', 'f');
Result: 2
SELECT FIELD(ARRAY[1, 2, 3], 1, 'b', 'c', ARRAY[1, 2, 3], 'e', 'f');
Result: 4
SELECT FIELD(15, 10, 20, 15, 40);
Result: 3
SELECT FIELD('c', 2.1, 'b');
Result: 0
SELECT FIELD('g', '');
Result: 0
SELECT FIELD(null, 'a', 2, 'c');
Result: 0
SELECT FIELD('a', null);
Result: 0
```

See also:
MySQL:https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_field

## Verifying this change
- This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
