### PR TITLE
[FLINK-32525][Deployment/YARN] Remove dependency convergence line for commons-beanutils

### DIFF
--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -255,14 +255,6 @@ under the License.
 		<dependencies>
 			<dependency>
 				<!-- dependency convergence -->
-				<groupId>commons-beanutils</groupId>
-				<artifactId>commons-beanutils</artifactId>
-				<!-- Beanutils 1.9.+ doesn't work with Hadoop 2 -->
-				<version>1.8.3</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<!-- dependency convergence -->
 				<groupId>org.codehaus.woodstox</groupId>
 				<artifactId>stax2-api</artifactId>
 				<version>4.2.1</version>


### PR DESCRIPTION
## What is the purpose of the change

* Remove tech debt on outdated commons-beanutils

## Brief change log

* Removed dependency convergence line

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
