### PR TITLE
[FLINK-31476] AdaptiveScheduler respects minimum parallelism 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismInfo.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 
 /** A {@link VertexParallelismInformation} implementation that provides common validation. */
 public class DefaultVertexParallelismInfo implements VertexParallelismInformation {
+    private final int minParallelism;
     private int parallelism;
     private int maxParallelism;
     private final Function<Integer, Optional<String>> rescaleMaxValidator;
@@ -45,6 +46,15 @@ public class DefaultVertexParallelismInfo implements VertexParallelismInformatio
             int parallelism,
             int maxParallelism,
             Function<Integer, Optional<String>> rescaleMaxValidator) {
+        this(1, parallelism, maxParallelism, rescaleMaxValidator);
+    }
+
+    public DefaultVertexParallelismInfo(
+            int minParallelism,
+            int parallelism,
+            int maxParallelism,
+            Function<Integer, Optional<String>> rescaleMaxValidator) {
+        this.minParallelism = minParallelism;
         this.parallelism = checkInitialParallelism(parallelism);
         this.maxParallelism = normalizeAndCheckMaxParallelism(maxParallelism);
         this.rescaleMaxValidator = Preconditions.checkNotNull(rescaleMaxValidator);
@@ -77,6 +87,11 @@ public class DefaultVertexParallelismInfo implements VertexParallelismInformatio
                 KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM,
                 parallelism);
         return parallelism;
