### PR TITLE
[FLINK-32310][table] Support enhanced show functions syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -762,15 +762,18 @@ SHOW CREATE VIEW [catalog_name.][db_name.]view_name
 SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-展示当前 catalog 和当前 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外返回的结果能被一个可选的匹配字符串过滤。
+展示当前 catalog 和当前 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
 
 **USER**
-展示当前 catalog 和当前 database 中仅用户定义的 function, 另外返回的结果能被一个可选的匹配字符串过滤。
+仅展示用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
+
+**FROM(IN)**
+展示指定的 catalog 和 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
 
 **LIKE**
-根据可选的 `LIKE` 语句与 `<sql_like_pattern>` 是否模糊相似的所有 function。
+根据可选的 `LIKE` 语句与 `<sql_like_pattern>` 是否模糊匹配的所有 function。
 
-`LIKE` 子句中 sql 正则式的语法与 `MySQL` 方言中的语法相同。
+`LIKE` 子句中 SQL 正则式的语法与 `MySQL` 方言中的语法相同。
 * `%` 匹配任意数量的字符, 也包括0数量字符, `\%` 匹配一个 `%` 字符.
 * `_` 只匹配一个字符, `\_` 匹配一个 `_` 字符.
 

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -762,13 +762,11 @@ SHOW CREATE VIEW [catalog_name.][db_name.]view_name
 SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-展示当前 catalog 和当前 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
+展示指定 catalog 和 database 下的所有 function，包括：系统 function 和用户定义的 function。
+如果没有指定 catalog 和 database，则将使用当前 catalog 和 当前 database。另外可以用 `<sql_like_pattern>` 来过滤要返回的 function。
 
 **USER**
-仅展示用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
-
-**FROM(IN)**
-展示指定的 catalog 和 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外可以用 sql_like_pattern 来过滤要返回的 function。
+仅展示用户定义的 function, 另外可以用 `<sql_like_pattern>` 来过滤要返回的 function。
 
 **LIKE**
 根据可选的 `LIKE` 语句与 `<sql_like_pattern>` 是否模糊匹配的所有 function。

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -759,13 +759,23 @@ SHOW CREATE VIEW [catalog_name.][db_name.]view_name
 ## SHOW FUNCTIONS
 
 ```sql
-SHOW [USER] FUNCTIONS
+SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-展示当前 catalog 和当前 database 中所有的 function，包括：系统 function 和用户定义的 function。
+展示当前 catalog 和当前 database 中所有的 function，包括：系统 function 和用户定义的 function, 另外返回的结果能被一个可选的匹配字符串过滤。
 
 **USER**
-仅仅展示当前 catalog 和当前 database 中用户定义的 function。
+展示当前 catalog 和当前 database 中仅用户定义的 function, 另外返回的结果能被一个可选的匹配字符串过滤。
+
+**LIKE**
+根据可选的 `LIKE` 语句与 `<sql_like_pattern>` 是否模糊相似的所有 function。
+
+`LIKE` 子句中 sql 正则式的语法与 `MySQL` 方言中的语法相同。
+* `%` 匹配任意数量的字符, 也包括0数量字符, `\%` 匹配一个 `%` 字符.
+* `_` 只匹配一个字符, `\_` 匹配一个 `_` 字符.
+
+**ILIKE**
+它的行为和 LIKE 相同，只是对于大小写是不敏感的。
 
 ## SHOW MODULES
 

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -762,10 +762,10 @@ Show create view statement for specified view.
 SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]	
 ```
 
-Show all functions including system functions and user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `sql_like_pattern` can be used to filter the functions.
+Show all functions including system functions and user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `<sql_like_pattern>` can be used to filter the functions.
 
 **USER**
