### PR TITLE
[FLINK-32261]-table-Add-MAP_UNION-function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -658,6 +658,9 @@ collection:
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.
+  - sql: MAP_UNION(map1, map2)
+    table: map1.mapUnion(map2)
+    description: Returns a map created by merging two maps, 'map1' and 'map2'. These two maps should have same data structure. If there are overlapping keys, the value from 'map2' will overwrite the value from 'map1'. If any of maps is null, return null.
   - sql: MAP_VALUES(map)
     table: MAP.mapValues()
     description: Returns the values of the map as array. No order guaranteed.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -760,7 +760,9 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
-
+  - sql: MAP_UNION(map1, map2)
+    table: map1.mapUnion(map2)
+    description: 返回一个通过合并两个图 'map1' 和 'map2' 创建的图。这两个图应该有相同的数据结构。如果有重叠的键，'map2' 的值将覆盖 'map1' 的值。如果任一图为空，则返回 null。
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]
     table: STRING.isJson([JsonType type])

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -236,6 +236,7 @@ advanced type helper functions
     Expression.array_union
     Expression.map_entries
     Expression.map_keys
+    Expression.map_union
     Expression.map_values
 
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1559,6 +1559,18 @@ class Expression(Generic[T]):
         return _unary_op("mapKeys")(self)
 
     @property
