### PR TITLE
[FLINK-32404][table] Add catalog modification listener interface and create listener for catalog manager

### DIFF
--- a/docs/layouts/shortcodes/generated/table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/table_config_configuration.html
@@ -21,6 +21,12 @@
             <td>The name of the default database in the initial catalog to be created when instantiating TableEnvironment.</td>
         </tr>
         <tr>
+            <td><h5>table.catalog-modification.listeners</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>A (semicolon-separated) list of factories that creates listener for catalog modification which will be notified in catalog manager after it performs database and table ddl operations successfully.</td>
+        </tr>
+        <tr>
             <td><h5>table.rtas-ctas.atomicity-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/table_config_configuration.html
@@ -27,12 +27,6 @@
             <td>A (semicolon-separated) list of factories that creates listener for catalog modification which will be notified in catalog manager after it performs database and table ddl operations successfully.</td>
         </tr>
         <tr>
-            <td><h5>table.rtas-ctas.atomicity-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Specifies if the CREATE TABLE/REPLACE TABLE/CREATE OR REPLACE AS SELECT statement is executed atomically. By default, the statement is non-atomic. The target table is created/replaced on the client side, and it will not be rolled back even though the job fails or is canceled. If set this option to true and the underlying DynamicTableSink implements the SupportsStaging interface, the statement is expected to be executed atomically, the behavior of which depends on the actual DynamicTableSink.</td>
-        </tr>
-        <tr>
             <td><h5>table.display.max-column-width</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">30</td>
             <td>Integer</td>
@@ -85,6 +79,12 @@
             <td style="word-wrap: break-word;">System.getProperty("java.io.tmpdir")</td>
             <td>String</td>
             <td>Local directory that is used by planner for storing downloaded resources.</td>
+        </tr>
+        <tr>
+            <td><h5>table.rtas-ctas.atomicity-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Specifies if the CREATE TABLE/REPLACE TABLE/CREATE OR REPLACE AS SELECT statement is executed atomically. By default, the statement is non-atomic. The target table is created/replaced on the client side, and it will not be rolled back even though the job fails or is canceled. If set this option to true and the underlying DynamicTableSink implements the SupportsStaging interface, the statement is expected to be executed atomically, the behavior of which depends on the actual DynamicTableSink.</td>
         </tr>
         <tr>
             <td><h5>table.sql-dialect</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.gateway.api.endpoint.EndpointVersion;
 import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
@@ -325,7 +326,10 @@ public class SessionContext {
                 CatalogManager.newBuilder()
                         // Currently, the classloader is only used by DataTypeFactory.
                         .classLoader(userClassLoader)
-                        .config(configuration);
+                        .config(configuration)
+                        .catalogModificationListeners(
+                                TableFactoryUtil.findCatalogModificationListenerList(
+                                        configuration, userClassLoader));
 
         // init default catalog
         String defaultCatalogName;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -44,6 +44,7 @@ import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.PlannerFactoryUtil;
+import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -123,6 +124,9 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
                                         settings.getBuiltInCatalogName(),
                                         settings.getBuiltInDatabaseName()))
                         .executionConfig(executionEnvironment.getConfig())
+                        .catalogModificationListeners(
+                                TableFactoryUtil.findCatalogModificationListenerList(
+                                        settings.getConfiguration(), userClassLoader))
                         .build();
 
         final FunctionCatalog functionCatalog =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -28,6 +28,8 @@ import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.catalog.Catalog;
 
+import java.util.List;
+
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
 
@@ -57,6 +59,17 @@ public class TableConfigOptions {
                     .withDescription(
                             "The name of the default database in the initial catalog to be created "
                                     + "when instantiating TableEnvironment.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<List<String>> TABLE_CATALOG_MODIFICATION_LISTENERS =
+            key("table.catalog-modification.listeners")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A (semicolon-separated) list of factories that creates listener for catalog "
+                                    + "modification which will be notified in catalog manager after it "
+                                    + "performs database and table ddl operations successfully.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_DML_SYNC =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -254,6 +254,9 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                                 new GenericInMemoryCatalog(
                                         settings.getBuiltInCatalogName(),
                                         settings.getBuiltInDatabaseName()))