-Show only user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `sql_like_pattern` can be used to filter the functions.
+Show only user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `<sql_like_pattern>` can be used to filter the functions.
 
 **LIKE**
 Show all functions with a `LIKE` clause, whose name is similar to the `<sql_like_pattern>`.

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -762,20 +762,20 @@ Show create view statement for specified view.
 SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]	
 ```
 
-Show all functions including system functions and user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+Show all functions including system functions and user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `sql_like_pattern` can be used to filter the functions.
 
 **USER**
-Show only user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+Show only user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, a `sql_like_pattern` can be used to filter the functions.
 
 **LIKE**
-Show all tables with given table name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.
+Show all functions with a `LIKE` clause, whose name is similar to the `<sql_like_pattern>`.
 
-The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
-* `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
+The syntax of the SQL pattern in the `LIKE` clause is the same as that of the `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, and `\%` matches one `%` character.
 * `_` matches exactly one character, `\_` matches one `_` character.
 
 **ILIKE**
-The same behavior as `LIKE` but sql pattern is case-insensitive.
+The same behavior as `LIKE` but the SQL pattern is case-insensitive.
 
 ## SHOW MODULES
 

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -759,13 +759,23 @@ Show create view statement for specified view.
 ## SHOW FUNCTIONS
 
 ```sql
