### PR TITLE
[FLINK-32391][yarn][test] Extend log whitelist for expected Akka shutdown WARN exception

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -158,7 +158,7 @@ public abstract class YarnTestBase {
         // filter out expected ResourceManagerException caused by intended shutdown request
         Pattern.compile(YarnResourceManagerDriver.ERROR_MESSAGE_ON_SHUTDOWN_REQUEST),
 
-        // this can happen in Akka 2.4 on shutdown.
+        // this can happen in Akka on shutdown.
         Pattern.compile(
                 "java\\.util\\.concurrent\\.RejectedExecutionException: Worker has already been shutdown"),
         Pattern.compile("org\\.apache\\.flink.util\\.FlinkException: Stopping JobMaster"),
@@ -167,6 +167,8 @@ public abstract class YarnTestBase {
         Pattern.compile("lost the leadership."),
         Pattern.compile(
                 "akka.remote.transport.netty.NettyTransport.*Remote connection to \\[[^]]+\\] failed with java.io.IOException: Broken pipe"),
+        Pattern.compile(
+                "akka.remote.transport.netty.NettyTransport.*Remote connection to \\[.+\\] failed with java.net.SocketException: Connection reset"),
 
         // this can happen during cluster shutdown, if AMRMClient happens to be heartbeating
         Pattern.compile("Exception on heartbeat"),


### PR DESCRIPTION
# What is the purpose of the change

in `YARNSessionFIFOSecuredITCase` test case teardown, it seems a new kind of Akka warning can happen, that actually logs an exception that we did not whitelist yet. The relevant log piece (last 2 lines) that triggers to fail the test exec:
```
Jun 20 01:30:32 2023-06-20 01:29:57,749 INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService             [] - Stopping Akka RPC service.
Jun 20 01:30:32 2023-06-20 01:29:57,767 WARN  akka.actor.CoordinatedShutdown                               [] - Could not addJvmShutdownHook, due to: Shutdown in progress
Jun 20 01:30:32 2023-06-20 01:29:57,767 INFO  akka.actor.CoordinatedShutdown                               [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
Jun 20 01:30:32 2023-06-20 01:29:57,768 WARN  akka.actor.CoordinatedShutdown                               [] - Could not addJvmShutdownHook, due to: Shutdown in progress
Jun 20 01:30:32 2023-06-20 01:29:57,768 INFO  akka.actor.CoordinatedShutdown                               [] - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
Jun 20 01:30:32 2023-06-20 01:29:57,781 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Shutting down remote daemon.
Jun 20 01:30:32 2023-06-20 01:29:57,781 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Shutting down remote daemon.
Jun 20 01:30:32 2023-06-20 01:29:57,782 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remote daemon shut down; proceeding with flushing remote transports.
Jun 20 01:30:32 2023-06-20 01:29:57,782 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remote daemon shut down; proceeding with flushing remote transports.
Jun 20 01:30:32 2023-06-20 01:29:57,788 WARN  akka.remote.transport.netty.NettyTransport                   [] - Remote connection to [264d5b384bcc/192.168.224.2:42920] failed with java.net.SocketException: Connection reset
Jun 20 01:30:32 2023-06-20 01:29:57,788 WARN  akka.remote.transport.netty.NettyTransport                   [] - Remote connection to [264d5b384bcc/192.168.224.2:42920] failed with java.net.SocketException: Connection reset
```

Since we are in the Akka shutdown process it is expected that Netty gets disconnected. Complete Azure run [here](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=50217&view=logs&j=d871f0ce-7328-5d00-023b-e7391f5801c8&t=77cbea27-feb9-5cf5-53f7-3267f9f9c6b6&l=27971).

## Brief change log

Added a new exception to the `YarnTestBase` whitelist.
