### PR TITLE
[FLINK-32137] Added filtering of lambdas when building the flame graph

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.threadinfo;
+
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.ThreadInfoSample;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/** Tests for {@link VertexFlameGraphFactory}. */
+public class VertexFlameGraphFactoryTest extends TestLogger {
+    /** Tests that lambda class names are cleaned up inside the stack traces. */
+    @Test
+    public void testLambdaClassNamesCleanUp() {
+        Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samplesBySubtask = generateSamples();
+
+        VertexThreadInfoStats sample = new VertexThreadInfoStats(0, 0, 0, samplesBySubtask);
+
+        VertexFlameGraph graph = VertexFlameGraphFactory.createFullFlameGraphFrom(sample);
+        int encounteredLambdas = verifyRecursively(graph.getRoot());
+        if (encounteredLambdas == 0) {
+            fail("No lambdas encountered in the test, cleanup functionality was not tested");
+        }
+    }
+
+    private int verifyRecursively(VertexFlameGraph.Node node) {
+        String location = node.getStackTraceLocation();
+        int lambdas = 0;
+        if (location.contains("$Lambda$")) {
+            lambdas++;
+            //    com.example.ClassName.method:123
+            // -> com.example.ClassName.method
+            // -> com.example.ClassName
+            String locationWithoutLineNumber = location.substring(0, location.lastIndexOf(":"));
+            String className =
+                    locationWithoutLineNumber.substring(
+                            0, locationWithoutLineNumber.lastIndexOf("."));
+            assertThat(className).endsWith("$Lambda$0/0");
+        }
+        return lambdas + node.getChildren().stream().mapToInt(this::verifyRecursively).sum();
+    }
+
+    private Map<ExecutionAttemptID, Collection<ThreadInfoSample>> generateSamples() {
+        ThreadInfoSample sample1 = ThreadInfoSample.from(getStackTraceWithLambda()).get();
+
+        List<ThreadInfoSample> samples = new ArrayList<>();
+        samples.add(sample1);
+
+        ExecutionAttemptID executionAttemptID =
+                new ExecutionAttemptID(
+                        new ExecutionGraphID(), new ExecutionVertexID(new JobVertexID(), 0), 0);
+
+        Map<ExecutionAttemptID, Collection<ThreadInfoSample>> result = new HashMap<>();
+        result.put(executionAttemptID, samples);
+
+        return result;
+    }
+
+    private ThreadInfo getStackTraceWithLambda() {
+        Supplier<ThreadInfo> r1 =
+                () ->
+                        ManagementFactory.getThreadMXBean()
+                                .getThreadInfo(Thread.currentThread().getId(), Integer.MAX_VALUE);
+        Supplier<ThreadInfo> r2 = () -> r1.get();
+        return r2.get();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Because lambda "class names" can be different across different JVMs, the flame graph in Flink UI is often unreadable, especially with high parallelism with large number of task managers (there are 5 task managers here and therefore 5 "columns", but if the application has 50+ task managers, this becomes completely unreadable):
<img width="1337" alt="bad-1" src="https://github.com/apache/flink/assets/280456/a45ec88d-e5d6-4905-93e3-7d20f872481c">

This can happen in both Flink's internal logic which uses lambdas:
<img width="1337" alt="bad-3" src="https://github.com/apache/flink/assets/280456/b1f6ca32-989f-4715-bf5e-20c2ae782524">

and in user code:
<img width="1337" alt="bad-2" src="https://github.com/apache/flink/assets/280456/765e528a-47d1-4796-8b06-96ea7be59f3d">

The subtask view does help partially, but it is bad for understanding of the big picture, when you want to check what happens within the task as a whole.

This PR adds filtering logic to the code which collects stack traces which are subsequently used to build flame graphs. This logic modifies the stack trace elements which correspond to lambda invocations by replacing unique parts with static values, so in the final stack trace used for flame graphs these lambda calls are the same across different JVMS:
![good](https://github.com/apache/flink/assets/280456/f80ce6ae-6d3f-4f76-a75a-18e9bffd8fdf)

## Brief change log

- Added modification of stack traces to fix lambda-related entries
- Added tests for this functionality

## Verifying this change

This change added tests and can be verified as follows:

  - Manually verified the change by running a 6 node cluster with 1 JobManager and 5 TaskManagers, and captured flame graphs of a simple job with a parallel cpu-heavy map operation before and after the change. The pictures are available above.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable