### PR TITLE
[FLINK-30984][table] Upgrade Janino to 3.1.10 and Remove explicit cast required by 3.1.9

### DIFF
--- a/flink-formats/flink-protobuf/pom.xml
+++ b/flink-formats/flink-protobuf/pom.xml
@@ -36,7 +36,7 @@ under the License.
 
 	<properties>
 		<!-- the same with flink-table/pom.xml -->
-		<janino.version>3.1.9</janino.version>
+		<janino.version>3.1.10</janino.version>
 	</properties>
 
 	<dependencies>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -936,9 +936,7 @@ object CodeGenUtils {
     if (targetDataType.getConversionClass.isPrimitive) {
       externalResultTerm
     } else {
-      // Cast of null is required because of janino issue https://github.com/janino-compiler/janino/issues/188
-      val externalResultTypeTerm = typeTerm(targetDataType.getConversionClass)
-      s"${internalExpr.nullTerm} ? ($externalResultTypeTerm) null : ($externalResultTerm)"
+      s"${internalExpr.nullTerm} ? null : ($externalResultTerm)"
     }
   }
 
@@ -1036,19 +1034,16 @@ object CodeGenUtils {
     }
 
     // convert internal format to target type
-    val (externalResultTerm, externalResultTypeTerm) = if (isInternalClass(targetDataType)) {
-      (s"($targetTypeTerm) ${internalExpr.resultTerm}", s"($targetTypeTerm)")
+    val externalResultTerm = if (isInternalClass(targetDataType)) {
+      s"($targetTypeTerm) ${internalExpr.resultTerm}"
     } else {
-      (
-        genToExternalConverterWithLegacy(ctx, targetDataType, internalExpr.resultTerm),
-        typeTerm(targetDataType.getConversionClass))
+      genToExternalConverterWithLegacy(ctx, targetDataType, internalExpr.resultTerm)
     }
     // merge null term into the result term
     if (targetDataType.getConversionClass.isPrimitive) {
       externalResultTerm
     } else {
-      // Cast of null is required because of janino issue https://github.com/janino-compiler/janino/issues/188
-      s"${internalExpr.nullTerm} ? ($externalResultTypeTerm) null : ($externalResultTerm)"
+      s"${internalExpr.nullTerm} ? null : ($externalResultTerm)"
     }
   }
 

--- a/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.jayway.jsonpath:json-path:2.7.0
-- org.codehaus.janino:janino:3.1.9
-- org.codehaus.janino:commons-compiler:3.1.9
+- org.codehaus.janino:janino:3.1.10
+- org.codehaus.janino:commons-compiler:3.1.10

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -80,9 +80,9 @@ under the License.
 	<properties>
 		<calcite.version>1.32.0</calcite.version>
 		<!-- Calcite 1.32.0 depends on 3.1.8,
-		at the same time minimum 3.1.x Janino version passing Flink tests is 3.1.9,
+		at the same time minimum 3.1.x Janino version passing Flink tests without WAs is 3.1.10,
 		more details are in FLINK-27995 -->
-		<janino.version>3.1.9</janino.version>
+		<janino.version>3.1.10</janino.version>
 		<jsonpath.version>2.7.0</jsonpath.version>
 		<guava.version>31.1-jre</guava.version>
 	</properties>


### PR DESCRIPTION

## What is the purpose of the change

The PR updates Janino to 3.1.10 and removed WA with explicit cast of nulls which was introduced at https://github.com/apache/flink/pull/21500 to cope with Janino issue https://github.com/janino-compiler/janino/issues/188.
Now the fix of this issue is in 3.1.10, so no need for WA anymore

## Verifying this change


This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
