### PR TITLE
[FLINK-32385][runtime] Introduce SerializedShuffleDescriptorAndIndices to identify a group of ShuffleDescriptorAndIndex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
@@ -42,7 +42,7 @@ public class CachedShuffleDescriptors {
      * serialized unknown shuffle descriptor to this list first, and then added the real descriptor
      * later.
      */
-    private final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> serializedShuffleDescriptors;
+    private final List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors;
 
     /**
      * Stores all to be serialized shuffle descriptors, They will be serialized and added to
@@ -72,7 +72,7 @@ public class CachedShuffleDescriptors {
         }
     }
 
-    public List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> getAllSerializedShuffleDescriptors() {
+    public List<SerializedShuffleDescriptorAndIndices> getAllSerializedShuffleDescriptors() {
         // the deployment of task is not executed in jobMaster's main thread, copy this list to
         // avoid new element added to the serializedShuffleDescriptors before TDD is not serialized.
         return new ArrayList<>(serializedShuffleDescriptors);
@@ -86,7 +86,8 @@ public class CachedShuffleDescriptors {
                     shuffleDescriptorSerializer.serializeAndTryOffloadShuffleDescriptor(
                             toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]), numConsumers);
             toBeSerialized.clear();
-            serializedShuffleDescriptors.add(serializedShuffleDescriptor);
+            serializedShuffleDescriptors.add(
+                    new SerializedShuffleDescriptorAndIndices(serializedShuffleDescriptor));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -79,7 +79,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
     private transient ShuffleDescriptor[] inputChannels;
 
     /** Serialized value of shuffle descriptors. */
-    private final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> serializedInputChannels;
+    private final List<SerializedShuffleDescriptorAndIndices> serializedInputChannels;
 
     /** Number of input channels. */
     private final int numberOfInputChannels;
@@ -97,7 +97,9 @@ public class InputGateDeploymentDescriptor implements Serializable {
                 new IndexRange(consumedSubpartitionIndex, consumedSubpartitionIndex),
                 inputChannels.length,
                 Collections.singletonList(
-                        new NonOffloaded<>(CompressedSerializedValue.fromObject(inputChannels))));
+                        new SerializedShuffleDescriptorAndIndices(
+                                new NonOffloaded<>(
+                                        CompressedSerializedValue.fromObject(inputChannels)))));
     }
 
     public InputGateDeploymentDescriptor(
@@ -105,7 +107,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
             ResultPartitionType consumedPartitionType,
             IndexRange consumedSubpartitionIndexRange,
             int numberOfInputChannels,
-            List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> serializedInputChannels) {
+            List<SerializedShuffleDescriptorAndIndices> serializedInputChannels) {
         this.consumedResultId = checkNotNull(consumedResultId);
         this.consumedPartitionType = checkNotNull(consumedPartitionType);
         this.consumedSubpartitionIndexRange = checkNotNull(consumedSubpartitionIndexRange);
@@ -143,7 +145,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
             throws IOException {
         for (int i = 0; i < serializedInputChannels.size(); i++) {
             MaybeOffloaded<ShuffleDescriptorAndIndex[]> shuffleDescriptors =
-                    serializedInputChannels.get(i);
+                    serializedInputChannels.get(i).getSerializedShuffleDescriptors();
             if (shuffleDescriptors instanceof Offloaded) {
                 PermanentBlobKey blobKey =
                         ((Offloaded<ShuffleDescriptorAndIndex[]>) shuffleDescriptors)
@@ -157,7 +159,10 @@ public class InputGateDeploymentDescriptor implements Serializable {
                 // partition is no longer available or the job enters a terminal state)
                 CompressedSerializedValue<ShuffleDescriptorAndIndex[]> serializedValue =
                         CompressedSerializedValue.fromBytes(blobService.readFile(jobId, blobKey));
-                serializedInputChannels.set(i, new NonOffloaded<>(serializedValue));
+                serializedInputChannels.set(
+                        i,
+                        new SerializedShuffleDescriptorAndIndices(
+                                new NonOffloaded<>(serializedValue)));
             }
         }
     }
@@ -166,8 +171,11 @@ public class InputGateDeploymentDescriptor implements Serializable {
         try {
             if (inputChannels == null) {
                 inputChannels = new ShuffleDescriptor[numberOfInputChannels];
-                for (MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptors :
+                for (SerializedShuffleDescriptorAndIndices serializedShuffleDescriptorAndIndices :
                         serializedInputChannels) {
+                    MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptors =
+                            serializedShuffleDescriptorAndIndices.getSerializedShuffleDescriptors();
+
                     if (serializedShuffleDescriptors instanceof NonOffloaded) {
                         NonOffloaded<ShuffleDescriptorAndIndex[]> nonOffloadedSerializedValue =
                                 (NonOffloaded<ShuffleDescriptorAndIndex[]>)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndices.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+
+import java.io.Serializable;
+
+/** Wrapper of serializedShuffleDescriptors, used for {@link InputGateDeploymentDescriptor}. */
+public class SerializedShuffleDescriptorAndIndices implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** Serialized value of shuffle descriptors with index. */
+    private final MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptors;
+
+    private final SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorAndIndicesId;
+
+    public SerializedShuffleDescriptorAndIndices(
+            TaskDeploymentDescriptor.MaybeOffloaded<
+                            TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]>
+                    serializedShuffleDescriptors) {
+        this.serializedShuffleDescriptors = serializedShuffleDescriptors;
+        this.serializedShuffleDescriptorAndIndicesId =
+                new SerializedShuffleDescriptorAndIndicesID();
+    }
+
+    public MaybeOffloaded<ShuffleDescriptorAndIndex[]> getSerializedShuffleDescriptors() {
+        return serializedShuffleDescriptors;
+    }
+
+    public SerializedShuffleDescriptorAndIndicesID getSerializedShuffleDescriptorsId() {
+        return serializedShuffleDescriptorAndIndicesId;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndicesID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndicesID.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.util.AbstractID;
+
+/** Identity of {@link SerializedShuffleDescriptorAndIndices}. */
+public class SerializedShuffleDescriptorAndIndicesID extends AbstractID {
+    private static final long serialVersionUID = 1L;
+
+    public SerializedShuffleDescriptorAndIndicesID() {
+        super();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -198,12 +198,11 @@ public class TaskDeploymentDescriptorFactory {
         return inputGates;
     }
 
-    private List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>>
-            getConsumedPartitionShuffleDescriptors(
-                    IntermediateResult intermediateResult,
-                    ConsumedPartitionGroup consumedPartitionGroup,
-                    InternalExecutionGraphAccessor internalExecutionGraphAccessor)
-                    throws IOException {
+    private List<SerializedShuffleDescriptorAndIndices> getConsumedPartitionShuffleDescriptors(
+            IntermediateResult intermediateResult,
+            ConsumedPartitionGroup consumedPartitionGroup,
+            InternalExecutionGraphAccessor internalExecutionGraphAccessor)
+            throws IOException {
         CachedShuffleDescriptors cachedShuffleDescriptors =
                 intermediateResult.getCachedShuffleDescriptors(consumedPartitionGroup);
         if (cachedShuffleDescriptors == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -290,10 +290,12 @@ public class IntermediateResult {
             cache.getAllSerializedShuffleDescriptors()
                     .forEach(
                             shuffleDescriptors -> {
-                                if (shuffleDescriptors instanceof Offloaded) {
+                                if (shuffleDescriptors.getSerializedShuffleDescriptors()
+                                        instanceof Offloaded) {
                                     PermanentBlobKey blobKey =
                                             ((Offloaded<ShuffleDescriptorAndIndex[]>)
-                                                            shuffleDescriptors)
+                                                            shuffleDescriptors
+                                                                    .getSerializedShuffleDescriptors())
                                                     .serializedValueKey;
                                     this.producer
                                             .getGraph()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
@@ -88,7 +88,10 @@ class CachedShuffleDescriptorsTest {
                 new TestingShuffleDescriptorSerializer());
         assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(1);
         MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloadedShuffleDescriptor =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(0);
+                cachedShuffleDescriptors
+                        .getAllSerializedShuffleDescriptors()
+                        .get(0)
+                        .getSerializedShuffleDescriptors();
         assertNonOffloadedShuffleDescriptorAndIndexEquals(
                 maybeOffloadedShuffleDescriptor,
                 Collections.singletonList(shuffleDescriptor),
@@ -132,7 +135,10 @@ class CachedShuffleDescriptorsTest {
         assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(2);
 
         MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloaded =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(1);
+                cachedShuffleDescriptors
+                        .getAllSerializedShuffleDescriptors()
+                        .get(1)
+                        .getSerializedShuffleDescriptors();
         ShuffleDescriptor expectedShuffleDescriptor1 =
                 TaskDeploymentDescriptorFactory.getConsumedPartitionShuffleDescriptor(
                         intermediateResultPartition1,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -102,13 +100,13 @@ class TaskDeploymentDescriptorFactoryTest {
 
         // The ShuffleDescriptors should be cached
         final IntermediateResult consumedResult = executionJobVertices.f1.getInputs().get(0);
-        final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        final List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev21.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
 
         final ShuffleDescriptor[] cachedShuffleDescriptors =
-                deserializeShuffleDescriptors(maybeOffloaded, jobId, blobWriter);
+                deserializeShuffleDescriptors(serializedShuffleDescriptors, jobId, blobWriter);
 
         // Check if the ShuffleDescriptors are cached correctly
         assertThat(ev21.getConsumedPartitionGroup(0)).hasSize(cachedShuffleDescriptors.length);
@@ -139,22 +137,22 @@ class TaskDeploymentDescriptorFactoryTest {
         final ExecutionVertex ev22 = ejv2.getTaskVertices()[1];
         createTaskDeploymentDescriptor(ev22);
         IntermediateResult consumedResult = ejv2.getInputs().get(0);
-        List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev22.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(2);
+        assertThat(serializedShuffleDescriptors).hasSize(2);
 
         final ExecutionVertex ev13 = ejv1.getTaskVertices()[2];
         ev13.finishPartitionsIfNeeded();
         final ExecutionVertex ev23 = ejv2.getTaskVertices()[2];
         createTaskDeploymentDescriptor(ev23);
         consumedResult = ejv2.getInputs().get(0);
-        maybeOffloaded =
+        serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev23.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(3);
+        assertThat(serializedShuffleDescriptors).hasSize(3);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
@@ -38,13 +38,16 @@ import java.util.Map;
 public class TaskDeploymentDescriptorTestUtils {
 
     public static ShuffleDescriptor[] deserializeShuffleDescriptors(
-            List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded,
+            List<SerializedShuffleDescriptorAndIndices> allSerializedShuffleDescriptors,
             JobID jobId,
             TestingBlobWriter blobWriter)
             throws IOException, ClassNotFoundException {
         Map<Integer, ShuffleDescriptor> shuffleDescriptorsMap = new HashMap<>();
         int maxIndex = 0;
-        for (MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd : maybeOffloaded) {
+        for (SerializedShuffleDescriptorAndIndices serializedShuffleDescriptors :
+                allSerializedShuffleDescriptors) {
+            MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd =
+                    serializedShuffleDescriptors.getSerializedShuffleDescriptors();
             ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices;
             if (sd instanceof NonOffloaded) {
                 shuffleDescriptorAndIndices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndices;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -1322,8 +1323,10 @@ public class SingleInputGateTest extends InputGateTestBase {
                         subpartitionIndexRange,
                         channelDescs.length,
                         Collections.singletonList(
-                                new TaskDeploymentDescriptor.NonOffloaded<>(
-                                        CompressedSerializedValue.fromObject(channelDescs))));
+                                new SerializedShuffleDescriptorAndIndices(
+                                        new TaskDeploymentDescriptor.NonOffloaded<>(
+                                                CompressedSerializedValue.fromObject(
+                                                        channelDescs)))));
 
         final TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();


### PR DESCRIPTION
## What is the purpose of the change
refer to https://issues.apache.org/jira/browse/FLINK-32385

Introduce SerializedShuffleDescriptorAndIndices to identify a group of ShuffleDescriptorAndIndex, we will cache this group of ShuffleDescriptorAndIndex in TaskExecutor

## Brief change log
  - *Introduce SerializedShuffleDescriptorAndIndices to identify a group of ShuffleDescriptorAndIndex*

## Verifying this change
This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector:(no)

## Documentation

  - Does this pull request introduce a new feature? (no)
