### PR TITLE
[FLINK-32422][test] Adds test to cover the issue of forwarding the revoke event immediately to the contender for the EmbeddedLeaderService

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -20,20 +20,15 @@ package org.apache.flink.runtime.highavailability.nonha.embedded;
 
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.leaderelection.LeaderElection;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link EmbeddedLeaderService}. */
-public class EmbeddedLeaderServiceTest extends TestLogger {
+public class EmbeddedLeaderServiceTest {
 
     /**
      * Tests that the {@link EmbeddedLeaderService} can handle a concurrent grant leadership call
@@ -54,16 +49,13 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
             leaderElection.startLeaderElection(contender);
             leaderElection.close();
 
-            try {
-                // check that no exception occurred
-                contender.getLeaderSessionFuture().get(10L, TimeUnit.MILLISECONDS);
-                fail("The future shouldn't have completed.");
-            } catch (TimeoutException ignored) {
-                // we haven't participated in the leader election
-            }
+            assertThat(contender.getLeaderSessionFuture())
+                    .as(
+                            "The future shouldn't have completed because the grant event wasn't processed, yet.")
+                    .isNotDone();
 
             // the election service should still be running
-            Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+            assertThat(embeddedLeaderService.isShutdown()).isFalse();
         } finally {
             embeddedLeaderService.shutdown();
 
@@ -98,16 +90,13 @@ public class EmbeddedLeaderServiceTest extends TestLogger {
                     embeddedLeaderService.revokeLeadership();
             leaderElection.close();
 
-            try {
-                // check that no exception occurred
-                revokeLeadershipFuture.get(10L, TimeUnit.MILLISECONDS);
-                fail("The future shouldn't have completed.");
-            } catch (TimeoutException ignored) {
-                // the leader election service has been stopped before revoking could be executed
-            }
+            assertThat(revokeLeadershipFuture)
+                    .as(
+                            "The future shouldn't have completed because the revoke event wasn't processed, yet.")
+                    .isNotDone();
 
             // the election service should still be running
-            Assert.assertThat(embeddedLeaderService.isShutdown(), is(false));
+            assertThat(embeddedLeaderService.isShutdown()).isFalse();
         } finally {
             embeddedLeaderService.shutdown();
 


### PR DESCRIPTION
## What is the purpose of the change

I thought about it once more: The revoke leadership event should be immediately handled by the LeaderElectionService because it means that the contender is deregistered and wouldn't be able to handle any outstanding leadership events anymore, anyway. In this way, we have to accept that a revoke event can be sent to the contender twice.

It's implemented in the same way in the DefaultLeaderElectionService (see [DefaultLeaderElectionService:233](https://github.com/apache/flink/blob/caa5f181598658403d081a0d8b733330c70ec51c/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java#L233)).

## Brief change log

* Added a test to cover the scenario for the `EmbeddedLeaderService` as well

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable