### PR TITLE
[FLINK-32501][table-planner] Fix wrong plan of a proctime window aggregation generated due to incorrect cost evaluation

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivity.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivity.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.{JArrayList, JDouble}
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, WindowAggregate}
+import org.apache.flink.table.planner.plan.nodes.common.CommonPhysicalWindowTableFunction
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.utils.FlinkRelMdUtil
 
@@ -254,6 +255,13 @@ class FlinkRelMdSelectivity private extends MetadataHandler[BuiltInMetadata.Sele
         if (sumRows < 1.0) sumSelectedRows else sumSelectedRows / sumRows
       }
     }
+  }
+
+  def getSelectivity(
+      rel: CommonPhysicalWindowTableFunction,
+      mq: RelMetadataQuery,
+      predicate: RexNode): JDouble = {
+    estimateSelectivity(rel, mq, predicate)
   }
 
   def getSelectivity(subset: RelSubset, mq: RelMetadataQuery, predicate: RexNode): JDouble = {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -1658,6 +1658,98 @@ Sink(table=[default_catalog.default_database.s1], fields=[window_start, window_e
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProctimeWindowWithFilter[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink
+    select
+        window_start,
+        window_end,
+        b,
+        COALESCE(sum(case
+            when a = 11
+            then 1
+        end), 0) c
+    from
+        TABLE(
+            TUMBLE(TABLE source, DESCRIPTOR(proctime), INTERVAL '10' SECONDS)
+        )
+    where
+        a in (1, 5, 7, 9, 11)
+    GROUP BY
+        window_start, window_end, b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[ws, we, b, c])
++- LogicalProject(ws=[CAST($0):TIMESTAMP(6)], we=[CAST($1):TIMESTAMP(6)], b=[$2], c=[CAST(COALESCE($3, 0)):BIGINT])
+   +- LogicalAggregate(group=[{0, 1, 2}], agg#0=[SUM($3)])
+      +- LogicalProject(window_start=[$5], window_end=[$6], b=[$1], $f3=[CASE(=($0, 11), 1, null:INTEGER)])
+         +- LogicalFilter(condition=[OR(=($0, 1), =($0, 5), =($0, 7), =($0, 9), =($0, 11))])
+            +- LogicalTableFunctionScan(invocation=[TUMBLE($4, DESCRIPTOR($4), 10000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[$4])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[ws, we, b, c])
++- Calc(select=[CAST(window_start AS TIMESTAMP(6)) AS ws, CAST(window_end AS TIMESTAMP(6)) AS we, b, CAST(COALESCE($f1, 0) AS BIGINT) AS c])
+   +- WindowAggregate(groupBy=[b], window=[TUMBLE(time_col=[proctime], size=[10 s])], select=[b, SUM($f3) AS $f1, start('w$) AS window_start, end('w$) AS window_end])
+      +- Exchange(distribution=[hash[b]])
+         +- Calc(select=[b, CASE((a = 11), 1, null:INTEGER) AS $f3, PROCTIME() AS proctime], where=[SEARCH(a, Sarg[1, 5, 7, 9, 11])])
+            +- TableSourceScan(table=[[default_catalog, default_database, source, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowWithFilter[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink
+    select
+        window_start,
+        window_end,
+        b,
+        COALESCE(sum(case
+            when a = 11
+            then 1
+        end), 0) c
+    from
+        TABLE(
+            TUMBLE(TABLE source, DESCRIPTOR(proctime), INTERVAL '10' SECONDS)
+        )
+    where
+        a in (1, 5, 7, 9, 11)
+    GROUP BY
+        window_start, window_end, b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[ws, we, b, c])
++- LogicalProject(ws=[CAST($0):TIMESTAMP(6)], we=[CAST($1):TIMESTAMP(6)], b=[$2], c=[CAST(COALESCE($3, 0)):BIGINT])
+   +- LogicalAggregate(group=[{0, 1, 2}], agg#0=[SUM($3)])
+      +- LogicalProject(window_start=[$5], window_end=[$6], b=[$1], $f3=[CASE(=($0, 11), 1, null:INTEGER)])
+         +- LogicalFilter(condition=[OR(=($0, 1), =($0, 5), =($0, 7), =($0, 9), =($0, 11))])
+            +- LogicalTableFunctionScan(invocation=[TUMBLE($4, DESCRIPTOR($4), 10000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[$4])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, source]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[ws, we, b, c])
++- Calc(select=[CAST(window_start AS TIMESTAMP(6)) AS ws, CAST(window_end AS TIMESTAMP(6)) AS we, b, CAST(COALESCE($f1, 0) AS BIGINT) AS c])
+   +- WindowAggregate(groupBy=[b], window=[TUMBLE(time_col=[proctime], size=[10 s])], select=[b, SUM($f3) AS $f1, start('w$) AS window_start, end('w$) AS window_end])
+      +- Exchange(distribution=[hash[b]])
+         +- Calc(select=[b, CASE((a = 11), 1, null:INTEGER) AS $f3, PROCTIME() AS proctime], where=[SEARCH(a, Sarg[1, 5, 7, 9, 11])])
+            +- TableSourceScan(table=[[default_catalog, default_database, source, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTumble_CalcOnTVF[aggPhaseEnforcer=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
@@ -670,4 +670,23 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
     assertEquals(0.5, mq.getSelectivity(testRel, pred))
   }
 
+  @Test
+  def testGetSelectivityOnWindowTableFunction(): Unit = {
+    // id in (1,3,5,7)
+    val predicate =
+      relBuilder
+        .push(windowTableFunctionScan)
+        .in(
+          relBuilder.field(0),
+          relBuilder.literal(1),
+          relBuilder.literal(3),
+          relBuilder.literal(5),
+          relBuilder.literal(7))
+    // unknown node, selectivity = 0.25 (unknown call type)
+    assertEquals(0.25, mq.getSelectivity(windowTableFunctionScan, predicate))
+    // known node, selectivity = 0.15 x 4 (4 literals)
+    Array(streamTumbleWindowTVFRel, batchTumbleWindowTVFRel).foreach {
+      tvf => assertEquals(0.6, mq.getSelectivity(tvf, predicate))
+    }
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change
Currently when uses window aggregation referring a windowing tvf with a filter condition, may encounter wrong plan which may hang forever in runtime(the window aggregate operator never output), because the plan which didn't combine the proctime `WindowTableFunction` into `WindowAggregate` (so when translate to execution plan the `WindowAggregate` will wrongly recognize the window as an event-time window, then the `WindowAggregateOperator` will not receive watermark nor setup timers to fire any windows in runtime).

The root cause is the incorrectly cost evaluation in such cases for streaming, we can fix this by simply adding a branch for calculating selectivity of `CommonPhysicalWindowTableFunction` node which is the base factor for row count.

Ideally, maybe we can do some more refactoring to move this combination optimization to the rbo phase (not rely on cost)

## Brief change log
adding a branch for calculating selectivity of `CommonPhysicalWindowTableFunction` node to correct the cost

## Verifying this change
add test cases to `WindowAggregateTest` & `FlinkRelMdSelectivityTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)