### PR TITLE
[FLINK-32426][table-runtime] Fix adaptive local hash can't work when auxGrouping exist

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -146,9 +146,13 @@ object ProjectionCodeGenerator {
       outClass: Class[_ <: RowData] = classOf[BinaryRowData],
       inputTerm: String = DEFAULT_INPUT1_TERM,
       aggInfos: Array[AggregateInfo],
+      auxGrouping: Array[Int],
       outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
       outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM): String = {
     val fieldExprs: ArrayBuffer[GeneratedExpression] = ArrayBuffer()
+    // The auxGrouping also need to consider which is aggBuffer field
+    auxGrouping.foreach(i => fieldExprs += reuseFieldExprForAggFunc(ctx, inputType, inputTerm, i))
+
     aggInfos.map {
       aggInfo =>
         aggInfo.function match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -257,6 +257,7 @@ object HashAggCodeGenerator {
           classOf[BinaryRowData],
           inputTerm = inputTerm,
           aggInfos,
+          auxGrouping,
           outRecordTerm = currentValueTerm,
           outRecordWriterTerm = currentValueWriterTerm
         )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfi
 import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenerator
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
-import org.apache.flink.table.planner.runtime.utils.TestData.{data2, nullablesOfData2, type2}
+import org.apache.flink.table.planner.runtime.utils.TestData.{data1, nullablesOfData1, type1}
 import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 
 import org.junit.jupiter.api.TestTemplate
@@ -42,10 +42,10 @@ class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
   override def prepareAggOp(): Unit = {
     registerCollection(
       "AuxGroupingTable",
-      data2,
-      type2,
-      "a, b, c, d, e",
-      nullablesOfData2,
+      data1,
+      type1,
+      "a, b, c",
+      nullablesOfData1,
       FlinkStatistic.builder().uniqueKeys(Set(Set("a").asJava).asJava).build())
 
     tEnv.getConfig.set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "SortAgg")
@@ -349,11 +349,12 @@ class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
     checkResult(
       "SELECT a, b, COUNT(c) FROM AuxGroupingTable GROUP BY a, b",
       Seq(
-        row(1, 1, 1),
-        row(2, 3, 2),
-        row(3, 4, 3),
-        row(4, 10, 4),
-        row(5, 11, 5)
+        row(1, "a", 1),
+        row(2, "a", 1),
+        row(3, "b", 1),
+        row(4, "b", 1),
+        row(5, "c", 1),
+        row(6, "c", 1)
       )
     )
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/HashAggITCase.scala
@@ -21,13 +21,17 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenerator
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.TestData.{data2, nullablesOfData2, type2}
 import org.apache.flink.testutils.junit.extensions.parameterized.{Parameter, ParameterizedTestExtension, Parameters}
 
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.math.BigDecimal
+
+import scala.collection.JavaConverters._
 
 /** AggregateITCase using HashAgg Operator. */
 @ExtendWith(Array(classOf[ParameterizedTestExtension]))
@@ -36,6 +40,14 @@ class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
   @Parameter var adaptiveLocalHashAggEnable: Boolean = _
 
   override def prepareAggOp(): Unit = {
+    registerCollection(
+      "AuxGroupingTable",
+      data2,
+      type2,
+      "a, b, c, d, e",
+      nullablesOfData2,
+      FlinkStatistic.builder().uniqueKeys(Set(Set("a").asJava).asJava).build())
+
     tEnv.getConfig.set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "SortAgg")
     if (adaptiveLocalHashAggEnable) {
       tEnv.getConfig
@@ -45,7 +57,7 @@ class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
         Boolean.box(true))
       tEnv.getConfig.set(
         HashAggCodeGenerator.TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_SAMPLING_THRESHOLD,
-        Long.box(5L))
+        Long.box(3L))
     }
   }
 
@@ -328,6 +340,20 @@ class HashAggITCase extends AggregateITCaseBase("HashAggregate") {
           new BigDecimal("11111111111111111111.111111111111111111"),
           new BigDecimal("11111111111111111111.111111111111111111")
         )
+      )
+    )
+  }
+
+  @TestTemplate
+  def testAdaptiveHashAggWithAuxGrouping(): Unit = {
+    checkResult(
+      "SELECT a, b, COUNT(c) FROM AuxGroupingTable GROUP BY a, b",
+      Seq(
+        row(1, 1, 1),
+        row(2, 3, 2),
+        row(3, 4, 3),
+        row(4, 10, 4),
+        row(5, 11, 5)
       )
     )
   }


### PR DESCRIPTION
## What is the purpose of the change

*Currently, we don't consider the auxGrouping condition when generating the value projection code of adaptive local hash agg. This is a bug, so we need to fix it.*


## Brief change log

  - *Fix adaptive local hash can't work when auxGrouping exist*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in HashAggITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
