### PR TITLE
[FLINK-24911][table] Enable line numbers in SQL Client

### DIFF
--- a/docs/layouts/shortcodes/generated/sql_client_configuration.html
+++ b/docs/layouts/shortcodes/generated/sql_client_configuration.html
@@ -21,6 +21,12 @@
             <td>Deprecated, please use table.display.max-column-width instead. When printing the query results, this parameter determines the number of characters shown on screen before truncating. This only applies to columns with variable-length types (e.g. STRING) in streaming mode. Fixed-length types and all types in batch mode are printed using a deterministic column width.</td>
         </tr>
         <tr>
+            <td><h5>sql-client.display.show-line-numbers</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Determines whether there should be shown line numbers in multiline SQL or not.</td>
+        </tr>
+        <tr>
             <td><h5>sql-client.execution.max-table-result.rows</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">1000000</td>
             <td>Integer</td>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -32,6 +32,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
 import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.LineReaderImpl;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
@@ -63,6 +64,7 @@ public class CliClient implements AutoCloseable {
                     .style(AttributedStyle.DEFAULT)
                     .append("> ")
                     .toAnsi();
+    private static final String SHOW_LINE_NUMBERS_PATTERN = "%N%M> ";
 
     private final Executor executor;
 
@@ -182,6 +184,11 @@ public class CliClient implements AutoCloseable {
             try {
                 // read a statement from terminal and parse it
                 line = lineReader.readLine(NEWLINE_PROMPT, null, inputTransformer, null);
+                lineReader.setVariable(
+                        LineReader.SECONDARY_PROMPT_PATTERN,
+                        (executor.getSessionConfig().get(SqlClientOptions.DISPLAY_SHOW_LINE_NUMBERS)
+                                ? SHOW_LINE_NUMBERS_PATTERN
+                                : LineReaderImpl.DEFAULT_SECONDARY_PROMPT_PATTERN));
                 if (line.trim().isEmpty()) {
                     continue;
                 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -111,9 +111,14 @@ public class CliClient implements AutoCloseable {
 
     /** Opens the interactive CLI shell. */
     public void executeInInteractiveMode() {
+        executeInInteractiveMode(null);
+    }
+
+    @VisibleForTesting
+    void executeInInteractiveMode(LineReader lineReader) {
         try {
             terminal = terminalFactory.get();
-            executeInteractive();
+            executeInteractive(lineReader);
         } finally {
             closeTerminal();
         }
@@ -159,7 +164,7 @@ public class CliClient implements AutoCloseable {
      * Execute statement from the user input and prints status information and/or errors on the
      * terminal.
      */
-    private void executeInteractive() {
+    private void executeInteractive(LineReader inputLineReader) {
         // make space from previous output and test the writer
         terminal.writer().println();
         terminal.writer().flush();
@@ -167,7 +172,10 @@ public class CliClient implements AutoCloseable {
         // print welcome
         terminal.writer().append(CliStrings.MESSAGE_WELCOME);
 
-        LineReader lineReader = createLineReader(terminal, ExecutionMode.INTERACTIVE_EXECUTION);
+        LineReader lineReader =
+                inputLineReader == null
+                        ? createLineReader(terminal, ExecutionMode.INTERACTIVE_EXECUTION)
+                        : inputLineReader;
         getAndExecuteStatements(lineReader, false);
     }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
@@ -77,4 +77,12 @@ public class SqlClientOptions {
                     .defaultValue(SyntaxHighlightStyle.BuiltInStyle.DEFAULT.name())
                     .withDescription(
                             "SQL highlight color schema to be used at SQL client. Possible values: 'default', 'dark', 'light', 'chester', 'vs2010', 'solarized', 'obsidian', 'geshi'");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<Boolean> DISPLAY_SHOW_LINE_NUMBERS =
+            ConfigOptions.key("sql-client.display.show-line-numbers")
+                    .booleanType()
+                    .defaultValue(Boolean.FALSE)
+                    .withDescription(
+                            "Determines whether there should be shown line numbers in multiline SQL or not.");
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.client.cli.parser.SqlCommandParserImpl;
+import org.apache.flink.table.client.cli.parser.SqlMultiLineParser;
 import org.apache.flink.table.client.cli.utils.SqlScriptReader;
 import org.apache.flink.table.client.cli.utils.TestSqlStatement;
 import org.apache.flink.table.client.gateway.Executor;
@@ -42,6 +44,8 @@ import org.apache.flink.shaded.guava30.com.google.common.io.PatternFilenameFilte
 import org.apache.calcite.util.Util;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
@@ -51,6 +55,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.BufferedReader;
@@ -121,7 +126,7 @@ class CliClientITCase {
         final int commonPrefixLength = firstFile.getAbsolutePath().length() - first.length();
         File dir = firstFile.getParentFile();
         final List<String> paths = new ArrayList<>();
-        final FilenameFilter filter = new PatternFilenameFilter(".*\\.q$");
+        final FilenameFilter filter = new PatternFilenameFilter("select\\.q$");
         for (File f : Util.first(dir.listFiles(filter), new File[0])) {
             paths.add(f.getAbsolutePath().substring(commonPrefixLength));
         }
@@ -190,6 +195,64 @@ class CliClientITCase {
         List<Result> actualResults = runSqlStatements(sqlStatements, configuration);
         String out = transformOutput(testSqlStatements, actualResults);
         assertThat(out).isEqualTo(in);
+    }
+
+    @ParameterizedTest
+    @MethodSource("tableOptionToJlineVarProvider")
+    void testPropagationOfTableOptionToVars(
+            String setTableOptionCommand,
+            String jlineVarName,
+            String expectedValue,
+            @InjectClusterClientConfiguration Configuration configuration)
+            throws IOException {
+
+        DefaultContext defaultContext =
+                new DefaultContext(
+                        new Configuration(configuration)
+                                // Make sure we use the new cast behaviour
+                                .set(
+                                        ExecutionConfigOptions.TABLE_EXEC_LEGACY_CAST_BEHAVIOUR,
+                                        ExecutionConfigOptions.LegacyCastBehaviour.DISABLED),
+                        Collections.emptyList());
+
+        // Since DumbTerminal exits automatically with the last line need to add \n to have command
+        // processed before the exit
+        InputStream inputStream =
+                new ByteArrayInputStream((setTableOptionCommand + "\n").getBytes());
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(256);
+
+        try (final Executor executor =
+                        Executor.create(
+                                defaultContext,
+                                InetSocketAddress.createUnresolved(
+                                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort()),
+                                "test-session");
+                Terminal terminal = new DumbTerminal(inputStream, outputStream);
+                CliClient client =
+                        new CliClient(
+                                () -> terminal, executor, historyPath, HideSqlStatement.INSTANCE)) {
+
+            LineReader dummyLineReader =
+                    LineReaderBuilder.builder()
+                            .terminal(terminal)
+                            .parser(
+                                    new SqlMultiLineParser(
+                                            new SqlCommandParserImpl(),
+                                            executor,
+                                            CliClient.ExecutionMode.INTERACTIVE_EXECUTION))
+                            .build();
+            client.executeInInteractiveMode(dummyLineReader);
+            assertThat(dummyLineReader.getVariable(jlineVarName)).isEqualTo(expectedValue);
+        }
+    }
+
+    static Stream<Arguments> tableOptionToJlineVarProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "SET 'sql-client.display.show-line-numbers' = 'true';",
+                        LineReader.SECONDARY_PROMPT_PATTERN,
+                        "%N%M> "));
     }
 
     /**

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -126,7 +126,7 @@ class CliClientITCase {
         final int commonPrefixLength = firstFile.getAbsolutePath().length() - first.length();
         File dir = firstFile.getParentFile();
         final List<String> paths = new ArrayList<>();
-        final FilenameFilter filter = new PatternFilenameFilter("select\\.q$");
+        final FilenameFilter filter = new PatternFilenameFilter(".*\\.q$");
         for (File f : Util.first(dir.listFiles(filter), new File[0])) {
             paths.add(f.getAbsolutePath().substring(commonPrefixLength));
         }


### PR DESCRIPTION
## What is the purpose of the change

The PR allows to have line numbers in SQL Client for multiline SQL.
In fact line numbers are already implemented in JLine and the only thing the PR does is allowing to toggle line numbers via property.


## Verifying this change

This change is a trivial rework.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs )
