### PR TITLE
[FLINK-32488][REST] Introduce separate configuration to control expiry of E…

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_rest_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rest_section.html
@@ -21,6 +21,12 @@
             <td>The time in ms that the client waits for the leader address, e.g., Dispatcher or WebMonitorEndpoint</td>
         </tr>
         <tr>
+            <td><h5>rest.cache.execution-graph.expiry</h5></td>
+            <td style="word-wrap: break-word;">3 s</td>
+            <td>Duration</td>
+            <td>Expire after write duration for the execution graph cache. It can be specified using notation: "500 ms", "1 s".</td>
+        </tr>
+        <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/rest_configuration.html
+++ b/docs/layouts/shortcodes/generated/rest_configuration.html
@@ -39,6 +39,12 @@
             <td>The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Rest servers are running on the same machine.</td>
         </tr>
         <tr>
+            <td><h5>rest.cache.execution-graph.expiry</h5></td>
+            <td style="word-wrap: break-word;">3 s</td>
+            <td>Duration</td>
+            <td>Expire after write duration for the execution graph cache. It can be specified using notation: "500 ms", "1 s".</td>
+        </tr>
+        <tr>
             <td><h5>rest.client.max-content-length</h5></td>
             <td style="word-wrap: break-word;">104857600</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -193,6 +193,14 @@ public class RestOptions {
                                     + "Lowering the thread priority will give Flink's main components more CPU time whereas "
                                     + "increasing will allocate more time for the REST server's processing.");
 
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<Duration> CACHE_EXECUTION_GRAPH_EXPIRY =
+            key("rest.cache.execution-graph.expiry")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(3))
+                    .withDescription(
+                            "Expire after write duration for the execution graph cache. It can be specified using notation: \"500 ms\", \"1 s\".");
+
     /** Enables the experimental flame graph feature. */
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Boolean> ENABLE_FLAMEGRAPH =

