### PR TITLE
[FLINK-32256][table] Add built-in ARRAY_ MIN function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -658,6 +658,9 @@ collection:
   - sql: ARRAY_JOIN(array, delimiter[, nullReplacement])
     table: array.arrayJoin(delimiter[, nullReplacement])
     description: Returns a string that represents the concatenation of the elements in the given array and the elements' data type in the given array is string. The delimiter is a string that separates each pair of consecutive elements of the array. The optional nullReplacement is a string that replaces null elements in the array. If nullReplacement is not specified, null elements in the array will be omitted from the resulting string. Returns null if input array or delimiter or nullReplacement are null.
+  - sql: ARRAY_MIN(array)
+    table: array.arrayMin()
+    description: Returns the minimum value from the array, if array itself is null, the function returns null.
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -234,6 +234,7 @@ advanced type helper functions
     Expression.array_reverse
     Expression.array_max
     Expression.array_slice
+    Expression.array_min
     Expression.array_union
     Expression.map_entries
     Expression.map_keys

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1564,6 +1564,13 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("array_join")(self, delimiter, null_replacement)
 
+    def array_min(self) -> 'Expression':
+        """
+        Returns the minimum value from the array.
+        if array itself is null, the function returns null.
+        """
+        return _unary_op("arrayMin")(self)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -58,6 +58,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MAX;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REMOVE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_REVERSE;
@@ -1475,6 +1476,15 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayMax() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_MAX, toExpr()));
+    }
+
+    /**
+     * Returns the minimum value from the array.
+     *
+     * <p>if array itself is null, the function returns null.
+     */
+    public OutType arrayMin() {
+        return toApiSpecificExpression(unresolvedCall(ARRAY_MIN, toExpr()));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -344,6 +344,16 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayJoinFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_MIN =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_MIN")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(arrayFullyComparableElementType())
+                    .outputTypeStrategy(forceNullable(SpecificTypeStrategies.ARRAY_ELEMENT))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -300,6 +300,11 @@ public final class TypeInferenceUtil {
 
     // --------------------------------------------------------------------------------------------
 
+    public static boolean checkInputArgumentNumber(
+            ArgumentCount argumentCount, int actualCount, boolean throwOnFailure) {
+        return validateArgumentCount(argumentCount, actualCount, throwOnFailure);
+    }
+
     private static Result runTypeInferenceInternal(
             TypeInference typeInference,
             CallContext callContext,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayComparableElementTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayComparableElementTypeStrategy.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.TypeInferenceUtil;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
@@ -67,6 +68,10 @@ public final class ArrayComparableElementTypeStrategy implements InputTypeStrate
     public Optional<List<DataType>> inferInputTypes(
             CallContext callContext, boolean throwOnFailure) {
         final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        if (!TypeInferenceUtil.checkInputArgumentNumber(
+                argumentCount, argumentDataTypes.size(), throwOnFailure)) {
+            return callContext.fail(throwOnFailure, "the input argument number should be one");
+        }
         final DataType argumentType = argumentDataTypes.get(0);
         if (!argumentType.getLogicalType().is(LogicalTypeRoot.ARRAY)) {
             return callContext.fail(throwOnFailure, "All arguments requires to be an ARRAY type");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -50,7 +50,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayConcatTestCases(),
                         arrayMaxTestCases(),
                         arrayJoinTestCases(),
-                        arraySliceTestCases())
+                        arraySliceTestCases(),
+                        arrayMinTestCases())
                 .flatMap(s -> s);
     }
 
@@ -738,7 +739,169 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "ARRAY_MAX(f12)",
                                 "SQL validation failed. Invalid function call:\n"
-                                        + "ARRAY_MAX(ARRAY<ARRAY<INT>>)"));
+                                        + "ARRAY_MAX(ARRAY<ARRAY<INT>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MAX()", "No match found for function signature ARRAY_MAX()")
+                        .testSqlValidationError(
+                                "ARRAY_MAX(ARRAY[1], ARRAY[2])",
+                                "No match found for function signature ARRAY_MAX(<INTEGER ARRAY>, <INTEGER ARRAY>)"));
+    }
+
+    private Stream<TestSetSpec> arrayMinTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_MIN)
+                        .onFieldsWithData(
+                                new Integer[] {1, 2, null},
+                                null,
+                                new Double[] {1.2, null, 3.4, 8.0},
+                                new String[] {"a", null, "bc", "d", "def"},
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Map[] {
+                                    CollectionUtil.map(entry(1, "a"), entry(2, "b")),
+                                    CollectionUtil.map(entry(3, "c"), entry(4, "d")),
+                                    null
+                                },
+                                new Integer[][] {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, null},
+                                new Row[] {
+                                    Row.of(LocalDate.of(2022, 4, 20)),
+                                    Row.of(LocalDate.of(1990, 10, 14)),
+                                    Row.of(LocalDate.of(2022, 4, 20)),
+                                    Row.of(LocalDate.of(1990, 10, 14)),
+                                    Row.of(LocalDate.of(2022, 4, 20)),
+                                    Row.of(LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Boolean[] {true, false, true, false, true, null},
+                                new Row[] {
+                                    Row.of(true),
+                                    Row.of(false),
+                                    Row.of(true),
+                                    Row.of(false),
+                                    Row.of(true),
+                                    Row.of(false),
+                                    null
+                                },
+                                new Row[] {
+                                    Row.of(1), Row.of(2), Row.of(8), Row.of(4), Row.of(5),
+                                    Row.of(8), null
+                                },
+                                1,
+                                new Integer[][] {{1, 2}, {2, 3}, null},
+                                new LocalDate[] {
+                                    LocalDate.of(2022, 1, 2),
+                                    LocalDate.of(2023, 4, 21),
+                                    LocalDate.of(2022, 12, 24),
+                                    LocalDate.of(2026, 2, 10),
+                                    LocalDate.of(2012, 5, 16),
+                                    LocalDate.of(2092, 7, 19)
+                                },
+                                null)
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE()),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())),
+                                DataTypes.ARRAY(DataTypes.ROW(DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.BOOLEAN()),
+                                DataTypes.ARRAY(DataTypes.ROW(DataTypes.BOOLEAN())),
+                                DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT())),
+                                DataTypes.INT().notNull(),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())),
+                                DataTypes.ARRAY(DataTypes.DATE()),
+                                DataTypes.ARRAY(DataTypes.INT().notNull()))
+                        .testResult($("f0").arrayMin(), "ARRAY_MIN(f0)", 1, DataTypes.INT())
+                        .testResult($("f1").arrayMin(), "ARRAY_MIN(f1)", null, DataTypes.INT())
+                        .testResult($("f2").arrayMin(), "ARRAY_MIN(f2)", 1.2, DataTypes.DOUBLE())
+                        .testResult($("f3").arrayMin(), "ARRAY_MIN(f3)", "a", DataTypes.STRING())
+                        .testResult($("f14").arrayMin(), "ARRAY_MIN(f14)", null, DataTypes.INT())
+                        .testResult(
+                                $("f13").arrayMin(),
+                                "ARRAY_MIN(f13)",
+                                LocalDate.of(2012, 5, 16),
+                                DataTypes.DATE())
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f4)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ROW<`f0` BOOLEAN, `f1` DATE>>")
+                        .testTableApiValidationError(
+                                $("f4").arrayMin(),
+                                "Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ROW<`f0` BOOLEAN, `f1` DATE>>")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f5)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<MAP<INT, STRING>>")
+                        .testTableApiValidationError(
+                                $("f5").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<MAP<INT, STRING>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f6)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ARRAY<INT>>)")
+                        .testTableApiValidationError(
+                                $("f6").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<ARRAY<INT>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f7)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ROW<`f0` DATE>>)")
+                        .testTableApiValidationError(
+                                $("f7").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<ROW<`f0` DATE>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f8)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<BOOLEAN>)")
+                        .testTableApiValidationError(
+                                $("f8").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<BOOLEAN>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f9)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ROW<`f0` BOOLEAN>>)")
+                        .testTableApiValidationError(
+                                $("f9").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<ROW<`f0` BOOLEAN>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f10)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ROW<`f0` INT>>)")
+                        .testTableApiValidationError(
+                                $("f10").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<ROW<`f0` INT>>)")
+                        .testTableApiValidationError(
+                                $("f11").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(INT NOT NULL)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f11)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(INT NOT NULL)")
+                        .testTableApiValidationError(
+                                $("f12").arrayMin(),
+                                "Invalid function call:\n" + "ARRAY_MIN(ARRAY<ARRAY<INT>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(f12)",
+                                "SQL validation failed. Invalid function call:\n"
+                                        + "ARRAY_MIN(ARRAY<ARRAY<INT>>)")
+                        .testSqlValidationError(
+                                "ARRAY_MIN()", "No match found for function signature ARRAY_MIN()")
+                        .testSqlValidationError(
+                                "ARRAY_MIN(ARRAY[1], ARRAY[2])",
+                                "No match found for function signature ARRAY_MIN(<INTEGER ARRAY>, <INTEGER ARRAY>)")
+                        .withFunction(CreateEmptyArray.class)
+                        .testResult(
+                                call("CreateEmptyArray").arrayMin(),
+                                "ARRAY_MIN(CreateEmptyArray())",
+                                null,
+                                DataTypes.INT()));
     }
 
     private Stream<TestSetSpec> arrayJoinTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayMinFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayMinFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_MIN}. */
