### PR TITLE
[FLINK-32496][connectors/common] Fix the bug that source cannot resume after enabling the watermark alignment and idleness

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -181,9 +181,11 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
         Set<Integer> subTaskIds = combinedWatermark.keySet();
         LOG.info(
-                "Distributing maxAllowedWatermark={} to subTaskIds={}",
+                "Distributing maxAllowedWatermark={} of group={} to subTaskIds={} for source {}.",
                 maxAllowedWatermark,
-                subTaskIds);
+                watermarkAlignmentParams.getWatermarkGroup(),
+                subTaskIds,
+                operatorName);
 
         // Subtask maybe during deploying or restarting, so we only send WatermarkAlignmentEvent
         // to ready task to avoid period task fail (Java-ThreadPoolExecutor will not schedule
@@ -611,7 +613,11 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             + "scenario (e.g. if speculative execution is enabled)");
         }
 
-        LOG.debug("New reported watermark={} from subTaskId={}", watermark, subtask);
+        LOG.debug(
+                "New reported watermark={} from subTaskId={} of source {}.",
+                watermark,
+                subtask,
+                operatorName);
 
         checkState(watermarkAlignmentParams.isEnabled());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import java.time.Duration;
 
@@ -46,11 +45,14 @@ public interface TimestampsAndWatermarks<T> {
     /** Lets the owner/creator of the output know about latest emitted watermark. */
     @Internal
     interface WatermarkUpdateListener {
+
+        /** It should be called once the idle is changed. */
+        void updateIdle(boolean isIdle);
+
         /**
-         * Effective watermark covers the {@link WatermarkStatus}. If an output becomes idle, this
-         * method should be called with {@link Long#MAX_VALUE}, but what is more important, once it
-         * becomes active again it should call this method with the last emitted value of the
-         * watermark.
+         * Update the effective watermark. If an output becomes idle, please call {@link
+         * this#updateIdle} instead of update the watermark to {@link Long#MAX_VALUE}. Because the
+         * output needs to distinguish between idle and real watermark.
          */
         void updateCurrentEffectiveWatermark(long watermark);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -46,6 +46,9 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
                 output,
                 new TimestampsAndWatermarks.WatermarkUpdateListener() {
                     @Override
+                    public void updateIdle(boolean isIdle) {}
+
+                    @Override
                     public void updateCurrentEffectiveWatermark(long watermark) {}
 
                     @Override
@@ -92,7 +95,7 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
         try {
             output.emitWatermarkStatus(WatermarkStatus.IDLE);
-            watermarkEmitted.updateCurrentEffectiveWatermark(Long.MAX_VALUE);
+            watermarkEmitted.updateIdle(true);
             isIdle = true;
         } catch (ExceptionInChainedOperatorException e) {
             throw e;
@@ -118,7 +121,7 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
         }
 
         output.emitWatermarkStatus(WatermarkStatus.ACTIVE);
-        watermarkEmitted.updateCurrentEffectiveWatermark(maxWatermarkSoFar);
+        watermarkEmitted.updateIdle(false);
         isIdle = false;
         return false;
     }


### PR DESCRIPTION
## What is the purpose of the change

When one source is always active and other sources are idle (Either there is no data, or alignment causes idle.), these source won't resume.

For example, sourceA is always active, sourceB is idle due to there is no data. SourceB won't resume forever even if it can read more data.

### Root cause

- Step1: When source is idle, [WatermarkToDataOutput will update](https://github.com/apache/flink/blob/c1740861727d2614f9bbf154bcdd274d7990e133/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java#L95C12-L95C12) the `Long.MAX_VALUE` to [`SourceOperator#lastEmittedWatermark`](https://github.com/apache/flink/blob/c1740861727d2614f9bbf154bcdd274d7990e133/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java#L605) as the watermark.
- Step2: [`SourceOperator#shouldWaitForAlignment`](https://github.com/apache/flink/blob/c1740861727d2614f9bbf154bcdd274d7990e133/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java#L678) is `currentMaxDesiredWatermark < lastEmittedWatermark`, the `lastEmittedWatermark` is updated to `Long.MAX_VALUE` and the `currentMaxDesiredWatermark` is normal due to one source is active. So `shouldWaitForAlignment` will be always true.
- Step3: `SourceOperator#updateCurrentEffectiveWatermark` ->  `checkWatermarkAlignment()` -> `shouldWaitForAlignment()` will update the `operatingMode` to `OperatingMode.WAITING_FOR_ALIGNMENT;`

### Bug 👻👻👻
- Bug1: Actually, it shouldn't be updated to WAITING_FOR_ALIGNMENT. It's updated, because the `lastEmittedWatermark` isn't the real watermark. It's very big due to idle.
- Bug2: The source operatingMode cannot convert from `WAITING_FOR_ALIGNMENT` to `READING` at `checkWatermarkAlignment` forever. Because `shouldWaitForAlignment` is always true.


## Brief change log

The idle shouldn't update `SourceOperator#lastEmittedWatermark` and shouldn't effect the `shouldWaitForAlignment()` logic.

I introduced the `SourceOperator#isIdle`, when it's true, `emitLatestWatermark` will send the `Watermark.MAX_WATERMARK` to the SourceCoordinator. It won't effect the alignment logic at SourceOperator side.


## Verifying this change

  - *Improve the SourceOperatorAlignmentTest#testWatermarkAlignmentWithIdleness*

This test  will fail when `allSubtasksIdle=false` with master branch, and it can pass with this PR.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)