### PR TITLE
[FLINK-32541][network] Fix the buffer leaking when buffer accumulator is released

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/HashSubpartitionBufferAccumulator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/HashSubpartitionBufferAccumulator.java
@@ -36,7 +36,6 @@ import java.util.Queue;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * {@link HashSubpartitionBufferAccumulator} accumulates the records in a subpartition.
@@ -76,7 +75,9 @@ public class HashSubpartitionBufferAccumulator {
     }
 
     public void close() {
-        checkState(unfinishedBuffers.isEmpty(), "There are unfinished buffers.");
+        while (!unfinishedBuffers.isEmpty()) {
+            unfinishedBuffers.poll().close();
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/SubpartitionDiskCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/SubpartitionDiskCacheManager.java
@@ -109,7 +109,6 @@ class SubpartitionDiskCacheManager {
     }
 
     void release() {
-        recycleBuffers();
         checkState(allBuffers.isEmpty(), "Leaking buffers.");
     }
 
@@ -130,17 +129,5 @@ class SubpartitionDiskCacheManager {
             allBuffers.add(new Tuple2<>(buffer, bufferIndex));
         }
         bufferIndex++;
-    }
-
-    private void recycleBuffers() {
-        synchronized (allBuffers) {
-            for (Tuple2<Buffer, Integer> bufferAndIndex : allBuffers) {
-                Buffer buffer = bufferAndIndex.f0;
-                if (!buffer.isRecycled()) {
-                    buffer.recycleBuffer();
-                }
-            }
-            allBuffers.clear();
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/SubpartitionDiskCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/SubpartitionDiskCacheManagerTest.java
@@ -76,7 +76,10 @@ class SubpartitionDiskCacheManagerTest {
                 new SubpartitionDiskCacheManager();
         Buffer buffer = BufferBuilderTestUtils.buildSomeBuffer();
         subpartitionDiskCacheManager.append(buffer);
+        List<Tuple2<Buffer, Integer>> bufferAndIndexes =
+                subpartitionDiskCacheManager.removeAllBuffers();
+        assertThat(bufferAndIndexes).hasSize(1);
+        assertThat(bufferAndIndexes.get(0).f0).isEqualTo(buffer);
         assertThatNoException().isThrownBy(subpartitionDiskCacheManager::release);
-        assertThat(buffer.isRecycled()).isTrue();
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix the buffer leaking when buffer accumulator is released*


## Brief change log

  - *Fix the buffer leaking when buffer accumulators is released*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for in the `SortBufferAccumulatorTest` and `HashBufferAccumulatorTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