+                        .catalogModificationListeners(
+                                TableFactoryUtil.findCatalogModificationListenerList(
+                                        settings.getConfiguration(), userClassLoader))
                         .build();
 
         final FunctionCatalog functionCatalog =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.CatalogNotExistException;
@@ -32,6 +33,7 @@ import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.listener.CatalogModificationListener;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.util.Preconditions;
@@ -86,11 +88,14 @@ public final class CatalogManager implements CatalogRegistry {
 
     private final ManagedTableListener managedTableListener;
 
+    private final List<CatalogModificationListener> catalogModificationListeners;
+
     private CatalogManager(
             String defaultCatalogName,
             Catalog defaultCatalog,
             DataTypeFactory typeFactory,
-            ManagedTableListener managedTableListener) {
+            ManagedTableListener managedTableListener,
+            List<CatalogModificationListener> catalogModificationListeners) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(defaultCatalogName),
                 "Default catalog name cannot be null or empty");
@@ -107,6 +112,12 @@ public final class CatalogManager implements CatalogRegistry {
 
         this.typeFactory = typeFactory;
         this.managedTableListener = managedTableListener;
+        this.catalogModificationListeners = catalogModificationListeners;
+    }
+
+    @VisibleForTesting
+    public List<CatalogModificationListener> getCatalogModificationListeners() {
+        return catalogModificationListeners;
     }
 
     public static Builder newBuilder() {
@@ -127,6 +138,9 @@ public final class CatalogManager implements CatalogRegistry {
         private @Nullable ExecutionConfig executionConfig;
 
         private @Nullable DataTypeFactory dataTypeFactory;
+
+        private List<CatalogModificationListener> catalogModificationListeners =
+                Collections.emptyList();
 
         public Builder classLoader(ClassLoader classLoader) {
             this.classLoader = classLoader;
@@ -154,6 +168,12 @@ public final class CatalogManager implements CatalogRegistry {
             return this;
         }
 
+        public Builder catalogModificationListeners(
+                List<CatalogModificationListener> catalogModificationListeners) {
+            this.catalogModificationListeners = catalogModificationListeners;
+            return this;
+        }
+
         public CatalogManager build() {
             checkNotNull(classLoader, "Class loader cannot be null");
             checkNotNull(config, "Config cannot be null");
@@ -163,7 +183,8 @@ public final class CatalogManager implements CatalogRegistry {
                     dataTypeFactory != null
                             ? dataTypeFactory
                             : new DataTypeFactoryImpl(classLoader, config, executionConfig),
-                    new ManagedTableListener(classLoader, config));
+                    new ManagedTableListener(classLoader, config),
+                    catalogModificationListeners);
         }
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogContext.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogContext.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.Catalog;
+
+import java.util.Optional;
+
+/**
+ * Context for catalog which provides the name, factory identifier and configuration to identify the
+ * same physical catalog for different logical catalog. For example, catalogs with different catalog
+ * name may be created on the same physical catalog.
+ */
+@PublicEvolving
+public interface CatalogContext {
+    /** The catalog name. */
+    String getCatalogName();
+
+    /** Identifier for the catalog from catalog factory. */
+    Optional<String> getFactoryIdentifier();
+
+    /** Class of the catalog. */
+    Class<? extends Catalog> getClazz();
+
+    /** The catalog configuration. */
+    Configuration getConfiguration();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * The basic interface for catalog modification event, all database and table related events are
+ * implements this interface.
+ */
+@PublicEvolving
+public interface CatalogModificationEvent {
+    /** The context to identify physical catalog for the event. */
+    CatalogContext context();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationListener.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationListener.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A listener that is notified on specific catalog changed in catalog manager.
+ *
+ * <p>It is highly recommended NOT to perform any blocking operation inside the callbacks. If you
+ * block the thread the invoker of catalog manager is possibly blocked. You can perform the
+ * operation asynchronously in an executor, but you need to handle timing issues.
+ */
+@PublicEvolving
+public interface CatalogModificationListener {
+    /** Callback on catalog modification such as database and table ddl operations. */
+    void onEvent(CatalogModificationEvent event);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationListenerFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CatalogModificationListenerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.factories.Factory;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A factory to create catalog modification listener instances based on context which contains job
+ * configuration and user classloader.
+ */
+@PublicEvolving
+public interface CatalogModificationListenerFactory extends Factory {
+    /** Creates and configures a {@link CatalogModificationListener} using the given context. */
+    CatalogModificationListener createListener(Context context);
+
+    @Override
+    default Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    default Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+
+    /** Context provided when a listener is created. */
+    @PublicEvolving
+    interface Context {
+        /** Returns the read-only job configuration with which the listener is created. */
+        ReadableConfig getConfiguration();
+
+        /** Returns the class loader of the current job. */
+        ClassLoader getUserClassLoader();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogFactory1.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogFactory1.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+/** Testing catalog modification factory. */
+public class CatalogFactory1 implements CatalogModificationListenerFactory {
+    public static final String IDENTIFIER = "factory1";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public CatalogModificationListener createListener(Context context) {
+        return new CatalogListener1();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogFactory2.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogFactory2.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+/** Testing catalog modification factory. */
+public class CatalogFactory2 implements CatalogModificationListenerFactory {
+    public static final String IDENTIFIER = "factory2";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public CatalogModificationListener createListener(Context context) {
+        return new CatalogListener2();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListener1.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListener1.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+/** Testing catalog modification listener. */
+public class CatalogListener1 implements CatalogModificationListener {
+
+    @Override
+    public void onEvent(CatalogModificationEvent event) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListener2.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListener2.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+/** Testing catalog modification listener. */
+public class CatalogListener2 implements CatalogModificationListener {
+
+    @Override
+    public void onEvent(CatalogModificationEvent event) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListenerFactoryTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/listener/CatalogListenerFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.factories.TableFactoryUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_CATALOG_MODIFICATION_LISTENERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests to discovery catalog listeners. */
+public class CatalogListenerFactoryTest {
+    @Test
+    void testFindCatalogModificationListenerList() {
+        Configuration configuration = new Configuration();
+        // Find no listener
+        assertThat(
+                        TableFactoryUtil.findCatalogModificationListenerList(
+                                        configuration, ClassLoader.getSystemClassLoader())
+                                .isEmpty())
+                .isTrue();
+
+        // Find listeners
+        configuration.set(
+                TABLE_CATALOG_MODIFICATION_LISTENERS,
+                Arrays.asList(CatalogFactory1.IDENTIFIER, CatalogFactory2.IDENTIFIER));
+        assertThat(
+                        TableFactoryUtil.findCatalogModificationListenerList(
+                                        configuration, ClassLoader.getSystemClassLoader())
+                                .stream()
+                                .map(l -> l.getClass().getName())
+                                .collect(Collectors.toList()))
+                .isEqualTo(
+                        Arrays.asList(
+                                CatalogListener1.class.getName(),
+                                CatalogListener2.class.getName()));
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-api-java/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -13,10 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.formats.testcsv.TestCsvFormatFactory
-org.apache.flink.table.planner.factories.TestValuesTableFactory
-org.apache.flink.table.planner.factories.TestFileFactory
-org.apache.flink.table.planner.factories.TableFactoryHarness$Factory
-org.apache.flink.table.planner.plan.stream.sql.TestTableFactory
-org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory
-org.apache.flink.table.planner.factories.TestSupportsStagingTableFactory
+org.apache.flink.table.catalog.listener.CatalogFactory1
+org.apache.flink.table.catalog.listener.CatalogFactory2

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -317,7 +317,7 @@ object StreamTableEnvironmentImpl {
         new GenericInMemoryCatalog(settings.getBuiltInCatalogName, settings.getBuiltInDatabaseName))
       .executionConfig(executionEnvironment.getConfig)
       .catalogModificationListeners(TableFactoryUtil
-        .findCatalogModificationListenerList(executor.getConfiguration, userClassLoader))
+        .findCatalogModificationListenerList(tableConfig.getConfiguration, userClassLoader))
       .build
 
     val functionCatalog =

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.catalog._
 import org.apache.flink.table.connector.ChangelogMode
 import org.apache.flink.table.delegation.{Executor, Planner}
 import org.apache.flink.table.expressions.Expression
-import org.apache.flink.table.factories.PlannerFactoryUtil
+import org.apache.flink.table.factories.{PlannerFactoryUtil, TableFactoryUtil}
 import org.apache.flink.table.functions.{AggregateFunction, TableAggregateFunction, TableFunction, UserDefinedFunctionHelper}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations._
@@ -38,7 +38,7 @@ import org.apache.flink.table.sources.{TableSource, TableSourceValidation}
 import org.apache.flink.table.types.AbstractDataType
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.types.Row
-import org.apache.flink.util.{FlinkUserCodeClassLoaders, MutableURLClassLoader, Preconditions}
+import org.apache.flink.util.{FlinkUserCodeClassLoaders, InstantiationUtil, MutableURLClassLoader, Preconditions}
 
 import java.net.URL
 import java.util.Optional
@@ -316,6 +316,8 @@ object StreamTableEnvironmentImpl {
         settings.getBuiltInCatalogName,
         new GenericInMemoryCatalog(settings.getBuiltInCatalogName, settings.getBuiltInDatabaseName))
       .executionConfig(executionEnvironment.getConfig)
+      .catalogModificationListeners(TableFactoryUtil
+        .findCatalogModificationListenerList(executor.getConfiguration, userClassLoader))
       .build
 
     val functionCatalog =

--- a/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -20,3 +20,5 @@ org.apache.flink.table.planner.factories.TableFactoryHarness$Factory
 org.apache.flink.table.planner.plan.stream.sql.TestTableFactory
 org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory
 org.apache.flink.table.planner.factories.TestSupportsStagingTableFactory
+org.apache.flink.table.api.EnvironmentTest$CatalogFactory1
+org.apache.flink.table.api.EnvironmentTest$CatalogFactory2

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/catalog/CatalogListenerTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/catalog/CatalogListenerTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.runtime.catalog
+
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
+import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.catalog.listener.{CatalogFactory1, CatalogFactory2}
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import java.util
+
+/** Catalog listener tests for environment. */
+class CatalogListenerTest {
+  @Test
+  def testFindCatalogListenerFromTableConfig(): Unit = {
+    val configuration = new Configuration()
+    val tEnv1 = StreamTableEnvironment
+      .create(
+        StreamExecutionEnvironment.getExecutionEnvironment,
+        EnvironmentSettings
+          .newInstance()
+          .withConfiguration(configuration)
+          .build())
+      .asInstanceOf[StreamTableEnvironmentImpl]
+    assertThat(tEnv1.getCatalogManager.getCatalogModificationListeners.isEmpty).isTrue
+
+    configuration.set(
+      TableConfigOptions.TABLE_CATALOG_MODIFICATION_LISTENERS,
+      util.Arrays.asList(CatalogFactory1.IDENTIFIER, CatalogFactory2.IDENTIFIER))
+    val tEnv2 = StreamTableEnvironment
+      .create(
+        StreamExecutionEnvironment.getExecutionEnvironment,
+        EnvironmentSettings
+          .newInstance()
+          .withConfiguration(configuration)
+          .build())
+      .asInstanceOf[StreamTableEnvironmentImpl]
+    assertThat(tEnv2.getCatalogManager.getCatalogModificationListeners.size()).isEqualTo(2)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add catalog modification listener interface and create the listeners for catalog manager from configuration

## Brief change log
  - Add catalog modification listener interface
  - Create listeners for CatalogManager

## Verifying this change

This change added tests and can be verified as follows:

  - Added `EnvironmentTest.testCreateCatalogModificationListeners` to create specific listeners for `CatalogManager` from configuration

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
