### PR TITLE
[FLINK-32436][runtime] Removes obsolete LeaderContender.getDescription() method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
@@ -77,12 +77,12 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 
     @Override
     public LeaderElection getResourceManagerLeaderElection() {
-        return resourceManagerLeaderService.createLeaderElectionService();
+        return resourceManagerLeaderService.createLeaderElectionService("resource_manager");
     }
 
     @Override
     public LeaderElection getDispatcherLeaderElection() {
-        return dispatcherLeaderService.createLeaderElectionService();
+        return dispatcherLeaderService.createLeaderElectionService("dispatcher");
     }
 
     @Override
@@ -114,13 +114,13 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
         synchronized (lock) {
             checkNotShutdown();
             EmbeddedLeaderService service = getOrCreateJobManagerService(jobID);
-            return service.createLeaderElectionService();
+            return service.createLeaderElectionService("job-" + jobID);
         }
     }
 
     @Override
     public LeaderElection getClusterRestEndpointLeaderElection() {
-        return clusterRestEndpointLeaderService.createLeaderElectionService();
+        return clusterRestEndpointLeaderService.createLeaderElectionService("rest_server");
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -154,9 +154,9 @@ public class EmbeddedLeaderService {
     //  creating contenders and listeners
     // ------------------------------------------------------------------------
 
-    public LeaderElection createLeaderElectionService() {
+    public LeaderElection createLeaderElectionService(String contenderID) {
         checkState(!shutdown, "leader election service is shut down");
-        return new EmbeddedLeaderElection();
+        return new EmbeddedLeaderElection(contenderID);
     }
 
     public LeaderRetrievalService createLeaderRetrievalService() {
@@ -311,9 +311,7 @@ public class EmbeddedLeaderService {
                 currentLeaderProposed = embeddedLeaderElection;
                 currentLeaderProposed.isLeader = true;
 
-                LOG.info(
-                        "Proposing leadership to contender {}",
-                        embeddedLeaderElection.contender.getDescription());
+                LOG.info("Proposing leadership to contender {}", embeddedLeaderElection.contender);
 
                 return execute(
                         new GrantLeadershipCall(
@@ -442,11 +440,16 @@ public class EmbeddedLeaderService {
 
     private class EmbeddedLeaderElection implements LeaderElection {
 
+        final String contenderID;
         volatile LeaderContender contender;
 
         volatile boolean isLeader;
 
         volatile boolean running;
+
+        EmbeddedLeaderElection(String contenderID) {
+            this.contenderID = contenderID;
+        }
 
         @Override
         public void startLeaderElection(LeaderContender contender) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -203,7 +203,7 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
 
             LOG.info(
                     "LeaderContender {} has been registered for {}.",
-                    contender.getDescription(),
+                    this.contenderID,
                     leaderElectionDriver);
 
             if (issuedLeaderSessionID != null) {
@@ -395,7 +395,7 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
 
         LOG.debug(
                 "Granting leadership to contender {} with session ID {}.",
-                leaderContender.getDescription(),
+                contenderID,
                 issuedLeaderSessionID);
 
         leaderContender.grantLeadership(issuedLeaderSessionID);
@@ -433,11 +433,11 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
         if (confirmedLeaderInformation.isEmpty()) {
             LOG.debug(
                     "Revoking leadership to contender {} while a previous leadership grant wasn't confirmed, yet.",
-                    leaderContender.getDescription());
+                    contenderID);
         } else {
             LOG.debug(
                     "Revoking leadership to contender {} for {}.",
-                    leaderContender.getDescription(),
+                    contenderID,
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation));
         }
 
@@ -455,7 +455,7 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
         if (leaderContender != null) {
             LOG.trace(
                     "Leader node changed while {} is the leader with {}. New leader information {}.",
-                    leaderContender.getDescription(),
+                    contenderID,
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation),
                     LeaderElectionUtils.convertToString(leaderInformation));
             if (!confirmedLeaderInformation.isEmpty()) {
@@ -463,13 +463,11 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
                 if (leaderInformation.isEmpty()) {
                     LOG.debug(
                             "Writing leader information by {} since the external storage is empty.",
-                            leaderContender.getDescription());
+                            contenderID);
                     leaderElectionDriver.publishLeaderInformation(contenderID, confirmedLeaderInfo);
                 } else if (!leaderInformation.equals(confirmedLeaderInfo)) {
                     // the data field does not correspond to the expected leader information
-                    LOG.debug(
-                            "Correcting leader information by {}.",
-                            leaderContender.getDescription());
+                    LOG.debug("Correcting leader information by {}.", contenderID);
                     leaderElectionDriver.publishLeaderInformation(contenderID, confirmedLeaderInfo);
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
@@ -48,13 +48,4 @@ public interface LeaderContender {
      * @param exception Caught exception
      */
     void handleError(Exception exception);
-
-    /**
-     * Returns the description of the {@link LeaderContender} for logging purposes.
-     *
-     * @return Description of this contender.
-     */
-    default String getDescription() {
-        return "LeaderContender: " + getClass().getSimpleName();
-    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -1116,11 +1116,6 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
     }
 
     @Override
-    public String getDescription() {
-        return getRestBaseUrl();
-    }
-
-    @Override
     public void handleError(final Exception exception) {
         fatalErrorHandler.onFatalError(exception);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -53,7 +53,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             final TestingLeaderContender contender = new TestingLeaderContender();
 
             final LeaderElection leaderElection =
-                    embeddedLeaderService.createLeaderElectionService();
+                    embeddedLeaderService.createLeaderElectionService("contender_id");
             leaderElection.startLeaderElection(contender);
             leaderElection.close();
 
@@ -84,7 +84,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             final TestingLeaderContender contender = new TestingLeaderContender();
 
             final LeaderElection leaderElection =
-                    embeddedLeaderService.createLeaderElectionService();
+                    embeddedLeaderService.createLeaderElectionService("contender_id");
             leaderElection.startLeaderElection(contender);
 
             // wait for the leadership

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/TestingLeaderContender.java
@@ -56,11 +56,6 @@ final class TestingLeaderContender implements LeaderContender {
     }
 
     @Override
-    public String getDescription() {
-        return "foobar";
-    }
-
-    @Override
     public void handleError(Exception exception) {
         synchronized (lock) {
             if (!(leaderSessionFuture.isCompletedExceptionally()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -62,7 +62,6 @@ class DefaultLeaderElectionServiceTest {
                             grantLeadership(leaderSessionID);
 
                             testingContender.waitForLeader();
-                            assertThat(testingContender.getDescription()).isEqualTo(TEST_URL);
                             assertThat(testingContender.getLeaderSessionID())
                                     .isEqualTo(
                                             leaderElectionService.getLeaderSessionID(contenderID))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -127,11 +127,6 @@ public class LeaderElectionTest {
         }
 
         @Override
-        public String getDescription() {
-            return "foobar";
-        }
-
-        @Override
         public void handleError(Exception exception) {
             this.exception = exception;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -228,7 +228,7 @@ public class LeaderElectionTest {
 
         @Override
         public LeaderElection createLeaderElection() {
-            return embeddedLeaderService.createLeaderElectionService();
+            return embeddedLeaderService.createLeaderElectionService("embedded_leader_election");
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -64,11 +64,6 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
     }
 
     @Override
-    public String getDescription() {
-        return address;
-    }
-
-    @Override
     public void handleError(Exception exception) {
         super.handleError(exception);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.leaderelection;
 
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * {@code TestingGenericLeaderContender} is a more generic testing implementation of the {@link
@@ -33,17 +32,14 @@ public class TestingGenericLeaderContender implements LeaderContender {
     private final Consumer<UUID> grantLeadershipConsumer;
     private final Runnable revokeLeadershipRunnable;
     private final Consumer<Exception> handleErrorConsumer;
-    private final Supplier<String> getDescriptionSupplier;
 
     private TestingGenericLeaderContender(
             Consumer<UUID> grantLeadershipConsumer,
             Runnable revokeLeadershipRunnable,
-            Consumer<Exception> handleErrorConsumer,
-            Supplier<String> getDescriptionSupplier) {
+            Consumer<Exception> handleErrorConsumer) {
         this.grantLeadershipConsumer = grantLeadershipConsumer;
         this.revokeLeadershipRunnable = revokeLeadershipRunnable;
         this.handleErrorConsumer = handleErrorConsumer;
-        this.getDescriptionSupplier = getDescriptionSupplier;
     }
 
     @Override
@@ -67,11 +63,6 @@ public class TestingGenericLeaderContender implements LeaderContender {
         }
     }
 
-    @Override
-    public String getDescription() {
-        return getDescriptionSupplier.get();
-    }
-
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -84,7 +75,6 @@ public class TestingGenericLeaderContender implements LeaderContender {
                 error -> {
                     throw new AssertionError(error);
                 };
-        private Supplier<String> getDescriptionSupplier = () -> "testing contender";
 
         private Builder() {}
 
@@ -103,17 +93,9 @@ public class TestingGenericLeaderContender implements LeaderContender {
             return this;
         }
 
-        public Builder setGetDescriptionSupplier(Supplier<String> getDescriptionSupplier) {
-            this.getDescriptionSupplier = getDescriptionSupplier;
-            return this;
-        }
-
         public TestingGenericLeaderContender build() {
             return new TestingGenericLeaderContender(
-                    grantLeadershipConsumer,
-                    revokeLeadershipRunnable,
-                    handleErrorConsumer,
-                    getDescriptionSupplier);
+                    grantLeadershipConsumer, revokeLeadershipRunnable, handleErrorConsumer);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`LeaderContender.getDescription()` was barely used (only for the log output in the ZK driver implementation). With the `contenderID` becoming a more fundamental property of the `DefaultLeaderElectionService` we can get rid of the `getDescription()` method.

## Brief change log

* Removes method from interface and implementing classes

## Verifying this change

* Removes method from test classes (trivial change)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable