### PR TITLE
[FLINK-32381][runtime] Replaces FatalErrorHandler by Listener.onError

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
 import org.apache.flink.runtime.leaderelection.LeaderElectionDriver;
 import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.Preconditions;
 
 import java.util.concurrent.Executor;
@@ -52,15 +51,12 @@ public class KubernetesLeaderElectionDriverFactory implements LeaderElectionDriv
 
     @Override
     public KubernetesLeaderElectionDriver create(
-            LeaderElectionDriver.Listener leaderElectionListener,
-            FatalErrorHandler fatalErrorHandler)
-            throws Exception {
+            LeaderElectionDriver.Listener leaderElectionListener) throws Exception {
         return new KubernetesLeaderElectionDriver(
                 kubernetesLeaderElectionConfiguration,
                 kubeClient,
                 leaderElectionListener,
                 configMapSharedWatcher,
-                watchExecutor,
-                fatalErrorHandler);
+                watchExecutor);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -596,12 +596,6 @@ public class KubernetesUtils {
         }
     }
 
-    /** Cluster components. */
-    public enum ClusterComponent {
-        JOB_MANAGER,
-        TASK_MANAGER
-    }
-
     public static String encodeLeaderInformation(LeaderInformation leaderInformation) {
         Preconditions.checkArgument(leaderInformation.getLeaderSessionID() != null);
         Preconditions.checkArgument(leaderInformation.getLeaderAddress() != null);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalDriver;
 import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandler;
-import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.function.RunnableWithException;
@@ -83,8 +82,6 @@ class KubernetesHighAvailabilityTestBase {
         final LeaderElectionDriver leaderElectionDriver;
         final TestingLeaderElectionListener electionEventHandler;
 
-        final TestingFatalErrorHandler fatalErrorHandler;
-
         final LeaderRetrievalDriver leaderRetrievalDriver;
         final TestingLeaderRetrievalEventHandler retrievalEventHandler;
 
@@ -108,7 +105,6 @@ class KubernetesHighAvailabilityTestBase {
             deleteConfigMapByLabelsFuture =
                     kubernetesTestFixture.getDeleteConfigMapByLabelsFuture();
             electionEventHandler = new TestingLeaderElectionListener();
-            fatalErrorHandler = new TestingFatalErrorHandler();
             leaderElectionDriver = createLeaderElectionDriver();
 
             retrievalEventHandler = new TestingLeaderRetrievalEventHandler();
@@ -123,7 +119,7 @@ class KubernetesHighAvailabilityTestBase {
                 leaderRetrievalDriver.close();
                 kubernetesTestFixture.close();
 
-                fatalErrorHandler.rethrowError();
+                electionEventHandler.failIfErrorEventHappened();
             }
         }
 
@@ -197,7 +193,7 @@ class KubernetesHighAvailabilityTestBase {
                             leaderConfig,
                             kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService);
-            return factory.create(electionEventHandler, fatalErrorHandler);
+            return factory.create(electionEventHandler);
         }
 
         private LeaderRetrievalDriver createLeaderRetrievalDriver() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -94,8 +94,6 @@ class KubernetesLeaderElectionAndRetrievalITCase {
 
         final TestingLeaderElectionListener electionEventHandler =
                 new TestingLeaderElectionListener();
-        final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
-
         try {
             final KubernetesLeaderElectionDriver leaderElectionDriver =
                     new KubernetesLeaderElectionDriver(
@@ -104,8 +102,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
                             flinkKubeClient,
                             electionEventHandler,
                             configMapSharedWatcher,
-                            EXECUTOR_EXTENSION.getExecutor(),
-                            fatalErrorHandler);
+                            EXECUTOR_EXTENSION.getExecutor());
             closeables.add(leaderElectionDriver);
 
             final KubernetesLeaderRetrievalDriverFactory driverFactory =
@@ -115,6 +112,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
                             configMapName,
                             contenderID);
 
+            final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
             final TestingLeaderRetrievalEventHandler firstLeaderRetrievalEventHandler =
                     new TestingLeaderRetrievalEventHandler();
             closeables.add(
@@ -144,6 +142,8 @@ class KubernetesLeaderElectionAndRetrievalITCase {
             }
 
             flinkKubeClient.deleteConfigMap(configMapName).get();
+
+            electionEventHandler.failIfErrorEventHappened();
         }
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -89,11 +89,13 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
 
                             final String expectedErrorMessage =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
-                            assertThat(fatalErrorHandler.getException())
+
+                            final LeaderElectionEvent.ErrorEvent errorEvent =
+                                    electionEventHandler.await(
+                                            LeaderElectionEvent.ErrorEvent.class);
+                            assertThat(errorEvent.getError())
                                     .isInstanceOf(KubernetesException.class)
                                     .hasMessageContaining(expectedErrorMessage);
-
-                            fatalErrorHandler.clearError();
                         });
             }
         };
