### PR TITLE
[FLINK-32296][table] Support cast of collections with row element types

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -221,7 +221,8 @@ class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, R
                                     elseBodyWriter.stmt(writeNull));
         }
 
-        writer.stmt(methodCall(writerTerm, "complete")).assignStmt(returnVariable, rowTerm);
+        writer.stmt(methodCall(writerTerm, "complete"))
+                .assignStmt(returnVariable, methodCall(rowTerm, "copy"));
         return writer.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1212,6 +1212,18 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().notNull()))
                         .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new long[] {1L, 2L})
                         .build(),
+                CastTestSpecBuilder.testCastTo(ARRAY(ROW(INT(), STRING()).notNull()))
+                        .fromCase(
+                                ARRAY(ROW(INT(), VARCHAR(4)).notNull()),
+                                new Row[] {Row.of(1, "two"), Row.of(3, "four")},
+                                new Row[] {Row.of(1, "two"), Row.of(3, "four")})
+                        .build(),
+                CastTestSpecBuilder.testCastTo(MAP(ROW(INT()), STRING()))
+                        .fromCase(
+                                MAP(ROW(INT()), VARCHAR(4)),
+                                map(entry(Row.of(1), "two"), entry(Row.of(3), "four")),
+                                map(entry(Row.of(1), "two"), entry(Row.of(3), "four")))
+                        .build(),
                 CastTestSpecBuilder.testCastTo(ROW(BIGINT(), BIGINT(), STRING(), ARRAY(STRING())))
                         .fromCase(
                                 ROW(INT(), INT(), TIME(), ARRAY(CHAR(1))),


### PR DESCRIPTION
The PR addresses allows casting in correct way collections like `ARRAY` and `MAP` with `ROW` element types
e.g.
```sql
SELECT cast(array[row(1, 'one'), row(2, 'two')] as array<row<`f0` int, `f1` string>>);
SELECT cast(map[row(1), 'one', row(2), 'two'] as map<row<`f0` int>, string>);
```


## Brief change log

add `copy` method usage to fix overriding of collection's values


## Verifying this change

Tests are added to `org.apache.flink.table.planner.functions.CastFunctionITCase`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
