### PR TITLE
[FLINK-32387][runtime] InputGateDeploymentDescriptor uses cache to avoid deserializing shuffle descriptors multiple times

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -58,7 +58,7 @@ function setup_kubernetes_for_linux {
     sudo apt-get install conntrack
     # crictl is required for cri-dockerd
     VERSION="v1.24.2"
-    wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+    wget -nv https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
     sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
     rm -f crictl-$VERSION-linux-amd64.tar.gz
     # cri-dockerd is required to use Kubernetes 1.24+ and the none driver

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -57,18 +57,22 @@ function setup_kubernetes_for_linux {
     # conntrack is required for minikube 1.9 and later
     sudo apt-get install conntrack
     # crictl is required for cri-dockerd
-    VERSION="v1.24.2"
-    wget -nv https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
-    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-    rm -f crictl-$VERSION-linux-amd64.tar.gz
+    local crictl_version crictl_archive
+    crictl_version="v1.24.2"
+    crictl_archive="crictl-$crictl_version-linux-amd64.tar.gz"
+    wget -nv "https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictl_version}/crictl-${crictl_version}-linux-amd64.tar.gz"
+    sudo tar zxvf ${crictl_archive} -C /usr/local/bin
+    rm -f ${crictl_archive}
+
     # cri-dockerd is required to use Kubernetes 1.24+ and the none driver
+    local cri_dockerd_version
+    cri_dockerd_version="v0.2.3"
     if [ -e cri-dockerd ];
      then rm -r cri-dockerd
     fi
     git clone https://github.com/Mirantis/cri-dockerd.git
     cd cri-dockerd
-    # Checkout version 0.2.3
-    git checkout tags/v0.2.3 -b v0.2.3
+    git checkout tags/${cri_dockerd_version} -b ${cri_dockerd_version}
     mkdir bin
     go get && go build -o bin/cri-dockerd
     mkdir -p /usr/local/bin

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.deployment.CachedShuffleDescriptors;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
@@ -287,13 +288,12 @@ public class IntermediateResult {
         final CachedShuffleDescriptors cache =
                 this.shuffleDescriptorCache.remove(consumedPartitionGroup);
         if (cache != null) {
-            cache.getAllSerializedShuffleDescriptors()
+            cache.getAllSerializedShuffleDescriptorGroups()
                     .forEach(
                             shuffleDescriptors -> {
                                 if (shuffleDescriptors instanceof Offloaded) {
                                     PermanentBlobKey blobKey =
-                                            ((Offloaded<ShuffleDescriptorAndIndex[]>)
-                                                            shuffleDescriptors)
+                                            ((Offloaded<ShuffleDescriptorGroup>) shuffleDescriptors)
                                                     .serializedValueKey;
                                     this.producer
                                             .getGraph()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCache.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
+
+import org.apache.flink.shaded.guava31.com.google.common.base.Ticker;
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava31.com.google.common.cache.RemovalNotification;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implement of {@link ShuffleDescriptorsCache}. Entries will be expired after timeout. */
+public class DefaultShuffleDescriptorsCache implements ShuffleDescriptorsCache {
+    private final Cache<PermanentBlobKey, ShuffleDescriptorCacheEntry> shuffleDescriptorsCache;
+    private final Map<JobID, Set<PermanentBlobKey>> cachedBlobKeysPerJob;
+
+    private DefaultShuffleDescriptorsCache(
+            Duration expireTimeout, int cacheSizeLimit, Ticker ticker) {
+        this.cachedBlobKeysPerJob = new HashMap<>();
+        this.shuffleDescriptorsCache =
+                CacheBuilder.newBuilder()
+                        .concurrencyLevel(1)
+                        .maximumSize(cacheSizeLimit)
+                        .expireAfterAccess(expireTimeout)
+                        .ticker(ticker)
+                        .removalListener(this::onCacheRemoval)
+                        .build();
+    }
+
+    @Override
+    public void clear() {
+        cachedBlobKeysPerJob.clear();
+        shuffleDescriptorsCache.cleanUp();
+    }
+
+    @Override
+    public ShuffleDescriptorGroup get(PermanentBlobKey blobKey) {
+        ShuffleDescriptorCacheEntry entry = shuffleDescriptorsCache.getIfPresent(blobKey);
+        return entry == null ? null : entry.getShuffleDescriptorGroup();
+    }
+
+    @Override
+    public void put(
+            JobID jobId, PermanentBlobKey blobKey, ShuffleDescriptorGroup shuffleDescriptorGroup) {
+        shuffleDescriptorsCache.put(
+                blobKey, new ShuffleDescriptorCacheEntry(shuffleDescriptorGroup, jobId));
+        cachedBlobKeysPerJob.computeIfAbsent(jobId, ignore -> new HashSet<>()).add(blobKey);
+    }
+
+    @Override
+    public void clearCacheForJob(JobID jobId) {
+        Set<PermanentBlobKey> removed = cachedBlobKeysPerJob.remove(jobId);
+        if (removed != null) {
+            shuffleDescriptorsCache.invalidateAll(removed);
+        }
+    }
+
+    /**
+     * Removal listener that remove the index of serializedShuffleDescriptorsPerJob .
+     *
+     * @param removalNotification of removed element.
+     */
+    private void onCacheRemoval(
+            RemovalNotification<PermanentBlobKey, ShuffleDescriptorCacheEntry>
+                    removalNotification) {
+        PermanentBlobKey blobKey = removalNotification.getKey();
+        ShuffleDescriptorCacheEntry entry = removalNotification.getValue();
+        if (blobKey != null && entry != null) {
+            cachedBlobKeysPerJob.computeIfPresent(
+                    entry.getJobId(),
+                    (jobID, permanentBlobKeys) -> {
+                        permanentBlobKeys.remove(blobKey);
+                        if (permanentBlobKeys.isEmpty()) {
+                            return null;
+                        } else {
+                            return permanentBlobKeys;
+                        }
+                    });
+        }
+    }
+
+    private static class ShuffleDescriptorCacheEntry {
+        private final ShuffleDescriptorGroup shuffleDescriptorGroup;
+        private final JobID jobId;
+
+        public ShuffleDescriptorCacheEntry(
+                ShuffleDescriptorGroup shuffleDescriptorGroup, JobID jobId) {
+            this.shuffleDescriptorGroup = checkNotNull(shuffleDescriptorGroup);
+            this.jobId = checkNotNull(jobId);
+        }
+
+        public ShuffleDescriptorGroup getShuffleDescriptorGroup() {
+            return shuffleDescriptorGroup;
+        }
+
+        public JobID getJobId() {
+            return jobId;
+        }
+    }
+
+    /** The Factory of {@link DefaultShuffleDescriptorsCache}. */
+    public static class Factory {
+        private static final Duration DEFAULT_CACHE_EXPIRE_TIMEOUT = Duration.ofSeconds(300);
+        private static final int DEFAULT_CACHE_SIZE_LIMIT = 100;
+        private static final Ticker DEFAULT_TICKER = Ticker.systemTicker();
+
+        private final Duration cacheExpireTimeout;
+        private final int cacheSizeLimit;
+        private final Ticker ticker;
+
+        public Factory() {
+            this(DEFAULT_CACHE_EXPIRE_TIMEOUT, DEFAULT_CACHE_SIZE_LIMIT, DEFAULT_TICKER);
+        }
+
+        @VisibleForTesting
+        public Factory(Duration cacheExpireTimeout, int cacheSizeLimit, Ticker ticker) {
+            this.cacheExpireTimeout = cacheExpireTimeout;
+            this.cacheSizeLimit = cacheSizeLimit;
+            this.ticker = ticker;
+        }
+
+        public DefaultShuffleDescriptorsCache create() {
+            return new DefaultShuffleDescriptorsCache(cacheExpireTimeout, cacheSizeLimit, ticker);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ShuffleDescriptorsCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/ShuffleDescriptorsCache.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
+
+/** Cache of shuffle descriptors in TaskExecutor. */
+public interface ShuffleDescriptorsCache {
+
+    /** clear all cache. */
+    void clear();
+
+    /**
+     * Get shuffle descriptor group in cache.
+     *
+     * @param blobKey identify the shuffle descriptor group
+     * @return shuffle descriptor group in cache if exists, otherwise null
+     */
+    ShuffleDescriptorGroup get(PermanentBlobKey blobKey);
+
+    /**
+     * Put shuffle descriptor group to cache.
+     *
+     * @param jobId of job
+     * @param blobKey identify the shuffle descriptor group
+     * @param shuffleDescriptorGroup shuffle descriptor group to cache
+     */
+    void put(JobID jobId, PermanentBlobKey blobKey, ShuffleDescriptorGroup shuffleDescriptorGroup);
+
+    /**
+     * Clear all cache for the Job.
+     *
+     * @param jobId of job
+     */
+    void clearCacheForJob(JobID jobId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -289,6 +289,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private final ThreadInfoSampleService threadInfoSampleService;
 
+    private final ShuffleDescriptorsCache shuffleDescriptorsCache;
+
     public TaskExecutor(
             RpcService rpcService,
             TaskManagerConfiguration taskManagerConfiguration,
@@ -363,6 +365,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 taskExecutorServices.getSlotAllocationSnapshotPersistenceService();
 
         this.sharedResources = taskExecutorServices.getSharedResources();
+        this.shuffleDescriptorsCache = taskExecutorServices.getShuffleDescriptorCache();
     }
 
     private HeartbeatManager<Void, TaskExecutorHeartbeatPayload>
@@ -491,6 +494,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
         changelogStoragesManager.shutdown();
         channelStateExecutorFactoryManager.shutdown();
+
+        shuffleDescriptorsCache.clear();
 
         Preconditions.checkState(jobTable.isEmpty());
 
@@ -1886,6 +1891,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         changelogStoragesManager.releaseResourcesForJob(jobId);
         currentSlotOfferPerJob.remove(jobId);
         channelStateExecutorFactoryManager.releaseResourcesForJob(jobId);
+        shuffleDescriptorsCache.clearCacheForJob(jobId);
     }
 
     private void scheduleResultPartitionCleanup(JobID jobId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -656,9 +656,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 throw new TaskSubmissionException(message);
             }
 
-            // re-integrate offloaded data:
+            // re-integrate offloaded data and deserialize shuffle descriptors
             try {
-                tdd.loadBigData(taskExecutorBlobService.getPermanentBlobService());
+                tdd.loadBigData(
+                        taskExecutorBlobService.getPermanentBlobService(), shuffleDescriptorsCache);
             } catch (IOException | ClassNotFoundException e) {
                 throw new TaskSubmissionException(
                         "Could not re-integrate offloaded TaskDeploymentDescriptor data.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -87,6 +87,7 @@ public class TaskManagerServices {
     private final LibraryCacheManager libraryCacheManager;
     private final SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService;
     private final SharedResources sharedResources;
+    private final ShuffleDescriptorsCache shuffleDescriptorsCache;
 
     TaskManagerServices(
             UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
@@ -105,7 +106,8 @@ public class TaskManagerServices {
             ExecutorService ioExecutor,
             LibraryCacheManager libraryCacheManager,
             SlotAllocationSnapshotPersistenceService slotAllocationSnapshotPersistenceService,
-            SharedResources sharedResources) {
+            SharedResources sharedResources,
+            ShuffleDescriptorsCache shuffleDescriptorsCache) {
 
         this.unresolvedTaskManagerLocation =
                 Preconditions.checkNotNull(unresolvedTaskManagerLocation);
@@ -125,6 +127,7 @@ public class TaskManagerServices {
         this.libraryCacheManager = Preconditions.checkNotNull(libraryCacheManager);
         this.slotAllocationSnapshotPersistenceService = slotAllocationSnapshotPersistenceService;
         this.sharedResources = Preconditions.checkNotNull(sharedResources);
+        this.shuffleDescriptorsCache = Preconditions.checkNotNull(shuffleDescriptorsCache);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -193,6 +196,10 @@ public class TaskManagerServices {
 
     public SharedResources getSharedResources() {
         return sharedResources;
+    }
+
+    public ShuffleDescriptorsCache getShuffleDescriptorCache() {
+        return shuffleDescriptorsCache;
     }
 
     // --------------------------------------------------------------------------------------------
@@ -382,6 +389,9 @@ public class TaskManagerServices {
                     NoOpSlotAllocationSnapshotPersistenceService.INSTANCE;
         }
 
+        final ShuffleDescriptorsCache shuffleDescriptorsCache =
+                new DefaultShuffleDescriptorsCache.Factory().create();
+
         return new TaskManagerServices(
                 unresolvedTaskManagerLocation,
                 taskManagerServicesConfiguration.getManagedMemorySize().getBytes(),
@@ -399,7 +409,8 @@ public class TaskManagerServices {
                 ioExecutor,
                 libraryCacheManager,
                 slotAllocationSnapshotPersistenceService,
-                new SharedResources());
+                new SharedResources(),
+                shuffleDescriptorsCache);
     }
 
     private static TaskSlotTable<Task> createTaskSlotTable(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptorsTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -83,12 +84,12 @@ class CachedShuffleDescriptorsTest {
                         consumedPartitionGroup,
                         createSingleShuffleDescriptorAndIndex(shuffleDescriptor, 0));
 
-        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).isEmpty();
+        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptorGroups()).isEmpty();
         cachedShuffleDescriptors.serializeShuffleDescriptors(
                 new TestingShuffleDescriptorSerializer());
-        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(1);
-        MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloadedShuffleDescriptor =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(0);
+        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptorGroups()).hasSize(1);
+        MaybeOffloaded<ShuffleDescriptorGroup> maybeOffloadedShuffleDescriptor =
+                cachedShuffleDescriptors.getAllSerializedShuffleDescriptorGroups().get(0);
         assertNonOffloadedShuffleDescriptorAndIndexEquals(
                 maybeOffloadedShuffleDescriptor,
                 Collections.singletonList(shuffleDescriptor),
@@ -129,10 +130,10 @@ class CachedShuffleDescriptorsTest {
         cachedShuffleDescriptors.markPartitionFinished(intermediateResultPartition1);
         cachedShuffleDescriptors.markPartitionFinished(intermediateResultPartition2);
         cachedShuffleDescriptors.serializeShuffleDescriptors(testingShuffleDescriptorSerializer);
-        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptors()).hasSize(2);
+        assertThat(cachedShuffleDescriptors.getAllSerializedShuffleDescriptorGroups()).hasSize(2);
 
-        MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloaded =
-                cachedShuffleDescriptors.getAllSerializedShuffleDescriptors().get(1);
+        MaybeOffloaded<ShuffleDescriptorGroup> maybeOffloaded =
+                cachedShuffleDescriptors.getAllSerializedShuffleDescriptorGroups().get(1);
         ShuffleDescriptor expectedShuffleDescriptor1 =
                 TaskDeploymentDescriptorFactory.getConsumedPartitionShuffleDescriptor(
                         intermediateResultPartition1,
@@ -150,16 +151,19 @@ class CachedShuffleDescriptorsTest {
     }
 
     private void assertNonOffloadedShuffleDescriptorAndIndexEquals(
-            MaybeOffloaded<ShuffleDescriptorAndIndex[]> maybeOffloaded,
+            MaybeOffloaded<ShuffleDescriptorGroup> maybeOffloaded,
             List<ShuffleDescriptor> expectedDescriptors,
             List<Integer> expectedIndices)
             throws Exception {
         assertThat(expectedDescriptors).hasSameSizeAs(expectedIndices);
         assertThat(maybeOffloaded).isInstanceOf(NonOffloaded.class);
-        NonOffloaded<ShuffleDescriptorAndIndex[]> nonOffloaded =
-                (NonOffloaded<ShuffleDescriptorAndIndex[]>) maybeOffloaded;
+        NonOffloaded<ShuffleDescriptorGroup> nonOffloaded =
+                (NonOffloaded<ShuffleDescriptorGroup>) maybeOffloaded;
         ShuffleDescriptorAndIndex[] shuffleDescriptorAndIndices =
-                nonOffloaded.serializedValue.deserializeValue(getClass().getClassLoader());
+                nonOffloaded
+                        .serializedValue
+                        .deserializeValue(getClass().getClassLoader())
+                        .getShuffleDescriptors();
         assertThat(shuffleDescriptorAndIndices).hasSameSizeAs(expectedDescriptors);
         for (int i = 0; i < shuffleDescriptorAndIndices.length; i++) {
             assertThat(shuffleDescriptorAndIndices[i].getIndex()).isEqualTo(expectedIndices.get(i));
@@ -214,10 +218,9 @@ class CachedShuffleDescriptorsTest {
             implements TaskDeploymentDescriptorFactory.ShuffleDescriptorSerializer {
 
         @Override
-        public MaybeOffloaded<ShuffleDescriptorAndIndex[]> serializeAndTryOffloadShuffleDescriptor(
-                ShuffleDescriptorAndIndex[] shuffleDescriptors, int numConsumer)
-                throws IOException {
-            return new NonOffloaded<>(CompressedSerializedValue.fromObject(shuffleDescriptors));
+        public MaybeOffloaded<ShuffleDescriptorGroup> serializeAndTryOffloadShuffleDescriptor(
+                ShuffleDescriptorGroup shuffleDescriptorGroup, int numConsumer) throws IOException {
+            return new NonOffloaded<>(CompressedSerializedValue.fromObject(shuffleDescriptorGroup));
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -102,13 +102,13 @@ class TaskDeploymentDescriptorFactoryTest {
 
         // The ShuffleDescriptors should be cached
         final IntermediateResult consumedResult = executionJobVertices.f1.getInputs().get(0);
-        final List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        final List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev21.getConsumedPartitionGroup(0))
-                        .getAllSerializedShuffleDescriptors();
+                        .getAllSerializedShuffleDescriptorGroups();
 
         final ShuffleDescriptor[] cachedShuffleDescriptors =
-                deserializeShuffleDescriptors(maybeOffloaded, jobId, blobWriter);
+                deserializeShuffleDescriptors(serializedShuffleDescriptors, jobId, blobWriter);
 
         // Check if the ShuffleDescriptors are cached correctly
         assertThat(ev21.getConsumedPartitionGroup(0)).hasSize(cachedShuffleDescriptors.length);
@@ -139,22 +139,22 @@ class TaskDeploymentDescriptorFactoryTest {
         final ExecutionVertex ev22 = ejv2.getTaskVertices()[1];
         createTaskDeploymentDescriptor(ev22);
         IntermediateResult consumedResult = ejv2.getInputs().get(0);
-        List<MaybeOffloaded<ShuffleDescriptorAndIndex[]>> maybeOffloaded =
+        List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev22.getConsumedPartitionGroup(0))
-                        .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(2);
+                        .getAllSerializedShuffleDescriptorGroups();
+        assertThat(serializedShuffleDescriptors).hasSize(2);
 
         final ExecutionVertex ev13 = ejv1.getTaskVertices()[2];
         ev13.finishPartitionsIfNeeded();
         final ExecutionVertex ev23 = ejv2.getTaskVertices()[2];
         createTaskDeploymentDescriptor(ev23);
         consumedResult = ejv2.getInputs().get(0);
-        maybeOffloaded =
+        serializedShuffleDescriptors =
                 consumedResult
                         .getCachedShuffleDescriptors(ev23.getConsumedPartitionGroup(0))
-                        .getAllSerializedShuffleDescriptors();
-        assertThat(maybeOffloaded).hasSize(3);
+                        .getAllSerializedShuffleDescriptorGroups();
+        assertThat(serializedShuffleDescriptors).hasSize(3);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.taskexecutor.NoOpShuffleDescriptorsCache;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -178,7 +179,8 @@ class DefaultExecutionGraphDeploymentTest {
         taskManagerGateway.setSubmitConsumer(
                 FunctionUtils.uncheckedConsumer(
                         taskDeploymentDescriptor -> {
-                            taskDeploymentDescriptor.loadBigData(blobCache);
+                            taskDeploymentDescriptor.loadBigData(
+                                    blobCache, NoOpShuffleDescriptorsCache.INSTANCE);
                             tdd.complete(taskDeploymentDescriptor);
                         }));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.taskexecutor.NoOpShuffleDescriptorsCache;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.function.FunctionUtils;
@@ -119,7 +120,8 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         taskManagerGateway.setSubmitConsumer(
                 FunctionUtils.uncheckedConsumer(
                         taskDeploymentDescriptor -> {
-                            taskDeploymentDescriptor.loadBigData(blobCache);
+                            taskDeploymentDescriptor.loadBigData(
+                                    blobCache, NoOpShuffleDescriptorsCache.INSTANCE);
                             tdds.offer(taskDeploymentDescriptor);
                         }));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -139,7 +139,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptors =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptors).hasSize(PARALLELISM);
@@ -207,7 +207,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptors =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptors).hasSize(PARALLELISM);
@@ -272,7 +272,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptors =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptors).hasSize(1);
@@ -298,7 +298,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptorsForOtherVertex =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2, 1)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptorsForOtherVertex).hasSize(1);
@@ -354,7 +354,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptors =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptors).hasSize(1);
@@ -374,7 +374,7 @@ class RemoveCachedShuffleDescriptorTest {
                     final ShuffleDescriptor[] shuffleDescriptorsForOtherVertex =
                             deserializeShuffleDescriptors(
                                     getConsumedCachedShuffleDescriptor(executionGraph, v2, 1)
-                                            .getAllSerializedShuffleDescriptors(),
+                                            .getAllSerializedShuffleDescriptorGroups(),
                                     jobId,
                                     blobWriter);
                     assertThat(shuffleDescriptorsForOtherVertex).hasSize(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.IndexRange;
@@ -1323,7 +1324,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                         channelDescs.length,
                         Collections.singletonList(
                                 new TaskDeploymentDescriptor.NonOffloaded<>(
-                                        CompressedSerializedValue.fromObject(channelDescs))));
+                                        CompressedSerializedValue.fromObject(
+                                                new ShuffleDescriptorGroup(channelDescs)))));
 
         final TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultShuffleDescriptorsCacheTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
+
+import org.apache.flink.shaded.guava31.com.google.common.base.Ticker;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DefaultShuffleDescriptorsCache}. */
+class DefaultShuffleDescriptorsCacheTest {
+    private final Duration expireTimeout = Duration.ofSeconds(10);
+
+    @Test
+    void testGetEntry() {
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache.Factory(
+                                expireTimeout, Integer.MAX_VALUE, Ticker.systemTicker())
+                        .create();
+
+        JobID jobId = new JobID();
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        ShuffleDescriptorGroup shuffleDescriptorGroup =
+                new ShuffleDescriptorGroup(
+                        new ShuffleDescriptorAndIndex[] {
+                            new ShuffleDescriptorAndIndex(shuffleDescriptor, 0)
+                        });
+
+        PermanentBlobKey blobKey = new PermanentBlobKey();
+
+        assertThat(cache.get(blobKey)).isNull();
+
+        cache.put(jobId, blobKey, shuffleDescriptorGroup);
+        assertThat(cache.get(blobKey)).isEqualTo(shuffleDescriptorGroup);
+    }
+
+    @Test
+    void testClearCacheForJob() {
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache.Factory(
+                                expireTimeout, Integer.MAX_VALUE, Ticker.systemTicker())
+                        .create();
+
+        JobID jobId = new JobID();
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        ShuffleDescriptorGroup shuffleDescriptorGroup =
+                new ShuffleDescriptorGroup(
+                        new ShuffleDescriptorAndIndex[] {
+                            new ShuffleDescriptorAndIndex(shuffleDescriptor, 0)
+                        });
+        PermanentBlobKey blobKey = new PermanentBlobKey();
+
+        assertThat(cache.get(blobKey)).isNull();
+
+        cache.put(jobId, blobKey, shuffleDescriptorGroup);
+        assertThat(cache.get(blobKey)).isEqualTo(shuffleDescriptorGroup);
+
+        cache.clearCacheForJob(jobId);
+        assertThat(cache.get(blobKey)).isNull();
+    }
+
+    @Test
+    void testPutWhenOverLimit() {
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache.Factory(expireTimeout, 1, Ticker.systemTicker())
+                        .create();
+
+        JobID jobId = new JobID();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        ShuffleDescriptorGroup shuffleDescriptorGroup =
+                new ShuffleDescriptorGroup(
+                        new ShuffleDescriptorAndIndex[] {
+                            new ShuffleDescriptorAndIndex(shuffleDescriptor, 0)
+                        });
+        PermanentBlobKey blobKey = new PermanentBlobKey();
+
+        cache.put(jobId, blobKey, shuffleDescriptorGroup);
+        assertThat(cache.get(blobKey)).isEqualTo(shuffleDescriptorGroup);
+
+        ShuffleDescriptorGroup otherShuffleDescriptorGroup =
+                new ShuffleDescriptorGroup(
+                        new ShuffleDescriptorAndIndex[] {
+                            new ShuffleDescriptorAndIndex(
+                                    new UnknownShuffleDescriptor(new ResultPartitionID()), 0)
+                        });
+        PermanentBlobKey otherBlobKey = new PermanentBlobKey();
+
+        cache.put(jobId, otherBlobKey, otherShuffleDescriptorGroup);
+        assertThat(cache.get(blobKey)).isNull();
+        assertThat(cache.get(otherBlobKey)).isEqualTo(otherShuffleDescriptorGroup);
+    }
+
+    @Test
+    void testEntryExpired() {
+        TestingTicker ticker = new TestingTicker();
+        DefaultShuffleDescriptorsCache cache =
+                new DefaultShuffleDescriptorsCache.Factory(
+                                Duration.ofSeconds(1), Integer.MAX_VALUE, ticker)
+                        .create();
+
+        JobID jobId = new JobID();
+
+        ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(new ResultPartitionID());
+        ShuffleDescriptorGroup shuffleDescriptorGroup =
+                new ShuffleDescriptorGroup(
+                        new ShuffleDescriptorAndIndex[] {
+                            new ShuffleDescriptorAndIndex(shuffleDescriptor, 0)
+                        });
+        PermanentBlobKey blobKey = new PermanentBlobKey();
+
+        cache.put(jobId, blobKey, shuffleDescriptorGroup);
+        assertThat(cache.get(blobKey)).isEqualTo(shuffleDescriptorGroup);
+
+        ticker.advance(Duration.ofSeconds(2));
+        assertThat(cache.get(blobKey)).isNull();
+    }
+
+    private static class TestingTicker extends Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        public void advance(Duration duration) {
+            nanos.addAndGet(duration.toNanos());
+        }
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NoOpShuffleDescriptorsCache.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NoOpShuffleDescriptorsCache.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
+
+/** Non op implement of {@link ShuffleDescriptorsCache}. */
+public class NoOpShuffleDescriptorsCache implements ShuffleDescriptorsCache {
+
+    public static final NoOpShuffleDescriptorsCache INSTANCE = new NoOpShuffleDescriptorsCache();
+
+    @Override
+    public void clear() {}
+
+    @Override
+    public ShuffleDescriptorGroup get(PermanentBlobKey blobKey) {
+        return null;
+    }
+
+    @Override
+    public void put(
+            JobID jobId, PermanentBlobKey blobKey, ShuffleDescriptorGroup shuffleDescriptorGroup) {}
+
+    @Override
+    public void clearCacheForJob(JobID jobId) {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -189,6 +189,7 @@ public class TaskManagerServicesBuilder {
                 Executors.newSingleThreadScheduledExecutor(),
                 libraryCacheManager,
                 slotAllocationSnapshotPersistenceService,
-                sharedResources);
+                sharedResources,
+                NoOpShuffleDescriptorsCache.INSTANCE);
     }
 }

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -33,7 +33,7 @@ export -f run_mvn
 function setup_maven {
 	set -e # fail if there was an error setting up maven
 	if [ ! -d "${MAVEN_VERSIONED_DIR}" ]; then
-	  wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.zip
+	  wget -nv https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.zip
 	  unzip -d "${MAVEN_CACHE_DIR}" -qq "apache-maven-${MAVEN_VERSION}-bin.zip"
 	  rm "apache-maven-${MAVEN_VERSION}-bin.zip"
 	fi


### PR DESCRIPTION
## What is the purpose of the change
InputGateDeploymentDescriptor uses cache to avoid deserializing shuffle descriptors multiple times
The cache only affects when the shuffle descriptors are offloaded by the blob server. This means the shuffle descriptors size is large enough to use caches.

## Brief change log
  - InputGateDeploymentDescriptor tries to get the shuffle descriptors for the offloaded one.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (task deployment)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
