### PR TITLE
[FLINK-32476][runtime] Support configuring object-reuse for internal operators

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/Function.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/Function.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 
 /**
@@ -27,4 +28,13 @@ import org.apache.flink.annotation.Public;
  * method) interfaces that can be implemented via Java 8 lambdas.
  */
 @Public
-public interface Function extends java.io.Serializable {}
+public interface Function extends java.io.Serializable {
+    /**
+     * Returns false if it is guaranteed that the function will not store and access reference to
+     * the output value.
+     */
+    @Internal
+    default boolean isOutputValueStored() {
+        return false;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RichFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
@@ -168,4 +169,15 @@ public interface RichFunction extends Function {
      * @param t The runtime context.
      */
     void setRuntimeContext(RuntimeContext t);
+
+    /**
+     * RichFunction is able to put the values to the state backend so the method returns true by
+     * default. For RichFunction that doesn't store output value to the state backend, it can return
+     * false.
+     */
+    @Internal
+    @Override
+    default boolean isOutputValueStored() {
+        return true;
+    }
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/WrappingFunction.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/WrappingFunction.java
@@ -61,4 +61,9 @@ public abstract class WrappingFunction<T extends Function> extends AbstractRichF
     public T getWrappedFunction() {
         return this.wrappedFunction;
     }
+
+    @Override
+    public boolean isOutputValueStored() {
+        return getWrappedFunction().isOutputValueStored();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.transformations.SinkV1Adapter;
@@ -188,5 +190,13 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
     @Override
     public void processElement(StreamRecord<CommittableMessage<CommT>> element) throws Exception {
         committableCollector.addMessage(element.getValue());
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -332,6 +334,14 @@ public class ContinuousFileReaderOperator<OUT, T extends TimestampedInputSplit>
         if (state == ReaderState.IDLE) {
             enqueueProcessRecord();
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     private void enqueueProcessRecord() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
@@ -62,6 +64,14 @@ public class ContinuousFileReaderOperatorFactory<OUT, T extends TimestampedInput
                 parameters.getOutput());
         operator.setOutputType(type, executionConfig);
         return (O) operator;
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -147,6 +147,14 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
         StreamingFunctionUtils.setOutputType(userFunction, outTypeInfo, executionConfig);
     }
 
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setOutputStreamRecordValueStored(getUserFunction().isOutputValueStored())
+                .setInputStreamRecordStored(false)
+                .build();
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * OperatorAttributes element provides Job Manager with information that can be used to optimize job
+ * performance.
+ */
+@PublicEvolving
+public class OperatorAttributes {
+    private final boolean outputStreamRecordValueStored;
+    private final boolean inputStreamRecordStored;
+
+    public OperatorAttributes(
+            boolean outputStreamRecordValueStored, boolean inputStreamRecordStored) {
+        this.outputStreamRecordValueStored = outputStreamRecordValueStored;
+        this.inputStreamRecordStored = inputStreamRecordStored;
+    }
+
+    /**
+     * Returns false if it is guaranteed that the operator will not store and access reference to
+     * the StreamRecord#value that it has already emitted.
+     */
+    public boolean isOutputStreamRecordValueStored() {
+        return outputStreamRecordValueStored;
+    }
+
+    /**
+     * Return false if it is guaranteed that the operator will not store and access reference to the
+     * input StreamRecord instance.
+     */
+    public boolean isInputStreamRecordStored() {
+        return inputStreamRecordStored;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+/** The builder class for {@link OperatorAttributes}. */
+@Internal
+public class OperatorAttributesBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OperatorAttributesBuilder.class);
+    @Nullable private Boolean outputStreamRecordValueStored = null;
+    @Nullable private Boolean inputStreamRecordStored = null;
+
+    public OperatorAttributesBuilder() {}
+
+    /**
+     * Set to false if it is guaranteed that the operator will not store and access reference to the
+     * StreamRecord#value that it has already emitted.
+     */
+    public OperatorAttributesBuilder setOutputStreamRecordValueStored(
+            boolean outputStreamRecordValueStored) {
+        this.outputStreamRecordValueStored = outputStreamRecordValueStored;
+        return this;
+    }
+
+    /**
+     * Set false if it is guaranteed that the operator will not store and access reference to the
+     * input StreamRecord instance.
+     */
+    public OperatorAttributesBuilder setInputStreamRecordStored(boolean inputStreamRecordStored) {
+        this.inputStreamRecordStored = inputStreamRecordStored;
+        return this;
+    }
+
+    /**
+     * If any operator attribute is null, we will log it at DEBUG level and use the following
+     * default values.
+     *
+     * <ul>
+     *   <li>outputStreamRecordValueStored defaults to true
+     *   <li>inputStreamRecordStored defaults to true
+     * </ul>
+     */
+    public OperatorAttributes build() {
+        return new OperatorAttributes(
+                getAttributeOrDefaultValue(
+                        outputStreamRecordValueStored, "outputStreamRecordValueStored", true),
+                getAttributeOrDefaultValue(
+                        inputStreamRecordStored, "inputStreamRecordStored", true));
+    }
+
+    private <T> T getAttributeOrDefaultValue(
+            @Nullable T attribute, String attributeName, T defaultValue) {
+        if (attribute == null) {
+            LOG.debug("{} is not set, set it to default value {}.", attributeName, defaultValue);
+            return defaultValue;
+        }
+        return attribute;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -132,4 +132,9 @@ public class SimpleOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
     public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
         return operator.getClass();
     }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return operator.getOperatorAttributes();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -538,6 +538,14 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     }
 
     @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setOutputStreamRecordValueStored(false)
+                .setInputStreamRecordStored(false)
+                .build();
+    }
+
+    @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
         final ListState<byte[]> rawState =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -153,6 +153,14 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
         return true;
     }
 
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setOutputStreamRecordValueStored(false)
+                .setInputStreamRecordStored(false)
+                .build();
+    }
+
     /**
      * This is a utility method to conjure up a "SplitT" generics variable binding so that we can
      * construct the SourceOperator without resorting to "all raw types". That way, this methods

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -137,6 +137,10 @@ public interface StreamOperator<OUT> extends CheckpointListener, KeyContext, Ser
     /** Provides a context to initialize all state in the operator. */
     void initializeState(StreamTaskStateInitializer streamTaskStateManager) throws Exception;
 
+    default OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder().build();
+    }
+
     // ------------------------------------------------------------------------
     //  miscellaneous
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
@@ -87,4 +87,8 @@ public interface StreamOperatorFactory<OUT> extends Serializable {
 
     /** Returns the runtime class of the stream operator. */
     Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader);