+    def map_union(self, map2) -> 'Expression':
+        """
+        Returns a map created by merging two maps, 'map1' and 'map2'.
+        These two maps should have same data structure. If there are overlapping keys,
+        the value from 'map2' will overwrite the value from 'map1'.
+        If any of maps is null, return null.
+
+        .. seealso:: :py:attr:`~Expression.map_union`
+        """
+        return _binary_op("mapUnion")(self, map2)
+
+    @property
     def map_values(self) -> 'Expression':
         """
         Returns the values of the map as an array. No order guaranteed.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -126,6 +126,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LPAD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LTRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_ENTRIES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_KEYS;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_UNION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_VALUES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MD5;
@@ -1466,6 +1467,16 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns an array of all entries in the given map. */
     public OutType mapEntries() {
         return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
+    }
+
+    /**
+     * Returns a map created by merging two maps, 'map1' and 'map2'. These two maps should have same
+     * data structure. If there are overlapping keys, the value from 'map2' will overwrite the value
+     * from 'map1'. If any of maps is null, return null.
+     */
+    public OutType mapUnion(InType map2) {
+        return toApiSpecificExpression(
+                unresolvedCall(MAP_UNION, toExpr(), objectToExpression(map2)));
     }
 
     // Time definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -72,6 +72,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.TYPE_LI
 import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.arrayFullyComparableElementType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonArrayType;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.commonMapType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonMultipleArrayType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.comparable;
@@ -186,6 +187,16 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_FROM_ARRAYS))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.MapFromArraysFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition MAP_UNION =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_UNION")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonMapType(2))
+                    .outputTypeStrategy(COMMON)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapUnionFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition SOURCE_WATERMARK =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.inference.strategies.ArrayComparableElementT
 import org.apache.flink.table.types.inference.strategies.CommonArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonArrayInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonInputTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.CommonMapInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ComparableTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CompositeArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ConstraintArgumentTypeStrategy;
@@ -367,6 +368,14 @@ public final class InputTypeStrategies {
 
     public static InputTypeStrategy arrayFullyComparableElementType() {
         return new ArrayComparableElementTypeStrategy(StructuredComparison.FULL);
+    }
+
+    /**
+     * An {@link InputTypeStrategy} that expects {@code count} arguments that have a common map
+     * type.
+     */
+    public static InputTypeStrategy commonMapType(int count) {
+        return new CommonMapInputTypeStrategy(ConstantArgumentCount.of(count));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonMapInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonMapInputTypeStrategy.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** An {@link InputTypeStrategy} that expects that all arguments have a common map type. */
+@Internal
+public final class CommonMapInputTypeStrategy implements InputTypeStrategy {
+
+    private static final Argument COMMON_ARGUMENT = Argument.ofGroup("COMMON");
+
+    private final ArgumentCount argumentCount;
+
+    public CommonMapInputTypeStrategy(ArgumentCount argumentCount) {
+        this.argumentCount = argumentCount;
+    }
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return argumentCount;
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        List<LogicalType> argumentTypes =
+                argumentDataTypes.stream()
+                        .map(DataType::getLogicalType)
+                        .collect(Collectors.toList());
+
+        if (!argumentTypes.stream().allMatch(logicalType -> logicalType.is(LogicalTypeRoot.MAP))) {
+            return callContext.fail(throwOnFailure, "All arguments requires to be a MAP type");
+        }
+
+        if (argumentTypes.stream().anyMatch(CommonMapInputTypeStrategy::isLegacyType)) {
+            return Optional.of(argumentDataTypes);
+        }
+
+        Optional<LogicalType> commonType = LogicalTypeMerging.findCommonType(argumentTypes);
+
+        if (!commonType.isPresent()) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Could not find a common type for arguments: %s",
+                    argumentDataTypes);
+        }
+
+        return commonType.map(
+                type ->
+                        Collections.nCopies(
+                                argumentTypes.size(), TypeConversions.fromLogicalToDataType(type)));
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        Optional<Integer> minCount = argumentCount.getMinCount();
+        Optional<Integer> maxCount = argumentCount.getMaxCount();
+
+        int numberOfMandatoryArguments = minCount.orElse(0);
+
+        if (maxCount.isPresent()) {
+            return IntStream.range(numberOfMandatoryArguments, maxCount.get() + 1)
+                    .mapToObj(count -> Signature.of(Collections.nCopies(count, COMMON_ARGUMENT)))
+                    .collect(Collectors.toList());
+        }
+
+        List<Argument> arguments =
+                new ArrayList<>(Collections.nCopies(numberOfMandatoryArguments, COMMON_ARGUMENT));
+        arguments.add(Argument.ofGroupVarying("COMMON"));
+        return Collections.singletonList(Signature.of(arguments));
+    }
+
+    private static boolean isLegacyType(LogicalType type) {
+        return type instanceof LegacyTypeInformationType;
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapUnionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapUnionFunction.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_UNION}. */
+@Internal
+public class MapUnionFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter keyElementGetter;
+    private final ArrayData.ElementGetter valueElementGetter;
+
+    private final SpecializedFunction.ExpressionEvaluator keyEqualityEvaluator;
+    private transient MethodHandle keyEqualityHandle;
+
+    public MapUnionFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_UNION, context);
+        KeyValueDataType outputType =
+                ((KeyValueDataType) context.getCallContext().getOutputDataType().get());
+        final DataType keyDataType = outputType.getKeyDataType();
+        final DataType valueDataType = outputType.getValueDataType();
+        keyElementGetter =
+                ArrayData.createElementGetter(outputType.getKeyDataType().getLogicalType());
+        valueElementGetter =
+                ArrayData.createElementGetter(outputType.getValueDataType().getLogicalType());
+        keyEqualityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", keyDataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", keyDataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        keyEqualityHandle = keyEqualityEvaluator.open(context);
+    }
+
+    public @Nullable MapData eval(@Nullable MapData map1, @Nullable MapData map2) {
+        try {
+            if (map1 == null || map2 == null) {
+                return null;
+            }
+            if (map1.size() == 0) {
+                if (map2.size() == 0) {
+                    return map1;
+                }
+                return map2;
+            }
+            if (map2.size() == 0) {
+                return map1;
+            }
+            return new MapDataForMapUnion(map1, map2);
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    private class MapDataForMapUnion implements MapData {
+        private final GenericArrayData keysArray;
+        private final GenericArrayData valuesArray;
+
+        public MapDataForMapUnion(MapData map1, MapData map2) throws Throwable {
+            List<Object> keysList = new ArrayList<>();
+            List<Object> valuesList = new ArrayList<>();
+            boolean isKeyNullExist = false;
+            for (int i = 0; i < map2.size(); i++) {
+                Object key = keyElementGetter.getElementOrNull(map2.keyArray(), i);
+                if (key == null) {
+                    isKeyNullExist = true;
+                }
+                keysList.add(key);
+                valuesList.add(valueElementGetter.getElementOrNull(map2.valueArray(), i));
+            }
+
+            for (int i = 0; i < map1.size(); i++) {
+                final Object key1 = keyElementGetter.getElementOrNull(map1.keyArray(), i);
+                final Object value1 = valueElementGetter.getElementOrNull(map1.valueArray(), i);
+
+                boolean keyExists = false;
+                if (key1 != null) {
+                    for (int j = 0; j < keysList.size(); j++) {
+                        final Object key2 = keysList.get(j);
+                        if (key2 != null && (boolean) keyEqualityHandle.invoke(key1, key2)) {
+                            // If key exists in map2, skip this key-value pair
+                            keyExists = true;
+                            break;
+                        }
+                    }
+                }
+                if (isKeyNullExist && key1 == null) {
+                    continue;
+                }
+
+                // If key doesn't exist in map2, add the key-value pair from map1
+                if (!keyExists) {
+                    keysList.add(key1);
+                    valuesList.add(value1);
+                }
+            }
+            this.keysArray = new GenericArrayData(keysList.toArray());
+            this.valuesArray = new GenericArrayData(valuesList.toArray());
+        }
+
+        @Override
+        public int size() {
+            return keysArray.size();
+        }
+
+        @Override
+        public ArrayData keyArray() {
+            return keysArray;
+        }
+
+        @Override
+        public ArrayData valueArray() {
+            return valuesArray;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        keyEqualityEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is an implementation of MAP_UNION 

Returns a map created by merging two maps, 'map1' and 'map2'. This two maps should have same data structure. If there are overlapping keys, the value from 'map2' will overwrite the value from 'map1'. If any of maps are null, return null.

## Brief change log
MAP_UNION for Table API and SQL

- Syntax:
`MAP_UNION(map1, map2)`
- Arguments:
map1:The first map to be merged.
map2:The second map to be merged.
- Returns:If there are overlapping keys, the value from 'map2' will overwrite the value from 'map1'. If any of maps are null, return null.
- Examples:

Merging maps with unique keys:
```
map1 = ['a': 1, 'b': 2] map2 = ['c': 3, 'd': 4] 
map_union(map1, map2)  
Output: ['a': 1, 'b': 2, 'c': 3, 'd': 4]
```

Merging maps with overlapping keys:
```
map1 = ['a': 1, 'b': 2] map2 = ['b': 3, 'c': 4] 
map_union[dict1, dict2] 
Output: ['a': 1, 'b': 3, 'c': 4]
```

## Verifying this change
- This change added tests in MapFunctionITCase.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
