### PR TITLE
[FLINK-32530][table] Fix array_position return null value semantic, w…

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -636,7 +636,7 @@ collection:
     description: Returns an array with unique elements. If the array itself is null, the function will return null. Keeps ordering of elements.
   - sql: ARRAY_POSITION(haystack, needle)
     table: haystack.arrayPosition(needle)
-    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
+    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. If the array itself is null, the function will return null. And this is not zero based, but 1-based index. The first element in the array has index 1.
   - sql: ARRAY_REMOVE(haystack, needle)
     table: haystack.arrayRemove(needle)
     description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -738,7 +738,7 @@ collection:
     description: Returns an array with unique elements. If the array itself is null, the function will return null. Keeps ordering of elements.
   - sql: ARRAY_POSITION(haystack, needle)
     table: haystack.arrayPosition(needle)
-    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. Returns null if either of the arguments are null. And this is not zero based, but 1-based index. The first element in the array has index 1.
+    description: Returns the position of the first occurrence of element in the given array as int. Returns 0 if the given value could not be found in the array. If the array itself is null, the function will return null. And this is not zero based, but 1-based index. The first element in the array has index 1.
   - sql: ARRAY_REMOVE(haystack, needle)
     table: haystack.arrayRemove(needle)
     description: Removes all elements that equal to element from array. If the array itself is null, the function will return null. Keeps ordering of elements.

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1491,8 +1491,8 @@ class Expression(Generic[T]):
         """
         Returns the position of the first occurrence of element in the given array as int.
 
-        Returns 0 if the given value could not be found in the array. Returns null if either of the
-        arguments are null.
+        Returns 0 if the given value could not be found in the array. If the array itself is null,
+        the function will return null.
         NOTE: that this is not zero based, but 1-based index. The first element in the array
         has index 1.
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1370,8 +1370,8 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Returns the position of the first occurrence of element in the given array as int. Returns 0
-     * if the given value could not be found in the array. Returns null if either of the arguments
-     * are null
+     * if the given value could not be found in the array. If the array itself is null, the function
+     * will return null.
      *
      * <p>NOTE: that this is not zero based, but 1-based index. The first element in the array has
      * index 1.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -246,7 +246,8 @@ public final class BuiltInFunctionDefinitions {
                                     Arrays.asList("haystack", "needle"),
                                     Arrays.asList(
                                             logical(LogicalTypeRoot.ARRAY), ARRAY_ELEMENT_ARG)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT())))
+                    .outputTypeStrategy(
+                            nullableIfArgs(ConstantArgumentCount.of(0), explicit(DataTypes.INT())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayPositionFunction")
                     .build();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -226,7 +226,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     CollectionUtil.map(entry(3, "c"), entry(4, "d")),
                                 })
                         .andDataTypes(
-                                DataTypes.ARRAY(DataTypes.INT().notNull()).notNull(),
+                                DataTypes.ARRAY(DataTypes.INT()).notNull(),
                                 DataTypes.ARRAY(DataTypes.INT()),
                                 DataTypes.ARRAY(
                                         DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
@@ -240,8 +240,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").arrayPosition(null),
                                 "ARRAY_POSITION(f0, NULL)",
-                                null,
-                                DataTypes.INT())
+                                1,
+                                DataTypes.INT().notNull())
                         .testResult(
                                 $("f1").arrayPosition(2),
                                 "ARRAY_POSITION(f1, 2)",


### PR DESCRIPTION
the spark and flink's behavior is different.

```
spark: array_contains(array(1, null), null) -> null
flink: array_contains(array[1, null], null) -> true  
so array_remove is also different(the array_remove is  supported by me, which aligns with flink).
```
```
spark: array_remove(array(1, null), null) -> null 
flink: array_remove(array[1, null], null) -> 1  
while array_position is align with spark, i think it is not correct.
```

```
spark: array_position(array(1, null), null) -> null
flink: array_position(array[1, null], null) -> 2   
and i test on postgre which is also 2

postgre:
select array_position(ARRAY[1, null], null); 
```
so the semantic should only follow one way to handle null element. so i think it should be changed