### PR TITLE
[FLINK-32469][REST] Improve checkpoint REST APIs for programmatic access

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_rest_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rest_section.html
@@ -21,6 +21,18 @@
             <td>The time in ms that the client waits for the leader address, e.g., Dispatcher or WebMonitorEndpoint</td>
         </tr>
         <tr>
+            <td><h5>rest.cache.checkpoint-statistics.size</h5></td>
+            <td style="word-wrap: break-word;">1000</td>
+            <td>Integer</td>
+            <td>Maximum number of entries in the checkpoint statistics cache.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.cache.checkpoint-statistics.timeout</h5></td>
+            <td style="word-wrap: break-word;">3 s</td>
+            <td>Duration</td>
+            <td>Duration from write after which cached checkpoints statistics are cleaned up. For backwards compatibility, if no value is configured, <code class="highlighter-rouge">web.refresh-interval</code> will be used instead.</td>
+        </tr>
+        <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/rest_configuration.html
+++ b/docs/layouts/shortcodes/generated/rest_configuration.html
@@ -39,6 +39,18 @@
             <td>The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Rest servers are running on the same machine.</td>
         </tr>
         <tr>
+            <td><h5>rest.cache.checkpoint-statistics.size</h5></td>
+            <td style="word-wrap: break-word;">1000</td>
+            <td>Integer</td>
+            <td>Maximum number of entries in the checkpoint statistics cache.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.cache.checkpoint-statistics.timeout</h5></td>
+            <td style="word-wrap: break-word;">3 s</td>
+            <td>Duration</td>
+            <td>Duration from write after which cached checkpoints statistics are cleaned up. For backwards compatibility, if no value is configured, <code class="highlighter-rouge">web.refresh-interval</code> will be used instead.</td>
+        </tr>
+        <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.description.Description;
 import java.time.Duration;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
 
 /** Configuration parameters for REST communication. */
@@ -192,6 +193,29 @@ public class RestOptions {
                             "Thread priority of the REST server's executor for processing asynchronous requests. "
                                     + "Lowering the thread priority will give Flink's main components more CPU time whereas "
                                     + "increasing will allocate more time for the REST server's processing.");
+
+    /** Duration from write, after which cached checkpoints statistics are cleaned up. */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<Duration> CACHE_CHECKPOINT_STATISTICS_TIMEOUT =
+            key("rest.cache.checkpoint-statistics.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(WebOptions.REFRESH_INTERVAL.defaultValue()))
+                    .withFallbackKeys(WebOptions.REFRESH_INTERVAL.key())
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Duration from write after which cached checkpoints statistics are cleaned up. For backwards compatibility, if no value is configured, %s will be used instead.",
+                                            code(WebOptions.REFRESH_INTERVAL.key()))
+                                    .build());
+
+    /** Maximum number of entries in the checkpoint statistics cache. */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<Integer> CACHE_CHECKPOINT_STATISTICS_SIZE =
+            key("rest.cache.checkpoint-statistics.size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "Maximum number of entries in the checkpoint statistics cache.");
 
     /** Enables the experimental flame graph feature. */
     @Documentation.Section(Documentation.Sections.EXPERT_REST)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -38,6 +38,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
@@ -935,6 +936,13 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         return maybeJob.map(job -> job.requestJob(timeout))
                 .orElse(FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId)))
                 .exceptionally(checkExecutionGraphStoreOnException);
