### PR TITLE
[FLINK-32420][connectors/common] Improve the watermark aggregation performance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -38,6 +38,10 @@ import org.apache.flink.runtime.source.event.ReportedWatermarkEvent;
 import org.apache.flink.runtime.source.event.RequestSplitEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
 import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.PriorityComparator;
+import org.apache.flink.runtime.state.heap.AbstractHeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueue;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TemporaryClassLoaderContext;
@@ -46,6 +50,7 @@ import org.apache.flink.util.function.ThrowingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -53,7 +58,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -642,9 +646,47 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         }
     }
 
-    private static class WatermarkAggregator<T> {
-        private final Map<T, Watermark> watermarks = new HashMap<>();
-        private Watermark aggregatedWatermark = new Watermark(Long.MIN_VALUE);
+    /** The watermark element for {@link HeapPriorityQueue}. */
+    public static class WatermarkElement extends AbstractHeapPriorityQueueElement
+            implements PriorityComparable<WatermarkElement> {
+
+        private final Watermark watermark;
+
+        public WatermarkElement(Watermark watermark) {
+            this.watermark = watermark;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o instanceof WatermarkElement) {
+                return watermark.equals(((WatermarkElement) o).watermark);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return watermark.hashCode();
+        }
+
+        @Override
+        public int comparePriorityTo(@Nonnull WatermarkElement other) {
+            return Long.compare(watermark.getTimestamp(), other.watermark.getTimestamp());
+        }
+    }
+
+    /** The aggregated watermark is the smallest watermark of all keys. */
+    static class WatermarkAggregator<T> {
+
+        private final Map<T, WatermarkElement> watermarks = new HashMap<>();
+
+        private final HeapPriorityQueue<WatermarkElement> orderedWatermarks =
+                new HeapPriorityQueue<>(PriorityComparator.forPriorityComparableObjects(), 10);
+
+        private static final Watermark DEFAULT_WATERMARK = new Watermark(Long.MIN_VALUE);
 
         /**
          * Update the {@link Watermark} for the given {@code key)}.
@@ -653,17 +695,20 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
          *     Optional.empty()} otherwise.
          */
         public Optional<Watermark> aggregate(T key, Watermark watermark) {
-            watermarks.put(key, watermark);
-            Watermark newMinimum =
-                    watermarks.values().stream()
-                            .min(Comparator.comparingLong(Watermark::getTimestamp))
-                            .orElseThrow(IllegalStateException::new);
-            if (newMinimum.equals(aggregatedWatermark)) {
-                return Optional.empty();
-            } else {
-                aggregatedWatermark = newMinimum;
-                return Optional.of(aggregatedWatermark);
+            Watermark oldAggregatedWatermark = getAggregatedWatermark();
+
+            WatermarkElement watermarkElement = new WatermarkElement(watermark);
+            WatermarkElement oldWatermarkElement = watermarks.put(key, watermarkElement);
+            if (oldWatermarkElement != null) {
+                orderedWatermarks.remove(oldWatermarkElement);
             }
+            orderedWatermarks.add(watermarkElement);
+
+            Watermark newAggregatedWatermark = getAggregatedWatermark();
+            if (newAggregatedWatermark.equals(oldAggregatedWatermark)) {
+                return Optional.empty();
+            }
+            return Optional.of(newAggregatedWatermark);
         }
 
         public Set<T> keySet() {
@@ -671,7 +716,10 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         }
 
         public Watermark getAggregatedWatermark() {
-            return aggregatedWatermark;
+            WatermarkElement aggregatedWatermarkElement = orderedWatermarks.peek();
+            return aggregatedWatermarkElement == null
+                    ? DEFAULT_WATERMARK
+                    : aggregatedWatermarkElement.watermark;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapPriorityQueueElement.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapPriorityQueueElement.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+/** Abstract base class for {@link HeapPriorityQueueElement}. */
+public abstract class AbstractHeapPriorityQueueElement implements HeapPriorityQueueElement {
+
+    private int internalIndex;
+
+    public AbstractHeapPriorityQueueElement() {
+        this.internalIndex = HeapPriorityQueueElement.NOT_CONTAINED;
+    }
+
+    @Override
+    public int getInternalIndex() {
+        return internalIndex;
+    }
+
+    @Override
+    public void setInternalIndex(int newIndex) {
+        this.internalIndex = newIndex;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.AbstractHeapPriorityQueueElement;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.MathUtils;
 
@@ -343,17 +343,15 @@ public abstract class InternalPriorityQueueTestBase {
     protected abstract boolean testSetSemanticsAgainstDuplicateElements();
 
     /** Payload for usage in the test. */
-    protected static class TestElement
-            implements HeapPriorityQueueElement, Keyed<Long>, PriorityComparable<TestElement> {
+    protected static class TestElement extends AbstractHeapPriorityQueueElement
+            implements Keyed<Long>, PriorityComparable<TestElement> {
 
         private final long key;
         private final long priority;
-        private int internalIndex;
 
         public TestElement(long key, long priority) {
             this.key = key;
             this.priority = priority;
-            this.internalIndex = NOT_CONTAINED;
         }
 
         @Override
@@ -367,16 +365,6 @@ public abstract class InternalPriorityQueueTestBase {
 
         public long getPriority() {
             return priority;
-        }
-
-        @Override
-        public int getInternalIndex() {
-            return internalIndex;
-        }
-
-        @Override
-        public void setInternalIndex(int newIndex) {
-            internalIndex = newIndex;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.PriorityComparable;
-import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.AbstractHeapPriorityQueueElement;
 
 import org.junit.Assert;
 
@@ -38,10 +38,8 @@ import java.util.Objects;
  *
  * <p>This is implemented so that the type can also be used as keyed priority queue state.
  */
-public class TestType
-        implements HeapPriorityQueueElement, PriorityComparable<TestType>, Keyed<String> {
-
-    private int index;
+public class TestType extends AbstractHeapPriorityQueueElement
+        implements PriorityComparable<TestType>, Keyed<String> {
 
     private final int value;
     private final String key;
@@ -63,16 +61,6 @@ public class TestType
     @Override
     public int comparePriorityTo(@Nonnull TestType other) {
         return Integer.compare(value, other.value);
-    }
-
-    @Override
-    public int getInternalIndex() {
-        return index;
-    }
-
-    @Override
-    public void setInternalIndex(int newIndex) {
-        this.index = newIndex;
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.InternalPriorityQueue;
+import org.apache.flink.runtime.state.heap.AbstractHeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -56,7 +57,7 @@ import static org.apache.flink.contrib.streaming.state.RocksDBCachingPriorityQue
  * @param <E> the type of the contained elements in the queue.
  */
 public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
-        implements InternalPriorityQueue<E>, HeapPriorityQueueElement {
+        extends AbstractHeapPriorityQueueElement implements InternalPriorityQueue<E> {
 
     /** Serialized empty value to insert into RocksDB. */
     private static final byte[] DUMMY_BYTES = new byte[] {};
@@ -102,9 +103,6 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
     /** This flag is true iff all elements in RocksDB are also contained in the cache. */
     private boolean allElementsInCache;
 
-    /** Index for management as a {@link HeapPriorityQueueElement}. */
-    private int internalIndex;
-
     RocksDBCachingPriorityQueueSet(
             @Nonnegative int keyGroupId,
             @Nonnegative int keyGroupPrefixBytes,
@@ -127,7 +125,6 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
         this.allElementsInCache = false;
         this.groupPrefixBytes = createKeyGroupBytes(keyGroupId, keyGroupPrefixBytes);
         this.seekHint = groupPrefixBytes;
-        this.internalIndex = HeapPriorityQueueElement.NOT_CONTAINED;
     }
 
     @Nullable
@@ -287,16 +284,6 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
             }
             return count;
         }
-    }
-
-    @Override
-    public int getInternalIndex() {
-        return internalIndex;
-    }
-
-    @Override
-    public void setInternalIndex(int newIndex) {
-        this.internalIndex = newIndex;
     }
 
     @Nonnull


### PR DESCRIPTION
## What is the purpose of the change

Watermark aggregation performance is poor when watermark alignment is enabled and parallelism is high. I have described the issue in detail in FLINK-32420, you can get more detailed background from FLINK-32420.

## Brief change log

Based on the suggestion of @StefanRRichter  and @pnowojski .

 Improve the watermark aggregation performance, the general idea of using some ordered data structure should be still applicable here.

We could use the already existing Map watermarks just as it is. And on top of that have an ordered structure of watermarks called fooBar. Now per each aggregate invocation

- we are using watermarks map to know what was the old value for the given key
- remove the old value from fooBar
- add new watermark value to fooBar

Giving us O(n*log n). We use the `HeapPriorityQueue` as the ordered structure based on this comment: https://github.com/apache/flink/pull/22852#discussion_r1245546244


## Verifying this change

This change added tests and can be verified as follows:

  - *SourceCoordinatorAlignmentTest#testWatermarkAggregatorBenchmark*
  - *SourceCoordinatorAlignmentTest#testWatermarkAggregator*
  - *SourceCoordinatorAlignmentTest#testWatermarkAggregatorRandomly*
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