+    }
+
+    @Override
+    public int getMinParallelism() {
+        return minParallelism;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
@@ -23,6 +23,9 @@ package org.apache.flink.runtime.scheduler;
  * change during runtime.
  */
 public interface VertexParallelismInformation {
+
+    int getMinParallelism();
+
     /**
      * Returns a vertex's parallelism.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexParallelismInformation.java
@@ -24,6 +24,11 @@ package org.apache.flink.runtime.scheduler;
  */
 public interface VertexParallelismInformation {
 
+    /**
+     * Returns a vertex's min parallelism.
+     *
+     * @return the min parallelism for the vertex
+     */
     int getMinParallelism();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1160,14 +1160,12 @@ public class AdaptiveScheduler
         final Optional<VertexParallelism> maybeNewParallelism =
                 slotAllocator.determineParallelism(
                         jobInformation, declarativeSlotPool.getAllSlotsInformation());
-        return !maybeNewParallelism.isPresent()
-                || maybeNewParallelism
-                        .filter(
-                                vertexParallelism ->
-                                        rescalingController.shouldRescale(
-                                                getCurrentParallelism(executionGraph),
-                                                vertexParallelism))
-                        .isPresent();
+        return maybeNewParallelism
+                .filter(
+                        vertexParallelism ->
+                                rescalingController.shouldRescale(
+                                        getCurrentParallelism(executionGraph), vertexParallelism))
+                .isPresent();
     }
 
     private static VertexParallelism getCurrentParallelism(ExecutionGraph executionGraph) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1160,12 +1160,14 @@ public class AdaptiveScheduler
         final Optional<VertexParallelism> maybeNewParallelism =
                 slotAllocator.determineParallelism(
                         jobInformation, declarativeSlotPool.getAllSlotsInformation());
-        return maybeNewParallelism
-                .filter(
-                        vertexParallelism ->
-                                rescalingController.shouldRescale(
-                                        getCurrentParallelism(executionGraph), vertexParallelism))
-                .isPresent();
+        return !maybeNewParallelism.isPresent()
+                || maybeNewParallelism
+                        .filter(
+                                vertexParallelism ->
+                                        rescalingController.shouldRescale(
+                                                getCurrentParallelism(executionGraph),
+                                                vertexParallelism))
+                        .isPresent();
     }
 
     private static VertexParallelism getCurrentParallelism(ExecutionGraph executionGraph) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
@@ -105,6 +105,11 @@ public class JobGraphJobInformation implements JobInformation {
         }
 
         @Override
+        public int getMinParallelism() {
+            return parallelismInfo.getMinParallelism();
+        }
+
+        @Override
         public int getParallelism() {
             return parallelismInfo.getParallelism();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobInformation.java
@@ -42,6 +42,8 @@ public interface JobInformation {
     interface VertexInformation {
         JobVertexID getJobVertexID();
 
+        int getMinParallelism();
+
         int getParallelism();
 
         int getMaxParallelism();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -231,8 +231,7 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
     private static List<SlotSharingGroupId> sortSlotSharingGroupsByHighestParallelismRange(
             JobInformation jobInformation) {
 
-        return getParallelismRangeForSlotSharingGroups(jobInformation.getVertices())
-                .entrySet()
+        return getParallelismRangeForSlotSharingGroups(jobInformation.getVertices()).entrySet()
                 .stream()
                 .sorted(Comparator.comparingInt(Map.Entry::getValue))
                 .map(Map.Entry::getKey)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -207,7 +207,7 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
             // the minimum requirement of other groups); so we only need to distribute the remaining
             // "optional" slots while only accounting for the requirements beyond the minimum
 
-            // the number of slots we can use beyond the minimum
+            // the number of slots this group can use beyond the minimum
             final int maxOptionalSlots =
                     maxParallelismForSlotSharingGroups.get(slotSharingGroup) - minParallelism;
             // the number of slots that are not implicitly reserved for minimum requirements

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -231,7 +231,8 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
     private static List<SlotSharingGroupId> sortSlotSharingGroupsByHighestParallelismRange(
             JobInformation jobInformation) {
 
-        return getParallelismRangeForSlotSharingGroups(jobInformation.getVertices()).entrySet()
+        return getParallelismRangeForSlotSharingGroups(jobInformation.getVertices())
+                .entrySet()
                 .stream()
                 .sorted(Comparator.comparingInt(Map.Entry::getValue))
                 .map(Map.Entry::getKey)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultVertexParallelismStoreTest.java
@@ -53,6 +53,11 @@ public class DefaultVertexParallelismStoreTest extends TestLogger {
 
     private static final class MockVertexParallelismInfo implements VertexParallelismInformation {
         @Override
+        public int getMinParallelism() {
+            return 0;
+        }
+
+        @Override
         public int getParallelism() {
             return 0;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestVertexInformation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestVertexInformation.java
@@ -23,12 +23,22 @@ import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 class TestVertexInformation implements JobInformation.VertexInformation {
 
     private final JobVertexID jobVertexId;
+    private final int minParallelism;
     private final int parallelism;
     private final SlotSharingGroup slotSharingGroup;
 
     TestVertexInformation(
             JobVertexID jobVertexId, int parallelism, SlotSharingGroup slotSharingGroup) {
+        this(jobVertexId, 1, parallelism, slotSharingGroup);
+    }
+
+    TestVertexInformation(
+            JobVertexID jobVertexId,
+            int minParallelism,
+            int parallelism,
+            SlotSharingGroup slotSharingGroup) {
         this.jobVertexId = jobVertexId;
+        this.minParallelism = minParallelism;
         this.parallelism = parallelism;
         this.slotSharingGroup = slotSharingGroup;
         slotSharingGroup.addVertexToGroup(jobVertexId);
@@ -41,7 +51,7 @@ class TestVertexInformation implements JobInformation.VertexInformation {
 
     @Override
     public int getMinParallelism() {
-        return 1;
+        return minParallelism;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestVertexInformation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/TestVertexInformation.java
@@ -40,6 +40,11 @@ class TestVertexInformation implements JobInformation.VertexInformation {
     }
 
     @Override
+    public int getMinParallelism() {
+        return 1;
+    }
+
+    @Override
     public int getParallelism() {
         return parallelism;
     }


### PR DESCRIPTION
based on #22795 for ease of testing.

The Adaptive Scheduler now supports a _minimum_ parallelism per vertex.

* a job is only run if the minimum required slots of all vertices is fulfilled
* if the minimum parallelism is being raised above the currently available number of slots (== implicitly above the current parallelism) the scheduler immediately cancels the job and tries to rescale it. It will either restart the job if it could acquire the additionally required slots, or fail the job once the stabilization timeout kicked in.
  * We could consider adding some timeout here for the cancellation, to give us some time to acquire more slots.
* if the minimum parallelism is lowered, or raised below the current parallelism, the job just keeps running.