### PR TITLE
[FLINK-32379][build] Skip archunit tests in java1X-target profiles

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/ConnectorRules.java
+++ b/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/ConnectorRules.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.junit.ArchTag;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.thirdparty.com.google.common.base.Joiner;
@@ -57,6 +58,8 @@ public class ConnectorRules {
     }
 
     @ArchTest
+    @ArchTag(value = "org.apache.flink.testutils.junit.FailsOnJava11")
+    @ArchTag(value = "org.apache.flink.testutils.junit.FailsOnJava17")
     public static final ArchRule CONNECTOR_CLASSES_ONLY_DEPEND_ON_PUBLIC_API =
             freeze(
                     javaClassesThat(resideInAnyPackage(CONNECTOR_PACKAGES))


### PR DESCRIPTION
## What is the purpose of the change

Archunit generates different violation sets depending on bytecode.
The PR makes skipping of Archunit rule `CONNECTOR_CLASSES_ONLY_DEPEND_ON_PUBLIC_API` for JDK11, 17.

## Verifying this change

This change is a trivial rework.
manually 
```
mvn clean install -DskipTests -Dfast -Pjava17-target
mvn verify -pl flink-architecture-tests/flink-architecture-tests-production/ -Darchunit.freeze.store.default.allowStoreUpdate=false
```
or 
```
mvn clean install -DskipTests -Dfast -Pjava11-target
mvn verify -pl flink-architecture-tests/flink-architecture-tests-production/ -Darchunit.freeze.store.default.allowStoreUpdate=false
```
Also there are a couple of nightly tests testing it

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
