### PR TITLE
[FLINK-32465][runtime][security] Fix KerberosLoginProvider.isLoginPossible accidental login with keytab

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
@@ -67,13 +67,11 @@ public class KerberosLoginProvider {
             return false;
         }
 
-        UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
-
         if (principal != null) {
             LOG.debug("Login from keytab is possible");
             return true;
-        } else if (!HadoopUserUtils.isProxyUser(currentUser)) {
-            if (useTicketCache && currentUser.hasKerberosCredentials()) {
+        } else if (!HadoopUserUtils.isProxyUser(UserGroupInformation.getCurrentUser())) {
+            if (useTicketCache && UserGroupInformation.getCurrentUser().hasKerberosCredentials()) {
                 LOG.debug("Login from ticket cache is possible");
                 return true;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
@@ -53,6 +53,26 @@ public class KerberosLoginProviderITCase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    public void isLoginPossibleMustNotDoAccidentalLoginWithKeytab(
+            boolean supportProxyUser, @TempDir Path tmpDir) throws IOException {
+        Configuration configuration = new Configuration();
+        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
+        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
+
+        try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
+            ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
+            ugi.when(UserGroupInformation::getCurrentUser)
+                    .thenThrow(
+                            new IllegalStateException(
+                                    "isLoginPossible must not do login with keytab"));
+            kerberosLoginProvider.isLoginPossible(supportProxyUser);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     public void isLoginPossibleMustReturnFalseByDefault(boolean supportProxyUser)
             throws IOException {
         Configuration configuration = new Configuration();


### PR DESCRIPTION
## What is the purpose of the change

In `KerberosLoginProvider.isLoginPossible()` there is a call to `UserGroupInformation.getCurrentUser()` before principal check (keytab usage). This triggers an accidental login with either kerberos credentials if available, or as the local OS user, based on security settings. This is not problematic most of the time since `KerberosLoginProvider.doLogin()` overwrites the credentials with keytab. The problem hurts however when login in `KerberosLoginProvider.isLoginPossible()` fails for whatever reason. Such case the workload is just not starting.

## Brief change log

Removed accidental login in `KerberosLoginProvider.isLoginPossible()`.

## Verifying this change

Added new automated test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