-SHOW [USER] FUNCTIONS
+SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]	
 ```
 
-Show all functions including system functions and user-defined functions in the current catalog and current database.
+Show all functions including system functions and user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
 
 **USER**
-Show only user-defined functions in the current catalog and current database.
+Show only user-defined functions for an optionally specified database. If no database is specified then the functions are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+
+**LIKE**
+Show all tables with given table name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.
+
+The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
+
+**ILIKE**
+The same behavior as `LIKE` but sql pattern is case-insensitive.
 
 ## SHOW MODULES
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -42,6 +42,24 @@ show user functions;
 1 row in set
 !ok
 
+show user functions like 'func%';
++---------------+
+| function name |
++---------------+
+|         func1 |
++---------------+
+1 row in set
+!ok
+
+show user functions ilike 'func%';
++---------------+
+| function name |
++---------------+
+|         func1 |
++---------------+
+1 row in set
+!ok
+
 SET 'sql-client.execution.result-mode' = 'tableau';
 [INFO] Execute statement succeed.
 !info
@@ -71,6 +89,24 @@ show user functions;
 |         func2 |
 +---------------+
 2 rows in set
+!ok
+
+show user functions like 'func1%';
++---------------+
+| function name |
++---------------+
+|         func1 |
++---------------+
+1 row in set
+!ok
+
+show user functions ilike 'func2%';
++---------------+
+| function name |
++---------------+
+|         func2 |
++---------------+
+1 row in set
 !ok
 
 # ====== test function with full qualified name ======
@@ -108,6 +144,38 @@ show user functions;
 |         func2 |
 +---------------+
 2 rows in set
+!ok
+
+# ====== test function with specified catalog and db ======
+
+# we are not under catalog c1
+
+show user functions from c1.db;
++---------------+
+| function name |
++---------------+
+|         func3 |
+|         func4 |
++---------------+
+2 rows in set
+!ok
+
+show user functions from c1.db like 'func3%';
++---------------+
+| function name |
++---------------+
+|         func3 |
++---------------+
+1 row in set
+!ok
+
+show user functions in c1.db ilike 'FUNC3%';
++---------------+
+| function name |
++---------------+
+|         func3 |
++---------------+
+1 row in set
 !ok
 
 use catalog c1;

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -468,20 +468,21 @@ SqlShowFunctions SqlShowFunctions() :
             }
         ]
         (
-            <LIKE>  <QUOTED_STRING>
+            <LIKE>
             {
                 likeType = "LIKE";
-                String likeCondition1 = SqlParserUtil.parseString(token.image);
-                likeLiteral = SqlLiteral.createCharString(likeCondition1, getPos());
             }
         |
-            <ILIKE>  <QUOTED_STRING>
+            <ILIKE>
             {
                 likeType = "ILIKE";
-                String likeCondition2 = SqlParserUtil.parseString(token.image);
-                likeLiteral = SqlLiteral.createCharString(likeCondition2, getPos());
             }
         )
+        <QUOTED_STRING>
+        {
+            String likeCondition = SqlParserUtil.parseString(token.image);
+            likeLiteral = SqlLiteral.createCharString(likeCondition, getPos());
+        }
     ]
     {
         return new SqlShowFunctions(pos, requireUser, prep, databaseName, likeType, likeLiteral, notLike);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowFunctions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowFunctions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -28,18 +30,55 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-/** SHOW [USER] FUNCTIONS Sql Call. */
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Show Functions sql call. The full syntax for show functions is as followings:
+ *
+ * <pre>{@code
+ * SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE)
+ * <sql_like_pattern> ] statement
+ * }</pre>
+ */
 public class SqlShowFunctions extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("SHOW FUNCTIONS", SqlKind.OTHER);
 
     private final boolean requireUser;
+    private final String preposition;
+    private final SqlIdentifier databaseName;
+    // different like type such as like, ilike
+    private final String likeType;
+    private final SqlCharStringLiteral likeLiteral;
+    private final boolean notLike;
 
-    public SqlShowFunctions(SqlParserPos pos, boolean requireUser) {
+    public SqlShowFunctions(
+            SqlParserPos pos,
+            boolean requireUser,
+            String preposition,
+            SqlIdentifier databaseName,
+            String likeType,
+            SqlCharStringLiteral likeLiteral,
+            boolean notLike) {
         super(pos);
         this.requireUser = requireUser;
+        this.preposition = preposition;
+        this.databaseName =
+                preposition != null
+                        ? requireNonNull(databaseName, "Database name must not be null.")
+                        : null;
+        if (likeType != null) {
+            this.likeType = likeType;
+            this.likeLiteral = requireNonNull(likeLiteral, "Like pattern must not be null");
+            this.notLike = notLike;
+        } else {
+            this.likeType = null;
+            this.likeLiteral = null;
+            this.notLike = false;
+        }
     }
 
     @Override
@@ -49,19 +88,61 @@ public class SqlShowFunctions extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.EMPTY_LIST;
+        return Objects.isNull(databaseName)
+                ? Collections.emptyList()
+                : Collections.singletonList(databaseName);
     }
 
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        String keyword;
         if (requireUser) {
-            writer.keyword("SHOW USER FUNCTIONS");
+            keyword = "SHOW USER FUNCTIONS";
         } else {
-            writer.keyword("SHOW FUNCTIONS");
+            keyword = "SHOW FUNCTIONS";
+        }
+        if (preposition == null) {
+            writer.keyword(keyword);
+        } else if (databaseName != null) {
+            writer.keyword(keyword + " " + preposition);
+            databaseName.unparse(writer, leftPrec, rightPrec);
+        }
+        if (isWithLike()) {
+            if (isNotLike()) {
+                writer.keyword(String.format("NOT %s '%s'", likeType, getLikeSqlPattern()));
+            } else {
+                writer.keyword(String.format("%s '%s'", likeType, getLikeSqlPattern()));
+            }
         }
     }
 
     public boolean requireUser() {
         return requireUser;
+    }
+
+    public String getPreposition() {
+        return preposition;
+    }
+
+    public String[] fullDatabaseName() {
+        return Objects.isNull(this.databaseName)
+                ? new String[] {}
+                : databaseName.names.toArray(new String[0]);
+    }
+
+    public boolean isWithLike() {
+        return likeType != null;
+    }
+
+    public String getLikeType() {
+        return likeType;
+    }
+
+    public String getLikeSqlPattern() {
+        return Objects.isNull(likeLiteral) ? null : likeLiteral.getValueAs(String.class);
+    }
+
+    public boolean isNotLike() {
+        return notLike;
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -213,6 +213,61 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     void testShowFunctions() {
         sql("show functions").ok("SHOW FUNCTIONS");
         sql("show user functions").ok("SHOW USER FUNCTIONS");
+
+        sql("show functions like '%'").ok("SHOW FUNCTIONS LIKE '%'");
+        sql("show functions not like '%'").ok("SHOW FUNCTIONS NOT LIKE '%'");
+        sql("show user functions like '%'").ok("SHOW USER FUNCTIONS LIKE '%'");
+        sql("show user functions not like '%'").ok("SHOW USER FUNCTIONS NOT LIKE '%'");
+
+        sql("show functions from db1").ok("SHOW FUNCTIONS FROM `DB1`");
+        sql("show user functions from db1").ok("SHOW USER FUNCTIONS FROM `DB1`");
+        sql("show functions in db1").ok("SHOW FUNCTIONS IN `DB1`");
+        sql("show user functions in db1").ok("SHOW USER FUNCTIONS IN `DB1`");
+
+        sql("show functions from catalog1.db1").ok("SHOW FUNCTIONS FROM `CATALOG1`.`DB1`");
+        sql("show user functions from catalog1.db1")
+                .ok("SHOW USER FUNCTIONS FROM `CATALOG1`.`DB1`");
+        sql("show functions in catalog1.db1").ok("SHOW FUNCTIONS IN `CATALOG1`.`DB1`");
+        sql("show user functions in catalog1.db1").ok("SHOW USER FUNCTIONS IN `CATALOG1`.`DB1`");
+
+        sql("show functions from db1 like '%'").ok("SHOW FUNCTIONS FROM `DB1` LIKE '%'");
+        sql("show user functions from db1 like '%'").ok("SHOW USER FUNCTIONS FROM `DB1` LIKE '%'");
+        sql("show functions in db1 ilike '%'").ok("SHOW FUNCTIONS IN `DB1` ILIKE '%'");
+        sql("show user functions in db1 ilike '%'").ok("SHOW USER FUNCTIONS IN `DB1` ILIKE '%'");
+
+        sql("show functions from catalog1.db1 ilike '%'")
+                .ok("SHOW FUNCTIONS FROM `CATALOG1`.`DB1` ILIKE '%'");
+        sql("show user functions from catalog1.db1 ilike '%'")
+                .ok("SHOW USER FUNCTIONS FROM `CATALOG1`.`DB1` ILIKE '%'");
+        sql("show functions in catalog1.db1 like '%'")
+                .ok("SHOW FUNCTIONS IN `CATALOG1`.`DB1` LIKE '%'");
+        sql("show user functions in catalog1.db1 like '%'")
+                .ok("SHOW USER FUNCTIONS IN `CATALOG1`.`DB1` LIKE '%'");
+
+        sql("show functions from db1 not like '%'").ok("SHOW FUNCTIONS FROM `DB1` NOT LIKE '%'");
+        sql("show user functions from db1 not like '%'")
+                .ok("SHOW USER FUNCTIONS FROM `DB1` NOT LIKE '%'");
+        sql("show functions in db1 not ilike '%'").ok("SHOW FUNCTIONS IN `DB1` NOT ILIKE '%'");
+        sql("show user functions in db1 not ilike '%'")
+                .ok("SHOW USER FUNCTIONS IN `DB1` NOT ILIKE '%'");
+
+        sql("show functions from catalog1.db1 not like '%'")
+                .ok("SHOW FUNCTIONS FROM `CATALOG1`.`DB1` NOT LIKE '%'");
+        sql("show user functions from catalog1.db1 not like '%'")
+                .ok("SHOW USER FUNCTIONS FROM `CATALOG1`.`DB1` NOT LIKE '%'");
+        sql("show functions in catalog1.db1 not ilike '%'")
+                .ok("SHOW FUNCTIONS IN `CATALOG1`.`DB1` NOT ILIKE '%'");
+        sql("show user functions in catalog1.db1 not ilike '%'")
+                .ok("SHOW USER FUNCTIONS IN `CATALOG1`.`DB1` NOT ILIKE '%'");
+
+        sql("show functions ^likes^")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 16.\n.*");
+        sql("show functions not ^likes^")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 20" + ".\n" + ".*");
+        sql("show functions ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 16.\n.*");
+        sql("show functions not ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 20" + ".\n" + ".*");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -339,6 +339,22 @@ public final class FunctionCatalog {
     }
 
     /**
+     * Get names of all functions, including temp system functions, system functions, temp catalog
+     * functions and catalog functions with specific catalog and database.
+     */
+    public String[] getFunctions(String catalogName, String databaseName) {
+        Set<String> result =
+                getUserDefinedFunctions(catalogName, databaseName).stream()
+                        .map(FunctionIdentifier::getFunctionName)
+                        .collect(Collectors.toSet());
+
+        // add system functions
+        result.addAll(moduleManager.listFunctions());
+
+        return result.toArray(new String[0]);
+    }
+
+    /**
      * Check whether a temporary catalog function is already registered.
      *
      * @param functionIdentifier the object identifier of function

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -324,18 +324,8 @@ public final class FunctionCatalog {
      * functions and catalog functions in the current catalog and current database.
      */
     public String[] getFunctions() {
-        Set<String> result =
-                getUserDefinedFunctions(
-                                catalogManager.getCurrentCatalog(),
-                                catalogManager.getCurrentDatabase())
-                        .stream()
-                        .map(FunctionIdentifier::getFunctionName)
-                        .collect(Collectors.toSet());
-
-        // add system functions
-        result.addAll(moduleManager.listFunctions());
-
-        return result.toArray(new String[0]);
+        return getFunctions(
+                catalogManager.getCurrentCatalog(), catalogManager.getCurrentDatabase());
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/SqlLikeUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/SqlLikeUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.functions;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -56,6 +57,19 @@ public class SqlLikeUtils {
     public static boolean like(String s, String pattern, String escape) {
         final String regex = sqlToRegexLike(pattern, escape);
         return Pattern.matches(regex, s);
+    }
+
+    /** SQL {@code ILIKE} function. */
+    public static boolean ilike(String s, String patternStr) {
+        return ilike(s, patternStr, null);
+    }
+
+    /** SQL {@code ILIKE} function with escape. */
+    public static boolean ilike(String s, String patternStr, String escape) {
+        final String regex = sqlToRegexLike(patternStr, escape);
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(s);
+        return matcher.matches();
     }
 
     /** SQL {@code SIMILAR} function. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LikeType.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/LikeType.java
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.operations.utils;
+package org.apache.flink.table.operations;
 
-/** Like types utils. */
-public enum OperationLikeType {
-    /** sql like pattern, case sensitive. */
+/** Like types enums. */
+public enum LikeType {
+    /** case-sensitive to match a pattern. */
     LIKE,
-    /** sql like pattern, case insensitive. */
+    /** case-insensitive to match a pattern. */
     ILIKE;
 
-    public static OperationLikeType of(String type) {
-        return OperationLikeType.valueOf(type.toUpperCase());
+    public static LikeType of(String type) {
+        return LikeType.valueOf(type.toUpperCase());
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
@@ -19,12 +19,19 @@
 package org.apache.flink.table.operations;
 
 import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.SqlLikeUtils;
+import org.apache.flink.table.operations.utils.OperationLikeType;
 
 import java.util.Arrays;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
 
-/** Operation to describe a SHOW [USER] FUNCTIONS statement. */
+/**
+ * Operation to describe a SHOW FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT]
+ * (LIKE | ILIKE) &lt;sql_like_pattern&gt; ] statement.
+ */
 public class ShowFunctionsOperation implements ShowOperation {
 
     /**
@@ -41,45 +48,161 @@ public class ShowFunctionsOperation implements ShowOperation {
     }
 
     private final FunctionScope functionScope;
+    private final String preposition;
+    private final String catalogName;
+    private final String databaseName;
+    // different like type such as like, ilike
+    private final OperationLikeType likeType;
+    private final String likePattern;
+    private final boolean notLike;
 
     public ShowFunctionsOperation() {
         // "SHOW FUNCTIONS" default is ALL scope
         this.functionScope = FunctionScope.ALL;
+        this.preposition = null;
+        this.catalogName = null;
+        this.databaseName = null;
+        this.likeType = null;
+        this.likePattern = null;
+        this.notLike = false;
     }
 
-    public ShowFunctionsOperation(FunctionScope functionScope) {
+    public ShowFunctionsOperation(
+            FunctionScope functionScope, String likeType, String likePattern, boolean notLike) {
         this.functionScope = functionScope;
+        this.preposition = null;
+        this.catalogName = null;
+        this.databaseName = null;
+        if (likeType != null) {
+            this.likeType = OperationLikeType.of(likeType);
+            this.likePattern = requireNonNull(likePattern, "Like pattern must not be null");
+            this.notLike = notLike;
+        } else {
+            this.likeType = null;
+            this.likePattern = null;
+            this.notLike = false;
+        }
+    }
+
+    public ShowFunctionsOperation(
+            FunctionScope functionScope,
+            String preposition,
+            String catalogName,
+            String databaseName,
+            String likeType,
+            String likePattern,
+            boolean notLike) {
+        this.functionScope = functionScope;
+        this.preposition = preposition;
+        this.catalogName = catalogName;
+        this.databaseName = databaseName;
+        if (likeType != null) {
+            this.likeType = OperationLikeType.of(likeType);
+            this.likePattern = requireNonNull(likePattern, "Like pattern must not be null");
+            this.notLike = notLike;
+        } else {
+            this.likeType = null;
+            this.likePattern = null;
+            this.notLike = false;
+        }
     }
 
     @Override
     public String asSummaryString() {
+        StringBuilder builder = new StringBuilder();
         if (functionScope == FunctionScope.ALL) {
-            return "SHOW FUNCTIONS";
+            builder.append("SHOW FUNCTIONS");
         } else {
-            return String.format("SHOW %s FUNCTIONS", functionScope);
+            builder.append(String.format("SHOW %s FUNCTIONS", functionScope));
         }
+        if (preposition != null) {
+            builder.append(String.format(" %s %s.%s", preposition, catalogName, databaseName));
+        }
+        if (isWithLike()) {
+            if (isNotLike()) {
+                builder.append(String.format(" NOT %s '%s'", likeType.name(), likePattern));
+            } else {
+                builder.append(String.format(" %s '%s'", likeType.name(), likePattern));
+            }
+        }
+        return builder.toString();
     }
 
     public FunctionScope getFunctionScope() {
         return functionScope;
     }
 
+    public boolean isLike() {
+        return likeType == OperationLikeType.LIKE;
+    }
+
+    public boolean isWithLike() {
+        return likeType != null;
+    }
+
+    public boolean isNotLike() {
+        return notLike;
+    }
+
     @Override
     public TableResultInternal execute(Context ctx) {
         final String[] functionNames;
-        switch (functionScope) {
-            case USER:
-                functionNames = ctx.getFunctionCatalog().getUserDefinedFunctions();
-                break;
-            case ALL:
-                functionNames = ctx.getFunctionCatalog().getFunctions();
-                break;
-            default:
-                throw new UnsupportedOperationException(
-                        String.format(
-                                "SHOW FUNCTIONS with %s scope is not supported.", functionScope));
+        if (preposition == null) {
+            // it's to show current_catalog.current_database
+            switch (functionScope) {
+                case USER:
+                    functionNames = ctx.getFunctionCatalog().getUserDefinedFunctions();
+                    break;
+                case ALL:
+                    functionNames = ctx.getFunctionCatalog().getFunctions();
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "SHOW FUNCTIONS with %s scope is not supported.",
+                                    functionScope));
+            }
+        } else {
+            switch (functionScope) {
+                case USER:
+                    functionNames =
+                            ctx.getFunctionCatalog()
+                                    .getUserDefinedFunctions(catalogName, databaseName).stream()
+                                    .map(FunctionIdentifier::getFunctionName)
+                                    .toArray(String[]::new);
+                    break;
+                case ALL:
+                    functionNames =
+                            ctx.getFunctionCatalog().getFunctions(catalogName, databaseName);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "SHOW FUNCTIONS with %s scope is not supported.",
+                                    functionScope));
+            }
         }
-        Arrays.sort(functionNames);
-        return buildStringArrayResult("function name", functionNames);
+
+        String[] rows;
+        if (isWithLike()) {
+            rows =
+                    Arrays.stream(functionNames)
+                            .filter(
+                                    row -> {
+                                        if (likeType == OperationLikeType.ILIKE) {
+                                            return isNotLike()
+                                                    != SqlLikeUtils.ilike(row, likePattern, "\\");
+                                        } else {
+                                            return isNotLike()
+                                                    != SqlLikeUtils.like(row, likePattern, "\\");
+                                        }
+                                    })
+                            .sorted()
+                            .toArray(String[]::new);
+        } else {
+            rows = Arrays.stream(functionNames).sorted().toArray(String[]::new);
+        }
+
+        return buildStringArrayResult("function name", rows);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.operations;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.functions.SqlLikeUtils;
-import org.apache.flink.table.operations.utils.OperationLikeType;
 
 import java.util.Arrays;
 
@@ -52,7 +51,7 @@ public class ShowFunctionsOperation implements ShowOperation {
     private final String catalogName;
     private final String databaseName;
     // different like type such as like, ilike
-    private final OperationLikeType likeType;
+    private final LikeType likeType;
     private final String likePattern;
     private final boolean notLike;
 
@@ -74,7 +73,7 @@ public class ShowFunctionsOperation implements ShowOperation {
         this.catalogName = null;
         this.databaseName = null;
         if (likeType != null) {
-            this.likeType = OperationLikeType.of(likeType);
+            this.likeType = LikeType.of(likeType);
             this.likePattern = requireNonNull(likePattern, "Like pattern must not be null");
             this.notLike = notLike;
         } else {
@@ -97,7 +96,7 @@ public class ShowFunctionsOperation implements ShowOperation {
         this.catalogName = catalogName;
         this.databaseName = databaseName;
         if (likeType != null) {
-            this.likeType = OperationLikeType.of(likeType);
+            this.likeType = LikeType.of(likeType);
             this.likePattern = requireNonNull(likePattern, "Like pattern must not be null");
             this.notLike = notLike;
         } else {
@@ -133,7 +132,7 @@ public class ShowFunctionsOperation implements ShowOperation {
     }
 
     public boolean isLike() {
-        return likeType == OperationLikeType.LIKE;
+        return likeType == LikeType.LIKE;
     }
 
     public boolean isWithLike() {
@@ -189,7 +188,7 @@ public class ShowFunctionsOperation implements ShowOperation {
                     Arrays.stream(functionNames)
                             .filter(
                                     row -> {
-                                        if (likeType == OperationLikeType.ILIKE) {
+                                        if (likeType == LikeType.ILIKE) {
                                             return isNotLike()
                                                     != SqlLikeUtils.ilike(row, likePattern, "\\");
                                         } else {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationLikeType.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationLikeType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.utils;
+
+/** Like types utils. */
+public enum OperationLikeType {
+    /** sql like pattern, case sensitive. */
+    LIKE,
+    /** sql like pattern, case insensitive. */
+    ILIKE;
+
+    public static OperationLikeType of(String type) {
+        return OperationLikeType.valueOf(type.toUpperCase());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -70,7 +70,6 @@ import org.apache.flink.sql.parser.dql.SqlShowCreateView;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
-import org.apache.flink.sql.parser.dql.SqlShowFunctions;
 import org.apache.flink.sql.parser.dql.SqlShowJars;
 import org.apache.flink.sql.parser.dql.SqlShowJobs;
 import org.apache.flink.sql.parser.dql.SqlShowModules;
@@ -133,8 +132,6 @@ import org.apache.flink.table.operations.ShowCreateViewOperation;
 import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
 import org.apache.flink.table.operations.ShowCurrentDatabaseOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
-import org.apache.flink.table.operations.ShowFunctionsOperation;
-import org.apache.flink.table.operations.ShowFunctionsOperation.FunctionScope;
 import org.apache.flink.table.operations.ShowModulesOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.ShowViewsOperation;
@@ -340,8 +337,6 @@ public class SqlNodeToOperationConversion {
             return Optional.of(converter.convertShowCreateTable((SqlShowCreateTable) validated));
         } else if (validated instanceof SqlShowCreateView) {
             return Optional.of(converter.convertShowCreateView((SqlShowCreateView) validated));
-        } else if (validated instanceof SqlShowFunctions) {
-            return Optional.of(converter.convertShowFunctions((SqlShowFunctions) validated));
         } else if (validated instanceof SqlRichExplain) {
             return Optional.of(converter.convertRichExplain((SqlRichExplain) validated));
         } else if (validated instanceof SqlRichDescribeTable) {
@@ -968,12 +963,6 @@ public class SqlNodeToOperationConversion {
                 UnresolvedIdentifier.of(sqlShowCreateView.getFullViewName());
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
         return new ShowCreateViewOperation(identifier);
-    }
-
-    /** Convert SHOW FUNCTIONS statement. */
-    private Operation convertShowFunctions(SqlShowFunctions sqlShowFunctions) {
-        return new ShowFunctionsOperation(
-                sqlShowFunctions.requireUser() ? FunctionScope.USER : FunctionScope.ALL);
     }
 
     /** Convert DROP VIEW statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -48,6 +48,7 @@ public class SqlNodeConverters {
         register(new SqlQueryConverter());
         register(new SqlShowPartitionsConverter());
         register(new SqlTruncateTableConverter());
+        register(new SqlShowFunctionsConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowFunctionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowFunctionsConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowFunctions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowFunctionsOperation;
+
+/** A converter for {@link SqlShowFunctions}. */
+public class SqlShowFunctionsConverter implements SqlNodeConverter<SqlShowFunctions> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowFunctions sqlShowFunctions, ConvertContext context) {
+        ShowFunctionsOperation.FunctionScope functionScope =
+                sqlShowFunctions.requireUser()
+                        ? ShowFunctionsOperation.FunctionScope.USER
+                        : ShowFunctionsOperation.FunctionScope.ALL;
+
+        if (sqlShowFunctions.getPreposition() == null) {
+            return new ShowFunctionsOperation(
+                    functionScope,
+                    sqlShowFunctions.getLikeType(),
+                    sqlShowFunctions.getLikeSqlPattern(),
+                    sqlShowFunctions.isNotLike());
+        }
+
+        String[] fullDatabaseName = sqlShowFunctions.fullDatabaseName();
+        if (fullDatabaseName.length > 2) {
+            throw new ValidationException(
+                    String.format(
+                            "Show functions from/in identifier [ %s ] format error, it should be [catalog_name.]database_name.",
+                            String.join(".", fullDatabaseName)));
+        }
+        CatalogManager catalogManager = context.getCatalogManager();
+        String catalogName =
+                (fullDatabaseName.length == 1)
+                        ? catalogManager.getCurrentCatalog()
+                        : fullDatabaseName[0];
+        String databaseName =
+                (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
+        return new ShowFunctionsOperation(
+                functionScope,
+                sqlShowFunctions.getPreposition(),
+                catalogName,
+                databaseName,
+                sqlShowFunctions.getLikeType(),
+                sqlShowFunctions.getLikeSqlPattern(),
+                sqlShowFunctions.isNotLike());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -202,6 +202,28 @@ public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversion
 
         final String sql2 = "SHOW USER FUNCTIONS";
         assertShowFunctions(sql2, sql2, ShowFunctionsOperation.FunctionScope.USER);
+
+        String sql = "show functions from cat1.db1 not like 'f%'";
+        assertShowFunctions(
+                sql,
+                "SHOW FUNCTIONS FROM cat1.db1 NOT LIKE 'f%'",
+                ShowFunctionsOperation.FunctionScope.ALL);
+
+        sql = "show user functions from cat1.db1 ilike 'f%'";
+        assertShowFunctions(
+                sql,
+                "SHOW USER FUNCTIONS FROM cat1.db1 ILIKE 'f%'",
+                ShowFunctionsOperation.FunctionScope.USER);
+
+        sql = "show functions in db1";
+        assertShowFunctions(
+                sql, "SHOW FUNCTIONS IN builtin.db1", ShowFunctionsOperation.FunctionScope.ALL);
+
+        // test fail case
+        assertThatThrownBy(() -> parse("show functions in cat.db.t"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Show functions from/in identifier [ cat.db.t ] format error, it should be [catalog_name.]database_name.");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Support enhanced show functions syntax for [FLIP-297](https://cwiki.apache.org/confluence/display/FLINK/FLIP-297%3A+Improve+Auxiliary+Sql+Statements)


## Brief change log
Support enhanced show functions syntax:
```sql
SHOW [USER] FUNCTIONS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
```

## Verifying this change

Add cases in FlinkSqlParserImplTest:
- testShowFunctions

Add cases in SqlOtherOperationConverterTest:
- testShowFunctions


## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  yes
- If yes, how is the feature documented? docs