### PR TITLE
[BP-1.16][FLINK-32314][rpc] Ignore classloading errors after actorsystem shutdown 

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/TestingUncaughtExceptionHandler.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/TestingUncaughtExceptionHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.util.concurrent;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -35,5 +36,9 @@ public class TestingUncaughtExceptionHandler implements Thread.UncaughtException
 
     public Throwable waitForUncaughtException() {
         return uncaughtExceptionFuture.join();
+    }
+
+    public Optional<Throwable> findUncaughtExceptionNow() {
+        return Optional.ofNullable(uncaughtExceptionFuture.getNow(null));
     }
 }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/RobustActorSystem.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/RobustActorSystem.java
@@ -65,13 +65,13 @@ public abstract class RobustActorSystem extends ActorSystemImpl {
                                 Optional.empty(),
                                 Optional.of(applicationConfig),
                                 Optional.empty())),
-                Option.apply(uncaughtExceptionHandler));
+                uncaughtExceptionHandler);
     }
 
     private static RobustActorSystem create(
             String name,
             ActorSystemSetup setup,
-            Option<Thread.UncaughtExceptionHandler> uncaughtExceptionHandler) {
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
         final Optional<BootstrapSetup> bootstrapSettings = setup.get(BootstrapSetup.class);
         final ClassLoader classLoader = RobustActorSystem.class.getClassLoader();
         final Config appConfig =
@@ -89,7 +89,7 @@ public abstract class RobustActorSystem extends ActorSystemImpl {
                 new RobustActorSystem(name, appConfig, classLoader, defaultEC, setup) {
                     @Override
                     public Thread.UncaughtExceptionHandler uncaughtExceptionHandler() {
-                        return uncaughtExceptionHandler.getOrElse(super::uncaughtExceptionHandler);
+                        return uncaughtExceptionHandler;
                     }
                 };
         robustActorSystem.start();


### PR DESCRIPTION
This is a backport of  https://github.com/apache/flink/pull/22764
It contains cherry-pick of 2 commits since the required one depends on [[hotfix] Simplify ActorSystem construction](https://github.com/apache/flink/commit/625e4db143d9ca5041e7b2d7875e413cb5f6f612)

the main reason is that same issue is still actual for 1.16 and 1.17
