### PR TITLE
[FLINK-32447][table-planner] Fix missing table hints when they inside a view referenced by an external query

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.utils.Expander;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.validate.SqlValidator;
 
@@ -60,7 +60,9 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
     public String toQuotedSqlString(SqlNode sqlNode) {
         SqlParser.Config parserConfig = flinkPlanner.config().getParserConfig();
         SqlDialect dialect =
-                new CalciteSqlDialect(
+                // The default implementation of SqlDialect suppresses all table hints since
+                // CALCITE-4640, so we should use AnsiSqlDialect instead to reserve table hints.
+                new AnsiSqlDialect(
                         SqlDialect.EMPTY_CONTEXT
                                 .withQuotedCasing(parserConfig.unquotedCasing())
                                 .withConformance(parserConfig.conformance())

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
@@ -158,24 +158,6 @@ MultipleInput(readOrder=[0,1], members=[\nHashJoin(joinType=[InnerJoin], where=[
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOverrideOptions[1: is-bounded=false]">
-    <Resource name="sql">
-      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v1, k2=#v2}]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, (a + 1) AS c])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testJoinWithOverriddenOptions[1: is-bounded=false]">
     <Resource name="sql">
       <![CDATA[
@@ -203,6 +185,77 @@ Join(joinType=[InnerJoin], where=[(a = d)], select=[a, b, c, d, e, f], leftInput
 :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
 +- Exchange(distribution=[hash[d]])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=#v3, k4=#v4})], dynamic options: {k3=#v3, k4=#v4}]], fields=[d, e, f], hints=[[[OPTIONS options:{k3=#v3, k4=#v4}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintInsideView[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[
+select * from t2 join v1 on v1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], a=[$3], b=[$4], c=[$5])
++- LogicalJoin(condition=[=($3, $0)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v111, k4=#v444}]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+MultipleInput(readOrder=[1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d)], select=[d, e, f, a, b, c], build=[right])\n:- [#1] Exchange(distribution=[hash[d]])\n+- Calc(select=[a, b, (a + 1) AS c])\n   +- [#2] Exchange(distribution=[hash[a]])\n])
+:- Exchange(distribution=[hash[d]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
++- Exchange(distribution=[hash[a]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v111, k4=#v444}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverrideOptions[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v1, k2=#v2}]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, (a + 1) AS c])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v1, k2=#v2}]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintInsideView[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[
+select * from t2 join v1 on v1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(d=[$0], e=[$1], f=[$2], a=[$3], b=[$4], c=[$5])
++- LogicalJoin(condition=[=($3, $0)], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], hints=[[[OPTIONS inheritPath:[] options:{k1=#v111, k4=#v444}]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[(a = d)], select=[d, e, f, a, b, c], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[d]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a, b, (a + 1) AS c])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v111, k2=v2, k4=#v444})], dynamic options: {k1=#v111, k4=#v444}]], fields=[a, b], hints=[[[OPTIONS options:{k1=#v111, k4=#v444}]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
@@ -181,6 +181,15 @@ class OptionsHintTest(param: Param) extends TableTestBase {
         "cannot be enriched with new options. Hints can only be applied to tables.")
       .isInstanceOf[ValidationException]
   }
+
+  @Test
+  def testOptionsHintInsideView(): Unit = {
+    util.tableEnv.executeSql(
+      "create view v1 as select * from t1 /*+ OPTIONS(k1='#v111', k4='#v444')*/")
+    util.verifyExecPlan(s"""
+                           |select * from t2 join v1 on v1.a = t2.d
+                           |""".stripMargin)
+  }
 }
 
 object OptionsHintTest {


### PR DESCRIPTION
## What is the purpose of the change
Table hints will lost when they inside a view referenced by an external query, this is due to the upgrading of calcite-1.28 (affected by [CALCITE-4640](https://issues.apache.org/jira/browse/CALCITE-4640) which changed the default implementation of `SqlDialect` suppresses all table hints).  We should use `AnsiSqlDialect` instead to reserve table hints.

## Brief change log
use `AnsiSqlDialect` instead to reserve table hints

## Verifying this change
add new case into existing `OptionsHintTest` 

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)

