### PR TITLE
[FLINK-32327][python] Fix PyFlink Kafka support to support JDK17

### DIFF
--- a/flink-python/pyflink/datastream/connectors/kafka.py
+++ b/flink-python/pyflink/datastream/connectors/kafka.py
@@ -961,7 +961,11 @@ class KafkaSinkBuilder(object):
             'CachingTopicSelector'
         ) and (
             get_field_value(j_topic_selector, 'topicSelector').getClass().getCanonicalName()
-                .startswith('com.sun.proxy')
+            is not None and
+            (get_field_value(j_topic_selector, 'topicSelector').getClass().getCanonicalName()
+             .startswith('com.sun.proxy') or
+             get_field_value(j_topic_selector, 'topicSelector').getClass().getCanonicalName()
+             .startswith('jdk.proxy'))
         ):
             record_serializer._wrap_serialization_schema()
             self._preprocessing = record_serializer._build_preprocessing()


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes PyFlink Kafka connector support to support JDK17*


## Verifying this change

This change is already covered by existing tests, such as *test_kafka.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
