### PR TITLE
[FLINK-26549][table][tests] Add tests for INSERT INTO with VALUES leads to wrong type inference with nested types

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
@@ -33,6 +34,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.RowType;
@@ -50,9 +52,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,6 +170,48 @@ class FlinkTypeFactoryTest {
         assertThat(typeFactory.builder().add("f0", genericRelType).build())
                 .as("The type expect to be not canonized")
                 .isNotEqualTo(typeFactory.builder().add("f0", genericRelType3).build());
+    }
+
+    static Stream<Arguments> testLeastRestrictive() {
+        return Stream.of(
+                Arguments.of(
+                        Arrays.asList(
+                                new ArrayType(new VarCharType(6)),
+                                new ArrayType(VarCharType.STRING_TYPE),
+                                new ArrayType(new CharType(1))),
+                        new ArrayType(VarCharType.STRING_TYPE)),
+                Arguments.of(
+                        Arrays.asList(
+                                new MultisetType(new VarCharType(6)),
+                                new MultisetType(VarCharType.STRING_TYPE),
+                                new MultisetType(new CharType(1))),
+                        new MultisetType(VarCharType.STRING_TYPE)),
+                Arguments.of(
+                        Arrays.asList(
+                                new MapType(new CharType(1), new CharType(1)),
+                                new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE)),
+                        new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE)),
+                Arguments.of(
+                        Arrays.asList(
+                                new MapType(new CharType(1), new VarCharType(6)),
+                                new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE),
+                                new MapType(new CharType(1), new CharType(1))),
+                        new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE)));
+    }
+
+    @MethodSource("testLeastRestrictive")
+    @ParameterizedTest
+    void testLeastRestrictive(List<LogicalType> input, LogicalType expected) {
+        FlinkTypeFactory typeFactory =
+                new FlinkTypeFactory(
+                        Thread.currentThread().getContextClassLoader(), FlinkTypeSystem.INSTANCE);
+
+        assertThat(
+                        typeFactory.leastRestrictive(
+                                input.stream()
+                                        .map(typeFactory::createFieldTypeFromLogicalType)
+                                        .collect(Collectors.toList())))
+                .isEqualTo(typeFactory.createFieldTypeFromLogicalType(expected));
     }
 
     public static class TestClass {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
@@ -174,6 +174,12 @@ class FlinkTypeFactoryTest {
 
     static Stream<Arguments> testLeastRestrictive() {
         return Stream.of(
+                // Since the problem is actual for collection
+                // then tests are for array, map, multiset
+                // Also as https://issues.apache.org/jira/browse/CALCITE-4603 says
+                // before Calcite 1.27.0  it derived the type of nested collection based on the last
+                // element, for that reason the type of the last element is narrower
+                // than the type of element in the middle
                 Arguments.of(
                         Arrays.asList(
                                 new ArrayType(new VarCharType(6)),
@@ -189,7 +195,8 @@ class FlinkTypeFactoryTest {
                 Arguments.of(
                         Arrays.asList(
                                 new MapType(new CharType(1), new CharType(1)),
-                                new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE)),
+                                new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE),
+                                new MapType(new CharType(1), new CharType(1))),
                         new MapType(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE)),
                 Arguments.of(
                         Arrays.asList(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.planner.utils.JavaStreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Test;
+
+/** Plan test for INSERT INTO. */
+public class InsertIntoValuesTest extends TableTestBase {
+    private final JavaStreamTableTestUtil util = javaStreamTestUtil();
+
+    @Test
+    public void testTypeInferenceWithNestedTypes() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE t1 ("
+                                + "  `mapWithStrings` MAP<STRING, STRING>,"
+                                + "  `mapWithBytes` MAP<STRING, BYTES>"
+                                + ") WITH ("
+                                + "   'connector' = 'values'"
+                                + ")");
+
+        util.verifyExecPlanInsert(
+                "INSERT INTO t1 VALUES "
+                        + "(MAP['a', '123', 'b', '123456'], MAP['k1', X'C0FFEE', 'k2', X'BABE']), "
+                        + "(CAST(NULL AS MAP<STRING, STRING>), CAST(NULL AS MAP<STRING, BYTES>)), "
+                        + "(MAP['a', '1', 'b', '1'], MAP['k1', X'10', 'k2', X'20'])");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.java
@@ -38,6 +38,9 @@ public class InsertIntoValuesTest extends TableTestBase {
                                 + "   'connector' = 'values'"
                                 + ")");
 
+        // As https://issues.apache.org/jira/browse/CALCITE-4603 says
+        // before Calcite 1.27.0 it derived the type of nested collection based on the last element,
+        // thus the type of the last element is narrower than the type of element in the middle
         util.verifyExecPlanInsert(
                 "INSERT INTO t1 VALUES "
                         + "(MAP['a', '123', 'b', '123456'], MAP['k1', X'C0FFEE', 'k2', X'BABE']), "

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/InsertIntoValuesTest.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testTypeInferenceWithNestedTypes">
+		<Resource name="ast">
+			<![CDATA[
+LogicalSink(table=[default_catalog.default_database.t1], fields=[EXPR$0, EXPR$1])
++- LogicalUnion(all=[true])
+   :- LogicalProject(EXPR$0=[MAP(_UTF-16LE'a', _UTF-16LE'123':VARCHAR(6) CHARACTER SET "UTF-16LE", _UTF-16LE'b', _UTF-16LE'123456':VARCHAR(6) CHARACTER SET "UTF-16LE")], EXPR$1=[MAP(_UTF-16LE'k1', X'c0ffee':VARBINARY(3), _UTF-16LE'k2', X'babe':VARBINARY(3))])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   :- LogicalProject(EXPR$0=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARCHAR(2147483647) CHARACTER SET "UTF-16LE") MAP], EXPR$1=[null:(VARCHAR(2147483647) CHARACTER SET "UTF-16LE", VARBINARY(2147483647)) MAP])
+   :  +- LogicalValues(tuples=[[{ 0 }]])
+   +- LogicalProject(EXPR$0=[MAP(_UTF-16LE'a', _UTF-16LE'1', _UTF-16LE'b', _UTF-16LE'1')], EXPR$1=[MAP(_UTF-16LE'k1', X'10':BINARY(1), _UTF-16LE'k2', X'20':BINARY(1))])
+      +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.t1], fields=[EXPR$0, EXPR$1])
++- Union(all=[true], union=[EXPR$0, EXPR$1])
+   :- Calc(select=[CAST(MAP('a', '123', 'b', '123456') AS (VARCHAR(2147483647), VARCHAR(2147483647)) MAP) AS EXPR$0, CAST(MAP('k1', X'c0ffee', 'k2', X'babe') AS (VARCHAR(2147483647), VARBINARY(2147483647)) MAP) AS EXPR$1])
+   :  +- Values(tuples=[[{ 0 }]])(reuse_id=[1])
+   :- Calc(select=[null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$0, null:(VARCHAR(2147483647), VARBINARY(2147483647)) MAP AS EXPR$1])
+   :  +- Reused(reference_id=[1])
+   +- Calc(select=[CAST(MAP('a', '1', 'b', '1') AS (VARCHAR(2147483647), VARCHAR(2147483647)) MAP) AS EXPR$0, CAST(MAP('k1', X'10', 'k2', X'20') AS (VARCHAR(2147483647), VARBINARY(2147483647)) MAP) AS EXPR$1])
+      +- Reused(reference_id=[1])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Sink(table=[default_catalog.default_database.t1], fields=[EXPR$0, EXPR$1])
++- Union(all=[true], union=[EXPR$0, EXPR$1])
+   :- Calc(select=[CAST(MAP('a', '123', 'b', '123456') AS (VARCHAR(2147483647), VARCHAR(2147483647)) MAP) AS EXPR$0, CAST(MAP('k1', X'c0ffee', 'k2', X'babe') AS (VARCHAR(2147483647), VARBINARY(2147483647)) MAP) AS EXPR$1])
+   :  +- Values(tuples=[[{ 0 }]])(reuse_id=[1])
+   :- Calc(select=[null:(VARCHAR(2147483647), VARCHAR(2147483647)) MAP AS EXPR$0, null:(VARCHAR(2147483647), VARBINARY(2147483647)) MAP AS EXPR$1])
+   :  +- Reused(reference_id=[1])
+   +- Calc(select=[CAST(MAP('a', '1', 'b', '1') AS (VARCHAR(2147483647), VARCHAR(2147483647)) MAP) AS EXPR$0, CAST(MAP('k1', X'10', 'k2', X'20') AS (VARCHAR(2147483647), VARBINARY(2147483647)) MAP) AS EXPR$1])
+      +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
+</Root>


### PR DESCRIPTION

## What is the purpose of the change

The PR adds tsets confirming that the issue from previous versions (before Calcite 1.27.0) is fixed


## Brief change log

2 tests from FLINK-26549


## Verifying this change

The PR itself adds only tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
