### PR TITLE
[BP-1.16][FLINK-32421][test] EmbeddedLeaderServiceTest.testConcurrentRevokeLeadershipAndShutdown is not properly implemented

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -18,36 +18,35 @@
 
 package org.apache.flink.runtime.highavailability.nonha.embedded;
 
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
 /** Tests for the {@link EmbeddedLeaderService}. */
 public class EmbeddedLeaderServiceTest extends TestLogger {
 
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
     /**
      * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant leadership call
      * and a shutdown.
      */
     @Test
     public void testConcurrentGrantLeadershipAndShutdown() throws Exception {
+        final ManuallyTriggeredScheduledExecutorService executorService =
+                new ManuallyTriggeredScheduledExecutorService();
         final EmbeddedLeaderService embeddedLeaderService =
-                new EmbeddedLeaderService(EXECUTOR_RESOURCE.getExecutor());
+                new EmbeddedLeaderService(executorService);
 
         try {
             final LeaderElectionService leaderElectionService =
@@ -61,6 +60,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             try {
                 // check that no exception occurred
                 contender.getLeaderSessionFuture().get(10L, TimeUnit.MILLISECONDS);
+                fail("The future shouldn't have completed.");
             } catch (TimeoutException ignored) {
                 // we haven't participated in the leader election
             }
@@ -69,6 +69,9 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
         } finally {
             embeddedLeaderService.shutdown();
+
+            // triggers the grant event processing after shutdown
+            executorService.triggerAll();
         }
     }
 
@@ -78,8 +81,10 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
      */
     @Test
     public void testConcurrentRevokeLeadershipAndShutdown() throws Exception {
+        final ManuallyTriggeredScheduledExecutorService executorService =
+                new ManuallyTriggeredScheduledExecutorService();
         final EmbeddedLeaderService embeddedLeaderService =
-                new EmbeddedLeaderService(EXECUTOR_RESOURCE.getExecutor());
+                new EmbeddedLeaderService(executorService);
 
         try {
             final LeaderElectionService leaderElectionService =
@@ -90,6 +95,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             leaderElectionService.start(contender);
 
             // wait for the leadership
+            executorService.trigger();
             contender.getLeaderSessionFuture().get();
 
             final CompletableFuture<Void> revokeLeadershipFuture =
@@ -99,6 +105,7 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             try {
                 // check that no exception occurred
                 revokeLeadershipFuture.get(10L, TimeUnit.MILLISECONDS);
+                fail("The future shouldn't have completed.");
             } catch (TimeoutException ignored) {
                 // the leader election service has been stopped before revoking could be executed
             }
@@ -107,6 +114,9 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
         } finally {
             embeddedLeaderService.shutdown();
+
+            // triggers the revoke event processing after shutdown
+            executorService.triggerAll();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -20,22 +20,15 @@ package org.apache.flink.runtime.highavailability.nonha.embedded;
 
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
-import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link EmbeddedLeaderService}. */
-public class EmbeddedLeaderServiceTest extends TestLogger {
+class EmbeddedLeaderServiceTest {
 
     /**
      * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant leadership call
@@ -57,16 +50,13 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             leaderElectionService.start(contender);
             leaderElectionService.stop();
 
-            try {
-                // check that no exception occurred
-                contender.getLeaderSessionFuture().get(10L, TimeUnit.MILLISECONDS);
-                fail("The future shouldn't have completed.");
-            } catch (TimeoutException ignored) {
-                // we haven't participated in the leader election
-            }
+            assertThat(contender.getLeaderSessionFuture())
+                    .as(
+                            "The future shouldn't have completed because the grant event wasn't processed, yet.")
+                    .isNotDone();
 
             // the election service should still be running
-            Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+            assertThat(embeddedLeaderService.isShutdown()).isFalse();
         } finally {
             embeddedLeaderService.shutdown();
 
@@ -102,16 +92,13 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
                     embeddedLeaderService.revokeLeadership();
             leaderElectionService.stop();
 
-            try {
-                // check that no exception occurred
-                revokeLeadershipFuture.get(10L, TimeUnit.MILLISECONDS);
-                fail("The future shouldn't have completed.");
-            } catch (TimeoutException ignored) {
-                // the leader election service has been stopped before revoking could be executed
-            }
+            assertThat(revokeLeadershipFuture)
+                    .as(
+                            "The future shouldn't have completed because the revoke event wasn't processed, yet.")
+                    .isNotDone();
 
             // the election service should still be running
-            Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+            assertThat(embeddedLeaderService.isShutdown()).isFalse();
         } finally {
             embeddedLeaderService.shutdown();
 


### PR DESCRIPTION
1.16 backport PR for parent PR https://github.com/apache/flink/pull/22865