+    }
+
+    @Override
+    public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(
+            JobID jobId, Time timeout) {
+        return performOperationOnJobMasterGateway(
+                jobId, gateway -> gateway.requestCheckpointStats(timeout));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.blocklist.BlocklistContext;
 import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -861,6 +862,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     @Override
     public CompletableFuture<ExecutionGraphInfo> requestJob(Time timeout) {
         return CompletableFuture.completedFuture(schedulerNG.requestJob());
+    }
+
+    @Override
+    public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(Time timeout) {
+        return CompletableFuture.completedFuture(schedulerNG.requestCheckpointStats());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.blocklist.BlocklistListener;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorGateway;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -205,6 +206,14 @@ public interface JobMasterGateway
      * @return Future which is completed with the {@link ExecutionGraphInfo} of the executed job
      */
     CompletableFuture<ExecutionGraphInfo> requestJob(@RpcTimeout Time timeout);
+
+    /**
+     * Requests the {@link CheckpointStatsSnapshot} of the job.
+     *
+     * @param timeout for the rpc call
+     * @return Future which is completed with the {@link CheckpointStatsSnapshot} of the job
+     */
+    CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(@RpcTimeout Time timeout);
 
     /**
      * Triggers taking a savepoint of the executed job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -21,17 +21,23 @@ package org.apache.flink.runtime.rest.handler;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.Preconditions;
 
 import java.io.File;
+import java.time.Duration;
 
 /** Configuration object containing values for the rest handler configuration. */
 public class RestHandlerConfiguration {
 
     private final long refreshInterval;
 
-    private final int maxCheckpointStatisticCacheEntries;
+    private final int checkpointHistorySize;
+
+    private final Duration checkpointCacheExpireAfterWrite;
+
+    private final int checkpointCacheSize;
 
     private final Time timeout;
 
@@ -45,7 +51,9 @@ public class RestHandlerConfiguration {
 
     public RestHandlerConfiguration(
             long refreshInterval,
-            int maxCheckpointStatisticCacheEntries,
+            int checkpointHistorySize,
+            Duration checkpointCacheExpireAfterWrite,
+            int checkpointCacheSize,
             Time timeout,
             File webUiDir,
             boolean webSubmitEnabled,
@@ -55,7 +63,9 @@ public class RestHandlerConfiguration {
                 refreshInterval > 0L, "The refresh interval (ms) should be larger than 0.");
         this.refreshInterval = refreshInterval;
 
-        this.maxCheckpointStatisticCacheEntries = maxCheckpointStatisticCacheEntries;
+        this.checkpointHistorySize = checkpointHistorySize;
+        this.checkpointCacheExpireAfterWrite = checkpointCacheExpireAfterWrite;
+        this.checkpointCacheSize = checkpointCacheSize;
 
         this.timeout = Preconditions.checkNotNull(timeout);
         this.webUiDir = Preconditions.checkNotNull(webUiDir);
@@ -68,8 +78,16 @@ public class RestHandlerConfiguration {
         return refreshInterval;
     }
 
-    public int getMaxCheckpointStatisticCacheEntries() {
-        return maxCheckpointStatisticCacheEntries;
+    public int getCheckpointHistorySize() {
+        return checkpointHistorySize;
+    }
+
+    public Duration getCheckpointCacheExpireAfterWrite() {
+        return checkpointCacheExpireAfterWrite;
+    }
+
+    public int getCheckpointCacheSize() {
+        return checkpointCacheSize;
     }
 
     public Time getTimeout() {
@@ -95,8 +113,14 @@ public class RestHandlerConfiguration {
     public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
         final long refreshInterval = configuration.getLong(WebOptions.REFRESH_INTERVAL);
 
-        final int maxCheckpointStatisticCacheEntries =
+        final int checkpointHistorySize =
                 configuration.getInteger(WebOptions.CHECKPOINTS_HISTORY_SIZE);
+        final Duration checkpointStatsSnapshotCacheExpireAfterWrite =
+                configuration
+                        .getOptional(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT)
+                        .orElse(Duration.ofMillis(refreshInterval));
+        final int checkpointStatsSnapshotCacheSize =
+                configuration.get(RestOptions.CACHE_CHECKPOINT_STATISTICS_SIZE);
 
         final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
 
@@ -113,7 +137,9 @@ public class RestHandlerConfiguration {
 
         return new RestHandlerConfiguration(
                 refreshInterval,
-                maxCheckpointStatisticCacheEntries,
+                checkpointHistorySize,
+                checkpointStatsSnapshotCacheExpireAfterWrite,
+                checkpointStatsSnapshotCacheSize,
                 timeout,
                 webUiDir,
                 webSubmitEnabled,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointStatsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointStatsHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.checkpoints;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.rest.NotFoundException;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+/**
+ * Abstract class for checkpoint handlers that will cache the {@link CheckpointStatsSnapshot}
+ * object.
+ *
+ * @param <R> the response type
+ * @param <M> the message parameters
+ */
+@Internal
+public abstract class AbstractCheckpointStatsHandler<
+                R extends ResponseBody, M extends JobMessageParameters>
+        extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, R, M> {
+
+    private final Executor executor;
+    private final Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+            checkpointStatsSnapshotCache;
+
+    protected AbstractCheckpointStatsHandler(
+            GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+            Time timeout,
+            Map<String, String> responseHeaders,
+            MessageHeaders<EmptyRequestBody, R, M> messageHeaders,
+            Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>> checkpointStatsSnapshotCache,
+            Executor executor) {
+        super(leaderRetriever, timeout, responseHeaders, messageHeaders);
+        this.executor = executor;
+        this.checkpointStatsSnapshotCache = checkpointStatsSnapshotCache;
+    }
+
+    @Override
+    protected CompletableFuture<R> handleRequest(
+            @Nonnull HandlerRequest<EmptyRequestBody> request, @Nonnull RestfulGateway gateway)
+            throws RestHandlerException {
+        JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+
+        try {
+            return checkpointStatsSnapshotCache
+                    .get(jobId, () -> gateway.requestCheckpointStats(jobId, timeout))
+                    .thenApplyAsync(
+                            checkpointStatsSnapshot -> {
+                                try {
+                                    return handleCheckpointStatsRequest(
+                                            request, checkpointStatsSnapshot);
+                                } catch (RestHandlerException e) {
+                                    throw new CompletionException(e);
+                                }
+                            },
+                            executor)
+                    .exceptionally(
+                            throwable -> {
+                                throwable = ExceptionUtils.stripCompletionException(throwable);
+                                if (throwable instanceof FlinkJobNotFoundException) {
+                                    throw new CompletionException(
+                                            new NotFoundException(
+                                                    String.format("Job %s not found", jobId),
+                                                    throwable));
+                                } else {
+                                    throw new CompletionException(throwable);
+                                }
+                            });
+        } catch (ExecutionException e) {
+            CompletableFuture<R> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
+    }
+
+    protected abstract R handleCheckpointStatsRequest(
+            HandlerRequest<EmptyRequestBody> request,
+            CheckpointStatsSnapshot checkpointStatsSnapshot)
+            throws RestHandlerException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointStatisticDetailsHandler.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.runtime.rest.handler.job.checkpoints;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
@@ -37,12 +37,15 @@ import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /** REST handler which returns the details for a checkpoint. */
@@ -56,16 +59,16 @@ public class CheckpointStatisticDetailsHandler
             Map<String, String> responseHeaders,
             MessageHeaders<EmptyRequestBody, CheckpointStatistics, CheckpointMessageParameters>
                     messageHeaders,
-            ExecutionGraphCache executionGraphCache,
             Executor executor,
+            Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>> checkpointStatsSnapshotCache,
             CheckpointStatsCache checkpointStatsCache) {
         super(
                 leaderRetriever,
                 timeout,
                 responseHeaders,
                 messageHeaders,
-                executionGraphCache,
                 executor,
+                checkpointStatsSnapshotCache,
                 checkpointStatsCache);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler.job.checkpoints;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
@@ -30,7 +31,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.NotFoundException;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
-import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
@@ -46,12 +46,15 @@ import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /** REST handler which serves checkpoint statistics for subtasks. */
@@ -69,16 +72,16 @@ public class TaskCheckpointStatisticDetailsHandler
                             TaskCheckpointStatisticsWithSubtaskDetails,
                             TaskCheckpointMessageParameters>
                     messageHeaders,
-            ExecutionGraphCache executionGraphCache,
             Executor executor,
+            Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>> checkpointStatsSnapshotCache,
             CheckpointStatsCache checkpointStatsCache) {
         super(
                 leaderRetriever,
                 timeout,
                 responseHeaders,
                 messageHeaders,
-                executionGraphCache,
                 executor,
+                checkpointStatsSnapshotCache,
                 checkpointStatsCache);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
@@ -792,6 +793,12 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         mainThreadExecutor.assertRunningInMainThread();
         return new ExecutionGraphInfo(
                 ArchivedExecutionGraph.createFrom(executionGraph), getExceptionHistory());
+    }
+
+    @Override
+    public CheckpointStatsSnapshot requestCheckpointStats() {
+        mainThreadExecutor.assertRunningInMainThread();
+        return executionGraph.getCheckpointStatsSnapshot();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -92,6 +93,15 @@ public interface SchedulerNG extends GlobalFailureHandler, AutoCloseableAsync {
             throws PartitionProducerDisposedException;
 
     ExecutionGraphInfo requestJob();
+
+    /**
+     * Returns the checkpoint statistics for a given job. Although the {@link
+     * CheckpointStatsSnapshot} is included in the {@link ExecutionGraphInfo}, this method is
+     * preferred to {@link SchedulerNG#requestJob()} because it is less expensive.
+     *
+     * @return checkpoint statistics snapshot for job graph
+     */
+    CheckpointStatsSnapshot requestCheckpointStats();
 
     JobStatus requestJobStatus();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
@@ -591,6 +592,11 @@ public class AdaptiveScheduler
     @Override
     public ExecutionGraphInfo requestJob() {
         return new ExecutionGraphInfo(state.getJob(), exceptionHistory.toArrayList());
+    }
+
+    @Override
+    public CheckpointStatsSnapshot requestCheckpointStats() {
+        return state.getJob().getCheckpointStatsSnapshot();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/NonLeaderRetrievalRestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/NonLeaderRetrievalRestfulGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -65,6 +66,12 @@ public class NonLeaderRetrievalRestfulGateway implements RestfulGateway {
 
     @Override
     public CompletableFuture<ExecutionGraphInfo> requestExecutionGraphInfo(
+            JobID jobId, Time timeout) {
+        throw new UnsupportedOperationException(MESSAGE);
+    }
+
+    @Override
+    public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(
             JobID jobId, Time timeout) {
         throw new UnsupportedOperationException(MESSAGE);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.TriggerSavepointMode;
@@ -93,6 +94,16 @@ public interface RestfulGateway extends RpcGateway {
      *     {@link FlinkJobNotFoundException}
      */
     CompletableFuture<ExecutionGraphInfo> requestExecutionGraphInfo(
+            JobID jobId, @RpcTimeout Time timeout);
+
+    /**
+     * Requests the {@link CheckpointStatsSnapshot} containing checkpointing information.
+     *
+     * @param jobId identifying the job whose {@link CheckpointStatsSnapshot} is requested
+     * @param timeout for the asynchronous operation
+     * @return Future containing the {@link CheckpointStatsSnapshot} for the given jobId
+     */
+    CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(
             JobID jobId, @RpcTimeout Time timeout);
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -118,7 +118,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
     @Override
     public boolean isInitialized() {
-        throw new UnsupportedOperationException();
+        return true;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -130,6 +131,10 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Nonnull private final Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier;
 
     @Nonnull private final Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier;
+
+    @Nonnull
+    private final Supplier<CompletableFuture<CheckpointStatsSnapshot>>
+            checkpointStatsSnapshotSupplier;
 
     @Nonnull
     private final TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
@@ -241,6 +246,9 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             @Nonnull Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier,
             @Nonnull Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier,
             @Nonnull
+                    Supplier<CompletableFuture<CheckpointStatsSnapshot>>
+                            checkpointStatsSnapshotSupplier,
+            @Nonnull
                     TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
                             triggerSavepointFunction,
             @Nonnull
@@ -320,6 +328,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
         this.resourceManagerHeartbeatFunction = resourceManagerHeartbeatFunction;
         this.requestJobDetailsSupplier = requestJobDetailsSupplier;
         this.requestJobSupplier = requestJobSupplier;
+        this.checkpointStatsSnapshotSupplier = checkpointStatsSnapshotSupplier;
         this.triggerSavepointFunction = triggerSavepointFunction;
         this.triggerCheckpointFunction = triggerCheckpointFunction;
         this.stopWithSavepointFunction = stopWithSavepointFunction;
@@ -415,6 +424,11 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Override
     public CompletableFuture<ExecutionGraphInfo> requestJob(Time timeout) {
         return requestJobSupplier.get();
+    }
+
+    @Override
+    public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(Time timeout) {
+        return checkpointStatsSnapshotSupplier.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -120,6 +121,8 @@ public class TestingJobMasterGatewayBuilder {
     private Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier =
             () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
     private Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier =
+            () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
+    private Supplier<CompletableFuture<CheckpointStatsSnapshot>> checkpointStatsSnapshotSupplier =
             () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
     private TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
             triggerSavepointFunction =
@@ -289,6 +292,12 @@ public class TestingJobMasterGatewayBuilder {
         return this;
     }
 
+    public TestingJobMasterGatewayBuilder setCheckpointStatsSnapshotSupplier(
+            Supplier<CompletableFuture<CheckpointStatsSnapshot>> checkpointStatsSnapshotSupplier) {
+        this.checkpointStatsSnapshotSupplier = checkpointStatsSnapshotSupplier;
+        return this;
+    }
+
     public TestingJobMasterGatewayBuilder setTriggerSavepointFunction(
             TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
                     triggerSavepointFunction) {
@@ -439,6 +448,7 @@ public class TestingJobMasterGatewayBuilder {
                 resourceManagerHeartbeatFunction,
                 requestJobDetailsSupplier,
                 requestJobSupplier,
+                checkpointStatsSnapshotSupplier,
                 triggerSavepointFunction,
                 triggerCheckpointFunction,
                 stopWithSavepointFunction,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.TestLoggerExtension;
@@ -28,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,5 +105,40 @@ class RestHandlerConfigurationTest {
         RestHandlerConfiguration restHandlerConfiguration =
                 RestHandlerConfiguration.fromConfiguration(config);
         assertThat(restHandlerConfiguration.isWebCancelEnabled()).isEqualTo(webCancelEnabled);
+    }
+
+    @Test
+    public void testCheckpointCacheExpireAfterWrite() {
+        final Duration testDuration = Duration.ofMillis(100L);
+        final Configuration config = new Configuration();
+        config.set(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT, testDuration);
+
+        RestHandlerConfiguration restHandlerConfiguration =
+                RestHandlerConfiguration.fromConfiguration(config);
+        assertThat(restHandlerConfiguration.getCheckpointCacheExpireAfterWrite())
+                .isEqualTo(testDuration);
+    }
+
+    @Test
+    public void testCheckpointCacheExpiryFallbackToRefreshInterval() {
+        final long refreshInterval = 1000L;
+        final Configuration config = new Configuration();
+        config.set(WebOptions.REFRESH_INTERVAL, refreshInterval);
+
+        RestHandlerConfiguration restHandlerConfiguration =
+                RestHandlerConfiguration.fromConfiguration(config);
+        assertThat(restHandlerConfiguration.getCheckpointCacheExpireAfterWrite())
+                .isEqualTo(Duration.ofMillis(1000L));
+    }
+
+    @Test
+    public void testCheckpointCacheSize() {
+        final int testCacheSize = 50;
+        final Configuration config = new Configuration();
+        config.set(RestOptions.CACHE_CHECKPOINT_STATISTICS_SIZE, testCacheSize);
+
+        RestHandlerConfiguration restHandlerConfiguration =
+                RestHandlerConfiguration.fromConfiguration(config);
+        assertThat(restHandlerConfiguration.getCheckpointCacheSize()).isEqualTo(testCacheSize);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointStatsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/checkpoints/AbstractCheckpointStatsHandlerTest.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.checkpoints;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.StatsSummaryDto;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+/** Test class for {@link AbstractCheckpointStatsHandler}. */
+public class AbstractCheckpointStatsHandlerTest extends TestLogger {
+
+    private static final Time TIMEOUT = Time.seconds(10);
+
+    private static final JobID JOB_ID = new JobID();
+
+    private static final CheckpointStatsTracker checkpointStatsTracker =
+            new CheckpointStatsTracker(
+                    10, UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup());
+
+    @Test
+    public void testRetrieveSnapshotFromCache() throws Exception {
+        GatewayRetriever<RestfulGateway> leaderRetriever =
+                () -> CompletableFuture.completedFuture(null);
+        CheckpointingStatistics checkpointingStatistics = getTestCheckpointingStatistics();
+        CheckpointStatsSnapshot checkpointStatsSnapshot1 = getTestCheckpointStatsSnapshot();
+
+        // Create a passthrough cache so the latest object will always be returned
+        Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>> cache =
+                CacheBuilder.newBuilder().build();
+
+        try (RecordingCheckpointStatsHandler checkpointStatsHandler =
+                new RecordingCheckpointStatsHandler(
+                        leaderRetriever,
+                        TIMEOUT,
+                        Collections.emptyMap(),
+                        CheckpointingStatisticsHeaders.getInstance(),
+                        cache,
+                        Executors.directExecutor(),
+                        checkpointingStatistics)) {
+            RestfulGateway functioningRestfulGateway =
+                    new TestingRestfulGateway.Builder()
+                            .setRequestCheckpointStatsSnapshotFunction(
+                                    jobID ->
+                                            CompletableFuture.completedFuture(
+                                                    checkpointStatsSnapshot1))
+                            .build();
+            HandlerRequest<EmptyRequestBody> request =
+                    HandlerRequest.resolveParametersAndCreate(
+                            EmptyRequestBody.getInstance(),
+                            new JobMessageParameters(),
+                            Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
+                            Collections.emptyMap(),
+                            Collections.emptyList());
+
+            assertThat(
+                            checkpointStatsHandler
+                                    .handleRequest(request, functioningRestfulGateway)
+                                    .get())
+                    .usingRecursiveComparison()
+                    .isEqualTo(checkpointingStatistics);
+            assertThat(checkpointStatsHandler.getStoredCheckpointStats())
+                    .isEqualTo(checkpointStatsSnapshot1);
+
+            // Refresh the checkpoint stats data
+            CheckpointStatsSnapshot checkpointStatsSnapshot2 = getTestCheckpointStatsSnapshot();
+            RestfulGateway refreshedRestfulGateway =
+                    new TestingRestfulGateway.Builder()
+                            .setRequestCheckpointStatsSnapshotFunction(
+                                    jobID ->
+                                            CompletableFuture.completedFuture(
+                                                    checkpointStatsSnapshot2))
+                            .build();
+            assertThat(checkpointStatsHandler.handleRequest(request, refreshedRestfulGateway).get())
+                    .usingRecursiveComparison()
+                    .isEqualTo(checkpointingStatistics);
+            assertThat(checkpointStatsHandler.getStoredCheckpointStats())
+                    .isEqualTo(checkpointStatsSnapshot2);
+        }
+    }
+
+    @Test
+    public void testRestExceptionPassedThrough() throws Exception {
+        GatewayRetriever<RestfulGateway> leaderRetriever =
+                () -> CompletableFuture.completedFuture(null);
+        CheckpointStatsSnapshot checkpointStatsSnapshot1 = getTestCheckpointStatsSnapshot();
+        RestHandlerException restHandlerException =
+                new RestHandlerException(
+                        "some exception thrown", HttpResponseStatus.INTERNAL_SERVER_ERROR);
+
+        try (ThrowingCheckpointStatsHandler checkpointStatsHandler =
+                new ThrowingCheckpointStatsHandler(
+                        leaderRetriever,
+                        TIMEOUT,
+                        Collections.emptyMap(),
+                        CheckpointingStatisticsHeaders.getInstance(),
+                        CacheBuilder.newBuilder().build(),
+                        Executors.directExecutor(),
+                        restHandlerException)) {
+            RestfulGateway restfulGateway =
+                    new TestingRestfulGateway.Builder()
+                            .setRequestCheckpointStatsSnapshotFunction(
+                                    jobID ->
+                                            CompletableFuture.completedFuture(
+                                                    checkpointStatsSnapshot1))
+                            .build();
+            HandlerRequest<EmptyRequestBody> request =
+                    HandlerRequest.resolveParametersAndCreate(
+                            EmptyRequestBody.getInstance(),
+                            new JobMessageParameters(),
+                            Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
+                            Collections.emptyMap(),
+                            Collections.emptyList());
+
+            assertThatExceptionOfType(ExecutionException.class)
+                    .isThrownBy(
+                            () ->
+                                    checkpointStatsHandler
+                                            .handleRequest(request, restfulGateway)
+                                            .get())
+                    .withCause(restHandlerException);
+        }
+    }
+
+    @Test
+    public void testFlinkJobNotFoundException() throws Exception {
+        GatewayRetriever<RestfulGateway> leaderRetriever =
+                () -> CompletableFuture.completedFuture(null);
+        CheckpointStatsSnapshot checkpointStatsSnapshot1 = getTestCheckpointStatsSnapshot();
+        CompletableFuture<CheckpointStatsSnapshot> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new FlinkJobNotFoundException(JOB_ID));
+
+        try (RecordingCheckpointStatsHandler checkpointStatsHandler =
+                new RecordingCheckpointStatsHandler(
+                        leaderRetriever,
+                        TIMEOUT,
+                        Collections.emptyMap(),
+                        CheckpointingStatisticsHeaders.getInstance(),
+                        CacheBuilder.newBuilder().build(),
+                        Executors.directExecutor(),
+                        null)) {
+            RestfulGateway restfulGateway =
+                    new TestingRestfulGateway.Builder()
+                            .setRequestCheckpointStatsSnapshotFunction(jobID -> failedFuture)
+                            .build();
+            HandlerRequest<EmptyRequestBody> request =
+                    HandlerRequest.resolveParametersAndCreate(
+                            EmptyRequestBody.getInstance(),
+                            new JobMessageParameters(),
+                            Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
+                            Collections.emptyMap(),
+                            Collections.emptyList());
+
+            assertThat(checkpointStatsHandler.handleRequest(request, restfulGateway))
+                    .isCompletedExceptionally()
+                    .failsWithin(Duration.ofSeconds(1))
+                    .withThrowableOfType(ExecutionException.class)
+                    .withStackTraceContaining("Job %s not found", JOB_ID);
+        }
+    }
+
+    private static CheckpointStatsSnapshot getTestCheckpointStatsSnapshot() {
+        return checkpointStatsTracker.createSnapshot();
+    }
+
+    private CheckpointingStatistics getTestCheckpointingStatistics() {
+        final CheckpointingStatistics.Counts counts =
+                new CheckpointingStatistics.Counts(1, 2, 3, 4, 5);
+        final CheckpointingStatistics.Summary summary =
+                new CheckpointingStatistics.Summary(
+                        new StatsSummaryDto(1L, 1L, 1L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(1L, 1L, 1L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(2L, 2L, 2L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(3L, 3L, 3L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(4L, 4L, 4L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(5L, 5L, 5L, 0, 0, 0, 0, 0));
+        return new CheckpointingStatistics(
+                counts,
+                summary,
+                new CheckpointingStatistics.LatestCheckpoints(null, null, null, null),
+                Collections.emptyList());
+    }
+
+    private static class RecordingCheckpointStatsHandler
+            extends AbstractCheckpointStatsHandler<CheckpointingStatistics, JobMessageParameters> {
+
+        private final CheckpointingStatistics returnValue;
+        private CheckpointStatsSnapshot storedCheckpointStats;
+
+        protected RecordingCheckpointStatsHandler(
+                GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+                Time timeout,
+                Map<String, String> responseHeaders,
+                MessageHeaders<EmptyRequestBody, CheckpointingStatistics, JobMessageParameters>
+                        messageHeaders,
+                Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                        checkpointStatsSnapshotCache,
+                Executor executor,
+                CheckpointingStatistics returnValue) {
+            super(
+                    leaderRetriever,
+                    timeout,
+                    responseHeaders,
+                    messageHeaders,
+                    checkpointStatsSnapshotCache,
+                    executor);
+            this.returnValue = returnValue;
+        }
+
+        @Override
+        protected CheckpointingStatistics handleCheckpointStatsRequest(
+                HandlerRequest<EmptyRequestBody> request,
+                CheckpointStatsSnapshot checkpointStatsSnapshot)
+                throws RestHandlerException {
+            storedCheckpointStats = checkpointStatsSnapshot;
+            return returnValue;
+        }
+
+        public CheckpointStatsSnapshot getStoredCheckpointStats() {
+            return storedCheckpointStats;
+        }
+    }
+
+    private static class ThrowingCheckpointStatsHandler
+            extends AbstractCheckpointStatsHandler<CheckpointingStatistics, JobMessageParameters> {
+
+        private final RestHandlerException exception;
+
+        protected ThrowingCheckpointStatsHandler(
+                GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+                Time timeout,
+                Map<String, String> responseHeaders,
+                MessageHeaders<EmptyRequestBody, CheckpointingStatistics, JobMessageParameters>
+                        messageHeaders,
+                Cache<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                        checkpointStatsSnapshotCache,
+                Executor executor,
+                RestHandlerException exception) {
+            super(
+                    leaderRetriever,
+                    timeout,
+                    responseHeaders,
+                    messageHeaders,
+                    checkpointStatsSnapshotCache,
+                    executor);
+            this.exception = exception;
+        }
+
+        @Override
+        protected CheckpointingStatistics handleCheckpointStatsRequest(
+                HandlerRequest<EmptyRequestBody> request,
+                CheckpointStatsSnapshot checkpointStatsSnapshot)
+                throws RestHandlerException {
+            throw exception;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -140,6 +141,12 @@ public class TestingSchedulerNG implements SchedulerNG {
 
     @Override
     public ExecutionGraphInfo requestJob() {
+        failOperation();
+        return null;
+    }
+
+    @Override
+    public CheckpointStatsSnapshot requestCheckpointStats() {
         failOperation();
         return null;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -120,6 +121,8 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
             Function<JobID, CompletableFuture<ArchivedExecutionGraph>> requestJobFunction,
             Function<JobID, CompletableFuture<ExecutionGraphInfo>>
                     requestExecutionGraphInfoFunction,
+            Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                    requestCheckpointStatsSnapshotFunction,
             Function<JobID, CompletableFuture<JobResult>> requestJobResultFunction,
             Function<JobID, CompletableFuture<JobStatus>> requestJobStatusFunction,
             Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier,
@@ -173,6 +176,7 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
                 cancelJobFunction,
                 requestJobFunction,
                 requestExecutionGraphInfoFunction,
+                requestCheckpointStatsSnapshotFunction,
                 requestJobResultFunction,
                 requestJobStatusFunction,
                 requestMultipleJobDetailsSupplier,
@@ -355,6 +359,7 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway
                     cancelJobFunction,
                     requestJobFunction,
                     requestExecutionGraphInfoFunction,
+                    requestCheckpointStatsSnapshotFunction,
                     requestJobResultFunction,
                     requestJobStatusFunction,
                     requestMultipleJobDetailsSupplier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.TriggerSavepointMode;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -63,6 +64,10 @@ public class TestingRestfulGateway implements RestfulGateway {
                             FutureUtils.completedExceptionally(new UnsupportedOperationException());
     static final Function<JobID, CompletableFuture<ExecutionGraphInfo>>
             DEFAULT_REQUEST_EXECUTION_GRAPH_INFO =
+                    jobId ->
+                            FutureUtils.completedExceptionally(new UnsupportedOperationException());
+    static final Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+            DEFAULT_REQUEST_CHECKPOINT_STATS_SNAPSHOT =
                     jobId ->
                             FutureUtils.completedExceptionally(new UnsupportedOperationException());
     static final Function<JobID, CompletableFuture<JobStatus>> DEFAULT_REQUEST_JOB_STATUS_FUNCTION =
@@ -148,6 +153,9 @@ public class TestingRestfulGateway implements RestfulGateway {
     protected Function<JobID, CompletableFuture<ExecutionGraphInfo>>
             requestExecutionGraphInfoFunction;
 
+    protected Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+            requestCheckpointStatsSnapshotFunction;
+
     protected Function<JobID, CompletableFuture<JobResult>> requestJobResultFunction;
 
     protected Function<JobID, CompletableFuture<JobStatus>> requestJobStatusFunction;
@@ -202,6 +210,7 @@ public class TestingRestfulGateway implements RestfulGateway {
                 DEFAULT_CANCEL_JOB_FUNCTION,
                 DEFAULT_REQUEST_JOB_FUNCTION,
                 DEFAULT_REQUEST_EXECUTION_GRAPH_INFO,
+                DEFAULT_REQUEST_CHECKPOINT_STATS_SNAPSHOT,
                 DEFAULT_REQUEST_JOB_RESULT_FUNCTION,
                 DEFAULT_REQUEST_JOB_STATUS_FUNCTION,
                 DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER,
@@ -225,6 +234,8 @@ public class TestingRestfulGateway implements RestfulGateway {
             Function<JobID, CompletableFuture<ArchivedExecutionGraph>> requestJobFunction,
             Function<JobID, CompletableFuture<ExecutionGraphInfo>>
                     requestExecutionGraphInfoFunction,
+            Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                    requestCheckpointStatsSnapshotFunction,
             Function<JobID, CompletableFuture<JobResult>> requestJobResultFunction,
             Function<JobID, CompletableFuture<JobStatus>> requestJobStatusFunction,
             Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier,
@@ -264,6 +275,7 @@ public class TestingRestfulGateway implements RestfulGateway {
         this.cancelJobFunction = cancelJobFunction;
         this.requestJobFunction = requestJobFunction;
         this.requestExecutionGraphInfoFunction = requestExecutionGraphInfoFunction;
+        this.requestCheckpointStatsSnapshotFunction = requestCheckpointStatsSnapshotFunction;
         this.requestJobResultFunction = requestJobResultFunction;
         this.requestJobStatusFunction = requestJobStatusFunction;
         this.requestMultipleJobDetailsSupplier = requestMultipleJobDetailsSupplier;
@@ -302,6 +314,12 @@ public class TestingRestfulGateway implements RestfulGateway {
     public CompletableFuture<ExecutionGraphInfo> requestExecutionGraphInfo(
             JobID jobId, Time timeout) {
         return requestExecutionGraphInfoFunction.apply(jobId);
+    }
+
+    @Override
+    public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(
+            JobID jobId, Time timeout) {
+        return requestCheckpointStatsSnapshotFunction.apply(jobId);
     }
 
     @Override
@@ -410,6 +428,8 @@ public class TestingRestfulGateway implements RestfulGateway {
         protected Function<JobID, CompletableFuture<ArchivedExecutionGraph>> requestJobFunction;
         protected Function<JobID, CompletableFuture<ExecutionGraphInfo>>
                 requestExecutionGraphInfoFunction;
+        protected Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                requestCheckpointStatsSnapshotFunction;
         protected Function<JobID, CompletableFuture<JobResult>> requestJobResultFunction;
         protected Function<JobID, CompletableFuture<JobStatus>> requestJobStatusFunction;
         protected Supplier<CompletableFuture<MultipleJobsDetails>>
@@ -452,6 +472,7 @@ public class TestingRestfulGateway implements RestfulGateway {
             cancelJobFunction = DEFAULT_CANCEL_JOB_FUNCTION;
             requestJobFunction = DEFAULT_REQUEST_JOB_FUNCTION;
             requestExecutionGraphInfoFunction = DEFAULT_REQUEST_EXECUTION_GRAPH_INFO;
+            requestCheckpointStatsSnapshotFunction = DEFAULT_REQUEST_CHECKPOINT_STATS_SNAPSHOT;
             requestJobResultFunction = DEFAULT_REQUEST_JOB_RESULT_FUNCTION;
             requestJobStatusFunction = DEFAULT_REQUEST_JOB_STATUS_FUNCTION;
             requestMultipleJobDetailsSupplier = DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER;
@@ -496,6 +517,13 @@ public class TestingRestfulGateway implements RestfulGateway {
                 Function<JobID, CompletableFuture<ExecutionGraphInfo>>
                         requestExecutionGraphInfoFunction) {
             this.requestExecutionGraphInfoFunction = requestExecutionGraphInfoFunction;
+            return self();
+        }
+
+        public T setRequestCheckpointStatsSnapshotFunction(
+                Function<JobID, CompletableFuture<CheckpointStatsSnapshot>>
+                        requestCheckpointStatsSnapshotFunction) {
+            this.requestCheckpointStatsSnapshotFunction = requestCheckpointStatsSnapshotFunction;
             return self();
         }
 
@@ -625,6 +653,7 @@ public class TestingRestfulGateway implements RestfulGateway {
                     cancelJobFunction,
                     requestJobFunction,
                     requestExecutionGraphInfoFunction,
+                    requestCheckpointStatsSnapshotFunction,
                     requestJobResultFunction,
                     requestJobStatusFunction,
                     requestMultipleJobDetailsSupplier,


### PR DESCRIPTION
## What is the purpose of the change

Simplify the checkpoint handler API.
The checkpoint endpoints do not require the entire ExecutionGraph to produce their result. In fact, they only require the CheckpointStatsSnapshot. This change refactors the handlers to use only the CheckpointStatsSnapshot.


## Brief change log
- Checkpoint REST handlers now consume from `AbstractCheckpointStatsHandler` that provides the `CheckpointStatsSnapshot`.
- `CheckpointsStatsSnapshot` is cached, to reduce call rate to underlying JobMaster. 

## Verifying this change
This change added tests and can be verified as follows:
  - Added unit tests
  - Manually ran the Flink dashboard and tested the refresh rate on checkpoint API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
