### PR TITLE
[FLINK-31837][runtime] Makes LeaderElectionDriver instantiation happen lazily

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -121,13 +121,13 @@ public interface HighAvailabilityServices
     }
 
     /** Gets the {@link LeaderElection} for the cluster's resource manager. */
-    LeaderElection getResourceManagerLeaderElection() throws Exception;
+    LeaderElection getResourceManagerLeaderElection();
 
     /** Gets the {@link LeaderElection} for the cluster's dispatcher. */
-    LeaderElection getDispatcherLeaderElection() throws Exception;
+    LeaderElection getDispatcherLeaderElection();
 
     /** Gets the {@link LeaderElection} for the job with the given {@link JobID}. */
-    LeaderElection getJobManagerLeaderElection(JobID jobID) throws Exception;
+    LeaderElection getJobManagerLeaderElection(JobID jobID);
 
     /**
      * Gets the {@link LeaderElection} for the cluster's rest endpoint.
@@ -176,7 +176,7 @@ public interface HighAvailabilityServices
     BlobStore createBlobStore() throws IOException;
 
     /** Gets the {@link LeaderElection} for the cluster's rest endpoint. */
-    default LeaderElection getClusterRestEndpointLeaderElection() throws Exception {
+    default LeaderElection getClusterRestEndpointLeaderElection() {
         // for backwards compatibility we delegate to getWebMonitorLeaderElectionService
         // all implementations of this interface should override
         // getClusterRestEndpointLeaderElectionService, though

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -74,7 +74,7 @@ class DefaultLeaderElection implements LeaderElection {
          * Removes the {@code LeaderContender} from the {@code ParentService} that is associated
          * with the {@code contenderID}.
          */
-        abstract void remove(String contenderID);
+        abstract void remove(String contenderID) throws Exception;
 
         /**
          * Confirms the leadership with the {@code leaderSessionID} and {@code leaderAddress} for

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -54,11 +54,6 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
     private static final String LEADER_ACQUISITION_EVENT_LOG_NAME = "Leader Acquisition";
     private static final String LEADER_REVOCATION_EVENT_LOG_NAME = "Leader Revocation";
-    private static final String SINGLE_LEADER_INFORMATION_CHANGE_EVENT_LOG_NAME =
-            "Single LeaderInformation Change";
-    private static final String ALL_LEADER_INFORMATION_CHANGE_EVENT_LOG_NAME =
-            "All LeaderInformation Change";
-
     private final Object lock = new Object();
 
     private final LeaderElectionDriverFactory leaderElectionDriverFactory;
@@ -79,7 +74,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
     /**
      * Saves the {@link LeaderInformation} for the registered {@link LeaderContender}s. There's no
-     * semantical difference between an entry with an empty {@code LeaderInformation} and no entry
+     * semantic difference between an entry with an empty {@code LeaderInformation} and no entry
      * being present at all here. Both mean that no confirmed {@code LeaderInformation} is available
      * for the corresponding {@code contenderID}.
      */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -692,7 +692,6 @@ class JobMasterServiceLeadershipRunnerTest {
         // in connection with the DefaultLeaderElectionService generates the nested locking
         final DefaultLeaderElectionService defaultLeaderElectionService =
                 new DefaultLeaderElectionService(driverFactory, fatalErrorHandler);
-        defaultLeaderElectionService.startLeaderElectionBackend();
 
         final TestingLeaderElectionDriver currentLeaderDriver =
                 driverFactory.assertAndGetOnlyCreatedDriver();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -179,7 +179,6 @@ public class LeaderElectionTest {
                     new ZooKeeperLeaderElectionDriverFactory(
                             curatorFrameworkWrapper.asCuratorFramework());
             leaderElectionService = new DefaultLeaderElectionService(driverFactory);
-            leaderElectionService.startLeaderElectionBackend();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -216,6 +216,10 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
 
             return driver;
         }
+
+        public int getCreatedDriverCount() {
+            return createdDrivers.size();
+        }
     }
 
     /** {@link Builder} for creating {@link TestingLeaderElectionDriver} instances. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -139,7 +139,6 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
                 new DefaultLeaderElectionService(
                         leaderElectionDriverFactory,
                         testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
-        leaderElectionService.startLeaderElectionBackend();
 
         final TestingConnectionStateListener connectionStateListener =
                 new TestingConnectionStateListener();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -175,11 +175,7 @@ class ZooKeeperLeaderElectionTest {
             for (int i = 0; i < num; i++) {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                leaderElectionService[i] =
-                        new DefaultLeaderElectionService(
-                                driverFactory,
-                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
-                leaderElectionService[i].startLeaderElectionBackend();
+                leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
                 leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
                 contenders[i] = new TestingContender(createAddress(i), leaderElections[i]);
 
@@ -279,11 +275,7 @@ class ZooKeeperLeaderElectionTest {
             for (int i = 0; i < num; i++) {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                leaderElectionService[i] =
-                        new DefaultLeaderElectionService(
-                                driverFactory,
-                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
-                leaderElectionService[i].startLeaderElectionBackend();
+                leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
                 leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
                 contenders[i] =
                         new TestingContender(LEADER_ADDRESS + "_" + i + "_0", leaderElections[i]);
@@ -317,11 +309,7 @@ class ZooKeeperLeaderElectionTest {
                     // create new leader election service which takes part in the leader election
                     final LeaderElectionDriverFactory driverFactory =
                             new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                    leaderElectionService[index] =
-                            new DefaultLeaderElectionService(
-                                    driverFactory,
-                                    testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
-                    leaderElectionService[index].startLeaderElectionBackend();
+                    leaderElectionService[index] = new DefaultLeaderElectionService(driverFactory);
                     leaderElections[index] =
                             leaderElectionService[index].createLeaderElection(CONTENDER_ID);
 


### PR DESCRIPTION
## What is the purpose of the change

The driver doesn't need to be instantiated when the `DefaultLeaderElectionService` is instantiated. Instead, we can instantiated when the first contender is registered. This way we can avoid creating the `DefaultLeaderElectionService` lazily in the HaServices.

## Brief change log

* Made `startLeaderElectionBackend` private
* Calls the method instead in `DefaultLeaderElectionService#register`
* Aligned Preconditions in `DefaultLeaderElectionService` accordingly

## Verifying this change

* Adds testcase for verifying the lazy driver instantiation
* Adds tests for proper close handling
* Removes `DefaultLeaderElectionServiceTest#testContenderRegistrationWithoutDriverBeingInstantiatedFails` because this case isn't possible anymore: The driver instantiation always happens when registering the first contender

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable