### PR TITLE
[FLINK-31575][hive] Avoid swapping table-planner-loader and table-planner to use hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveReflectionUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveReflectionUtils.java
@@ -97,7 +97,11 @@ public class HiveReflectionUtils {
 
     public static Class tryGetClass(String name) {
         try {
-            return Thread.currentThread().getContextClassLoader().loadClass(name);
+            // we use the classloader of HiveReflectionUtils to load the class
+            // since the current class to be loaded via this method should be loaded by the
+            // classloader(which is PlannerComponentClassLoader in
+            // org.apache.flink.table.planner.loader).
+            return HiveReflectionUtils.class.getClassLoader().loadClass(name);
         } catch (ClassNotFoundException e) {
             return null;
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -212,6 +212,9 @@ public class HiveParser implements Parser {
             }
         }
 
+        // Note: it's equal to HiveCatalog#getHiveConf, but we can't use HiveCatalog#getHiveConf
+        // directly for classloader issue.
+        // For more detail, please see class HiveCatalogUtils.
         HiveConf hiveConf = HiveCatalogUtils.getHiveConf(currentCatalog);
         Optional<Operation> nonSqlOperation = tryProcessHiveNonSqlStatement(hiveConf, statement);
         if (nonSqlOperation.isPresent()) {
@@ -221,6 +224,9 @@ public class HiveParser implements Parser {
         hiveConfCopy.setVar(HiveConf.ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
         hiveConfCopy.set("hive.allow.udf.load.on.demand", "false");
         hiveConfCopy.setVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
+        // Note: it's equal to HiveCatalog#getHiveVersion, but we can't use
+        // HiveCatalog#getHiveVersion directly for classloader issue.
+        // For more detail, please see class HiveCatalogUtils.
         HiveShim hiveShim =
                 HiveShimLoader.loadHiveShim(HiveCatalogUtils.getHiveVersion(currentCatalog));
         try {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogRegistry;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
-import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.delegation.Parser;
@@ -53,6 +52,7 @@ import org.apache.flink.table.planner.delegation.hive.parse.HiveASTParser;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserCreateViewInfo;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserDDLSemanticAnalyzer;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserLoadSemanticAnalyzer;
+import org.apache.flink.table.planner.utils.HiveCatalogUtils;
 import org.apache.flink.table.planner.utils.TableSchemaUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -195,7 +195,7 @@ public class HiveParser implements Parser {
 
         Catalog currentCatalog =
                 catalogRegistry.getCatalogOrError(catalogRegistry.getCurrentCatalog());
-        if (!(currentCatalog instanceof HiveCatalog)) {
+        if (!HiveCatalogUtils.isHiveCatalog(currentCatalog)) {
             // current, if it's not a hive catalog, we can't use hive dialect;
             // but we try to parse it to set command, if it's a set command, we can return
             // the SetOperation directly which enables users to switch dialect when hive dialect
@@ -212,26 +212,25 @@ public class HiveParser implements Parser {
             }
         }
 
-        Optional<Operation> nonSqlOperation =
-                tryProcessHiveNonSqlStatement(
-                        ((HiveCatalog) currentCatalog).getHiveConf(), statement);
+        HiveConf hiveConf = HiveCatalogUtils.getHiveConf(currentCatalog);
+        Optional<Operation> nonSqlOperation = tryProcessHiveNonSqlStatement(hiveConf, statement);
         if (nonSqlOperation.isPresent()) {
             return Collections.singletonList(nonSqlOperation.get());
         }
-        HiveConf hiveConf = new HiveConf(((HiveCatalog) currentCatalog).getHiveConf());
-        hiveConf.setVar(HiveConf.ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
-        hiveConf.set("hive.allow.udf.load.on.demand", "false");
-        hiveConf.setVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
+        HiveConf hiveConfCopy = new HiveConf(hiveConf);
+        hiveConfCopy.setVar(HiveConf.ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
+        hiveConfCopy.set("hive.allow.udf.load.on.demand", "false");
+        hiveConfCopy.setVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
         HiveShim hiveShim =
-                HiveShimLoader.loadHiveShim(((HiveCatalog) currentCatalog).getHiveVersion());
+                HiveShimLoader.loadHiveShim(HiveCatalogUtils.getHiveVersion(currentCatalog));
         try {
             // substitute variables for the statement
-            statement = substituteVariables(hiveConf, statement);
+            statement = substituteVariables(hiveConfCopy, statement);
             // creates SessionState
-            HiveSessionState.startSessionState(hiveConf, catalogRegistry);
+            HiveSessionState.startSessionState(hiveConfCopy, catalogRegistry);
             // We override Hive's grouping function. Refer to the implementation for more details.
             hiveShim.registerTemporaryFunction("grouping", HiveGenericUDFGrouping.class);
-            return processCmd(statement, hiveConf, hiveShim, (HiveCatalog) currentCatalog);
+            return processCmd(statement, hiveConfCopy, hiveShim, currentCatalog);
         } finally {
             HiveSessionState.clearSessionState();
         }
@@ -371,7 +370,7 @@ public class HiveParser implements Parser {
     }
 
     private List<Operation> processCmd(
-            String cmd, HiveConf hiveConf, HiveShim hiveShim, HiveCatalog hiveCatalog) {
+            String cmd, HiveConf hiveConf, HiveShim hiveShim, Catalog hiveCatalog) {
         try {
             HiveParserContext context = new HiveParserContext(hiveConf);
             // parse statement to get AST

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
@@ -48,7 +48,6 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
-import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
@@ -108,6 +107,7 @@ import org.apache.flink.table.planner.delegation.hive.copy.HiveParserSemanticAna
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserStorageFormat;
 import org.apache.flink.table.planner.delegation.hive.operations.HiveExecutableOperation;
 import org.apache.flink.table.planner.delegation.hive.operations.HiveShowCreateTableOperation;
+import org.apache.flink.table.planner.utils.HiveCatalogUtils;
 import org.apache.flink.table.planner.utils.TableSchemaUtils;
 import org.apache.flink.table.resource.ResourceType;
 import org.apache.flink.table.resource.ResourceUri;
@@ -199,7 +199,7 @@ public class HiveParserDDLSemanticAnalyzer {
     private final Set<String> reservedPartitionValues;
     private final HiveConf conf;
     private final HiveParserQueryState queryState;
-    private final HiveCatalog hiveCatalog;
+    private final Catalog hiveCatalog;
     private final CatalogRegistry catalogRegistry;
     private final String currentDB;
     private final HiveParser hiveParser;
@@ -266,7 +266,7 @@ public class HiveParserDDLSemanticAnalyzer {
 
     public HiveParserDDLSemanticAnalyzer(
             HiveParserQueryState queryState,
-            HiveCatalog hiveCatalog,
+            Catalog hiveCatalog,
             CatalogRegistry catalogRegistry,
             HiveParser hiveParser,
             HiveShim hiveShim,
@@ -305,11 +305,7 @@ public class HiveParserDDLSemanticAnalyzer {
     }
 
     private Table getTable(ObjectPath tablePath) {
-        try {
-            return new Table(hiveCatalog.getHiveTable(tablePath));
-        } catch (TableNotExistException e) {
-            throw new ValidationException("Table not found", e);
-        }
+        return new Table(HiveCatalogUtils.getTable(hiveCatalog, tablePath));
     }
 
     public Operation convertToOperation(HiveParserASTNode ast) throws SemanticException {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/utils/HiveCatalogUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/utils/HiveCatalogUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+/**
+ * Utils related to Hive Catalog for Hive dialect. In Hive dialect, the classloader of the Hive's
+ * catalog got in Hive dialect is FlinkUserClassloader. But the classloader of the class HiveCatalog
+ * is Flink's ComponentClassLoader. The classloader is not same, so we can't cast the Hive's catalog
+ * got to HiveCatalog directly which cause us can only call these methods in HiveCatalog via
+ * reflection.
+ *
+ * <p>It's a hack logic, we can remove the hack logic after we split the Hive connector into two,
+ * one of which is for source/sink, and the other one is only for hive dialect. Then, the class
+ * loader will be same.
+ */
+public class HiveCatalogUtils {
+
+    public static boolean isHiveCatalog(Catalog catalog) {
+        // we can't use catalog instanceof HiveCatalog directly
+        // as the classloaders for catalog and HiveCatalog are different
+        return catalog instanceof HiveCatalog
+                || catalog.getClass().getName().equals(HiveCatalog.class.getName());
+    }
+
+    public static HiveConf getHiveConf(Catalog catalog) {
+        try {
+            return (HiveConf)
+                    HiveReflectionUtils.invokeMethod(
+                            catalog.getClass(), catalog, "getHiveConf", null, null);
+        } catch (Exception e) {
+            throw new TableException(
+                    String.format("Fail to get HiveConf via catalog: %s.", catalog.getClass()), e);
+        }
+    }
+
+    public static String getHiveVersion(Catalog catalog) {
+        try {
+            return (String)
+                    HiveReflectionUtils.invokeMethod(
+                            catalog.getClass(), catalog, "getHiveVersion", null, null);
+        } catch (Exception e) {
+            throw new TableException(
+                    String.format("Fail to get Hive version via catalog: %s.", catalog.getClass()),
+                    e);
+        }
+    }
+
+    public static Table getTable(Catalog catalog, ObjectPath tablePath) {
+        try {
+            return (Table)
+                    HiveReflectionUtils.invokeMethod(
+                            catalog.getClass(),
+                            catalog,
+                            "getHiveTable",
+                            new Class[] {ObjectPath.class},
+                            new Object[] {tablePath});
+        } catch (Exception e) {
+            throw new TableException(
+                    String.format("Fail to get Table via catalog: %s.", catalog.getClass()), e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/utils/HiveCatalogUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/utils/HiveCatalogUtils.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.hive.metastore.api.Table;
  * got to HiveCatalog directly which cause us can only call these methods in HiveCatalog via
  * reflection.
  *
- * <p>It's a hack logic, we can remove the hack logic after we split the Hive connector into two,
- * one of which is for source/sink, and the other one is only for hive dialect. Then, the class
- * loader will be same.
+ * <p>It's a hack logic, we can remove the hack logic after we split the Hive connector into two
+ * jars, one of which is only for source/sink, and the other one is only for hive dialect. Then, the
+ * class loader will be same.
  */
 public class HiveCatalogUtils {
 

--- a/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
@@ -149,6 +149,14 @@ under the License.
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!--Hive 3.1.x depends on calcite-1.16 -->
+		<dependency>
+			<groupId>org.apache.calcite</groupId>
+			<artifactId>calcite-core</artifactId>
+			<version>1.16.0</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -184,6 +192,19 @@ under the License.
 										<exclude>org/apache/hadoop/hive/metastore/HiveMetaStoreClient.class</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>org.apache.calcite:calcite-core</artifact>
+									<includes>
+										<!-- We need include RelOptRule, otherwise, it'll throw class not found exception in Hive dialect.
+										  When use Hive dialect, user need to put hive-connector to FLINK_HOME/lib. And then
+										  in Hive parser, it will call method Hive#closeCurrent; But the class Hive is loaded by
+										  app classloader, see in org.apache.flink.table.planner.loader#PlannerModule. When load the class
+										  Hive, it requires org.apache.calcite.plan.RelOptRule, but this class won't be in app classloader,
+										  and then it'll throw class not found exception. So, we need to include this class.
+										  -->
+										<include>org/apache/calcite/plan/RelOptRule.class</include>
+									</includes>
+								</filter>
 							</filters>
 							<artifactSet>
 								<includes>
@@ -193,6 +214,8 @@ under the License.
 									<include>org.antlr:antlr-runtime</include>
 									<include>org.apache.avro:avro</include>
 									<include>org.apache.avro:avro-mapred</include>
+									<!-- calcite -->
+									<include>org.apache.calcite:calcite-core</include>
 								</includes>
 							</artifactSet>
 							<relocations>

--- a/flink-connectors/flink-sql-connector-hive-3.1.3/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/src/main/resources/META-INF/NOTICE
@@ -8,6 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - org.apache.avro:avro-mapred:hadoop2:1.8.2
 - org.apache.avro:avro:1.8.2
+- org.apache.calcite:calcite-core:1.16.0
 - org.apache.hive:hive-exec:3.1.3
 - org.apache.thrift:libfb303:0.9.3
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/HiveITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/HiveITCase.java
@@ -234,13 +234,8 @@ public class HiveITCase extends TestLogger {
     }
 
     private static FlinkResource buildFlinkResource() {
-        // swap planner
-        // todo: should remove planner swap logic after FLINK-31575
         FlinkResourceSetup.FlinkResourceSetupBuilder builder =
-                FlinkResourceSetup.builder()
-                        .addJar(sqlHiveJar, JarLocation.LIB)
-                        .moveJar("flink-table-planner", JarLocation.OPT, JarLocation.LIB)
-                        .moveJar("flink-table-planner-loader", JarLocation.LIB, JarLocation.OPT);
+                FlinkResourceSetup.builder().addJar(sqlHiveJar, JarLocation.LIB);
 
         // add hadoop jars
         File hadoopClasspathFile = new File(HADOOP_CLASS_PATH.toAbsolutePath().toString());

--- a/flink-table/flink-table-planner-loader/src/main/java/org/apache/flink/table/planner/loader/DelegatePlannerFactory.java
+++ b/flink-table/flink-table-planner-loader/src/main/java/org/apache/flink/table/planner/loader/DelegatePlannerFactory.java
@@ -19,20 +19,47 @@
 package org.apache.flink.table.planner.loader;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.delegation.ParserFactory;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.delegation.PlannerFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.HashSet;
+import java.util.Set;
 
 /** Delegate of {@link PlannerFactory}. */
 @Internal
 public class DelegatePlannerFactory extends BaseDelegateFactory<PlannerFactory>
         implements PlannerFactory {
 
+    private final Set<SqlDialect> seenDialect = new HashSet<>();
+
     public DelegatePlannerFactory() {
         super(PlannerModule.getInstance().loadPlannerFactory());
+        seenDialect.add(SqlDialect.DEFAULT);
     }
 
     @Override
     public Planner create(Context context) {
+        SqlDialect currentDialect = context.getTableConfig().getSqlDialect();
+        if (!seenDialect.contains(currentDialect)) {
+            URL dialectJarUrl =
+                    tryGetJarURLForDialect(PlannerFactory.class.getClassLoader(), currentDialect);
+            PlannerModule.getInstance().addUrlToClassLoader(dialectJarUrl);
+        }
         return delegate.create(context);
+    }
+
+    private URL tryGetJarURLForDialect(ClassLoader classLoader, SqlDialect sqlDialect) {
+        ParserFactory parserFactory =
+                FactoryUtil.discoverFactory(
+                        classLoader, ParserFactory.class, sqlDialect.name().toLowerCase());
+        // get the domain of this class
+        ProtectionDomain protectionDomain = parserFactory.getClass().getProtectionDomain();
+        // get the location for the jar which contains this class
+        return protectionDomain.getCodeSource().getLocation();
     }
 }


### PR DESCRIPTION
…nner to use hive dialect

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
From 1.15, we have to swap table-planner and table-planner-loader to use Hive dialect which is not convenient for users. So this pr is to make it's possible to use  Hive dialect without doing such swapping.


## Brief change log
The design is documented in https://docs.google.com/document/d/1VV88R1O1IN-zX3su6RCAgJPuZiymgh4xoL8OJrW-_00/edit

  -  In `DelegatePlannerFactory`, if it's not default dialect, try to discover the class for the corresponding `ParserFactory`,  and get the jar url for the class.  Add the jar url to the classloader maintained in flink-table-planer-loader to enable the Hive dialect to use the class in flink-table-planner
  -  Do some adjustment in Hive connector for HiveParser since its classloader has changed  and  we need to adjust some codes for calling methods of `HiveCatalog`
  -  Include `org/apache/calcite/plan/RelOptRule.class` in hive-connector-3.x, otherwise it'll throw class not found exception
  - Not to swap planner jar in `HiveITCase` to verify these changes



## Verifying this change
This change is already covered by existing tests, UT & e2e test in `HiveITCase`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