@@ -129,12 +131,13 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
 
                             final String expectedErrorMessage =
                                     "ConfigMap " + LEADER_CONFIGMAP_NAME + " does not exist.";
-                            assertThat(fatalErrorHandler.getException())
+                            final LeaderElectionEvent.ErrorEvent errorEvent =
+                                    electionEventHandler.assertNextEvent(
+                                            LeaderElectionEvent.ErrorEvent.class);
+                            assertThat(errorEvent.getError())
                                     .cause()
                                     .isInstanceOf(KubernetesException.class)
                                     .hasMessage(expectedErrorMessage);
-
-                            fatalErrorHandler.clearError();
                         });
             }
         };
@@ -210,11 +213,12 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                     "ConfigMap "
                                             + LEADER_CONFIGMAP_NAME
                                             + " has been deleted externally.";
-                            assertThat(fatalErrorHandler.getException())
+                            final LeaderElectionEvent.ErrorEvent errorEvent =
+                                    electionEventHandler.await(
+                                            LeaderElectionEvent.ErrorEvent.class);
+                            assertThat(errorEvent.getError())
                                     .isInstanceOf(LeaderElectionException.class)
                                     .hasMessage(expectedErrorMessage);
-
-                            fatalErrorHandler.clearError();
                         });
             }
         };
@@ -237,11 +241,14 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                     "Error while watching the ConfigMap "
                                             + LEADER_CONFIGMAP_NAME
                                             + ".";
-                            assertThat(fatalErrorHandler.getException())
+
+                            final LeaderElectionEvent.ErrorEvent errorEvent =
+                                    electionEventHandler.await(
+                                            LeaderElectionEvent.ErrorEvent.class);
+
+                            assertThat(errorEvent.getError())
                                     .isInstanceOf(LeaderElectionException.class)
                                     .hasMessage(expectedErrorMessage);
-
-                            fatalErrorHandler.clearError();
                         });
             }
         };

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -181,8 +181,7 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
 
             running = true;
 
-            leaderElectionDriver =
-                    leaderElectionDriverFactory.create(this, new LeaderElectionFatalErrorHandler());
+            leaderElectionDriver = leaderElectionDriverFactory.create(this);
 
             LOG.info(
                     "A connection to the HA backend was established through LeaderElectionDriver {}.",
@@ -590,11 +589,8 @@ public class DefaultLeaderElectionService extends AbstractLeaderElectionService
         }
     }
 
