### PR TITLE
[FLINK-32253][runtime] Update pending resource requests on nodes unblocked.

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
+import io.fabric8.kubernetes.api.model.Pod;
+
 /** Testing implementation of {@link KubernetesPod}. */
 public class TestingKubernetesPod extends KubernetesPod {
     private final String name;
@@ -30,6 +32,13 @@ public class TestingKubernetesPod extends KubernetesPod {
 
     public TestingKubernetesPod(String name, boolean isScheduled, boolean isTerminated) {
         super(null);
+        this.name = name;
+        this.isScheduled = isScheduled;
+        this.isTerminated = isTerminated;
+    }
+
+    public TestingKubernetesPod(Pod pod, String name, boolean isScheduled, boolean isTerminated) {
+        super(pod);
         this.name = name;
         this.isScheduled = isScheduled;
         this.isTerminated = isTerminated;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
@@ -210,6 +211,11 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         } catch (Exception e) {
             throw new ResourceManagerException("Cannot terminate resource provider.", e);
         }
+    }
+
+    @Override
+    protected void unblockResources(Collection<BlockedNode> unblockedNodes) {
+        resourceManagerDriver.unblockResources(unblockedNodes);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
@@ -26,6 +27,7 @@ import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -101,4 +103,11 @@ public interface ResourceManagerDriver<WorkerType extends ResourceIDRetrievable>
      * @param worker Worker node to be released, in the deployment specific type.
      */
     void releaseResource(WorkerType worker);
+
+    /**
+     * Unblock resources on the nodes.
+     *
+     * @param unblockedNodes the nodes to unblock resources
+     */
+    void unblockResources(Collection<BlockedNode> unblockedNodes);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
@@ -29,6 +30,7 @@ import org.apache.flink.util.function.TriFunctionWithException;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -91,6 +93,11 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
     public CompletableFuture<ResourceID> requestResource(
             TaskExecutorProcessSpec taskExecutorProcessSpec) {
         return requestResourceFunction.apply(taskExecutorProcessSpec);
+    }
+
+    @Override
+    public void unblockResources(Collection<BlockedNode> unblockedNodes) {
+        // noop
     }
 
     @Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptionsInternal;
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -368,6 +369,11 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         Set<String> difference = new HashSet<>(setA);
         difference.removeAll(setB);
         return difference;
+    }
+
+    @Override
+    public void unblockResources(Collection<BlockedNode> unblockedNodes) {
+        tryUpdateApplicationBlockList();
     }
 
     @Override

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
@@ -477,6 +478,15 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
                                     .get();
                             assertThat(yarnReceivedBlocklist)
                                     .containsExactlyInAnyOrder("node2", "node3");
+
+                            // Verification of unblock resources
+                            String node3 = "node3";
+                            blockedNodes.remove(node3);
+                            final List<BlockedNode> unblockedNodes = new ArrayList<>();
+                            unblockedNodes.add(new BlockedNode(node3, "cause", 1L));
+                            runInMainThread(() -> getDriver().unblockResources(unblockedNodes))
+                                    .get();
+                            assertThat(yarnReceivedBlocklist).doesNotContain(node3);
                         });
             }
         };


### PR DESCRIPTION
## What is the purpose of the change

Currently, Blocklist unblockResources does not update the existing pending resource request from YARN/K8S. It updates only for the new resource requests. The existing pending resource requests are not scheduled on the nodes which are unblocked. This Patch updates the pending resource requests.


## Brief change log

1. _unblockResources_ method is added in _ResourceManagerDriver_ interface which both _YarnResourceManagerDriver_ and _KubernetesResourceManagerDriver_ implements.
2. _ActiveResourceManager_ invokes the _unblockResources_ in _ResourceManagerDriver_ when _BlockListHandler_ removes the timedout blocked nodes.
3. _YarnResourceManagerDriver_ calls the _tryUpdateApplicationBlockList_ to update YARN with new block list details.
4. _KubernetesResourceManagerDriver_ gets the pending pod with node affinity notin set to any of the unblocked node and stops and reschedule.


## Verifying this change

1. _YarnResourceManagerDriverTest_#_testUpdateBlocklist_
2. _KubernetesResourceManagerDriverTest_#_testUnblockResources_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **(no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **(no)**
  - The serializers: **(no)**
  - The runtime per-record code paths (performance sensitive): **(no)**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **(no)**
  - The S3 file system connector: **(no)**

## Documentation

  - Does this pull request introduce a new feature?  **(no)**
  - If yes, how is the feature documented? **(not applicable)**
