### PR TITLE
[FLINK-32514] Support configuring checkpointing interval during process backlog

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
@@ -30,7 +30,13 @@
             <td><h5>execution.checkpointing.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Gets the interval in which checkpoints are periodically scheduled.<br /><br />This setting defines the base interval. Checkpoint triggering may be delayed by the settings <code class="highlighter-rouge">execution.checkpointing.max-concurrent-checkpoints</code> and <code class="highlighter-rouge">execution.checkpointing.min-pause</code></td>
+            <td>Gets the interval in which checkpoints are periodically scheduled.<br /><br />This setting defines the base interval. Checkpoint triggering may be delayed by the settings <code class="highlighter-rouge">execution.checkpointing.max-concurrent-checkpoints</code>, <code class="highlighter-rouge">execution.checkpointing.min-pause</code> and <code class="highlighter-rouge">execution.checkpointing.interval-during-backlog</code></td>
+        </tr>
+        <tr>
+            <td><h5>execution.checkpointing.interval-during-backlog</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>If it is not null and any source reports isProcessingBacklog=true, it is the interval in which checkpoints are periodically scheduled.<br /><br />Checkpoint triggering may be delayed by the settings <code class="highlighter-rouge">execution.checkpointing.max-concurrent-checkpoints</code> and <code class="highlighter-rouge">execution.checkpointing.min-pause</code>.<br /><br />Note: if it is not null, the value must either be 0, which means the checkpoint is disabled during backlog, or be larger than or equal to execution.checkpointing.interval.</td>
         </tr>
         <tr>
             <td><h5>execution.checkpointing.max-concurrent-checkpoints</h5></td>

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -302,6 +302,7 @@ public class HybridSourceSplitEnumerator
                     "Failed to create enumerator for sourceIndex=" + currentSourceIndex, e);
         }
         LOG.info("Starting enumerator for sourceIndex={}", currentSourceIndex);
+        context.setIsProcessingBacklog(currentSourceIndex < sources.size() - 1);
         currentEnumerator.start();
     }
 
@@ -421,6 +422,11 @@ public class HybridSourceSplitEnumerator
         @Override
         public void runInCoordinatorThread(Runnable runnable) {
             realContext.runInCoordinatorThread(runnable);
+        }
+
+        @Override
+        public void setIsProcessingBacklog(boolean isProcessingBacklog) {
+            realContext.setIsProcessingBacklog(isProcessingBacklog);
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.connector.source;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
 
 import java.util.Map;
@@ -181,4 +182,18 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
      * @param runnable a runnable to execute
      */
     void runInCoordinatorThread(Runnable runnable);
+
+    /**
+     * Reports to JM whether this source is currently processing backlog.
+     *
+     * <p>When source is processing backlog, it means the records being emitted by this source is
+     * already stale and there is no processing latency requirement for these records. This allows
+     * downstream operators to optimize throughput instead of reducing latency for intermediate
+     * results.
+     *
+     * <p>If no API has been explicitly invoked to specify the backlog status of a source, the
+     * source is considered to have isProcessingBacklog=false by default.
+     */
+    @PublicEvolving
+    void setIsProcessingBacklog(boolean isProcessingBacklog);
 }

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
@@ -199,6 +199,9 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
         mainExecutor.execute(runnable);
     }
 
+    @Override
+    public void setIsProcessingBacklog(boolean isProcessingBacklog) {}
+
     public void close() throws Exception {
         stoppedAcceptAsyncCalls.set(true);
         workerExecutor.shutdownNow();

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -125,6 +125,10 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
         execService.triggerNonPeriodicScheduledTasks();
     }
 