+@Internal
+public class ArrayMinFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+    private final SpecializedFunction.ExpressionEvaluator compareEvaluator;
+    private transient MethodHandle compareHandle;
+
+    public ArrayMinFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_MIN, context);
+
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+        compareEvaluator =
+                context.createEvaluator(
+                        $("element1").isLess($("element2")),
+                        DataTypes.BOOLEAN().notNull(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        compareHandle = compareEvaluator.open(context);
+    }
+
+    public @Nullable Object eval(ArrayData array) {
+        try {
+            if (array == null || array.size() == 0) {
+                return null;
+            }
+
+            Object minElement = null;
+            for (int i = 0; i < array.size(); i++) {
+                Object element = elementGetter.getElementOrNull(array, i);
+                if (element != null) {
+                    if (minElement == null || (boolean) compareHandle.invoke(element, minElement)) {
+                        minElement = element;
+                    }
+                }
+            }
+            return minElement;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        compareEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of ARRAY_MIN


## Brief change log
The array_min() function get the minimum element from input array.
The result matches the type of the elements. NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.

Arguments

array: Any ARRAY with elements for which order is supported.

Syntax
array_min(array)

Returns
The result matches the type of the elements. NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.

Examples

SQL

```
> SELECT array_min(array(1, 20, NULL, 3)); 
result: 1
```

See also
spark: https://spark.apache.org/docs/latest/api/sql/index.html#array_min

presto https://prestodb.io/docs/current/functions/array.html

## Verifying this change
This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:  
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
