### PR TITLE
[FLINK-32495][connectors/common] Fix the bug that the shared thread factory causes the source alignment unit test to fail

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -165,7 +165,8 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
                 new SourceCoordinatorContext<>(
                         coordinatorExecutorWithExceptionHandler,
                         manualWorkerExecutor,
-                        coordinatorThreadFactory,
+                        new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+                                coordinatorThreadName, operatorCoordinatorContext),
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),
                         splitSplitAssignmentTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -65,7 +65,7 @@ abstract class SourceCoordinatorTestBase {
     protected MockOperatorCoordinatorContext operatorCoordinatorContext;
 
     // ---- Mocks for the Source Coordinator Context ----
-    protected SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory;
+    protected String coordinatorThreadName;
     protected SplitAssignmentTracker<MockSourceSplit> splitSplitAssignmentTracker;
     protected SourceCoordinatorContext<MockSourceSplit> context;
 
@@ -82,10 +82,7 @@ abstract class SourceCoordinatorTestBase {
         operatorCoordinatorContext =
                 new MockOperatorCoordinatorContext(TEST_OPERATOR_ID, NUM_SUBTASKS);
         splitSplitAssignmentTracker = new SplitAssignmentTracker<>();
-        String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
-        coordinatorThreadFactory =
-                new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
-                        coordinatorThreadName, operatorCoordinatorContext);
+        coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
 
         sourceCoordinator = getNewSourceCoordinator();
         context = sourceCoordinator.getContext();
@@ -215,14 +212,14 @@ abstract class SourceCoordinatorTestBase {
 
     protected SourceCoordinatorContext<MockSourceSplit> getNewSourceCoordinatorContext()
             throws Exception {
+        SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
+                new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+                        coordinatorThreadName, operatorCoordinatorContext);
         SourceCoordinatorContext<MockSourceSplit> coordinatorContext =
                 new SourceCoordinatorContext<>(
                         Executors.newScheduledThreadPool(1, coordinatorThreadFactory),
                         Executors.newScheduledThreadPool(
-                                1,
-                                new ExecutorThreadFactory(
-                                        coordinatorThreadFactory.getCoordinatorThreadName()
-                                                + "-worker")),
+                                1, new ExecutorThreadFactory(coordinatorThreadName + "-worker")),
                         coordinatorThreadFactory,
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),


### PR DESCRIPTION
## What is the purpose of the change

SourceCoordinatorAlignmentTest.testWatermarkAlignmentWithTwoGroups fails.

I analyzed this CI :  https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=50668&view=logs&j=a57e0635-3fad-5b08-57c7-a4142d7d6fa9&t=2ef0effc-1da1-50e5-c2bd-aab434b1c5b7&l=9089

Root cause:

- The CoordinatorExecutorThreadFactory cannot new multiple threads. And too many callers will check `coordinatorThreadFactory.isCurrentThreadCoordinatorThread()`, such as: SourceCoordinatorContext.attemptReady.
- The CoordinatorExecutorThreadFactory is shared at [SourceCoordinatorTestBase](https://github.com/apache/flink/blob/21eba4ca4cb235a2189c94cdbf3abcec5cde1e6e/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java#L68)
- It will be used at multiple source coordinator, and the second source coordinator will overwrite the CoordinatorExecutorThreadFactory#t, so the check will fail for the first source.

## Brief change log

Don't share the CoordinatorExecutorThreadFactory.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
