### PR TITLE
Fix typo on schema_evolution.md

### DIFF
--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
@@ -106,7 +106,7 @@ Flink fully supports evolving schema of Avro type state, as long as the schema c
 One limitation is that Avro generated classes used as the state type cannot be relocated or have different
 namespaces when the job is restored.
 
-## Schema Migration Limiations
+## Schema Migration Limitations
 
 Flink's schema migration has some limitations that are required to ensure correctness. For users that need to work
 around these limitations, and understand them to be safe in their specific use-case, consider using


### PR DESCRIPTION
## What is the purpose of the change

Fix typo on word Limitation


## Brief change log

- Fix typo on word limitations on file schema_evolution.md


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
