### PR TITLE
[FLINK-32403][table] Add database related operations in CatalogManager

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
@@ -1021,5 +1023,70 @@ public final class CatalogManager implements CatalogRegistry {
         }
         final ResolvedSchema resolvedSchema = view.getUnresolvedSchema().resolve(schemaResolver);
         return new ResolvedCatalogView(view, resolvedSchema);
+    }
+
+    /**
+     * Create a database.
+     *
+     * @param catalogName Name of the catalog for database
+     * @param databaseName Name of the database to be created
+     * @param database The database definition
+     * @param ignoreIfExists Flag to specify behavior when a database with the given name already
+     *     exists: if set to false, throw a DatabaseAlreadyExistException, if set to true, do
+     *     nothing.
+     * @throws DatabaseAlreadyExistException if the given database already exists and ignoreIfExists
+     *     is false
+     * @throws CatalogException in case of any runtime exception
+     */
+    public void createDatabase(
+            String catalogName,
+            String databaseName,
+            CatalogDatabase database,
+            boolean ignoreIfExists)
+            throws DatabaseAlreadyExistException, CatalogException {
+        Catalog catalog = getCatalogOrThrowException(catalogName);
+        catalog.createDatabase(databaseName, database, ignoreIfExists);
+    }
+
+    /**
+     * Drop a database.
+     *
+     * @param catalogName Name of the catalog for database.
+     * @param databaseName Name of the database to be dropped.
+     * @param ignoreIfNotExists Flag to specify behavior when the database does not exist: if set to
+     *     false, throw an exception, if set to true, do nothing.
+     * @param cascade Flag to specify behavior when the database contains table or function: if set
+     *     to true, delete all tables and functions in the database and then delete the database, if
+     *     set to false, throw an exception.
+     * @throws DatabaseNotExistException if the given database does not exist
+     * @throws DatabaseNotEmptyException if the given database is not empty and isRestrict is true
+     * @throws CatalogException in case of any runtime exception
+     */
+    public void dropDatabase(
+            String catalogName, String databaseName, boolean ignoreIfNotExists, boolean cascade)
+            throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        Catalog catalog = getCatalogOrError(catalogName);
+        catalog.dropDatabase(databaseName, ignoreIfNotExists, cascade);
+    }
+
+    /**
+     * Modify an existing database.
+     *
+     * @param catalogName Name of the catalog for database
+     * @param databaseName Name of the database to be dropped
+     * @param newDatabase The new database definition
+     * @param ignoreIfNotExists Flag to specify behavior when the given database does not exist: if
+     *     set to false, throw an exception, if set to true, do nothing.
+     * @throws DatabaseNotExistException if the given database does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    public void alterDatabase(
+            String catalogName,
+            String databaseName,
+            CatalogDatabase newDatabase,
+            boolean ignoreIfNotExists)
+            throws DatabaseNotExistException, CatalogException {
+        Catalog catalog = getCatalogOrError(catalogName);
+        catalog.alterDatabase(databaseName, newDatabase, ignoreIfNotExists);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
-import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.operations.Operation;
@@ -70,10 +69,13 @@ public class AlterDatabaseOperation implements AlterOperation {
 
     @Override
     public TableResultInternal execute(Context ctx) {
-        Catalog catalog = ctx.getCatalogManager().getCatalogOrThrowException(getCatalogName());
         try {
-            catalog.alterDatabase(getDatabaseName(), getCatalogDatabase(), false);
+            ctx.getCatalogManager()
+                    .alterDatabase(
+                            getCatalogName(), getDatabaseName(), getCatalogDatabase(), false);
             return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
         } catch (DatabaseNotExistException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterDatabaseOperation.java
@@ -74,8 +74,6 @@ public class AlterDatabaseOperation implements AlterOperation {
                     .alterDatabase(
                             getCatalogName(), getDatabaseName(), getCatalogDatabase(), false);
             return TableResultImpl.TABLE_RESULT_OK;
-        } catch (ValidationException e) {
-            throw e;
         } catch (DatabaseNotExistException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
-import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.operations.Operation;
@@ -80,10 +79,12 @@ public class CreateDatabaseOperation implements CreateOperation {
 
     @Override
     public TableResultInternal execute(Context ctx) {
-        Catalog catalog = ctx.getCatalogManager().getCatalogOrThrowException(catalogName);
         try {
-            catalog.createDatabase(databaseName, catalogDatabase, ignoreIfExists);
+            ctx.getCatalogManager()
+                    .createDatabase(catalogName, databaseName, catalogDatabase, ignoreIfExists);
             return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
         } catch (DatabaseAlreadyExistException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateDatabaseOperation.java
@@ -83,8 +83,6 @@ public class CreateDatabaseOperation implements CreateOperation {
             ctx.getCatalogManager()
                     .createDatabase(catalogName, databaseName, catalogDatabase, ignoreIfExists);
             return TableResultImpl.TABLE_RESULT_OK;
-        } catch (ValidationException e) {
-            throw e;
         } catch (DatabaseAlreadyExistException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
-import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 
@@ -68,10 +67,12 @@ public class DropDatabaseOperation implements DropOperation {
 
     @Override
     public TableResultInternal execute(Context ctx) {
-        Catalog catalog = ctx.getCatalogManager().getCatalogOrThrowException(getCatalogName());
         try {
-            catalog.dropDatabase(getDatabaseName(), isIfExists(), isCascade());
+            ctx.getCatalogManager()
+                    .dropDatabase(getCatalogName(), getDatabaseName(), isIfExists(), isCascade());
             return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw e;
         } catch (DatabaseNotExistException | DatabaseNotEmptyException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropDatabaseOperation.java
@@ -71,8 +71,6 @@ public class DropDatabaseOperation implements DropOperation {
             ctx.getCatalogManager()
                     .dropDatabase(getCatalogName(), getDatabaseName(), isIfExists(), isCascade());
             return TableResultImpl.TABLE_RESULT_OK;
-        } catch (ValidationException e) {
-            throw e;
         } catch (DatabaseNotExistException | DatabaseNotEmptyException e) {
             throw new ValidationException(
                     String.format("Could not execute %s", asSummaryString()), e);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -165,11 +165,8 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
     @Test
     public void testAlterDatabase() throws Exception {
         catalogManager.registerCatalog("cat1", new GenericInMemoryCatalog("default", "default"));
-        catalogManager
-                .getCatalog("cat1")
-                .get()
-                .createDatabase(
-                        "db1", new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"), true);
+        catalogManager.createDatabase(
+                "cat1", "db1", new CatalogDatabaseImpl(new HashMap<>(), "db1_comment"), true);
         final String sql = "alter database cat1.db1 set ('k1'='v1', 'K2'='V2')";
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(AlterDatabaseOperation.class);
@@ -2256,7 +2253,8 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
         if (!catalogManager.getCatalog("cat1").isPresent()) {
             catalogManager.registerCatalog("cat1", catalog);
         }
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
+        catalogManager.createDatabase(
+                "cat1", "db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
         Schema.Builder builder =
                 Schema.newBuilder()
                         .column("a", DataTypes.INT().notNull())


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add database operations in CatalogManager, then Create/Alter/DropDatabaseOperation can use catalog manager to do some operations for database and we can add a listener in catalog manager for them later.

## Brief change log
  - Add create/alter/drop database method in catalog manager
  - Use catalog manager for database in Create/Alter/DropDatabaseOperation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
