### PR TITLE
[FLINK-32478][connectors/common] Fix the bug that the shared thread pool causes the source alignment unit test to fail

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -215,7 +215,7 @@ class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
             SourceCoordinator<?, ?> sourceCoordinator1, int subtask, long watermark) {
         sourceCoordinator1.handleEventFromOperator(
                 subtask, 0, new ReportedWatermarkEvent(watermark));
-        waitForCoordinatorToProcessActions();
+        waitForCoordinatorToProcessActions(sourceCoordinator1.getContext());
         sourceCoordinator1.announceCombinedWatermark();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
@@ -60,7 +60,7 @@ class SourceCoordinatorConcurrentAttemptsTest extends SourceCoordinatorTestBase 
 
     @Override
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
         supportsConcurrentExecutionAttempts = true;
         enumeratorSupportsHandleExecutionAttemptSourceEvent = true;
         super.setup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -96,7 +96,9 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         // Assign splits to the readers.
         SplitsAssignment<MockSourceSplit> splitsAssignment = getSplitsAssignment(2, 0);
         if (fromCoordinatorExecutor) {
-            coordinatorExecutor.submit(() -> context.assignSplits(splitsAssignment)).get();
+            context.getCoordinatorExecutor()
+                    .submit(() -> context.assignSplits(splitsAssignment))
+                    .get();
         } else {
             context.assignSplits(splitsAssignment);
         }
@@ -141,7 +143,7 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         verifyException(
                 () -> {
                     if (fromCoordinatorExecutor) {
-                        coordinatorExecutor
+                        context.getCoordinatorExecutor()
                                 .submit(() -> context.assignSplits(splitsAssignment))
                                 .get();
                     } else {


### PR DESCRIPTION
## What is the purpose of the change

SourceCoordinatorAlignmentTest.testAnnounceCombinedWatermarkWithoutStart fails

Root cause: multiple sources share the same thread pool, and the second source cannot start due to the first source closes the shared thread pool.

## Brief change log

Create new thread pool for each SourceCoordinatorContext.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no