### PR TITLE
[FLINK-32263]-table-Add-ELT-function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -670,6 +670,9 @@ collection:
   - sql: ARRAY_MIN(array)
     table: array.arrayMin()
     description: Returns the minimum value from the array, if array itself is null, the function returns null.
+  - sql: ELT(n, row)
+    table: row.elt(n)
+    description: Returns the element at the n-th position from a list of input values. If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is null, the function will return null.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -238,6 +238,7 @@ advanced type helper functions
     Expression.array_min
     Expression.array_sort
     Expression.array_union
+    Expression.elt
     Expression.map_entries
     Expression.map_keys
     Expression.map_values

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1609,6 +1609,14 @@ class Expression(Generic[T]):
         """
         return _unary_op("arrayMin")(self)
 
+    def elt(self, n) -> 'Expression':
+        """
+        Returns the element at the n-th position from a list of input values.
+        If 'n' is less than 1 or greater than the number of inputs,
+        or if any of the inputs is null, the function will return null.
+        """
+        return _binary_op("elt")(self, n)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -88,6 +88,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ELT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
@@ -1517,6 +1518,16 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayMin() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_MIN, toExpr()));
+    }
+
+    /**
+     * Returns the element at the n-th position from a list of input values.
+     *
+     * <p>If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is
+     * null, the function will return null.
+     */
+    public OutType elt(InType input) {
+        return toApiSpecificExpression(unresolvedCall(ELT, toExpr(), objectToExpression(input)));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.strategies.ArrayOfStringArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.MixedTypeOutputForRowStrategy;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
 import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -407,6 +408,17 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(forceNullable(SpecificTypeStrategies.ARRAY_ELEMENT))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ELT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ELT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeRoot.ROW), logical(LogicalTypeRoot.INTEGER)))
+                    .outputTypeStrategy(new MixedTypeOutputForRowStrategy())
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
+ */
+public class MixedTypeOutputForRowStrategy implements TypeStrategy {
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        // Obtain the index value from the first argument.
+        Optional<Integer> fieldIndex = callContext.getArgumentValue(1, Integer.class);
+        Optional<DataType> result = Optional.empty();
+        if (fieldIndex.isPresent()) {
+            // The index starts from 1 in the subsequence, so we adjust the index value by adding 1.
+            int adjustedIndex = fieldIndex.get();
+            List<DataType> children = argumentDataTypes.get(0).getChildren();
+            if (adjustedIndex > 0 && adjustedIndex <= children.size()) {
+                result = Optional.of(children.get(adjustedIndex - 1));
+            } else {
+                throw new ValidationException(
+                        "the input should not smaller than 1 and larger than " + children.size());
+            }
+        } else {
+            return Optional.of(DataTypes.INT());
+        }
+        return result.map(
+                (type) -> {
+                    return argumentDataTypes.get(1).getLogicalType().isNullable()
+                            ? (DataType) type.nullable()
+                            : type;
+                });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types.inference.strategies;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
@@ -30,6 +31,7 @@ import java.util.Optional;
 /**
  * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
  */
+@Internal
 public class MixedTypeOutputForRowStrategy implements TypeStrategy {
     @Override
     public Optional<DataType> inferType(CallContext callContext) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
+ */
+public class MixedTypeOutputStrategy implements TypeStrategy {
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        // Obtain the index value from the first argument.
+        Optional<Integer> fieldIndex = callContext.getArgumentValue(0, Integer.class);
+        Optional<DataType> result = Optional.empty();
+        if (fieldIndex.isPresent()) {
+            // The index starts from 1 in the subsequence, so we adjust the index value by adding 1.
+            int adjustedIndex = fieldIndex.get();
+            // Ensure the index is within the valid range.
+            if (adjustedIndex >= 0 && adjustedIndex < argumentDataTypes.size()) {
+                result = Optional.of(argumentDataTypes.get(adjustedIndex));
+            }
+        }
+        return result.map(
+                (type) -> {
+                    return argumentDataTypes.get(0).getLogicalType().isNullable()
+                            ? (DataType) type.nullable()
+                            : type;
+                });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types.inference.strategies;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.TypeStrategy;
@@ -28,6 +29,7 @@ import java.util.Optional;
 /**
  * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
  */
+@Internal
 public class MixedTypeOutputStrategy implements TypeStrategy {
     @Override
     public Optional<DataType> inferType(CallContext callContext) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -52,9 +52,9 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayConcatTestCases(),
                         arrayMaxTestCases(),
                         arrayJoinTestCases(),
-                        arraySliceTestCases(),
                         arrayMinTestCases(),
-                        arraySortTestCases())
+                        arraySortTestCases(),
+                        eltTestCases())
                 .flatMap(s -> s);
     }
 
@@ -1595,5 +1595,68 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     LocalDate.of(2012, 5, 16)
                                 },
                                 DataTypes.ARRAY(DataTypes.DATE())));
+    }
+
+    private Stream<TestSetSpec> eltTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ELT)
+                        .onFieldsWithData(
+                                Row.of(1, 2, "123", 56, 1.2, null, Row.of(1, 2, 3)),
+                                null,
+                                new Integer[] {1, 2, 3})
+                        .andDataTypes(
+                                DataTypes.ROW(
+                                        DataTypes.INT(),
+                                        DataTypes.INT(),
+                                        DataTypes.STRING(),
+                                        DataTypes.INT(),
+                                        DataTypes.DOUBLE(),
+                                        DataTypes.INT(),
+                                        DataTypes.ROW(
+                                                DataTypes.INT(), DataTypes.INT(), DataTypes.INT())),
+                                DataTypes.ROW(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult($("f0").elt(null), "ELT(f0, null)", null, DataTypes.INT())
+                        .testResult($("f0").elt(1), "ELT(f0, 1)", 1, DataTypes.INT())
+                        .testResult($("f1").elt(1), "ELT(f1, 1)", null, DataTypes.INT())
+                        .testResult($("f0").elt(2), "ELT(f0, 2)", 2, DataTypes.INT())
+                        .testResult($("f0").elt(3), "ELT(f0, 3)", "123", DataTypes.STRING())
+                        .testResult($("f0").elt(4), "ELT(f0, 4)", 56, DataTypes.INT())
+                        .testResult($("f0").elt(5), "ELT(f0, 5)", 1.2, DataTypes.DOUBLE())
+                        .testResult($("f0").elt(6), "ELT(f0, 6)", null, DataTypes.INT())
+                        .testResult(
+                                $("f0").elt(7),
+                                "ELT(f0, 7)",
+                                Row.of(1, 2, 3),
+                                DataTypes.ROW(DataTypes.INT(), DataTypes.INT(), DataTypes.INT()))
+                        .testSqlValidationError(
+                                "elt(f0, 0)",
+                                "the input should not smaller than 1 and larger than 7")
+                        .testTableApiValidationError(
+                                $("f0").elt(0),
+                                "the input should not smaller than 1 and larger than 7")
+                        .testSqlValidationError(
+                                "elt(f0, 8)",
+                                "the input should not smaller than 1 and larger than 7")
+                        .testTableApiValidationError(
+                                $("f0").elt(8),
+                                "the input should not smaller than 1 and larger than 7")
+                        .testSqlValidationError(
+                                "ELT(f0, true)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ELT(ROW<`f0` INT, `f1` INT, `f2` STRING, `f3` INT, `f4` DOUBLE, `f5` INT, `f6` ROW<`f0` INT, `f1` INT, `f2` INT>>, BOOLEAN NOT NULL)")
+                        .testTableApiValidationError(
+                                $("f0").elt(true),
+                                "Invalid function call:\n"
+                                        + "ELT(ROW<`f0` INT, `f1` INT, `f2` STRING, `f3` INT, `f4` DOUBLE, `f5` INT, `f6` ROW<`f0` INT, `f1` INT, `f2` INT>>, BOOLEAN NOT NULL)")
+                        .testSqlValidationError(
+                                "ELT(f0, true, 'abc')",
+                                "No match found for function signature ELT(<RecordType:peek_no_expand(INTEGER f0, INTEGER f1, VARCHAR(2147483647) f2, INTEGER f3, DOUBLE f4, INTEGER f5, RecordType:peek_no_expand(INTEGER f0, INTEGER f1, INTEGER f2) f6)>, <BOOLEAN>, <CHARACTER>)")
+                        .testSqlValidationError(
+                                "ELT(f0)",
+                                "No match found for function signature ELT(<RecordType:peek_no_expand(INTEGER f0, INTEGER f1, VARCHAR(2147483647) f2, INTEGER f3, DOUBLE f4, INTEGER f5, RecordType:peek_no_expand(INTEGER f0, INTEGER f1, INTEGER f2) f6)>)")
+                        .testSqlValidationError(
+                                "ELT()", "No match found for function signature ELT()")
+                        .testSqlValidationError("ELT(null, 'abc')", "Illegal use of 'NULL'"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ELT}. */
+@Internal
+public class EltFunction extends BuiltInScalarFunction {
+
+    private final List<DataType> copyOfDataType;
+
+    public EltFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ELT, context);
+        List<DataType> dataType = context.getCallContext().getArgumentDataTypes();
+        copyOfDataType = new ArrayList<>();
+        for (int i = 0; i < dataType.size(); ++i) {
+            copyOfDataType.add(dataType.get(i));
+        }
+    }
+
+    public @Nullable Object eval(RowData inputs, Integer n) {
+        try {
+            if (n == null || inputs == null) {
+                return null;
+            }
+            if (n < 1 || n > inputs.getArity()) {
+                return null;
+            }
+            RowData.FieldGetter fieldGetter =
+                    RowData.createFieldGetter(
+                            copyOfDataType.get(0).getChildren().get(n - 1).getLogicalType(), n - 1);
+            Object res = fieldGetter.getFieldOrNull(inputs);
+            return res;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Implement the elt function to extract the n-th input value from a row of inputs.
The elt function in the ETL pipeline extracts the value at the n-th position from a input row. It is similar to array indexing, where the first element is at position 1. This function provides a convenient way to retrieve specific elements from a row of inputs.

## Brief change log
ELT for Table API and SQL

## Verifying this change

Syntax:
`ELT(row, n)`

Arguments:
row: input row, it can contain mixed type data.
n: The index of the input value to extract. It should be a positive integer.

Returns: Returns the element at the n-th position from a row of input values. If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is null, the function will return null.

Examples:

```

SELECT ELT(('scala', 'java'), 2)
Output: 'java'

SELECT ELT((2, 'a'), 1)
Output: 2  
```

See also: 
spark:https://spark.apache.org/docs/latest/api/sql/index.html#elt

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
