### PR TITLE
[FLINK-32544][python] Fix test_java_sql_ddl to works in JDK17

### DIFF
--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -61,7 +61,7 @@ def read_from_config(key, default_value, flink_conf_file):
 
 
 def find_java_executable():
-    java_executable = "java.exe" if on_windows() else "/Library/Java/JavaVirtualMachines/jdk-17.0.5.jdk/Contents/Home/bin/java"
+    java_executable = "java.exe" if on_windows() else "java"
     flink_home = _find_flink_home()
     flink_conf_file = os.path.join(flink_home, "conf", "flink-conf.yaml")
     java_home = read_from_config(KEY_ENV_JAVA_HOME, None, flink_conf_file)

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -61,7 +61,7 @@ def read_from_config(key, default_value, flink_conf_file):
 
 
 def find_java_executable():
-    java_executable = "java.exe" if on_windows() else "java"
+    java_executable = "java.exe" if on_windows() else "/Library/Java/JavaVirtualMachines/jdk-17.0.5.jdk/Contents/Home/bin/java"
     flink_home = _find_flink_home()
     flink_conf_file = os.path.join(flink_home, "conf", "flink-conf.yaml")
     java_home = read_from_config(KEY_ENV_JAVA_HOME, None, flink_conf_file)

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -131,4 +131,5 @@ class JavaSqlTests(PyFlinkTestCase):
         test_jar_path = self.get_jar_path(test_jar_pattern)
         test_classpath = self.get_classpath() + os.pathsep + test_jar_path
         java_executable = self.get_java_executable()
-        subprocess.check_output([java_executable, "-cp", test_classpath, test_class], shell=False)
+        subprocess.check_output([java_executable, "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                                 "-cp", test_classpath, test_class], shell=False)

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -131,5 +131,7 @@ class JavaSqlTests(PyFlinkTestCase):
         test_jar_path = self.get_jar_path(test_jar_pattern)
         test_classpath = self.get_classpath() + os.pathsep + test_jar_path
         java_executable = self.get_java_executable()
-        subprocess.check_output([java_executable, "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        subprocess.check_output([java_executable,
+                                 "-XX:+IgnoreUnrecognizedVMOptions",
+                                 "--add-opens=java.base/java.lang=ALL-UNNAMED",
                                  "-cp", test_classpath, test_class], shell=False)


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes test_java_sql_ddl to works in JDK17*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