+
+    default OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder().build();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -55,6 +55,14 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
     }
 
     @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
+    }
+
+    @Override
     protected void reportOrForwardLatencyMarker(LatencyMarker marker) {
         // all operators are tracking latencies
         this.latencyStats.reportLatency(marker);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -35,6 +35,8 @@ import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.async.queue.OrderedStreamElementQueue;
@@ -273,6 +275,14 @@ public class AsyncWaitOperator<IN, OUT>
 
             userFunction.asyncInvoke(element.getValue(), resultHandler);
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(true)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
@@ -68,8 +70,8 @@ public class AsyncWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFac
     @Override
     public <T extends StreamOperator<OUT>> T createStreamOperator(
             StreamOperatorParameters<OUT> parameters) {
-        AsyncWaitOperator asyncWaitOperator =
-                new AsyncWaitOperator(
+        AsyncWaitOperator<IN, OUT> asyncWaitOperator =
+                new AsyncWaitOperator<>(
                         asyncFunction,
                         timeout,
                         capacity,
@@ -82,6 +84,14 @@ public class AsyncWaitOperatorFactory<IN, OUT> extends AbstractStreamOperatorFac
                 parameters.getStreamConfig(),
                 parameters.getOutput());
         return (T) asyncWaitOperator;
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setOutputStreamRecordValueStored(asyncFunction.isOutputValueStored())
+                .setInputStreamRecordStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.util.ReusingMutableToRegularIteratorWrapper;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
@@ -296,6 +298,14 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
             out = checkpointStorage.createTaskOwnedStateStream();
         }
         serializer.serialize(value, new DataOutputViewStreamWrapper(out));
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     private static final class PendingCheckpoint

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndWatermarksOperator.java
@@ -26,6 +26,8 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
@@ -102,6 +104,14 @@ public class TimestampsAndWatermarksOperator<T> extends AbstractStreamOperator<T
         element.setTimestamp(newTimestamp);
         output.collect(element);
         watermarkGenerator.onEvent(event, newTimestamp, wmOutput);
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.runtime.operators.sink.committables.CheckpointCommittableManager;
@@ -198,6 +200,14 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         if (checkpointId.isPresent() && checkpointId.getAsLong() <= lastCompletedCheckpointId) {
             commitAndEmitCheckpoints();
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -24,6 +24,8 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 
@@ -79,6 +81,14 @@ public final class CommitterOperatorFactory<CommT>
                             + parameters.getStreamConfig().getOperatorName(),
                     e);
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -44,6 +44,8 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -159,6 +161,14 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
     public void processElement(StreamRecord<InputT> element) throws Exception {
         context.element = element;
         sinkWriter.write(element.getValue(), context);
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorFactory.java
@@ -25,6 +25,8 @@ import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
@@ -66,6 +68,14 @@ public final class SinkWriterOperatorFactory<InputT, CommT>
                             + parameters.getStreamConfig().getOperatorName(),
                     e);
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder()
+                .setInputStreamRecordStored(false)
+                .setOutputStreamRecordValueStored(false)
+                .build();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ShallowCopyingChainingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ShallowCopyingChainingOutput.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.streaming.api.operators.Input;
@@ -26,18 +25,13 @@ import org.apache.flink.util.OutputTag;
 
 import javax.annotation.Nullable;
 
-final class CopyingChainingOutput<T> extends ChainingOutput<T> {
-
-    private final TypeSerializer<T> serializer;
-
-    public CopyingChainingOutput(
+final class ShallowCopyingChainingOutput<T> extends ChainingOutput<T> {
+    public ShallowCopyingChainingOutput(
             Input<T> input,
-            TypeSerializer<T> serializer,
-            @Nullable Counter prevRecordsOutCounter,
+            @Nullable Counter prevNumRecordsOut,
             OperatorMetricGroup curOperatorMetricGroup,
             @Nullable OutputTag<T> outputTag) {
-        super(input, prevRecordsOutCounter, curOperatorMetricGroup, outputTag);
-        this.serializer = serializer;
+        super(input, prevNumRecordsOut, curOperatorMetricGroup, outputTag);
     }
 
     @Override
@@ -50,8 +44,7 @@ final class CopyingChainingOutput<T> extends ChainingOutput<T> {
 
             numRecordsOut.inc();
             numRecordsIn.inc();
-            StreamRecord<T> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
-            recordProcessor.accept(copy);
+            recordProcessor.accept(castRecord.copy(castRecord.getValue()));
         } catch (ClassCastException e) {
             if (outputTag != null) {
                 // Enrich error message

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -99,6 +99,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
                     + "finish[], "
                     + "getCurrentKey[], "
                     + "getMetricGroup[], "
+                    + "getOperatorAttributes[], "
                     + "getOperatorID[], "
                     + "initializeState[interface org.apache.flink.streaming.api.operators.StreamTaskStateInitializer], "
                     + "notifyCheckpointAborted[long], "
@@ -111,7 +112,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
                     + "snapshotState[long, long, class org.apache.flink.runtime.checkpoint.CheckpointOptions, interface org.apache.flink.runtime.state.CheckpointStreamFactory]]";
 
     private static final String ALL_METHODS_RICH_FUNCTION =
-            "[close[], getIterationRuntimeContext[], getRuntimeContext[]"
+            "[close[], getIterationRuntimeContext[], getRuntimeContext[], isOutputValueStored[]"
                     + ", open[class org.apache.flink.configuration.Configuration], open[interface org.apache.flink.api.common.functions.OpenContext], setRuntimeContext[interface "
                     + "org.apache.flink.api.common.functions.RuntimeContext]]";
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -209,11 +209,7 @@ public class MultipleInputStreamTaskTest {
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
 
-            if (objectReuse) {
-                assertTrue(copiedElementsRef.get().isEmpty());
-            } else {
-                assertThat(copiedElementsRef.get(), containsInAnyOrder(42, 43));
-            }
+            assertTrue(copiedElementsRef.get().isEmpty());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR allows the internal operators to report whether the operators will modify the input so that Flink can decide whether to enable object-reuse for the operators. 

## Brief change log

- Add an internal method to `StreamOperator` to allow implementations to report whether the operator will modify the input.
- Update the internal SQL and DataStream operators to overwrite the method accordingly.


## Verifying this change

This change added tests and can be verified as follows:

- Add tests that validate the object reuse behavior in `StreamOperatorChainingTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
