### PR TITLE
[FLINK-31814][runtime] Enables Precondition that checks that the issuedLeaderSessionID is set on revoke processing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -287,7 +287,7 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
 
         // interrupt any outstanding events
         final List<Runnable> outstandingEventHandlingCalls =
-                Preconditions.checkNotNull(leadershipOperationExecutor).shutdownNow();
+                leadershipOperationExecutor.shutdownNow();
         if (!outstandingEventHandlingCalls.isEmpty()) {
             LOG.debug(
                     "The DefaultLeaderElectionService was closed with {} event(s) still not being processed. No further action necessary.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -424,9 +424,9 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
 
     @GuardedBy("lock")
     private void onRevokeLeadershipInternal() {
-        // TODO: FLINK-31814 covers adding this Precondition
-        // Preconditions.checkState(issuedLeaderSessionID != null,"The leadership should have
-        // been revoked while having the leadership acquired.");
+        Preconditions.checkState(
+                issuedLeaderSessionID != null,
+                "The leadership should have been revoked while having the leadership acquired.");
 
         if (!leaderContenderRegistry.isEmpty()) {
             leaderContenderRegistry.forEach(this::notifyLeaderContenderOfLeadershipLoss);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -317,39 +318,54 @@ class DefaultLeaderElectionServiceTest {
         };
     }
 
-    /**
-     * Test to cover the issue described in FLINK-31814. This test could be removed after
-     * FLINK-31814 is resolved.
-     */
     @Test
-    void testOnRevokeCallWhileClosingService() throws Exception {
-        final AtomicBoolean leadershipGranted = new AtomicBoolean();
-        final TestingLeaderElectionDriver.Builder driverBuilder =
-                TestingLeaderElectionDriver.newBuilder(leadershipGranted);
+    void testDelayedRevokeCallAfterContenderBeingDeregisteredAgain() throws Exception {
+        new Context() {
+            {
+                runTestWithManuallyTriggeredEvents(
+                        executorService -> {
+                            final UUID expectedSessionID = UUID.randomUUID();
+                            grantLeadership(expectedSessionID);
+                            executorService.trigger();
 
-        final TestingLeaderElectionDriver.Factory driverFactory =
-                new TestingLeaderElectionDriver.Factory(driverBuilder);
-        try (final DefaultLeaderElectionService testInstance =
-                new DefaultLeaderElectionService(
-                        driverFactory, fatalErrorHandlerExtension.getTestingFatalErrorHandler())) {
-            driverBuilder.setCloseConsumer(lock -> testInstance.onRevokeLeadership());
-            testInstance.startLeaderElectionBackend();
+                            final LeaderElection leaderElection =
+                                    leaderElectionService.createLeaderElection("contender_id");
 
-            leadershipGranted.set(true);
-            testInstance.onGrantLeadership(UUID.randomUUID());
+                            final AtomicInteger revokeCallCount = new AtomicInteger();
+                            final LeaderContender contender =
+                                    TestingGenericLeaderContender.newBuilder()
+                                            .setRevokeLeadershipRunnable(
+                                                    revokeCallCount::incrementAndGet)
+                                            .build();
+                            leaderElection.startLeaderElection(contender);
+                            executorService.trigger();
 
-            final LeaderElection leaderElection =
-                    testInstance.createLeaderElection(createRandomContenderID());
-            final TestingContender contender =
-                    new TestingContender("unused-address", leaderElection);
-            contender.startLeaderElection();
+                            assertThat(revokeCallCount)
+                                    .as("No revocation should have been triggered, yet.")
+                                    .hasValue(0);
 
-            contender.waitForLeader();
+                            revokeLeadership();
 
-            leaderElection.close();
+                            assertThat(revokeCallCount)
+                                    .as("A revocation was triggered but not processed, yet.")
+                                    .hasValue(0);
 
-            contender.throwErrorIfPresent();
-        }
+                            leaderElection.close();
+
+                            assertThat(revokeCallCount)
+                                    .as(
+                                            "A revocation should have been triggered and immediately processed through the close call.")
+                                    .hasValue(1);
+
+                            executorService.triggerAll();
+
+                            assertThat(revokeCallCount)
+                                    .as(
+                                            "The leadership revocation event that was triggered by the HA backend shouldn't have been forwarded to the contender, anymore.")
+                                    .hasValue(1);
+                        });
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This Precondition can be enabled because the processing of revoke calls is not happening anymore during close. The event processing is protected by the running flag within DefaultLeaderElectionService which is set to false as part of the close mechanism.

## Brief change log

* Enables the Precondition

## Verifying this change

I left the test case (with some refactoring) because it's a valid test to verify that we don't run into issues when an event is processed after the contender was already deregistered.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable