### PR TITLE
[FLINK-32495][connectors/common] Fix the bug that the shared thread factory causes the source alignment unit test to fail

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -35,6 +35,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /** The provider of {@link SourceCoordinator}. */
 public class SourceCoordinatorProvider<SplitT extends SourceSplit>
         extends RecreateOnResetOperatorCoordinator.Provider {
@@ -94,7 +96,10 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
                 coordinatorListeningID);
     }
 
-    /** A thread factory class that provides some helper methods. */
+    /**
+     * A thread factory class that provides some helper methods. Because it is used to check the
+     * current thread, it is a one-off, do not use this ThreadFactory to create multiple threads.
+     */
     public static class CoordinatorExecutorThreadFactory
             implements ThreadFactory, Thread.UncaughtExceptionHandler {
 
@@ -130,6 +135,10 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
 
         @Override
         public synchronized Thread newThread(Runnable r) {
+            checkState(
+                    t == null,
+                    "Please using the new CoordinatorExecutorThreadFactory,"
+                            + " this factory cannot new multiple threads.");
             t = new Thread(r, coordinatorThreadName);
             t.setContextClassLoader(cl);
             t.setUncaughtExceptionHandler(this);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -165,7 +165,8 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
                 new SourceCoordinatorContext<>(
                         coordinatorExecutorWithExceptionHandler,
                         manualWorkerExecutor,
-                        coordinatorThreadFactory,
+                        new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+                                coordinatorThreadName, operatorCoordinatorContext),
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),
                         splitSplitAssignmentTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit tests for {@link SourceCoordinatorProvider}. */
 class SourceCoordinatorProviderTest {
@@ -120,5 +121,20 @@ class SourceCoordinatorProviderTest {
                 context::isJobFailed,
                 Duration.ofSeconds(10L),
                 "The job did not fail before timeout.");
+    }
+
+    @Test
+    void testCoordinatorExecutorThreadFactoryNewMultipleThread() {
+        SourceCoordinatorProvider.CoordinatorExecutorThreadFactory
+                coordinatorExecutorThreadFactory =
+                        new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+                                "test_coordinator_thread",
+                                new MockOperatorCoordinatorContext(
+                                        new OperatorID(1234L, 5678L), 3));
+
+        coordinatorExecutorThreadFactory.newThread(() -> {});
+        // coordinatorExecutorThreadFactory cannot create multiple threads.
+        assertThatThrownBy(() -> coordinatorExecutorThreadFactory.newThread(() -> {}))
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
@@ -29,26 +29,24 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link SourceCoordinatorProvider}. */
-public class SourceCoordinatorProviderTest {
+class SourceCoordinatorProviderTest {
 
     private static final OperatorID OPERATOR_ID = new OperatorID(1234L, 5678L);
     private static final int NUM_SPLITS = 10;
 
     private SourceCoordinatorProvider<MockSourceSplit> provider;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         provider =
                 new SourceCoordinatorProvider<>(
                         "SourceCoordinatorProviderTest",
@@ -60,14 +58,14 @@ public class SourceCoordinatorProviderTest {
     }
 
     @Test
-    public void testCreate() throws Exception {
+    void testCreate() throws Exception {
         OperatorCoordinator coordinator =
                 provider.create(new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SPLITS));
-        assertTrue(coordinator instanceof RecreateOnResetOperatorCoordinator);
+        assertThat(coordinator).isInstanceOf(RecreateOnResetOperatorCoordinator.class);
     }
 
     @Test
-    public void testCheckpointAndReset() throws Exception {
+    void testCheckpointAndReset() throws Exception {
         final OperatorCoordinator.Context context =
                 new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SPLITS);
         final RecreateOnResetOperatorCoordinator coordinator =
@@ -94,19 +92,17 @@ public class SourceCoordinatorProviderTest {
         coordinator.resetToCheckpoint(0L, bytes);
         final SourceCoordinator<?, ?> restoredSourceCoordinator =
                 (SourceCoordinator<?, ?>) coordinator.getInternalCoordinator();
-        assertNotEquals(
-                "The restored source coordinator should be a different instance",
-                restoredSourceCoordinator,
-                sourceCoordinator);
+        assertThat(sourceCoordinator)
+                .as("The restored source coordinator should be a different instance")
+                .isNotEqualTo(restoredSourceCoordinator);
         // FLINK-21452: do not (re)store registered readers
-        assertEquals(
-                "There should be no registered reader.",
-                0,
-                restoredSourceCoordinator.getContext().registeredReaders().size());
+        assertThat(restoredSourceCoordinator.getContext().registeredReaders())
+                .as("There should be no registered reader.")
+                .isEmpty();
     }
 
     @Test
-    public void testCallAsyncExceptionFailsJob() throws Exception {
+    void testCallAsyncExceptionFailsJob() throws Exception {
         MockOperatorCoordinatorContext context =
                 new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SPLITS);
         RecreateOnResetOperatorCoordinator coordinator =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -65,7 +65,7 @@ abstract class SourceCoordinatorTestBase {
     protected MockOperatorCoordinatorContext operatorCoordinatorContext;
 
     // ---- Mocks for the Source Coordinator Context ----
-    protected SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory;
+    protected String coordinatorThreadName;
     protected SplitAssignmentTracker<MockSourceSplit> splitSplitAssignmentTracker;
     protected SourceCoordinatorContext<MockSourceSplit> context;
 
@@ -82,10 +82,7 @@ abstract class SourceCoordinatorTestBase {
         operatorCoordinatorContext =
                 new MockOperatorCoordinatorContext(TEST_OPERATOR_ID, NUM_SUBTASKS);
         splitSplitAssignmentTracker = new SplitAssignmentTracker<>();
-        String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
-        coordinatorThreadFactory =
-                new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, operatorCoordinatorContext);
+        coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
 
         sourceCoordinator = getNewSourceCoordinator();
         context = sourceCoordinator.getContext();
@@ -215,14 +212,14 @@ abstract class SourceCoordinatorTestBase {
 
     protected SourceCoordinatorContext<MockSourceSplit> getNewSourceCoordinatorContext()
             throws Exception {
+        SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
+                new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+                        coordinatorThreadName, operatorCoordinatorContext);
         SourceCoordinatorContext<MockSourceSplit> coordinatorContext =
                 new SourceCoordinatorContext<>(
                         Executors.newScheduledThreadPool(1, coordinatorThreadFactory),
                         Executors.newScheduledThreadPool(
-                                1,
-                                new ExecutorThreadFactory(
-                                        coordinatorThreadFactory.getCoordinatorThreadName()
-                                                + "-worker")),
+                                1, new ExecutorThreadFactory(coordinatorThreadName + "-worker")),
                         coordinatorThreadFactory,
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),


### PR DESCRIPTION
## What is the purpose of the change

SourceCoordinatorAlignmentTest.testWatermarkAlignmentWithTwoGroups fails.

I analyzed this CI :  https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=50668&view=logs&j=a57e0635-3fad-5b08-57c7-a4142d7d6fa9&t=2ef0effc-1da1-50e5-c2bd-aab434b1c5b7&l=9089

Root cause:

- The CoordinatorExecutorThreadFactory cannot new multiple threads. And too many callers will check `coordinatorThreadFactory.isCurrentThreadCoordinatorThread()`, such as: SourceCoordinatorContext.attemptReady.
- The CoordinatorExecutorThreadFactory is shared at [SourceCoordinatorTestBase](https://github.com/apache/flink/blob/21eba4ca4cb235a2189c94cdbf3abcec5cde1e6e/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java#L68)
- It will be used at multiple source coordinator, and the second source coordinator will overwrite the CoordinatorExecutorThreadFactory#t, so the check will fail for the first source.

## Brief change log

Don't share the CoordinatorExecutorThreadFactory.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