--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -33,6 +33,7 @@ public class TestingUtils {
 
     public static final Duration TESTING_DURATION = Duration.ofMinutes(2L);
     public static final Time TIMEOUT = Time.minutes(1L);
+    public static final Duration TIMEOUT_DURATION = Duration.ofMinutes(1L);
     public static final Duration DEFAULT_AKKA_ASK_TIMEOUT = Duration.ofSeconds(200);
 
     public static Time infiniteTime() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestEndpointFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestEndpointFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rest;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -56,7 +55,6 @@ public interface RestEndpointFactory<T extends RestfulGateway> {
     static ExecutionGraphCache createExecutionGraphCache(
             RestHandlerConfiguration restConfiguration) {
         return new DefaultExecutionGraphCache(
-                restConfiguration.getTimeout(),
-                Time.milliseconds(restConfiguration.getRefreshInterval()));
+                restConfiguration.getTimeout(), restConfiguration.getExecutionGraphCacheExpiry());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -21,10 +21,12 @@ package org.apache.flink.runtime.rest.handler;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.Preconditions;
 
 import java.io.File;
+import java.time.Duration;
 
 /** Configuration object containing values for the rest handler configuration. */
 public class RestHandlerConfiguration {
@@ -32,6 +34,7 @@ public class RestHandlerConfiguration {
     private final long refreshInterval;
 
     private final int maxCheckpointStatisticCacheEntries;
+    private final Duration executionGraphCacheExpiry;
 
     private final Time timeout;
 
@@ -46,6 +49,7 @@ public class RestHandlerConfiguration {
     public RestHandlerConfiguration(
             long refreshInterval,
             int maxCheckpointStatisticCacheEntries,
+            Duration executionGraphCacheExpiry,
             Time timeout,
             File webUiDir,
             boolean webSubmitEnabled,
@@ -56,6 +60,7 @@ public class RestHandlerConfiguration {
         this.refreshInterval = refreshInterval;
 
         this.maxCheckpointStatisticCacheEntries = maxCheckpointStatisticCacheEntries;
+        this.executionGraphCacheExpiry = executionGraphCacheExpiry;
 
         this.timeout = Preconditions.checkNotNull(timeout);
         this.webUiDir = Preconditions.checkNotNull(webUiDir);
@@ -70,6 +75,10 @@ public class RestHandlerConfiguration {
 
     public int getMaxCheckpointStatisticCacheEntries() {
         return maxCheckpointStatisticCacheEntries;
+    }
+
+    public Duration getExecutionGraphCacheExpiry() {
+        return executionGraphCacheExpiry;
     }
 
     public Time getTimeout() {
@@ -97,6 +106,8 @@ public class RestHandlerConfiguration {
 
         final int maxCheckpointStatisticCacheEntries =
                 configuration.getInteger(WebOptions.CHECKPOINTS_HISTORY_SIZE);
+        final Duration executionGraphCacheExpiry =
+                configuration.get(RestOptions.CACHE_EXECUTION_GRAPH_EXPIRY);
 
         final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
 
@@ -114,6 +125,7 @@ public class RestHandlerConfiguration {
         return new RestHandlerConfiguration(
                 refreshInterval,
                 maxCheckpointStatisticCacheEntries,
+                executionGraphCacheExpiry,
                 timeout,
                 webUiDir,
                 webSubmitEnabled,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCache.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.util.Preconditions;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -35,13 +36,13 @@ public class DefaultExecutionGraphCache implements ExecutionGraphCache {
 
     private final Time timeout;
 
-    private final Time timeToLive;
+    private final Duration timeToLive;
 
     private final ConcurrentHashMap<JobID, ExecutionGraphEntry> cachedExecutionGraphs;
 
     private volatile boolean running = true;
 
-    public DefaultExecutionGraphCache(Time timeout, Time timeToLive) {
+    public DefaultExecutionGraphCache(Time timeout, Duration timeToLive) {
         this.timeout = checkNotNull(timeout);
         this.timeToLive = checkNotNull(timeToLive);
 
@@ -86,7 +87,7 @@ public class DefaultExecutionGraphCache implements ExecutionGraphCache {
             }
 
             final ExecutionGraphEntry newEntry =
-                    new ExecutionGraphEntry(currentTime + timeToLive.toMilliseconds());
+                    new ExecutionGraphEntry(currentTime + timeToLive.toMillis());
 
             final boolean successfulUpdate;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -1048,7 +1048,8 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
     }
 
     private void startExecutionGraphCacheCleanupTask() {
-        final long cleanupInterval = 2 * restConfiguration.getRefreshInterval();
+        final long cleanupInterval =
+                2 * restConfiguration.getExecutionGraphCacheExpiry().toMillis();
         executionGraphCleanupTask =
                 executor.scheduleWithFixedDelay(
                         executionGraphCache::cleanup,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobConfigHandlerTest.java
@@ -58,7 +58,8 @@ public class JobConfigHandlerTest extends TestLogger {
                         TestingUtils.TIMEOUT,
                         Collections.emptyMap(),
                         JobConfigHeaders.getInstance(),
-                        new DefaultExecutionGraphCache(TestingUtils.TIMEOUT, TestingUtils.TIMEOUT),
+                        new DefaultExecutionGraphCache(
+                                TestingUtils.TIMEOUT, TestingUtils.TIMEOUT_DURATION),
                         Executors.directExecutor());
 
         final Map<String, String> globalJobParameters = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -92,7 +92,8 @@ public class JobExceptionsHandlerTest extends TestLogger {
                     TestingUtils.TIMEOUT,
                     Collections.emptyMap(),
                     JobExceptionsHeaders.getInstance(),
-                    new DefaultExecutionGraphCache(TestingUtils.TIMEOUT, TestingUtils.TIMEOUT),
+                    new DefaultExecutionGraphCache(
+                            TestingUtils.TIMEOUT, TestingUtils.TIMEOUT_DURATION),
                     Executors.directExecutor());
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
@@ -86,7 +86,7 @@ public class JobVertexFlameGraphHandlerTest extends TestLogger {
                         Collections.emptyMap(),
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
-                                Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+                                restHandlerConfiguration.getExecutionGraphCacheExpiry()),
                         Executors.directExecutor(),
                         new TestThreadInfoTracker(taskThreadInfoStatsDefaultSample));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -139,7 +139,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
                         SubtaskCurrentAttemptDetailsHeaders.getInstance(),
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
-                                Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+                                restHandlerConfiguration.getExecutionGraphCacheExpiry()),
                         Executors.directExecutor(),
                         metricFetcher);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -68,7 +68,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest extends TestLogger {
                         SubtaskExecutionAttemptAccumulatorsHeaders.getInstance(),
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
-                                Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+                                restHandlerConfiguration.getExecutionGraphCacheExpiry()),
                         Executors.directExecutor());
 
         // Instance a empty request.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -140,7 +140,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
                         SubtaskExecutionAttemptDetailsHeaders.getInstance(),
                         new DefaultExecutionGraphCache(
                                 restHandlerConfiguration.getTimeout(),
-                                Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+                                restHandlerConfiguration.getExecutionGraphCacheExpiry()),
                         Executors.directExecutor(),
                         metricFetcher);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
@@ -35,6 +35,7 @@ import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,7 +68,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
     @Test
     public void testExecutionGraphCaching() throws Exception {
         final Time timeout = Time.milliseconds(100L);
-        final Time timeToLive = Time.hours(1L);
+        final Duration timeToLive = Duration.ofHours(1L);
 
         final CountingRestfulGateway restfulGateway =
                 createCountingRestfulGateway(
@@ -94,7 +95,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
     @Test
     public void testExecutionGraphEntryInvalidation() throws Exception {
         final Time timeout = Time.milliseconds(100L);
-        final Time timeToLive = Time.milliseconds(1L);
+        final Duration timeToLive = Duration.ofMillis(1L);
 
         final CountingRestfulGateway restfulGateway =
                 createCountingRestfulGateway(
@@ -110,7 +111,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
             assertEquals(expectedExecutionGraphInfo, executionGraphInfoFuture.get());
 
             // sleep for the TTL
-            Thread.sleep(timeToLive.toMilliseconds() * 5L);
+            Thread.sleep(timeToLive.toMillis() * 5L);
 
             CompletableFuture<ExecutionGraphInfo> executionGraphInfoFuture2 =
                     executionGraphCache.getExecutionGraphInfo(expectedJobId, restfulGateway);
@@ -128,7 +129,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
     @Test
     public void testImmediateCacheInvalidationAfterFailure() throws Exception {
         final Time timeout = Time.milliseconds(100L);
-        final Time timeToLive = Time.hours(1L);
+        final Duration timeToLive = Duration.ofHours(1L);
 
         // let's first answer with a JobNotFoundException and then only with the correct result
         final CountingRestfulGateway restfulGateway =
@@ -165,7 +166,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
     @Test
     public void testCacheEntryCleanup() throws Exception {
         final Time timeout = Time.milliseconds(100L);
-        final Time timeToLive = Time.milliseconds(1L);
+        final Duration timeToLive = Duration.ofMillis(1L);
         final JobID expectedJobId2 = new JobID();
         final ExecutionGraphInfo expectedExecutionGraphInfo2 =
                 new ExecutionGraphInfo(new ArchivedExecutionGraphBuilder().build());
@@ -203,7 +204,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
 
             assertThat(requestJobCalls.get(), Matchers.equalTo(2));
 
-            Thread.sleep(timeToLive.toMilliseconds());
+            Thread.sleep(timeToLive.toMillis());
 
             executionGraphCache.cleanup();
 
@@ -215,7 +216,7 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
     @Test
     public void testConcurrentAccess() throws Exception {
         final Time timeout = Time.milliseconds(100L);
-        final Time timeToLive = Time.hours(1L);
+        final Duration timeToLive = Duration.ofHours(1L);
 
         final CountingRestfulGateway restfulGateway =
                 createCountingRestfulGateway(


### PR DESCRIPTION
…xecutionGraph cache

## What is the purpose of the change
Introduce a new configuration to control the cache expiry for ExecutionGraph cache. This should be separate from the `web.refresh-interval`, as that controls the Flink dashboard refresh rate.

## Brief change log
- Introduced a new configuration `rest.cache.execution-graph.expiry` to control ExecutionGraph expiry

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