-    private class LeaderElectionFatalErrorHandler implements FatalErrorHandler {
-
-        @Override
-        public void onFatalError(Throwable throwable) {
-            forwardErrorToLeaderContender(throwable);
-        }
+    @Override
+    public void onError(Throwable t) {
+        forwardErrorToLeaderContender(t);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
@@ -66,5 +66,8 @@ public interface LeaderElectionDriver extends AutoCloseable {
 
         /** Notifies the listener about all currently known leader information. */
         void onLeaderInformationChange(LeaderInformationRegister leaderInformationRegister);
+
+        /** Notifies the listener if an error occurred. */
+        void onError(Throwable t);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriverFactory.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
-
 /** Factory for {@link LeaderElectionDriver}. */
 public interface LeaderElectionDriverFactory {
 
@@ -28,12 +26,9 @@ public interface LeaderElectionDriverFactory {
      * it registers the given leader election listener with the service.
      *
      * @param leaderElectionListener listener for the callbacks of the {@link LeaderElectionDriver}
-     * @param fatalErrorHandler component for handling fatal errors.
      * @return created {@link LeaderElectionDriver} instance
      * @throws Exception if the creation fails
      */
-    LeaderElectionDriver create(
-            LeaderElectionDriver.Listener leaderElectionListener,
-            FatalErrorHandler fatalErrorHandler)
+    LeaderElectionDriver create(LeaderElectionDriver.Listener leaderElectionListener)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
@@ -34,10 +33,7 @@ public class ZooKeeperLeaderElectionDriverFactory implements LeaderElectionDrive
 
     @Override
     public ZooKeeperLeaderElectionDriver create(
-            LeaderElectionDriver.Listener leaderElectionListener,
-            FatalErrorHandler fatalErrorHandler)
-            throws Exception {
-        return new ZooKeeperLeaderElectionDriver(
-                curatorFramework, leaderElectionListener, fatalErrorHandler);
+            LeaderElectionDriver.Listener leaderElectionListener) throws Exception {
+        return new ZooKeeperLeaderElectionDriver(curatorFramework, leaderElectionListener);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -182,11 +182,10 @@ class AbstractHaServicesTest {
                 BlobStoreService blobStoreService,
                 Queue<? super CloseOperations> closeOperations,
                 RunnableWithException internalCleanupRunnable,
-                ThrowingConsumer<JobID, Exception> internalJobCleanupConsumer)
-                throws Exception {
+                ThrowingConsumer<JobID, Exception> internalJobCleanupConsumer) {
             super(
                     config,
-                    (listener, fatalErrorHandler) -> null,
+                    listener -> null,
                     ioExecutor,
                     blobStoreService,
                     TestingJobResultStore.builder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -220,10 +220,9 @@ class DefaultLeaderElectionServiceTest {
         final UUID expectedLeaderSessionID = UUID.randomUUID();
         try (final DefaultLeaderElectionService testInstance =
                 new DefaultLeaderElectionService(
-                        (listener, errorHandler) -> {
+                        listener -> {
                             listener.onGrantLeadership(expectedLeaderSessionID);
-                            return TestingLeaderElectionDriver.newNoOpBuilder()
-                                    .build(listener, errorHandler);
+                            return TestingLeaderElectionDriver.newNoOpBuilder().build(listener);
                         },
                         fatalErrorHandlerExtension.getTestingFatalErrorHandler(),
                         Executors.newDirectExecutorService())) {
@@ -967,7 +966,7 @@ class DefaultLeaderElectionServiceTest {
                         () -> {
                             final Exception testException = new Exception("test leader exception");
 
-                            testingLeaderElectionDriver.triggerFatalError(testException);
+                            leaderElectionService.onError(testException);
 
                             applyToBothContenderContexts(
                                     contenderContext -> {
@@ -992,7 +991,7 @@ class DefaultLeaderElectionServiceTest {
 
                             final Exception testException = new Exception("test leader exception");
 
-                            testingLeaderElectionDriver.triggerFatalError(testException);
+                            leaderElectionService.onError(testException);
 
                             applyToBothContenderContexts(
                                     ctx ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
@@ -38,6 +38,10 @@ public abstract class LeaderElectionEvent {
         return false;
     }
 
+    public boolean isErrorEvent() {
+        return false;
+    }
+
     public IsLeaderEvent asIsLeaderEvent() {
         return as(IsLeaderEvent.class);
     }
@@ -112,6 +116,28 @@ public abstract class LeaderElectionEvent {
 
         public LeaderInformationRegister getLeaderInformationRegister() {
             return leaderInformationRegister;
+        }
+    }
+
+    /**
+     * A {@code LeaderElectionEvent} that's triggered by {@link
+     * LeaderElectionDriver.Listener#onError(Throwable)}.
+     */
+    public static class ErrorEvent extends LeaderElectionEvent {
+
+        private final Throwable error;
+
+        ErrorEvent(Throwable error) {
+            this.error = error;
+        }
+
+        public Throwable getError() {
+            return error;
+        }
+
+        @Override
+        public boolean isErrorEvent() {
+            return true;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Simple {@link LeaderElectionDriver.Listener} implementation for testing purposes. */
 public final class TestingLeaderElectionListener implements LeaderElectionDriver.Listener {
     private final BlockingQueue<LeaderElectionEvent> leaderElectionEvents =
@@ -53,12 +55,29 @@ public final class TestingLeaderElectionListener implements LeaderElectionDriver
         put(new LeaderElectionEvent.AllLeaderInformationChangeEvent(leaderInformationRegister));
     }
 
+    @Override
+    public void onError(Throwable t) {
+        put(new LeaderElectionEvent.ErrorEvent(t));
+    }
+
     private void put(LeaderElectionEvent leaderElectionEvent) {
         try {
             leaderElectionEvents.put(leaderElectionEvent);
         } catch (InterruptedException e) {
             ExceptionUtils.rethrow(e);
         }
+    }
+
+    public <T> T assertNextEvent(Class<T> expectedEventClass) throws InterruptedException {
+        final LeaderElectionEvent leaderElectionEvent = leaderElectionEvents.take();
+
+        assertThat(leaderElectionEvent)
+                .as(
+                        "The next event didn't match the expected event type %s.",
+                        expectedEventClass.getSimpleName())
+                .isInstanceOf(expectedEventClass);
+
+        return leaderElectionEvent.as(expectedEventClass);
     }
 
     public <T> T await(Class<T> clazz) throws InterruptedException {
@@ -96,5 +115,38 @@ public final class TestingLeaderElectionListener implements LeaderElectionDriver
                 }
             }
         }
+    }
+
+    /**
+     * Returns the next {@link
+     * org.apache.flink.runtime.leaderelection.LeaderElectionEvent.ErrorEvent} or an empty {@code
+     * Optional} if no such event happened. Any other not-yet processed events that happened before
+     * the error will be removed from the queue. This method doesn't wait for events but processes
+     * the queue in its current state.
+     */
+    public Optional<LeaderElectionEvent.ErrorEvent> getNextErrorEvent() {
+        while (!leaderElectionEvents.isEmpty()) {
+            final LeaderElectionEvent event = leaderElectionEvents.remove();
+            if (event.isErrorEvent()) {
+                return Optional.of(event.as(LeaderElectionEvent.ErrorEvent.class));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Throws an {@code AssertionError} if an {@link LeaderElectionEvent.ErrorEvent} was observed.
+     * This method can be used to ensure that any error that was triggered unexpectedly is exposed
+     * within the test.
+     */
+    public void failIfErrorEventHappened() {
+        getNextErrorEvent()
+                .ifPresent(
+                        error -> {
+                            throw new AssertionError(
+                                    "An error was reported that wasn't properly handled.",
+                                    error.getError());
+                        });
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -175,7 +175,10 @@ class ZooKeeperLeaderElectionTest {
             for (int i = 0; i < num; i++) {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
+                leaderElectionService[i] =
+                        new DefaultLeaderElectionService(
+                                driverFactory,
+                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
                 leaderElectionService[i].startLeaderElectionBackend();
                 leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
                 contenders[i] = new TestingContender(createAddress(i), leaderElections[i]);
@@ -276,7 +279,10 @@ class ZooKeeperLeaderElectionTest {
             for (int i = 0; i < num; i++) {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
+                leaderElectionService[i] =
+                        new DefaultLeaderElectionService(
+                                driverFactory,
+                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
                 leaderElectionService[i].startLeaderElectionBackend();
                 leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
                 contenders[i] =
@@ -311,7 +317,10 @@ class ZooKeeperLeaderElectionTest {
                     // create new leader election service which takes part in the leader election
                     final LeaderElectionDriverFactory driverFactory =
                             new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
-                    leaderElectionService[index] = new DefaultLeaderElectionService(driverFactory);
+                    leaderElectionService[index] =
+                            new DefaultLeaderElectionService(
+                                    driverFactory,
+                                    testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
                     leaderElectionService[index].startLeaderElectionBackend();
                     leaderElections[index] =
                             leaderElectionService[index].createLeaderElection(CONTENDER_ID);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -140,6 +140,7 @@ class ZooKeeperLeaderRetrievalTest {
                             AddressResolution.NO_ADDRESS_RESOLUTION,
                             config);
 
+            final TestingLeaderElectionListener listener = new TestingLeaderElectionListener();
             try {
                 InetSocketAddress correctInetSocketAddress =
                         new InetSocketAddress(localHost, serverSocket.getLocalPort());
@@ -161,8 +162,7 @@ class ZooKeeperLeaderRetrievalTest {
                                                 testingFatalErrorHandlerResource
                                                         .getTestingFatalErrorHandler()),
                                         ZooKeeperUtils.generateLeaderLatchPath("")),
-                                new TestingLeaderElectionListener(),
-                                testingFatalErrorHandlerResource.getTestingFatalErrorHandler());
+                                listener);
                 externalProcessDriver.isLeader();
 
                 externalProcessDriver.publishLeaderInformation(
@@ -209,6 +209,7 @@ class ZooKeeperLeaderRetrievalTest {
                 if (leaderElection != null) {
                     leaderElection.close();
                 }
+                listener.failIfErrorEventHappened();
             }
         } catch (IOException e) {
             // may happen in certain test setups, skip test.


### PR DESCRIPTION
## PR Hierarchy

* https://github.com/apache/flink/pull/21742
* https://github.com/apache/flink/pull/22379
* https://github.com/apache/flink/pull/22422
* https://github.com/apache/flink/pull/22380
* https://github.com/apache/flink/pull/22623
* https://github.com/apache/flink/pull/22384
* https://github.com/apache/flink/pull/22390
* https://github.com/apache/flink/pull/22404
* https://github.com/apache/flink/pull/22601
* https://github.com/apache/flink/pull/22642
* https://github.com/apache/flink/pull/22640
* https://github.com/apache/flink/pull/22656
* https://github.com/apache/flink/pull/22828
* https://github.com/apache/flink/pull/22830
* https://github.com/apache/flink/pull/22829
* https://github.com/apache/flink/pull/22661
* https://github.com/apache/flink/pull/22844
* https://github.com/apache/flink/pull/22848
* https://github.com/apache/flink/pull/22873
* === THIS PR === FLINK-32381

## What is the purpose of the change

The driver has two different ways to communicate with the `DefaultLeaderElectionService` right now:
(1) Through the `Listener` interface
(2) Through the `FatalErrorHandler`

This PR merges the two ways into a single communication channel through the `Listener` interface

## Brief change log

* Removed `FatalErrorHandler` field from driver and its constructor
* Adds `onError` to `Listener` interface

## Verifying this change

* `TestingLeaderElectionListener` implements `onError` and some helper methods to retrieve any outstanding error
* `TestingLeaderElectionListener` is used in tests where `FatalErrorHandler` was used beforehand

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable