### PR TITLE
FLINK-28171 enable add appProtocol via the configuration

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -289,5 +290,28 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                                         KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL),
                                 "NotIn",
                                 new ArrayList<>(BLOCKED_NODES)));
+    }
+
+    @Test
+    void testMainContainerPortsAsInput() {
+        Container podMainContainer = new ContainerBuilder().build();
+        ContainerPort rpcConatinerPort =
+                new ContainerPortBuilder()
+                        .withName(Constants.TASK_MANAGER_RPC_PORT_NAME)
+                        .withContainerPort(RPC_PORT)
+                        .build();
+        rpcConatinerPort.setAdditionalProperty("appProtocol", "tcp");
+        podMainContainer.setPorts(Arrays.asList(rpcConatinerPort));
+        final FlinkPod baseFlinkPodWithPorts =
+                new FlinkPod.Builder().withMainContainer(podMainContainer).build();
+
+        final InitTaskManagerDecorator initTaskManagerDecorator =
+                new InitTaskManagerDecorator(kubernetesTaskManagerParameters);
+
+        final FlinkPod resultFlinkPodWithPort =
+                initTaskManagerDecorator.decorateFlinkPod(baseFlinkPodWithPorts);
+        final List<ContainerPort> expectedContainerPorts = Arrays.asList(rpcConatinerPort);
+        assertThat(resultFlinkPodWithPort.getMainContainer().getPorts())
+                .isEqualTo(expectedContainerPorts);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
enable the job manager and task manager communicate in a Kubernetes cluster with Istio and mTLS enabled.

## Brief change log
Add the “appProtocol” in the task manager and job manager configuration, verify they are not overridden by the default definition in the decorators

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, - -ZooKeeper: (yes / no / don't know)
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not documented