### PR TITLE
[FLINK-32459][connector] Force set the parallelism of SocketTableSource to 1

### DIFF
--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketDynamicTableSource.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketDynamicTableSource.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.table.examples.java.connectors;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
-import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
@@ -38,6 +42,9 @@ import org.apache.flink.table.types.DataType;
  * found in {@link #getScanRuntimeProvider(ScanContext)} where we instantiate the required {@link
  * Source} and its {@link DeserializationSchema} for runtime. Both instances are parameterized to
  * return internal data structures (i.e. {@link RowData}).
+ *
+ * <p>Note: This is only an example and should not be used in production. The source is not
+ * fault-tolerant and can only work with a parallelism of 1.
  */
 public final class SocketDynamicTableSource implements ScanTableSource {
 
@@ -69,16 +76,28 @@ public final class SocketDynamicTableSource implements ScanTableSource {
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        return new DataStreamScanProvider() {
+            @Override
+            public DataStream<RowData> produceDataStream(
+                    ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+                final DeserializationSchema<RowData> deserializer =
+                        decodingFormat.createRuntimeDecoder(
+                                runtimeProviderContext, producedDataType);
 
-        // create runtime classes that are shipped to the cluster
+                final SocketSource socketSource =
+                        new SocketSource(hostname, port, byteDelimiter, deserializer);
 
-        final DeserializationSchema<RowData> deserializer =
-                decodingFormat.createRuntimeDecoder(runtimeProviderContext, producedDataType);
+                return execEnv.fromSource(
+                                socketSource, WatermarkStrategy.noWatermarks(), "SocketSource")
+                        // SocketSource can only work with a parallelism of 1.
+                        .setParallelism(1);
+            }
 
-        final SocketSource socketSource =
-                new SocketSource(hostname, port, byteDelimiter, deserializer);
-
-        return SourceProvider.of(socketSource);
+            @Override
+            public boolean isBounded() {
+                return false;
+            }
+        };
     }
 
     @Override

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketSource.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketSource.java
@@ -35,6 +35,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.examples.java.connectors.SocketSource.DummyCheckpoint;
 import org.apache.flink.table.examples.java.connectors.SocketSource.DummySplit;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.ByteArrayOutputStream;
@@ -114,6 +115,9 @@ public final class SocketSource
     @Override
     public SourceReader<RowData, DummySplit> createReader(SourceReaderContext readerContext)
             throws Exception {
+        Preconditions.checkState(
+                readerContext.currentParallelism() == 1,
+                "SocketSource can only work with a parallelism of 1.");
         deserializer.open(
                 new DeserializationSchema.InitializationContext() {
                     @Override


### PR DESCRIPTION
## What is the purpose of the change

*`SocketSource` can only work with parallelism of 1, It is best to force set it when load it in `DynamicTableSource`.*


## Brief change log

  - *Force set the parallelism of `SocketTableSource` to `1`*
  - *Check parallelism of `SocketSource` when createReader.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