+    public void triggerNonPeriodicScheduledTasks(Class<?> taskClazz) {
+        execService.triggerNonPeriodicScheduledTasks(taskClazz);
+    }
+
     public void triggerPeriodicScheduledTasks() {
         execService.triggerPeriodicScheduledTasks();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -42,6 +42,8 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     private final long checkpointInterval;
 
+    private final long checkpointIntervalDuringBacklog;
+
     private final long checkpointTimeout;
 
     private final long minPauseBetweenCheckpoints;
@@ -84,6 +86,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
             long checkpointIdOfIgnoredInFlightData) {
         this(
                 checkpointInterval,
+                checkpointInterval,
                 checkpointTimeout,
                 minPauseBetweenCheckpoints,
                 maxConcurrentCheckpoints,
@@ -98,6 +101,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     private CheckpointCoordinatorConfiguration(
             long checkpointInterval,
+            long checkpointIntervalDuringBacklog,
             long checkpointTimeout,
             long minPauseBetweenCheckpoints,
             int maxConcurrentCheckpoints,
@@ -108,6 +112,11 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
             long alignedCheckpointTimeout,
             long checkpointIdOfIgnoredInFlightData,
             boolean enableCheckpointsAfterTasksFinish) {
+
+        if (checkpointIntervalDuringBacklog < MINIMAL_CHECKPOINT_TIME) {
+            // interval of max value means disable periodic checkpoint
+            checkpointIntervalDuringBacklog = DISABLED_CHECKPOINT_INTERVAL;
+        }
 
         // sanity checks
         if (checkpointInterval < MINIMAL_CHECKPOINT_TIME
@@ -122,6 +131,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 "maxConcurrentCheckpoints can't be > 1 if UnalignedCheckpoints enabled");
 
         this.checkpointInterval = checkpointInterval;
+        this.checkpointIntervalDuringBacklog = checkpointIntervalDuringBacklog;
         this.checkpointTimeout = checkpointTimeout;
         this.minPauseBetweenCheckpoints = minPauseBetweenCheckpoints;
         this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
@@ -140,6 +150,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     public boolean isCheckpointingEnabled() {
         return checkpointInterval > 0 && checkpointInterval < DISABLED_CHECKPOINT_INTERVAL;
+    }
+
+    public long getCheckpointIntervalDuringBacklog() {
+        return checkpointIntervalDuringBacklog;
     }
 
     public long getCheckpointTimeout() {
@@ -255,6 +269,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
     /** {@link CheckpointCoordinatorConfiguration} builder. */
     public static class CheckpointCoordinatorConfigurationBuilder {
         private long checkpointInterval = MINIMAL_CHECKPOINT_TIME;
+        private long checkpointIntervalDuringBacklog = MINIMAL_CHECKPOINT_TIME;
         private long checkpointTimeout = MINIMAL_CHECKPOINT_TIME;
         private long minPauseBetweenCheckpoints;
         private int maxConcurrentCheckpoints = 1;
@@ -270,6 +285,7 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         public CheckpointCoordinatorConfiguration build() {
             return new CheckpointCoordinatorConfiguration(
                     checkpointInterval,
+                    checkpointIntervalDuringBacklog,
                     checkpointTimeout,
                     minPauseBetweenCheckpoints,
                     maxConcurrentCheckpoints,
@@ -285,6 +301,12 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         public CheckpointCoordinatorConfigurationBuilder setCheckpointInterval(
                 long checkpointInterval) {
             this.checkpointInterval = checkpointInterval;
+            return this;
+        }
+
+        public CheckpointCoordinatorConfigurationBuilder setCheckpointIntervalDuringBacklog(
+                long checkpointIntervalDuringBacklog) {
+            this.checkpointIntervalDuringBacklog = checkpointIntervalDuringBacklog;
             return this;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -277,6 +278,10 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
          * concurrent running execution attempts.
          */
         boolean isConcurrentExecutionAttemptsSupported();
+
+        /** Gets the checkpoint coordinator of this job. Return null if checkpoint is disabled. */
+        @Nullable
+        CheckpointCoordinator getCheckpointCoordinator();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -266,6 +267,12 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
         @Override
         public boolean isConcurrentExecutionAttemptsSupported() {
             return context.isConcurrentExecutionAttemptsSupported();
+        }
+
+        @Override
+        @Nullable
+        public CheckpointCoordinator getCheckpointCoordinator() {
+            return context.getCheckpointCoordinator();
         }
 
         @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -73,7 +73,10 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     @Override
     public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
         for (OperatorCoordinatorHolder coordinatorHolder : coordinatorMap.values()) {
-            coordinatorHolder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+            coordinatorHolder.lazyInitialize(
+                    globalFailureHandler,
+                    mainThreadExecutor,
+                    executionGraph.getCheckpointCoordinator());
         }
     }
 
@@ -154,7 +157,10 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
 
         for (OperatorCoordinatorHolder coordinator : coordinators) {
             coordinatorMap.put(coordinator.operatorId(), coordinator);
-            coordinator.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+            coordinator.lazyInitialize(
+                    globalFailureHandler,
+                    mainThreadExecutor,
+                    executionGraph.getCheckpointCoordinator());
         }
         startOperatorCoordinators(coordinators);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
@@ -1077,6 +1078,21 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                         .getCheckpointCoordinatorConfiguration()
                         .isEnableCheckpointsAfterTasksFinish()) {
             vertexEndOfDataListener.recordTaskEndOfData(executionAttemptID);
+            if (vertexEndOfDataListener.areAllTasksOfJobVertexEndOfData(
+                    executionAttemptID.getJobVertexId())) {
+                List<OperatorIDPair> operatorIDPairs =
+                        executionGraph
+                                .getJobVertex(executionAttemptID.getJobVertexId())
+                                .getOperatorIDs();
+                CheckpointCoordinator checkpointCoordinator =
+                        executionGraph.getCheckpointCoordinator();
+                if (checkpointCoordinator != null) {
+                    for (OperatorIDPair operatorIDPair : operatorIDPairs) {
+                        checkpointCoordinator.setIsProcessingBacklog(
+                                operatorIDPair.getGeneratedOperatorID(), false);
+                    }
+                }
+            }
             if (vertexEndOfDataListener.areAllTasksEndOfData()) {
                 triggerCheckpoint(CheckpointType.CONFIGURED);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexEndOfDataListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexEndOfDataListener.java
@@ -51,6 +51,13 @@ public class VertexEndOfDataListener {
         subtaskStatus.set(executionAttemptID.getSubtaskIndex());
     }
 
+    public boolean areAllTasksOfJobVertexEndOfData(JobVertexID jobVertexID) {
+        BitSet subtaskStatus = tasksReachedEndOfData.get(jobVertexID);
+        return subtaskStatus == null
+                || subtaskStatus.cardinality()
+                        == executionGraph.getJobVertex(jobVertexID).getParallelism();
+    }
+
     public boolean areAllTasksEndOfData() {
         Iterator<Map.Entry<JobVertexID, BitSet>> iterator =
                 tasksReachedEndOfData.entrySet().iterator();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -29,6 +29,8 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.SupportsIntermediateNoMoreSplits;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.InternalSplitEnumeratorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
@@ -358,6 +360,16 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     @VisibleForTesting
     boolean isClosed() {
         return closed;
+    }
+
+    @Override
+    public void setIsProcessingBacklog(boolean isProcessingBacklog) {
+        CheckpointCoordinator checkpointCoordinator =
+                getCoordinatorContext().getCheckpointCoordinator();
+        OperatorID operatorID = getCoordinatorContext().getOperatorId();
+        if (checkpointCoordinator != null) {
+            checkpointCoordinator.setIsProcessingBacklog(operatorID, isProcessingBacklog);
+        }
     }
 
     // --------- Package private additional methods for the SourceCoordinator ------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
@@ -120,7 +120,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
             checkpointCoordinator.startCheckpointScheduler();
 
             for (int i = 0; i < 5; ++i) {
-                manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+                manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                        CheckpointCoordinator.ScheduledTrigger.class);
                 manuallyTriggeredScheduledExecutor.triggerAll();
             }
             checkRecordedTriggeredCheckpoints(5, start, gateway.getTriggeredCheckpoints(attemptID));
@@ -128,7 +129,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
             checkpointCoordinator.stopCheckpointScheduler();
 
             // no further calls may come.
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
             manuallyTriggeredScheduledExecutor.triggerAll();
             assertThat(gateway.getTriggeredCheckpoints(attemptID).size()).isEqualTo(5);
 
@@ -137,7 +139,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
             checkpointCoordinator.startCheckpointScheduler();
 
             for (int i = 0; i < 5; ++i) {
-                manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+                manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                        CheckpointCoordinator.ScheduledTrigger.class);
                 manuallyTriggeredScheduledExecutor.triggerAll();
             }
             checkRecordedTriggeredCheckpoints(5, start, gateway.getTriggeredCheckpoints(attemptID));
@@ -145,7 +148,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
             checkpointCoordinator.stopCheckpointScheduler();
 
             // no further calls may come
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
             manuallyTriggeredScheduledExecutor.triggerAll();
             assertThat(gateway.getTriggeredCheckpoints(attemptID).size()).isEqualTo(5);
 
@@ -540,7 +544,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
 
         try {
             checkpointCoordinator.startCheckpointScheduler();
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
             manuallyTriggeredScheduledExecutor.triggerAll();
 
             // wait until the first checkpoint was triggered
@@ -555,12 +560,14 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
             checkpointCoordinator.receiveAcknowledgeMessage(ackMsg, TASK_MANAGER_LOCATION_INFO);
 
             gateway.resetCount();
-            manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
             manuallyTriggeredScheduledExecutor.triggerAll();
             while (gateway.getTriggeredCheckpoints(attemptID).isEmpty()) {
                 // sleeps for a while to simulate periodic scheduling
                 Thread.sleep(checkpointInterval);
-                manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+                manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                        CheckpointCoordinator.ScheduledTrigger.class);
                 manuallyTriggeredScheduledExecutor.triggerAll();
             }
             // wait until the next checkpoint is triggered
@@ -760,7 +767,8 @@ class CheckpointCoordinatorTriggeringTest extends TestLogger {
         assertThat(checkpointCoordinator.isTriggering()).isTrue();
 
         // trigger cancellation
-        manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks();
+        manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                CheckpointCoordinator.CheckpointCanceller.class);
         assertThat(checkpointCoordinator.isTriggering()).isTrue();
 
         try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointRequestDeciderTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.LongConsumer;
+import java.util.function.BiConsumer;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
@@ -284,7 +284,7 @@ public class CheckpointRequestDeciderTest {
                 maxQueued);
     }
 
-    private static final LongConsumer NO_OP = unused -> {};
+    private static final BiConsumer<Long, Long> NO_OP = (currentTimeMillis, tillNextMillis) -> {};
 
     static CheckpointTriggerRequest regularCheckpoint() {
         return checkpointRequest(true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -108,7 +108,8 @@ class FailoverStrategyCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator.isCurrentPeriodicTriggerAvailable()).isTrue();
         // only trigger the periodic scheduling
         // we can't trigger all scheduled task, because there is also a cancellation scheduled
-        manualThreadExecutor.triggerPeriodicScheduledTasks();
+        manualThreadExecutor.triggerNonPeriodicScheduledTasks(
+                CheckpointCoordinator.ScheduledTrigger.class);
         manualThreadExecutor.triggerAll();
         assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isOne();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -351,7 +351,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
         CheckpointRequestDecider checkpointRequestDecider =
                 new CheckpointRequestDecider(
                         maxCleaningCheckpoints,
-                        unused -> {},
+                        (currentTimeMillis, tillNextMillis) -> {},
                         clock,
                         1,
                         new AtomicInteger(0)::get,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -19,6 +19,7 @@ limitations under the License.
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.InternalOperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -90,6 +91,11 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     @Override
     public boolean isConcurrentExecutionAttemptsSupported() {
         return false;
+    }
+
+    @Override
+    public CheckpointCoordinator getCheckpointCoordinator() {
+        throw new UnsupportedOperationException();
     }
 
     // -------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -529,7 +529,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                                 new Configuration()),
                         UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
-        holder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        holder.lazyInitialize(globalFailureHandler, mainThreadExecutor, null);
         holder.start();
 
         return holder;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -126,6 +126,29 @@ public class ExecutionCheckpointingOptions {
                                                                     .key()))
                                             .build());
 
+    public static final ConfigOption<Duration> CHECKPOINTING_INTERVAL_DURING_BACKLOG =
+            ConfigOptions.key("execution.checkpointing.interval-during-backlog")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If it is not null and any source reports isProcessingBacklog=true, "
+                                                    + "it is the interval in which checkpoints are periodically scheduled.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "Checkpoint triggering may be delayed by the settings %s and %s.",
+                                            TextElement.code(MAX_CONCURRENT_CHECKPOINTS.key()),
+                                            TextElement.code(MIN_PAUSE_BETWEEN_CHECKPOINTS.key()))
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "Note: if it is not null, the value must either be 0, "
+                                                    + "which means the checkpoint is disabled during backlog, "
+                                                    + "or be larger than or equal to execution.checkpointing.interval.")
+                                    .build());
+
     public static final ConfigOption<Duration> CHECKPOINTING_INTERVAL =
             ConfigOptions.key("execution.checkpointing.interval")
                     .durationType()
@@ -138,9 +161,11 @@ public class ExecutionCheckpointingOptions {
                                     .linebreak()
                                     .text(
                                             "This setting defines the base interval. Checkpoint triggering may be delayed by the settings "
-                                                    + "%s and %s",
+                                                    + "%s, %s and %s",
                                             TextElement.code(MAX_CONCURRENT_CHECKPOINTS.key()),
-                                            TextElement.code(MIN_PAUSE_BETWEEN_CHECKPOINTS.key()))
+                                            TextElement.code(MIN_PAUSE_BETWEEN_CHECKPOINTS.key()),
+                                            TextElement.code(
+                                                    CHECKPOINTING_INTERVAL_DURING_BACKLOG.key()))
                                     .build());
 
     public static final ConfigOption<Boolean> ENABLE_UNALIGNED =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -2011,6 +2011,8 @@ public class StreamingJobGraphGenerator {
                 new JobCheckpointingSettings(
                         CheckpointCoordinatorConfiguration.builder()
                                 .setCheckpointInterval(interval)
+                                .setCheckpointIntervalDuringBacklog(
+                                        cfg.getCheckpointIntervalDuringBacklog())
                                 .setCheckpointTimeout(cfg.getCheckpointTimeout())
                                 .setMinPauseBetweenCheckpoints(cfg.getMinPauseBetweenCheckpoints())
                                 .setMaxConcurrentCheckpoints(cfg.getMaxConcurrentCheckpoints())

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
@@ -160,6 +160,11 @@ public class TestingSplitEnumeratorContext<SplitT extends SourceSplit>
         executor.execute(runnable);
     }
 
+    @Override
+    public void setIsProcessingBacklog(boolean isProcessingBacklog) {
+        throw new UnsupportedOperationException();
+    }
+
     private static <T> Runnable callableWithResultHandler(
             Callable<T> callable, BiConsumer<T, Throwable> handler) {
         return () -> {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointIntervalDuringBacklogITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointIntervalDuringBacklogITCase.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.test.util.NumberSequenceSourceWithWaitForCheckpoint;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL_DURING_BACKLOG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A test suite that verifies the correctness of the configuration {@link
+ * org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions#CHECKPOINTING_INTERVAL_DURING_BACKLOG}.
+ */
+public class CheckpointIntervalDuringBacklogITCase {
+    private static final int NUM_SPLITS = 2;
+    private static final int NUM_RECORDS = 40;
+    private static final List<Long> EXPECTED_RESULT =
+            LongStream.rangeClosed(0, NUM_RECORDS - 1).boxed().collect(Collectors.toList());
+
+    @After
+    public void tearDown() {
+        CheckpointRecordingOperator.reset();
+    }
+
+    @Test
+    public void testCheckpoint() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
+        configuration.set(CHECKPOINTING_INTERVAL_DURING_BACKLOG, Duration.ofMillis(200));
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+
+        Source<Long, ?, ?> source =
+                HybridSource.builder(
+                                new NumberSequenceSourceWithWaitForCheckpoint(
+                                        0, NUM_RECORDS / 2 - 1, NUM_SPLITS))
+                        .addSource(
+                                new NumberSequenceSourceWithWaitForCheckpoint(
+                                        NUM_RECORDS / 2, NUM_RECORDS - 1, NUM_SPLITS))
+                        .build();
+
+        runAndVerifyResult(env, source);
+
+        assertThat(CheckpointRecordingOperator.numCheckpointsBeforeSwitchSource.get())
+                .isGreaterThan(0);
+        assertThat(CheckpointRecordingOperator.numCheckpointsAfterSwitchSource.get())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    public void testDefaultCheckpointIntervalDuringBacklog() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+
+        Source<Long, ?, ?> source =
+                HybridSource.builder(
+                                new NumberSequenceSourceWithWaitForCheckpoint(
+                                        0, NUM_RECORDS / 2 - 1, NUM_SPLITS))
+                        .addSource(new NumberSequenceSource(NUM_RECORDS / 2, NUM_RECORDS - 1))
+                        .build();
+
+        runAndVerifyResult(env, source);
+
+        assertThat(CheckpointRecordingOperator.numCheckpointsBeforeSwitchSource.get())
+                .isGreaterThan(0);
+        assertThat(CheckpointRecordingOperator.numCheckpointsAfterSwitchSource.get())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    public void testNoCheckpointDuringBacklog() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
+        configuration.set(CHECKPOINTING_INTERVAL_DURING_BACKLOG, Duration.ofMillis(0));
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+
+        Source<Long, ?, ?> source =
+                HybridSource.builder(new NumberSequenceSource(0, NUM_RECORDS / 2 - 1))
+                        .addSource(new NumberSequenceSource(NUM_RECORDS / 2, NUM_RECORDS - 1))
+                        .build();
+
+        runAndVerifyResult(env, source);
+
+        assertThat(CheckpointRecordingOperator.numCheckpointsBeforeSwitchSource.get()).isEqualTo(0);
+        assertThat(CheckpointRecordingOperator.numCheckpointsAfterSwitchSource.get())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    public void testExcludeFinishedOperatorBacklogStatus() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(CHECKPOINTING_INTERVAL, Duration.ofMillis(100));
+        configuration.set(CHECKPOINTING_INTERVAL_DURING_BACKLOG, Duration.ofMillis(0));
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+
+        DataStream<Long> source2 =
+                env.fromSource(
+                                new SourceWithBacklogReport<>(
+                                        new NumberSequenceSource(0L, 1L), true),
+                                WatermarkStrategy.noWatermarks(),
+                                "backlog-source")
+                        .returns(Long.class);
+
+        DataStream<Long> source =
+                env.fromSource(
+                        new NumberSequenceSourceWithWaitForCheckpoint(
+                                2, NUM_RECORDS - 1, NUM_SPLITS),
+                        WatermarkStrategy.noWatermarks(),
+                        "non-backlog-source");
+
+        final DataStream<Long> stream =
+                source.union(source2)
+                        .transform(
+                                "CheckpointRecordingOperator",
+                                Types.LONG,
+                                new CheckpointRecordingOperator<>());
+
+        final List<Long> result = new ArrayList<>();
+        try (CloseableIterator<Long> iterator = stream.executeAndCollect()) {
+            while (iterator.hasNext()) {
+                result.add(iterator.next());
+            }
+        }
+
+        Collections.sort(result);
+        assertThat(result).containsExactly(EXPECTED_RESULT.toArray(new Long[0]));
+    }
+
+    private void runAndVerifyResult(StreamExecutionEnvironment env, Source<Long, ?, ?> source)
+            throws Exception {
+        final DataStream<Long> stream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "hybrid-source")
+                        .returns(Long.class)
+                        .transform(
+                                "CheckpointRecordingOperator",
+                                Types.LONG,
+                                new CheckpointRecordingOperator<>());
+
+        final List<Long> result = new ArrayList<>();
+        try (CloseableIterator<Long> iterator = stream.executeAndCollect()) {
+            while (iterator.hasNext()) {
+                result.add(iterator.next());
+            }
+        }
+
+        Collections.sort(result);
+        assertThat(result).containsExactly(EXPECTED_RESULT.toArray(new Long[0]));
+    }
+
+    /**
+     * A {@link Source} decorator that reports the configured backlog status of the source during
+     * start.
+     */
+    private static class SourceWithBacklogReport<T, SplitT extends SourceSplit, EnumChkT>
+            implements Source<T, SplitT, EnumChkT> {
+        private final Source<T, SplitT, EnumChkT> source;
+        private final boolean isBacklog;
+
+        private SourceWithBacklogReport(Source<T, SplitT, EnumChkT> source, boolean isBacklog) {
+            this.source = source;
+            this.isBacklog = isBacklog;
+        }
+
+        @Override
+        public Boundedness getBoundedness() {
+            return source.getBoundedness();
+        }
+
+        @Override
+        public SplitEnumerator<SplitT, EnumChkT> createEnumerator(
+                SplitEnumeratorContext<SplitT> enumContext) throws Exception {
+            SplitEnumerator<SplitT, EnumChkT> enumerator = source.createEnumerator(enumContext);
+            return new EnumeratorWithBacklogReport<>(enumerator, enumContext, isBacklog);
+        }
+
+        @Override
+        public SplitEnumerator<SplitT, EnumChkT> restoreEnumerator(
+                SplitEnumeratorContext<SplitT> enumContext, EnumChkT checkpoint) throws Exception {
+            SplitEnumerator<SplitT, EnumChkT> enumerator =
+                    source.restoreEnumerator(enumContext, checkpoint);
+            return new EnumeratorWithBacklogReport<>(enumerator, enumContext, isBacklog);
+        }
+
+        @Override
+        public SimpleVersionedSerializer<SplitT> getSplitSerializer() {
+            return source.getSplitSerializer();
+        }
+
+        @Override
+        public SimpleVersionedSerializer<EnumChkT> getEnumeratorCheckpointSerializer() {
+            return source.getEnumeratorCheckpointSerializer();
+        }
+
+        @Override
+        public SourceReader<T, SplitT> createReader(SourceReaderContext readerContext)
+                throws Exception {
+            return source.createReader(readerContext);
+        }
+    }
+
+    /**
+     * A {@link SplitEnumerator} decorator that reports the configured backlog status of the source
+     * during start.
+     */
+    private static class EnumeratorWithBacklogReport<SplitT extends SourceSplit, CheckpointT>
+            implements SplitEnumerator<SplitT, CheckpointT> {
+        private final SplitEnumerator<SplitT, CheckpointT> enumerator;
+        private final SplitEnumeratorContext<SplitT> context;
+
+        private final boolean isBacklog;
+
+        private EnumeratorWithBacklogReport(
+                SplitEnumerator<SplitT, CheckpointT> enumerator,
+                SplitEnumeratorContext<SplitT> context,
+                boolean isBacklog) {
+            this.enumerator = enumerator;
+            this.context = context;
+            this.isBacklog = isBacklog;
+        }
+
+        @Override
+        public void start() {
+            this.enumerator.start();
+            this.context.setIsProcessingBacklog(isBacklog);
+        }
+
+        @Override
+        public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+            this.enumerator.handleSplitRequest(subtaskId, requesterHostname);
+        }
+
+        @Override
+        public void addSplitsBack(List<SplitT> splits, int subtaskId) {
+            this.enumerator.addSplitsBack(splits, subtaskId);
+        }
+
+        @Override
+        public void addReader(int subtaskId) {
+            this.enumerator.addReader(subtaskId);
+        }
+
+        @Override
+        public CheckpointT snapshotState(long checkpointId) throws Exception {
+            return this.enumerator.snapshotState(checkpointId);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.enumerator.close();
+        }
+    }
+
+    private static class CheckpointRecordingOperator<T> extends AbstractStreamOperator<T>
+            implements OneInputStreamOperator<T, T> {
+        private static final AtomicInteger numCheckpointsBeforeSwitchSource = new AtomicInteger(0);
+        private static final AtomicInteger numCheckpointsAfterSwitchSource = new AtomicInteger(0);
+
+        private int numRecords;
+
+        private CheckpointRecordingOperator() {
+            numRecords = 0;
+        }
+
+        private static void reset() {
+            numCheckpointsBeforeSwitchSource.set(0);
+            numCheckpointsAfterSwitchSource.set(0);
+        }
+
+        @Override
+        public void processElement(StreamRecord<T> element) {
+            numRecords++;
+            output.collect(element);
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) {
+            if (numRecords < NUM_RECORDS / 2) {
+                numCheckpointsBeforeSwitchSource.incrementAndGet();
+            } else {
+                numCheckpointsAfterSwitchSource.incrementAndGet();
+            }
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/util/NumberSequenceSourceWithWaitForCheckpoint.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/NumberSequenceSourceWithWaitForCheckpoint.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+import org.apache.flink.core.io.InputStatus;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * A {@link NumberSequenceSource} guaranteeing that a checkpoint has been invoked before the source
+ * ends its input.
+ */
+public class NumberSequenceSourceWithWaitForCheckpoint extends NumberSequenceSource {
+    private static final long serialVersionUID = 1L;
+
+    private final int numSplits;
+    private final long numAllowedMessageBeforeCheckpoint;
+
+    public NumberSequenceSourceWithWaitForCheckpoint(long from, long to, int numSplits) {
+        super(from, to);
+        this.numSplits = numSplits;
+        this.numAllowedMessageBeforeCheckpoint = (to - from) / numSplits;
+    }
+
+    @Override
+    public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>> createEnumerator(
+            final SplitEnumeratorContext<NumberSequenceSplit> enumContext) {
+        final List<NumberSequenceSplit> splits = splitNumberRange(getFrom(), getTo(), numSplits);
+        return new AssignAfterCheckpointEnumerator<>(enumContext, splits);
+    }
+
+    @Override
+    public SourceReader<Long, NumberSequenceSplit> createReader(SourceReaderContext readerContext) {
+        return new CheckpointListeningIteratorSourceReader<>(
+                readerContext, numAllowedMessageBeforeCheckpoint);
+    }
+
+    /**
+     * This is an enumerator for the {@link NumberSequenceSource}, which only responds to the split
+     * requests after the next checkpoint is complete. That way, we naturally draw the split
+     * processing across checkpoints without artificial sleep statements.
+     */
+    private static final class AssignAfterCheckpointEnumerator<
+                    SplitT extends IteratorSourceSplit<?, ?>>
+            extends IteratorSourceEnumerator<SplitT> {
+        private final Queue<Integer> pendingRequests = new ArrayDeque<>();
+        private final SplitEnumeratorContext<?> context;
+
+        public AssignAfterCheckpointEnumerator(
+                SplitEnumeratorContext<SplitT> context, Collection<SplitT> splits) {
+            super(context, splits);
+            this.context = context;
+        }
+
+        @Override
+        public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+            pendingRequests.add(subtaskId);
+        }
+
+        @Override
+        public Collection<SplitT> snapshotState(long checkpointId) throws Exception {
+            // this will be enqueued in the enumerator thread, so it will actually run after this
+            // method (the snapshot operation) is complete!
+            context.runInCoordinatorThread(this::fullFillPendingRequests);
+
+            return super.snapshotState(checkpointId);
+        }
+
+        private void fullFillPendingRequests() {
+            for (int subtask : pendingRequests) {
+                // respond only to requests for which we still have registered readers
+                if (!context.registeredReaders().containsKey(subtask)) {
+                    continue;
+                }
+                super.handleSplitRequest(subtask, null);
+            }
+            pendingRequests.clear();
+        }
+    }
+
+    private static class CheckpointListeningIteratorSourceReader<
+                    E, IterT extends Iterator<E>, SplitT extends IteratorSourceSplit<E, IterT>>
+            extends IteratorSourceReader<E, IterT, SplitT> {
+        private boolean checkpointed = false;
+        private long messagesProduced = 0;
+        private final long numAllowedMessageBeforeCheckpoint;
+
+        public CheckpointListeningIteratorSourceReader(
+                SourceReaderContext context, long waitForCheckpointAfterMessages) {
+            super(context);
+            this.numAllowedMessageBeforeCheckpoint = waitForCheckpointAfterMessages;
+        }
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<E> output) {
+            if (messagesProduced < numAllowedMessageBeforeCheckpoint || checkpointed) {
+                messagesProduced++;
+                return super.pollNext(output);
+            } else {
+                return InputStatus.NOTHING_AVAILABLE;
+            }
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            checkpointed = true;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support that a Flink job can change its checkpointing interval depending on the process backlog status of the job.


## Brief change log

- Adds configuration `execution.checkpointing.interval-during-backlog`
- Adds public method `SplitEnumeratorContext#setIsProcessingBacklog`
- Makes HybridSource reports processing backlog depending on source stages
- Supports changing checkpoint interval based on process backlog in CheckpointCoordinator

## Verifying this change

This change added tests and can be verified as follows:

- Added integration tests for changing checkpointing intervals.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & JavaDocs
