### PR TITLE
[hotfix][streaming] Fix typo in DataStream.java and DataStream.scala.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -839,7 +839,7 @@ public class DataStream<T> {
      * event time progress. The given {@link WatermarkStrategy} is used to create a {@link
      * TimestampAssigner} and {@link WatermarkGenerator}.
      *
-     * <p>For each event in the data stream, the {@link TimestampAssigner#extractTimestamp(Object,
+     * <p>For each element in the data stream, the {@link TimestampAssigner#extractTimestamp(Object,
      * long)} method is called to assign an event timestamp.
      *
      * <p>For each event in the data stream, the {@link WatermarkGenerator#onEvent(Object, long,

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -838,7 +838,7 @@ class DataStream[T](stream: JavaStream[T]) {
    * time progress. The given [[WatermarkStrategy is used to create a [[TimestampAssigner]] and
    * [[org.apache.flink.api.common.eventtime.WatermarkGenerator]].
    *
-   * For each event in the data stream, the [[TimestampAssigner#extractTimestamp(Object, long)]]
+   * For each element in the data stream, the [[TimestampAssigner#extractTimestamp(Object, long)]]
    * method is called to assign an event timestamp.
    *
    * For each event in the data stream, the


### PR DESCRIPTION
## What is the purpose of the change

*`TimestampAssigner#extractTimestamp` is used for element not event.*


## Brief change log

  - *Fix typo in `DataStream.java` and `DataStream.scala`.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
