### PR TITLE
[FLINK-32386][runtime] Introduce ShuffleDescriptorsCache to cache ShuffleDescriptorAndIndex

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -717,6 +717,18 @@ public class JobManagerOptions {
                                                             code(UNFINISHED_PRODUCERS.name())))
                                             .build());
 
+    @Documentation.ExcludeFromDocumentation(
+            "this is an expert option, that we do not want to expose in the documentation")
+    public static final ConfigOption<Integer> OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD =
+            key("jobmanager.deployment.offload-shuffle-descriptors-threshold")
+                    .intType()
+                    .defaultValue(10_000 * 10_000)
+                    .withDescription(
+                            "The threshold to force enable offload shuffle descriptors via blob server."
+                                    + " This is a fixed value since it is difficult for users to configure."
+                                    + " This default value means JobManager need to serialized and transport"
+                                    + " 10000 shuffle descriptors(almost 200KB) to 10000 consumer(2GB in total)");
+
     // ---------------------------------------------------------------------------------------------
 
     private JobManagerOptions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
@@ -43,7 +43,7 @@ public class CachedShuffleDescriptors {
      * serialized unknown shuffle descriptor to this list first, and then added the real descriptor
      * later.
      */
-    private final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> serializedShuffleDescriptors;
+    private final List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors;
 
     /**
      * Stores all to be serialized shuffle descriptors, They will be serialized and added to
@@ -73,7 +73,7 @@ public class CachedShuffleDescriptors {
         }
     }
 
-    public List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> getAllSerializedShuffleDescriptors() {
+    public List<SerializedShuffleDescriptorAndIndices> getAllSerializedShuffleDescriptors() {
         // the deployment of task is not executed in jobMaster's main thread, copy this list to
         // avoid new element added to the serializedShuffleDescriptors before TDD is not serialized.
         return new ArrayList<>(serializedShuffleDescriptors);
@@ -92,7 +92,8 @@ public class CachedShuffleDescriptors {
                     shuffleDescriptorSerializer.apply(
                             toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]), numConsumers);
             toBeSerialized.clear();
-            serializedShuffleDescriptors.add(serializedShuffleDescriptor);
+            serializedShuffleDescriptors.add(
+                    new SerializedShuffleDescriptorAndIndices(serializedShuffleDescriptor));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndices.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+
+/** Wrapper of serializedShuffleDescriptors, used for {@link InputGateDeploymentDescriptor}. */
+public class SerializedShuffleDescriptorAndIndices {
+    /** Serialized value of shuffle descriptors with index. */
+    private final MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializedShuffleDescriptors;
+
+    private final SerializedShuffleDescriptorAndIndicesID
+            serializedShuffleDescriptorAndIndicesId;
+
+    public SerializedShuffleDescriptorAndIndices(
+            TaskDeploymentDescriptor.MaybeOffloaded<
+                            TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]>
+                    serializedShuffleDescriptors) {
+        this.serializedShuffleDescriptors = serializedShuffleDescriptors;
+        this.serializedShuffleDescriptorAndIndicesId =
+                new SerializedShuffleDescriptorAndIndicesID();
+    }
+
+    public MaybeOffloaded<ShuffleDescriptorAndIndex[]> getSerializedShuffleDescriptors() {
+        return serializedShuffleDescriptors;
+    }
+
+    public SerializedShuffleDescriptorAndIndicesID getSerializedShuffleDescriptorsId() {
+        return serializedShuffleDescriptorAndIndicesId;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndicesID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/SerializedShuffleDescriptorAndIndicesID.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.util.AbstractID;
+
+/** Identity of {@link SerializedShuffleDescriptorAndIndices}. */
+public class SerializedShuffleDescriptorAndIndicesID extends AbstractID {
+    public SerializedShuffleDescriptorAndIndicesID() {
+        super();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -179,7 +179,7 @@ public class TaskDeploymentDescriptorFactory {
         return inputGates;
     }
 
-    private List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>>
+    private List<SerializedShuffleDescriptorAndIndices>
             getConsumedPartitionShuffleDescriptors(
                     IntermediateResult intermediateResult,
                     ConsumedPartitionGroup consumedPartitionGroup,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -118,6 +118,9 @@ public class DefaultExecutionGraphBuilder {
                 PartitionGroupReleaseStrategyFactoryLoader.loadPartitionGroupReleaseStrategyFactory(
                         jobManagerConfig);
 
+        final int offloadShuffleDescriptorsThreshold =
+                jobManagerConfig.get(JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD);
+
         final TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory;
         try {
             taskDeploymentDescriptorFactory =
@@ -126,7 +129,8 @@ public class DefaultExecutionGraphBuilder {
                             jobId,
                             partitionLocationConstraint,
                             blobWriter,
-                            nonFinishedHybridPartitionShouldBeUnknown);
+                            nonFinishedHybridPartitionShouldBeUnknown,
+                            offloadShuffleDescriptorsThreshold);
         } catch (IOException e) {
             throw new JobException("Could not create the TaskDeploymentDescriptorFactory.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -290,10 +290,12 @@ public class IntermediateResult {
             cache.getAllSerializedShuffleDescriptors()
                     .forEach(
                             shuffleDescriptors -> {
-                                if (shuffleDescriptors instanceof Offloaded) {
+                                if (shuffleDescriptors.getSerializedShuffleDescriptors()
+                                        instanceof Offloaded) {
                                     PermanentBlobKey blobKey =
                                             ((Offloaded<ShuffleDescriptorAndIndex[]>)
-                                                            shuffleDescriptors)
+                                                            shuffleDescriptors
+                                                                    .getSerializedShuffleDescriptors())
                                                     .serializedValueKey;
                                     this.producer
                                             .getGraph()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCache.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndicesID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/** Default implement of {@link ShuffleDescriptorsCache}. Entries will be expired after timeout. */
+public class DefaultShuffleDescriptorsCache implements ShuffleDescriptorsCache {
+    private final Clock clock;
+
+    private final Map<SerializedShuffleDescriptorAndIndicesID, ShuffleDescriptorCacheEntry> caches;
+    private final Map<JobID, Set<SerializedShuffleDescriptorAndIndicesID>>
+            serializedShuffleDescriptorsPerJob;
+    private final Duration idleTimeout;
+    private final int cachedShuffleDescriptorLimit;
+
+    private int totalCachedShuffleDescriptorNumber;
+    private boolean started;
+    private ComponentMainThreadExecutor mainThreadExecutor;
+
+    public DefaultShuffleDescriptorsCache(Duration idleTimeout, int cachedShuffleDescriptorLimit) {
+        this(idleTimeout, cachedShuffleDescriptorLimit, SystemClock.getInstance());
+    }
+
+    @VisibleForTesting
+    public DefaultShuffleDescriptorsCache(
+            Duration idleTimeout, int cachedShuffleDescriptorLimit, Clock clock) {
+        this.clock = clock;
+        this.idleTimeout = idleTimeout;
+        this.cachedShuffleDescriptorLimit = cachedShuffleDescriptorLimit;
+        this.caches = new LinkedHashMap<>(16, 0.75F, true);
+        this.serializedShuffleDescriptorsPerJob = new HashMap<>();
+    }
+
+    @Override
+    public void start(ComponentMainThreadExecutor mainThreadExecutor) {
+        this.started = true;
+        this.mainThreadExecutor = mainThreadExecutor;
+        mainThreadExecutor.schedule(
+                this::removeIdleEntry, this.idleTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() {
+        started = false;
+        mainThreadExecutor = null;
+        serializedShuffleDescriptorsPerJob.clear();
+        caches.clear();
+    }
+
+    @Override
+    public ShuffleDescriptorCacheEntry get(
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId) {
+        ShuffleDescriptorCacheEntry entry = caches.remove(serializedShuffleDescriptorsId);
+
+        if (entry != null) {
+            entry.updateIdleSince(clock.absoluteTimeMillis());
+            caches.put(serializedShuffleDescriptorsId, entry);
+        }
+        return entry;
+    }
+
+    @Override
+    public void put(
+            JobID jobId,
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId,
+            TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                    shuffleDescriptorAndIndices) {
+        removeIfOverLimit(shuffleDescriptorAndIndices.length);
+        caches.put(
+                serializedShuffleDescriptorsId,
+                new ShuffleDescriptorCacheEntry(
+                        shuffleDescriptorAndIndices, jobId, clock.absoluteTimeMillis()));
+        serializedShuffleDescriptorsPerJob
+                .computeIfAbsent(jobId, ignore -> new HashSet<>())
+                .add(serializedShuffleDescriptorsId);
+        totalCachedShuffleDescriptorNumber += shuffleDescriptorAndIndices.length;
+    }
+
+    public void clearCacheOfJob(JobID jobId) {
+        Set<SerializedShuffleDescriptorAndIndicesID> removed =
+                serializedShuffleDescriptorsPerJob.remove(jobId);
+        if (removed != null) {
+            removed.forEach(
+                    id -> {
+                        ShuffleDescriptorCacheEntry entry = caches.remove(id);
+                        if (entry != null) {
+                            totalCachedShuffleDescriptorNumber -=
+                                    entry.getShuffleDescriptorAndIndices().length;
+                        }
+                    });
+        }
+    }
+
+    private void removeIfOverLimit(int newSize) {
+        Iterator<Map.Entry<SerializedShuffleDescriptorAndIndicesID, ShuffleDescriptorCacheEntry>>
+                iterator = caches.entrySet().iterator();
+        while (iterator.hasNext()
+                && totalCachedShuffleDescriptorNumber + newSize > cachedShuffleDescriptorLimit) {
+            Map.Entry<SerializedShuffleDescriptorAndIndicesID, ShuffleDescriptorCacheEntry> next =
+                    iterator.next();
+            iterator.remove();
+            JobID jobId = next.getValue().getJobId();
+            serializedShuffleDescriptorsPerJob.get(jobId).remove(next.getKey());
+            if (serializedShuffleDescriptorsPerJob.get(jobId).isEmpty()) {
+                serializedShuffleDescriptorsPerJob.remove(jobId);
+            }
+            totalCachedShuffleDescriptorNumber -=
+                    next.getValue().getShuffleDescriptorAndIndices().length;
+        }
+    }
+
+    private void removeIdleEntry() {
+        if (!started || mainThreadExecutor == null) {
+            return;
+        }
+
+        long currentTs = clock.absoluteTimeMillis();
+        // delete elements and remove job
+        Iterator<Map.Entry<SerializedShuffleDescriptorAndIndicesID, ShuffleDescriptorCacheEntry>>
+                iterator = caches.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<SerializedShuffleDescriptorAndIndicesID, ShuffleDescriptorCacheEntry> next =
+                    iterator.next();
+            ShuffleDescriptorCacheEntry entry = next.getValue();
+            if (currentTs - entry.getIdleSince() > idleTimeout.toMillis()) {
+                iterator.remove();
+                totalCachedShuffleDescriptorNumber -= entry.getShuffleDescriptorAndIndices().length;
+
+                JobID jobId = entry.getJobId();
+                serializedShuffleDescriptorsPerJob.get(jobId).remove(next.getKey());
+                if (serializedShuffleDescriptorsPerJob.get(jobId).isEmpty()) {
+                    serializedShuffleDescriptorsPerJob.remove(jobId);
+                }
+            } else {
+                break;
+            }
+        }
+
+        mainThreadExecutor.schedule(
+                this::removeIdleEntry, idleTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ShuffleDescriptorsCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ShuffleDescriptorsCache.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndicesID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
+
+/** Cache of shuffle descriptors in TaskExecutor. */
+public interface ShuffleDescriptorsCache {
+    /**
+     * Start cache manager.
+     *
+     * @param mainThreadExecutor of main thread executor.
+     */
+    void start(ComponentMainThreadExecutor mainThreadExecutor);
+
+    /** Stop cache manager. */
+    void stop();
+
+    /**
+     * Get shuffle descriptors entry in cache.
+     *
+     * @param serializedShuffleDescriptorsId of cached serialized shuffle descriptors
+     * @return cache shuffle descriptors entry in cache if exists, otherwise null
+     */
+    ShuffleDescriptorCacheEntry get(
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId);
+
+    /**
+     * Put cache shuffle descriptors to cache.
+     *
+     * @param jobId of job
+     * @param serializedShuffleDescriptorsId of cached serialized shuffle descriptors
+     * @param shuffleDescriptorAndIndices of cached serialized shuffle descriptors
+     */
+    void put(
+            JobID jobId,
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId,
+            TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                    shuffleDescriptorAndIndices);
+
+    /**
+     * Clear all cache of Job.
+     *
+     * @param jobId of job
+     */
+    void clearCacheOfJob(JobID jobId);
+
+    /** Cached shuffle descriptors information. */
+    class ShuffleDescriptorCacheEntry {
+        private final TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                shuffleDescriptorAndIndices;
+        private final JobID jobId;
+        private long idleSince;
+
+        public ShuffleDescriptorCacheEntry(
+                TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                        shuffleDescriptorAndIndices,
+                JobID jobId,
+                long idleSince) {
+            this.shuffleDescriptorAndIndices = shuffleDescriptorAndIndices;
+            this.jobId = jobId;
+            this.idleSince = idleSince;
+        }
+
+        public void updateIdleSince(long idleSince) {
+            this.idleSince = idleSince;
+        }
+
+        public TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                getShuffleDescriptorAndIndices() {
+            return shuffleDescriptorAndIndices;
+        }
+
+        public JobID getJobId() {
+            return jobId;
+        }
+
+        public long getIdleSince() {
+            return idleSince;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
@@ -88,7 +88,10 @@ class CachedShuffleDescriptorsTest {
                 CachedShuffleDescriptorsTest::nonOffloadedShuffleDescriptor);
         assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(1);
         MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloadedShuffleDescriptor =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(0);
+                cachedShuffleDescriptors
+                        .getAllSerializedShuffleDescriptors()
+                        .get(0)
+                        .getSerializedShuffleDescriptors();
         assertNonOffloadedShuffleDescriptorAndIndexEquals(
                 maybeOffloadedShuffleDescriptor,
                 Collections.singletonList(shuffleDescriptor),
@@ -132,7 +135,10 @@ class CachedShuffleDescriptorsTest {
         assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(2);
 
         MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloaded =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(1);
+                cachedShuffleDescriptors
+                        .getAllSerializedShuffleDescriptors()
+                        .get(1)
+                        .getSerializedShuffleDescriptors();
         ShuffleDescriptor expectedShuffleDescriptor1 =
                 TaskDeploymentDescriptorFactory.getConsumedPartitionShuffleDescriptor(
                         intermediateResultPartition1,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
@@ -150,7 +150,7 @@ class CachedShuffleDescriptorsTest {
     }
 
     private static MaybeOffloaded<ShuffleDescriptorAndIndex[]> nonOffloadedShuffleDescriptor(
-            ShuffleDescriptorAndIndex[] toBeSerialized) throws IOException {
+            ShuffleDescriptorAndIndex[] toBeSerialized, int numConsumer) throws IOException {
         return new NonOffloaded<>(CompressedSerializedValue.fromObject(toBeSerialized));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -101,13 +99,13 @@ class TaskDeploymentDescriptorFactoryTest {
 
         // The ShuffleDescriptors should be cached
         final IntermediateResult consumedResult = executionJobVertices.f1.getInputs().get(0);
-        final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        final List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev21.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
 
         final ShuffleDescriptor[] cachedShuffleDescriptors =
-                deserializeShuffleDescriptors(maybeOffloaded, jobId, blobWriter);
+                deserializeShuffleDescriptors(serializedShuffleDescriptors, jobId, blobWriter);
 
         // Check if the ShuffleDescriptors are cached correctly
         assertThat(ev21.getConsumedPartitionGroup(0)).hasSize(cachedShuffleDescriptors.length);
@@ -138,22 +136,22 @@ class TaskDeploymentDescriptorFactoryTest {
         final ExecutionVertex ev22 = ejv2.getTaskVertices()[1];
         createTaskDeploymentDescriptor(ev22);
         IntermediateResult consumedResult = ejv2.getInputs().get(0);
-        List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        List<SerializedShuffleDescriptorAndIndices> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev22.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(2);
+        assertThat(serializedShuffleDescriptors).hasSize(2);
 
         final ExecutionVertex ev13 = ejv1.getTaskVertices()[2];
         ev13.finishPartitionsIfNeeded();
         final ExecutionVertex ev23 = ejv2.getTaskVertices()[2];
         createTaskDeploymentDescriptor(ev23);
         consumedResult = ejv2.getInputs().get(0);
-        maybeOffloaded =
+        serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev23.getConsumedPartitionGroup(0))
                         .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(3);
+        assertThat(serializedShuffleDescriptors).hasSize(3);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.deployment;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.TestingBlobWriter;
@@ -74,19 +76,25 @@ class TaskDeploymentDescriptorFactoryTest {
 
     @Test
     void testCacheShuffleDescriptorAsNonOffloaded() throws Exception {
-        testCacheShuffleDescriptor(new TestingBlobWriter(Integer.MAX_VALUE));
+        final Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(
+                JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD, Integer.MAX_VALUE);
+        testCacheShuffleDescriptor(jobMasterConfig);
     }
 
     @Test
     void testCacheShuffleDescriptorAsOffloaded() throws Exception {
-        testCacheShuffleDescriptor(new TestingBlobWriter(0));
+        final Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD, 0);
+        testCacheShuffleDescriptor(jobMasterConfig);
     }
 
-    private void testCacheShuffleDescriptor(TestingBlobWriter blobWriter) throws Exception {
+    private void testCacheShuffleDescriptor(Configuration jobMasterConfig) throws Exception {
         final JobID jobId = new JobID();
+        final TestingBlobWriter blobWriter = new TestingBlobWriter();
 
         final Tuple2<ExecutionJobVertex, ExecutionJobVertex> executionJobVertices =
-                setupExecutionGraphAndGetVertices(jobId, blobWriter);
+                setupExecutionGraphAndGetVertices(jobId, blobWriter, jobMasterConfig);
 
         final ExecutionVertex ev21 = executionJobVertices.f1.getTaskVertices()[0];
         createTaskDeploymentDescriptor(ev21);
@@ -153,9 +161,11 @@ class TaskDeploymentDescriptorFactoryTest {
         final TestingBlobWriter blobWriter = new TestingBlobWriter(0);
 
         final JobID jobId = new JobID();
+        final Configuration jobMasterConfig = new Configuration();
+        jobMasterConfig.set(JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD, 0);
 
         final Tuple2<ExecutionJobVertex, ExecutionJobVertex> executionJobVertices =
-                setupExecutionGraphAndGetVertices(jobId, blobWriter);
+                setupExecutionGraphAndGetVertices(jobId, blobWriter, jobMasterConfig);
 
         final ExecutionVertex ev21 = executionJobVertices.f1.getTaskVertices()[0];
         final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(ev21);
@@ -166,19 +176,21 @@ class TaskDeploymentDescriptorFactoryTest {
     }
 
     private Tuple2<ExecutionJobVertex, ExecutionJobVertex> setupExecutionGraphAndGetVertices(
-            JobID jobId, BlobWriter blobWriter) throws Exception {
+            JobID jobId, BlobWriter blobWriter, Configuration jobMasterConfig) throws Exception {
         return setupExecutionGraphAndGetVertices(
                 jobId,
                 blobWriter,
                 ResultPartitionType.BLOCKING,
-                ResultPartitionType::isBlockingOrBlockingPersistentResultPartition);
+                ResultPartitionType::isBlockingOrBlockingPersistentResultPartition,
+                jobMasterConfig);
     }
 
     private Tuple2<ExecutionJobVertex, ExecutionJobVertex> setupExecutionGraphAndGetVertices(
             JobID jobId,
             BlobWriter blobWriter,
             ResultPartitionType resultPartitionType,
-            MarkPartitionFinishedStrategy markPartitionFinishedStrategy)
+            MarkPartitionFinishedStrategy markPartitionFinishedStrategy,
+            Configuration jobMasterConfig)
             throws Exception {
         final JobVertex v1 = createJobVertex("v1", PARALLELISM);
         final JobVertex v2 = createJobVertex("v2", PARALLELISM);
@@ -188,7 +200,8 @@ class TaskDeploymentDescriptorFactoryTest {
         final List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
 
         final ExecutionGraph executionGraph =
-                createExecutionGraph(jobId, ordered, blobWriter, markPartitionFinishedStrategy);
+                createExecutionGraph(
+                        jobId, ordered, blobWriter, markPartitionFinishedStrategy, jobMasterConfig);
 
         return Tuple2.of(
                 executionGraph.getJobVertex(v1.getID()), executionGraph.getJobVertex(v2.getID()));
@@ -229,7 +242,8 @@ class TaskDeploymentDescriptorFactoryTest {
             final JobID jobId,
             final List<JobVertex> jobVertices,
             final BlobWriter blobWriter,
-            final MarkPartitionFinishedStrategy markPartitionFinishedStrategy)
+            final MarkPartitionFinishedStrategy markPartitionFinishedStrategy,
+            final Configuration jobMasterConfig)
             throws JobException, JobExecutionException {
 
         final JobGraph jobGraph =
@@ -239,6 +253,7 @@ class TaskDeploymentDescriptorFactoryTest {
                         .build();
 
         return TestingDefaultExecutionGraphBuilder.newBuilder()
+                .setJobMasterConfig(jobMasterConfig)
                 .setJobGraph(jobGraph)
                 .setBlobWriter(blobWriter)
                 .setMarkPartitionFinishedStrategy(markPartitionFinishedStrategy)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -33,9 +33,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.util.SerializedValue;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -45,14 +44,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link TaskDeploymentDescriptor}. */
-public class TaskDeploymentDescriptorTest extends TestLogger {
+class TaskDeploymentDescriptorTest {
 
     private static final JobID jobID = new JobID();
     private static final JobVertexID vertexID = new JobVertexID();
@@ -96,10 +92,10 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
                             invokableClass.getName(),
                             taskConfiguration));
 
-    public TaskDeploymentDescriptorTest() throws IOException {}
+    TaskDeploymentDescriptorTest() throws IOException {}
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final TaskDeploymentDescriptor orig =
                 createTaskDeploymentDescriptor(
                         new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
@@ -108,31 +104,33 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 
         final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 
-        assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
-        assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
-        assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
-        assertFalse(orig.getTaskRestore() == copy.getTaskRestore());
-        assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
-        assertFalse(orig.getInputGates() == copy.getInputGates());
+        assertThat(orig.getSerializedJobInformation())
+                .isNotSameAs(copy.getSerializedJobInformation());
+        assertThat(orig.getSerializedTaskInformation())
+                .isNotSameAs(copy.getSerializedTaskInformation());
+        assertThat(orig.getExecutionAttemptId()).isNotSameAs(copy.getExecutionAttemptId());
+        assertThat(orig.getTaskRestore()).isNotSameAs(copy.getTaskRestore());
+        assertThat(orig.getProducedPartitions()).isNotSameAs(copy.getProducedPartitions());
+        assertThat(orig.getInputGates()).isNotSameAs(copy.getInputGates());
 
-        assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
-        assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
-        assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
-        assertEquals(orig.getAllocationId(), copy.getAllocationId());
-        assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
-        assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
-        assertEquals(
-                orig.getTaskRestore().getRestoreCheckpointId(),
-                copy.getTaskRestore().getRestoreCheckpointId());
-        assertEquals(
-                orig.getTaskRestore().getTaskStateSnapshot(),
-                copy.getTaskRestore().getTaskStateSnapshot());
-        assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
-        assertEquals(orig.getInputGates(), copy.getInputGates());
+        assertThat(orig.getSerializedJobInformation())
+                .isEqualTo(copy.getSerializedJobInformation());
+        assertThat(orig.getSerializedTaskInformation())
+                .isEqualTo(copy.getSerializedTaskInformation());
+        assertThat(orig.getExecutionAttemptId()).isEqualTo(copy.getExecutionAttemptId());
+        assertThat(orig.getAllocationId()).isEqualTo(copy.getAllocationId());
+        assertThat(orig.getSubtaskIndex()).isEqualTo(copy.getSubtaskIndex());
+        assertThat(orig.getAttemptNumber()).isEqualTo(copy.getAttemptNumber());
+        assertThat(orig.getTaskRestore().getRestoreCheckpointId())
+                .isEqualTo(copy.getTaskRestore().getRestoreCheckpointId());
+        assertThat(orig.getTaskRestore().getTaskStateSnapshot())
+                .isEqualTo(copy.getTaskRestore().getTaskStateSnapshot());
+        assertThat(orig.getProducedPartitions()).isEqualTo(copy.getProducedPartitions());
+        assertThat(orig.getInputGates()).isEqualTo(copy.getInputGates());
     }
 
     @Test
-    public void testOffLoadedAndNonOffLoadedPayload() {
+    void testOffLoadedAndNonOffLoadedPayload() {
         final TaskDeploymentDescriptor taskDeploymentDescriptor =
                 createTaskDeploymentDescriptor(
                         new TaskDeploymentDescriptor.NonOffloaded<>(serializedJobInformation),
@@ -140,14 +138,10 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
 
         SerializedValue<JobInformation> actualSerializedJobInformation =
                 taskDeploymentDescriptor.getSerializedJobInformation();
-        assertThat(actualSerializedJobInformation, is(serializedJobInformation));
+        assertThat(actualSerializedJobInformation).isSameAs(serializedJobInformation);
 
-        try {
-            taskDeploymentDescriptor.getSerializedTaskInformation();
-            fail("Expected to fail since the task information should be offloaded.");
-        } catch (IllegalStateException expected) {
-            // expected
-        }
+        assertThatThrownBy(taskDeploymentDescriptor::getSerializedTaskInformation)
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Nonnull

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.TestingBlobWriter;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.util.CompressedSerializedValue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A collection of utility methods for testing the TaskDeploymentDescriptor and its related classes.
+ */
+public class TaskDeploymentDescriptorTestUtils {
+
+    public static ShuffleDescriptor[] deserializeShuffleDescriptors(
+            List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded,
+            JobID jobId,
+            TestingBlobWriter blobWriter)
+            throws IOException, ClassNotFoundException {
+        Map<Integer, ShuffleDescriptor> shuffleDescriptorsMap = new HashMap<>();
+        int maxIndex = 0;
+        for (MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd : maybeOffloaded) {
+            ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices;
+            if (sd instanceof NonOffloaded) {
+                shuffleDescriptorAndIndices =
+                        ((NonOffloaded<ShuffleDescriptorAndIndex[]>) sd)
+                                .serializedValue.deserializeValue(
+                                        ClassLoader.getSystemClassLoader());
+
+            } else {
+                final CompressedSerializedValue<ShuffleDescriptorAndIndex[]>
+                        compressedSerializedValue =
+                                CompressedSerializedValue.fromBytes(
+                                        blobWriter.getBlob(
+                                                jobId,
+                                                ((Offloaded<ShuffleDescriptorAndIndex[]>) sd)
+                                                        .serializedValueKey));
+                shuffleDescriptorAndIndices =
+                        compressedSerializedValue.deserializeValue(
+                                ClassLoader.getSystemClassLoader());
+            }
+            for (ShuffleDescriptorAndIndex shuffleDescriptorAndIndex :
+                    shuffleDescriptorAndIndices) {
+                int index = shuffleDescriptorAndIndex.getIndex();
+                maxIndex = Math.max(maxIndex, shuffleDescriptorAndIndex.getIndex());
+                shuffleDescriptorsMap.put(index, shuffleDescriptorAndIndex.getShuffleDescriptor());
+            }
+        }
+        ShuffleDescriptor[] shuffleDescriptors = new ShuffleDescriptor[maxIndex + 1];
+        shuffleDescriptorsMap.forEach((key, value) -> shuffleDescriptors[key] = value);
+        return shuffleDescriptors;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
@@ -38,13 +38,16 @@ import java.util.Map;
 public class TaskDeploymentDescriptorTestUtils {
 
     public static ShuffleDescriptor[] deserializeShuffleDescriptors(
-            List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded,
+            List<SerializedShuffleDescriptorAndIndices> allSerializedShuffleDescriptors,
             JobID jobId,
             TestingBlobWriter blobWriter)
             throws IOException, ClassNotFoundException {
         Map<Integer, ShuffleDescriptor> shuffleDescriptorsMap = new HashMap<>();
         int maxIndex = 0;
-        for (MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd : maybeOffloaded) {
+        for (SerializedShuffleDescriptorAndIndices serializedShuffleDescriptors :
+                allSerializedShuffleDescriptors) {
+            MaybeOffloaded<ShuffleDescriptorAndIndex[]> sd =
+                    serializedShuffleDescriptors.getSerializedShuffleDescriptors();
             ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices;
             if (sd instanceof NonOffloaded) {
                 shuffleDescriptorAndIndices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/BlockingResultPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/BlockingResultPartitionReleaseTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -106,7 +107,8 @@ class BlockingResultPartitionReleaseTest {
                         mainThreadExecutor,
                         ioExecutor,
                         partitionTracker,
-                        EXECUTOR_RESOURCE.getExecutor());
+                        EXECUTOR_RESOURCE.getExecutor(),
+                        new Configuration());
         ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         assertThat(partitionTracker.releasedPartitions).isEmpty();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactoryTest.deserializeShuffleDescriptors;
+import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorTestUtils.deserializeShuffleDescriptors;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishExecutionVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.finishJobVertex;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -92,7 +94,8 @@ class RemoveCachedShuffleDescriptorTest {
     @Test
     void testRemoveNonOffloadedCacheForAllToAllEdgeAfterFinished() throws Exception {
         // Here we expect no offloaded BLOB.
-        testRemoveCacheForAllToAllEdgeAfterFinished(new TestingBlobWriter(Integer.MAX_VALUE), 0, 0);
+        testRemoveCacheForAllToAllEdgeAfterFinished(
+                new TestingBlobWriter(Integer.MAX_VALUE), Integer.MAX_VALUE, 0, 0);
     }
 
     @Test
@@ -102,18 +105,32 @@ class RemoveCachedShuffleDescriptorTest {
         // edge (1).
         // When the downstream tasks are finished, the cache for ShuffleDescriptors should be
         // removed.
-        testRemoveCacheForAllToAllEdgeAfterFinished(new TestingBlobWriter(0), 4, 3);
+        testRemoveCacheForAllToAllEdgeAfterFinished(new TestingBlobWriter(0), 0, 4, 3);
     }
 
     private void testRemoveCacheForAllToAllEdgeAfterFinished(
-            TestingBlobWriter blobWriter, int expectedBefore, int expectedAfter) throws Exception {
+            TestingBlobWriter blobWriter,
+            int offloadShuffleDescriptorsThreshold,
+            int expectedBefore,
+            int expectedAfter)
+            throws Exception {
         final JobID jobId = new JobID();
 
         final JobVertex v1 = ExecutionGraphTestUtils.createNoOpVertex("v1", PARALLELISM);
         final JobVertex v2 = ExecutionGraphTestUtils.createNoOpVertex("v2", PARALLELISM);
+        final Configuration jobMasterConfiguration = new Configuration();
+        jobMasterConfiguration.set(
+                JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD,
+                offloadShuffleDescriptorsThreshold);
 
         final SchedulerBase scheduler =
-                createSchedulerAndDeploy(jobId, v1, v2, DistributionPattern.ALL_TO_ALL, blobWriter);
+                createSchedulerAndDeploy(
+                        jobId,
+                        v1,
+                        v2,
+                        DistributionPattern.ALL_TO_ALL,
+                        blobWriter,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         executionInMainThread(
@@ -145,7 +162,8 @@ class RemoveCachedShuffleDescriptorTest {
 
     @Test
     void testRemoveNonOffloadedCacheForAllToAllEdgeAfterFailover() throws Exception {
-        testRemoveCacheForAllToAllEdgeAfterFailover(new TestingBlobWriter(Integer.MAX_VALUE), 0, 0);
+        testRemoveCacheForAllToAllEdgeAfterFailover(
+                new TestingBlobWriter(Integer.MAX_VALUE), Integer.MAX_VALUE, 0, 0);
     }
 
     @Test
@@ -155,18 +173,32 @@ class RemoveCachedShuffleDescriptorTest {
         // edge (1).
         // When the failover occurs for upstream tasks, the cache for ShuffleDescriptors should be
         // removed.
-        testRemoveCacheForAllToAllEdgeAfterFailover(new TestingBlobWriter(0), 4, 3);
+        testRemoveCacheForAllToAllEdgeAfterFailover(new TestingBlobWriter(0), 0, 4, 3);
     }
 
     private void testRemoveCacheForAllToAllEdgeAfterFailover(
-            TestingBlobWriter blobWriter, int expectedBefore, int expectedAfter) throws Exception {
+            TestingBlobWriter blobWriter,
+            int offloadShuffleDescriptorsThreshold,
+            int expectedBefore,
+            int expectedAfter)
+            throws Exception {
         final JobID jobId = new JobID();
 
         final JobVertex v1 = ExecutionGraphTestUtils.createNoOpVertex("v1", PARALLELISM);
         final JobVertex v2 = ExecutionGraphTestUtils.createNoOpVertex("v2", PARALLELISM);
+        final Configuration jobMasterConfiguration = new Configuration();
+        jobMasterConfiguration.set(
+                JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD,
+                offloadShuffleDescriptorsThreshold);
 
         final SchedulerBase scheduler =
-                createSchedulerAndDeploy(jobId, v1, v2, DistributionPattern.ALL_TO_ALL, blobWriter);
+                createSchedulerAndDeploy(
+                        jobId,
+                        v1,
+                        v2,
+                        DistributionPattern.ALL_TO_ALL,
+                        blobWriter,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         executionInMainThread(
@@ -196,7 +228,7 @@ class RemoveCachedShuffleDescriptorTest {
     @Test
     void testRemoveNonOffloadedCacheForPointwiseEdgeAfterFinished() throws Exception {
         testRemoveCacheForPointwiseEdgeAfterFinished(
-                new TestingBlobWriter(Integer.MAX_VALUE), 0, 0);
+                new TestingBlobWriter(Integer.MAX_VALUE), Integer.MAX_VALUE, 0, 0);
     }
 
     @Test
@@ -206,18 +238,32 @@ class RemoveCachedShuffleDescriptorTest {
         // edges (4).
         // When the downstream tasks are finished, the cache for ShuffleDescriptors should be
         // removed.
-        testRemoveCacheForPointwiseEdgeAfterFinished(new TestingBlobWriter(0), 7, 6);
+        testRemoveCacheForPointwiseEdgeAfterFinished(new TestingBlobWriter(0), 0, 7, 6);
     }
 
     private void testRemoveCacheForPointwiseEdgeAfterFinished(
-            TestingBlobWriter blobWriter, int expectedBefore, int expectedAfter) throws Exception {
+            TestingBlobWriter blobWriter,
+            int offloadShuffleDescriptorsThreshold,
+            int expectedBefore,
+            int expectedAfter)
+            throws Exception {
         final JobID jobId = new JobID();
 
         final JobVertex v1 = ExecutionGraphTestUtils.createNoOpVertex("v1", PARALLELISM);
         final JobVertex v2 = ExecutionGraphTestUtils.createNoOpVertex("v2", PARALLELISM);
+        final Configuration jobMasterConfiguration = new Configuration();
+        jobMasterConfiguration.set(
+                JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD,
+                offloadShuffleDescriptorsThreshold);
 
         final SchedulerBase scheduler =
-                createSchedulerAndDeploy(jobId, v1, v2, DistributionPattern.POINTWISE, blobWriter);
+                createSchedulerAndDeploy(
+                        jobId,
+                        v1,
+                        v2,
+                        DistributionPattern.POINTWISE,
+                        blobWriter,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         executionInMainThread(
@@ -264,7 +310,7 @@ class RemoveCachedShuffleDescriptorTest {
     @Test
     void testRemoveNonOffloadedCacheForPointwiseEdgeAfterFailover() throws Exception {
         testRemoveCacheForPointwiseEdgeAfterFailover(
-                new TestingBlobWriter(Integer.MAX_VALUE), 0, 0);
+                new TestingBlobWriter(Integer.MAX_VALUE), Integer.MAX_VALUE, 0, 0);
     }
 
     @Test
@@ -274,18 +320,32 @@ class RemoveCachedShuffleDescriptorTest {
         // edges (4).
         // When the failover occurs for upstream tasks, the cache for ShuffleDescriptors should be
         // removed.
-        testRemoveCacheForPointwiseEdgeAfterFailover(new TestingBlobWriter(0), 7, 6);
+        testRemoveCacheForPointwiseEdgeAfterFailover(new TestingBlobWriter(0), 0, 7, 6);
     }
 
     private void testRemoveCacheForPointwiseEdgeAfterFailover(
-            TestingBlobWriter blobWriter, int expectedBefore, int expectedAfter) throws Exception {
+            TestingBlobWriter blobWriter,
+            int offloadShuffleDescriptorsThreshold,
+            int expectedBefore,
+            int expectedAfter)
+            throws Exception {
         final JobID jobId = new JobID();
 
         final JobVertex v1 = ExecutionGraphTestUtils.createNoOpVertex("v1", PARALLELISM);
         final JobVertex v2 = ExecutionGraphTestUtils.createNoOpVertex("v2", PARALLELISM);
+        final Configuration jobMasterConfiguration = new Configuration();
+        jobMasterConfiguration.set(
+                JobManagerOptions.OFFLOAD_SHUFFLE_DESCRIPTORS_THRESHOLD,
+                offloadShuffleDescriptorsThreshold);
 
         final SchedulerBase scheduler =
-                createSchedulerAndDeploy(jobId, v1, v2, DistributionPattern.POINTWISE, blobWriter);
+                createSchedulerAndDeploy(
+                        jobId,
+                        v1,
+                        v2,
+                        DistributionPattern.POINTWISE,
+                        blobWriter,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         executionInMainThread(
@@ -328,7 +388,8 @@ class RemoveCachedShuffleDescriptorTest {
             JobVertex v1,
             JobVertex v2,
             DistributionPattern distributionPattern,
-            BlobWriter blobWriter)
+            BlobWriter blobWriter,
+            Configuration jobMasterConfiguration)
             throws Exception {
         return SchedulerTestingUtils.createSchedulerAndDeploy(
                 false,
@@ -340,7 +401,8 @@ class RemoveCachedShuffleDescriptorTest {
                 mainThreadExecutor,
                 ioExecutor,
                 NoOpJobMasterPartitionTracker.INSTANCE,
-                EXECUTOR_RESOURCE.getExecutor());
+                EXECUTOR_RESOURCE.getExecutor(),
+                jobMasterConfiguration);
     }
 
     private void triggerGlobalFailoverAndComplete(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndices;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -1322,8 +1323,10 @@ public class SingleInputGateTest extends InputGateTestBase {
                         subpartitionIndexRange,
                         channelDescs.length,
                         Collections.singletonList(
-                                new TaskDeploymentDescriptor.NonOffloaded<>(
-                                        CompressedSerializedValue.fromObject(channelDescs))));
+                                new SerializedShuffleDescriptorAndIndices(
+                                        new TaskDeploymentDescriptor.NonOffloaded<>(
+                                                CompressedSerializedValue.fromObject(
+                                                        channelDescs)))));
 
         final TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -332,7 +333,8 @@ public class SchedulerTestingUtils {
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService ioExecutor,
             JobMasterPartitionTracker partitionTracker,
-            ScheduledExecutorService scheduledExecutor)
+            ScheduledExecutorService scheduledExecutor,
+            Configuration jobMasterConfiguration)
             throws Exception {
         final List<JobVertex> vertices = new ArrayList<>(Collections.singletonList(producer));
         IntermediateDataSetID dataSetId = new IntermediateDataSetID();
@@ -351,7 +353,8 @@ public class SchedulerTestingUtils {
                         mainThreadExecutor,
                         ioExecutor,
                         partitionTracker,
-                        scheduledExecutor);
+                        scheduledExecutor,
+                        jobMasterConfiguration);
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
         final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 
@@ -402,7 +405,8 @@ public class SchedulerTestingUtils {
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService ioExecutor,
             JobMasterPartitionTracker partitionTracker,
-            ScheduledExecutorService scheduledExecutor)
+            ScheduledExecutorService scheduledExecutor,
+            Configuration jobMasterConfiguration)
             throws Exception {
         final JobGraph jobGraph =
                 JobGraphBuilder.newBatchJobGraphBuilder()
@@ -415,7 +419,8 @@ public class SchedulerTestingUtils {
                         .setRestartBackoffTimeStrategy(new TestRestartBackoffTimeStrategy(true, 0))
                         .setBlobWriter(blobWriter)
                         .setIoExecutor(ioExecutor)
-                        .setPartitionTracker(partitionTracker);
+                        .setPartitionTracker(partitionTracker)
+                        .setJobMasterConfiguration(jobMasterConfiguration);
         return isAdaptive ? builder.buildAdaptiveBatchJobScheduler() : builder.build();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCacheTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredComponentMainThreadExecutor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndicesID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DefaultShuffleDescriptorsCache}. */
+class DefaultShuffleDescriptorsCacheTest {
+    private final Duration idleTimeout = Duration.ofMillis(100);
+
+    @Test
+    void testGetEntry() {
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache(idleTimeout, Integer.MAX_VALUE);
+
+        JobID jobId = new JobID();
+        SerializedShuffleDescriptorAndIndicesID shuffleDescriptorsID =
+                new SerializedShuffleDescriptorAndIndicesID();
+
+        assertThat(cache.get(shuffleDescriptorsID)).isNull();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices =
+                new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] {
+                    new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex(
+                            shuffleDescriptor, 0)
+                };
+        cache.put(jobId, shuffleDescriptorsID, shuffleDescriptorAndIndices);
+        assertThat(cache.get(shuffleDescriptorsID).getShuffleDescriptorAndIndices())
+                .isEqualTo(shuffleDescriptorAndIndices);
+    }
+
+    @Test
+    void testEntryWillExpiredAfterIdleTimeout() {
+        ManualClock clock = new ManualClock();
+        ManuallyTriggeredComponentMainThreadExecutor mainThreadExecutor =
+                new ManuallyTriggeredComponentMainThreadExecutor(Thread.currentThread());
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache(idleTimeout, Integer.MAX_VALUE, clock);
+        cache.start(mainThreadExecutor);
+
+        JobID jobId = new JobID();
+        SerializedShuffleDescriptorAndIndicesID shuffleDescriptorsID =
+                new SerializedShuffleDescriptorAndIndicesID();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices =
+                new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] {
+                    new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex(
+                            shuffleDescriptor, 0)
+                };
+        cache.put(jobId, shuffleDescriptorsID, shuffleDescriptorAndIndices);
+        clock.advanceTime(idleTimeout.toMillis() - 1, TimeUnit.MILLISECONDS);
+        assertThat(cache.get(shuffleDescriptorsID).getShuffleDescriptorAndIndices())
+                .isEqualTo(shuffleDescriptorAndIndices);
+
+        // get will update the idle since, so cache will not expire after (idle timeout - 1 + 2)
+        clock.advanceTime(2, TimeUnit.MILLISECONDS);
+        mainThreadExecutor.triggerScheduledTasks();
+        assertThat(cache.get(shuffleDescriptorsID).getShuffleDescriptorAndIndices())
+                .isEqualTo(shuffleDescriptorAndIndices);
+
+        // cache expired after (idle timeout + 1)
+        clock.advanceTime(idleTimeout.toMillis() + 1, TimeUnit.MILLISECONDS);
+        mainThreadExecutor.triggerScheduledTasks();
+        assertThat(cache.get(shuffleDescriptorsID)).isNull();
+    }
+
+    @Test
+    void testClearCacheOfJob() {
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache(idleTimeout, Integer.MAX_VALUE);
+
+        JobID jobId = new JobID();
+        SerializedShuffleDescriptorAndIndicesID shuffleDescriptorsID =
+                new SerializedShuffleDescriptorAndIndicesID();
+
+        assertThat(cache.get(shuffleDescriptorsID)).isNull();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices =
+                new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] {
+                    new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex(
+                            shuffleDescriptor, 0)
+                };
+        cache.put(jobId, shuffleDescriptorsID, shuffleDescriptorAndIndices);
+        assertThat(cache.get(shuffleDescriptorsID).getShuffleDescriptorAndIndices())
+                .isEqualTo(shuffleDescriptorAndIndices);
+
+        cache.clearCacheOfJob(jobId);
+        assertThat(cache.get(shuffleDescriptorsID)).isNull();
+    }
+
+    @Test
+    void testIdleCheckNotTriggeredAfterClose() {
+        ManualClock clock = new ManualClock();
+        ManuallyTriggeredComponentMainThreadExecutor mainThreadExecutor =
+                new ManuallyTriggeredComponentMainThreadExecutor(Thread.currentThread());
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache(idleTimeout, Integer.MAX_VALUE, clock);
+        cache.start(mainThreadExecutor);
+        assertThat(mainThreadExecutor.getAllScheduledTasks()).hasSize(1);
+
+        // idle check will be rescheduled after trigger
+        mainThreadExecutor.triggerScheduledTasks();
+        assertThat(mainThreadExecutor.getAllScheduledTasks()).hasSize(1);
+
+        // idle check will not be scheduled when cache manager stop
+        cache.stop();
+        mainThreadExecutor.triggerScheduledTasks();
+        assertThat(mainThreadExecutor.getAllScheduledTasks()).isEmpty();
+    }
+
+    @Test
+    void testPutWhenOverLimit() {
+        DefaultShuffleDescriptorsCache cache = new DefaultShuffleDescriptorsCache(idleTimeout, 1);
+
+        JobID jobId = new JobID();
+        SerializedShuffleDescriptorAndIndicesID shuffleDescriptorsID =
+                new SerializedShuffleDescriptorAndIndicesID();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices =
+                new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] {
+                    new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex(
+                            shuffleDescriptor, 0)
+                };
+        cache.put(jobId, shuffleDescriptorsID, shuffleDescriptorAndIndices);
+        assertThat(cache.get(shuffleDescriptorsID).getShuffleDescriptorAndIndices())
+                .isEqualTo(shuffleDescriptorAndIndices);
+
+        SerializedShuffleDescriptorAndIndicesID otherId =
+                new SerializedShuffleDescriptorAndIndicesID();
+        TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                otherShuffleDescriptorAndIndices =
+                        new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[] {
+                            new TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex(
+                                    new UnknownShuffleDescriptor(new ResultPartitionID()), 0)
+                        };
+        cache.put(jobId, otherId, otherShuffleDescriptorAndIndices);
+        assertThat(cache.get(shuffleDescriptorsID)).isNull();
+        assertThat(cache.get(otherId).getShuffleDescriptorAndIndices())
+                .isEqualTo(otherShuffleDescriptorAndIndices);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NoOpShuffleDescriptorsCache.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NoOpShuffleDescriptorsCache.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.deployment.SerializedShuffleDescriptorAndIndicesID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory;
+
+/** Non op implement of {@link ShuffleDescriptorsCache}. */
+public class NoOpShuffleDescriptorsCache implements ShuffleDescriptorsCache {
+
+    public static final NoOpShuffleDescriptorsCache INSTANCE = new NoOpShuffleDescriptorsCache();
+
+    @Override
+    public void start(ComponentMainThreadExecutor mainThreadExecutor) {}
+
+    @Override
+    public void stop() {}
+
+    @Override
+    public ShuffleDescriptorCacheEntry get(
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId) {
+        return null;
+    }
+
+    @Override
+    public void put(
+            JobID jobId,
+            SerializedShuffleDescriptorAndIndicesID serializedShuffleDescriptorsId,
+            TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex[]
+                    shuffleDescriptorAndIndices) {}
+
+    @Override
+    public void clearCacheOfJob(JobID jobId) {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -189,6 +189,7 @@ public class TaskManagerServicesBuilder {
                 Executors.newSingleThreadScheduledExecutor(),
                 libraryCacheManager,
                 slotAllocationSnapshotPersistenceService,
-                sharedResources);
+                sharedResources,
+                NoOpShuffleDescriptorsCache.INSTANCE);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

refer to https://issues.apache.org/jira/browse/FLINK-32386
Introduce ShuffleDescriptorsCache to cache ShuffleDescriptorAndIndex

## Brief change log
  - *Cache initialized in TaskManagerServices*
  - *Cache entry will expire after TTL exceed*
  - *Cache entry will be clear when job disconnected*
  - *Cache entry has limit control*

## Verifying this change
This change added tests and can be verified as follows:
  - *Added unit tests to verify TTL/job disconnection/size limit*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:(no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
