### PR TITLE
[FLINK-32509][core] Avoid using skip in InputStreamFSInputWrapper

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -88,6 +88,13 @@ under the License.
 			<!-- managed version -->
 		</dependency>
 
+		<!-- standard utilities -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<!-- managed version -->
+		</dependency>
+
 		<!-- for the fallback generic serializer -->
 		<dependency>
 			<groupId>com.esotericsoftware.kryo</groupId>

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputStreamFSInputWrapper.java
@@ -20,8 +20,8 @@ package org.apache.flink.api.common.io;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.util.IOUtils;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -51,14 +51,8 @@ public class InputStreamFSInputWrapper extends FSDataInputStream {
         if (desired < this.pos) {
             throw new IllegalArgumentException("Wrapped InputStream: cannot search backwards.");
         }
-
-        while (this.pos < desired) {
-            long numReadBytes = this.inStream.skip(desired - pos);
-            if (numReadBytes == -1) {
-                throw new EOFException("Unexpected EOF during forward seek.");
-            }
-            this.pos += numReadBytes;
-        }
+        IOUtils.skipFully(inStream, desired - pos);
+        this.pos = desired;
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -159,13 +159,7 @@ public final class IOUtils {
      *     EOF)
      */
     public static void skipFully(final InputStream in, long len) throws IOException {
-        while (len > 0) {
-            final long ret = in.skip(len);
-            if (ret < 0) {
-                throw new IOException("Premeture EOF from inputStream");
-            }
-            len -= ret;
-        }
+        org.apache.commons.io.IOUtils.skipFully(in, len);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/InputStreamFSInputWrapperTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/InputStreamFSInputWrapperTest.java
@@ -20,11 +20,14 @@ package org.apache.flink.api.common.io;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class InputStreamFSInputWrapperTest {
 
@@ -47,5 +50,24 @@ public class InputStreamFSInputWrapperTest {
         InputStreamFSInputWrapper wrapper = new InputStreamFSInputWrapper(mockedInputStream);
         wrapper.close();
         assertThat(closeCalled).isTrue();
+    }
+
+    @Test
+    public void testSeek() throws IOException {
+        byte[] bytes = "flink".getBytes();
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            InputStreamFSInputWrapper wrapper = new InputStreamFSInputWrapper(inputStream);
+            wrapper.seek(2);
+            assertThat(wrapper.getPos()).isEqualTo(2);
+        }
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            InputStreamFSInputWrapper wrapper = new InputStreamFSInputWrapper(inputStream);
+            wrapper.seek(5);
+            assertThat(wrapper.getPos()).isEqualTo(5);
+        }
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            InputStreamFSInputWrapper wrapper = new InputStreamFSInputWrapper(inputStream);
+            assertThatThrownBy(() -> wrapper.seek(6)).isInstanceOf(EOFException.class);
+        }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Method "skip" of InputStream does not return -1 for eof, so it can cause to infinite loop when desired exceed end of file.




## Brief change log


  - *use `IOUtil.skipFully` in InputStreamFSInputWrapper*
  - delegate to `org.apache.commons.io.IOUtils.skipFully` in `IOUtil.skipFully` 
 


## Verifying this change

Added test in InputStreamFSInputWrapperTest



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
