### PR TITLE
[hotfix] Improve error message when config serialization fails

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -189,13 +189,16 @@ public class StreamConfig implements Serializable {
      * the StreamConfig internally or test.
      */
     public void serializeAllConfigs() {
+        String errorMsg =
+                "Could not serialize object for key %s. "
+                        + "If the job involves non-static member class, try to clean the class "
+                        + "closure using StreamExecutionEnvironment#clean.";
         toBeSerializedConfigObjects.forEach(
                 (key, object) -> {
                     try {
                         InstantiationUtil.writeObjectToConfig(object, this.config, key);
                     } catch (IOException e) {
-                        throw new StreamTaskException(
-                                String.format("Could not serialize object for key %s.", key), e);
+                        throw new StreamTaskException(String.format(errorMsg, key), e);
                     }
                 });
     }


### PR DESCRIPTION
## What is the purpose of the change

Currently, if user uses a non-static member class in DataStream job, the job might fail with the following error:

```
Caused by: org.apache.flink.streaming.runtime.tasks.StreamTaskException: Could not serialize object for key serializedUDF.
	at org.apache.flink.streaming.api.graph.StreamConfig.lambda$serializeAllConfigs$1(StreamConfig.java:198)
	at java.base/java.util.HashMap.forEach(HashMap.java:1337)
	at org.apache.flink.streaming.api.graph.StreamConfig.serializeAllConfigs(StreamConfig.java:192)
	at org.apache.flink.streaming.api.graph.StreamConfig.lambda$triggerSerializationAndReturnFuture$0(StreamConfig.java:169)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:714)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

The issue can typically be fixed by cleaning the class closure using `StreamExecutionEnvironment#clean`. However, it is not easy to know the solution and users can get stuck on this issue.

## Brief change log

Updated the error message in StreamConfig#serializeAllConfigs to suggest using StreamExecutionEnvironment#clean.

## Verifying this change

Run a DataStream job that uses a non-static member class and verified that the following error message is used:

```
Caused by: java.util.concurrent.ExecutionException: org.apache.flink.streaming.runtime.tasks.StreamTaskException: Could not serialize object for key serializedUDF. If the job involves non-static member class, try to clean the class closure using StreamExecutionEnvironment#clean.
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable