### PR TITLE
[FLINK-32556][runtime] Renames contenderID into componentId

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -132,14 +132,14 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
     }
 
     @Override
-    public void publishLeaderInformation(String contenderID, LeaderInformation leaderInformation) {
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation) {
         Preconditions.checkState(running.get());
 
         try {
             kubeClient
                     .checkAndUpdateConfigMap(
                             configMapName,
-                            updateConfigMapWithLeaderInformation(contenderID, leaderInformation))
+                            updateConfigMapWithLeaderInformation(componentId, leaderInformation))
                     .get();
         } catch (InterruptedException | ExecutionException e) {
             leaderElectionListener.onError(e);
@@ -148,13 +148,13 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
         LOG.debug(
                 "Successfully wrote leader information {} for leader {} into the config map {}.",
                 leaderInformation,
-                contenderID,
+                componentId,
                 configMapName);
     }
 
     @Override
-    public void deleteLeaderInformation(String contenderID) {
-        publishLeaderInformation(contenderID, LeaderInformation.empty());
+    public void deleteLeaderInformation(String componentId) {
+        publishLeaderInformation(componentId, LeaderInformation.empty());
     }
 
     private Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
@@ -134,13 +134,13 @@ public class KubernetesLeaderElectionHaServices extends AbstractHaServices {
     }
 
     @Override
-    protected LeaderRetrievalService createLeaderRetrievalService(String contenderID) {
+    protected LeaderRetrievalService createLeaderRetrievalService(String componentId) {
         return new DefaultLeaderRetrievalService(
                 new KubernetesLeaderRetrievalDriverFactory(
                         configMapSharedWatcher,
                         watchExecutorService,
                         getClusterConfigMap(),
-                        contenderID));
+                        componentId));
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverFactory.java
@@ -43,17 +43,17 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
 
     private final String configMapName;
 
-    private final String contenderID;
+    private final String componentId;
 
     public KubernetesLeaderRetrievalDriverFactory(
             KubernetesConfigMapSharedWatcher configMapSharedWatcher,
             Executor watchExecutor,
             String configMapName,
-            String contenderID) {
+            String componentId) {
         this.configMapSharedWatcher = Preconditions.checkNotNull(configMapSharedWatcher);
         this.watchExecutor = Preconditions.checkNotNull(watchExecutor);
         this.configMapName = Preconditions.checkNotNull(configMapName);
-        this.contenderID = Preconditions.checkNotNull(contenderID);
+        this.componentId = Preconditions.checkNotNull(componentId);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class KubernetesLeaderRetrievalDriverFactory implements LeaderRetrievalDr
     }
 
     public LeaderInformation extractLeaderInformation(KubernetesConfigMap configMap) {
-        final String configDataLeaderKey = KubernetesUtils.createSingleLeaderKey(contenderID);
+        final String configDataLeaderKey = KubernetesUtils.createSingleLeaderKey(componentId);
 
         final Map<String, String> data = configMap.getData();
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -629,8 +629,8 @@ public class KubernetesUtils {
         return LeaderInformation.known(leaderSessionId, leaderAddress);
     }
 
-    public static String createSingleLeaderKey(String contenderID) {
-        return LEADER_PREFIX + contenderID;
+    public static String createSingleLeaderKey(String componentId) {
+        return LEADER_PREFIX + componentId;
     }
 
     public static boolean isSingleLeaderKey(String key) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -77,7 +77,7 @@ class KubernetesHighAvailabilityTestBase {
     protected class Context {
         private final KubernetesTestFixture kubernetesTestFixture;
 
-        final String contenderID;
+        final String componentId;
         final String leaderAddress;
         final LeaderElectionDriver leaderElectionDriver;
         final TestingLeaderElectionListener electionEventHandler;
@@ -96,7 +96,7 @@ class KubernetesHighAvailabilityTestBase {
                     new KubernetesTestFixture(CLUSTER_ID, LEADER_CONFIGMAP_NAME, LOCK_IDENTITY);
 
             final UUID randomTestID = UUID.randomUUID();
-            contenderID = "random-contender-id-" + randomTestID;
+            componentId = "random-component-id-" + randomTestID;
             leaderAddress = "random-address-" + randomTestID;
 
             flinkKubeClient = kubernetesTestFixture.getFlinkKubeClient();
@@ -136,7 +136,7 @@ class KubernetesHighAvailabilityTestBase {
         }
 
         String getLeaderInformationKey() {
-            return KubernetesUtils.createSingleLeaderKey(contenderID);
+            return KubernetesUtils.createSingleLeaderKey(componentId);
         }
 
         Optional<LeaderInformation> getLeaderInformationFromConfigMap() {
@@ -164,7 +164,7 @@ class KubernetesHighAvailabilityTestBase {
 
             final UUID leaderSessionID = UUID.randomUUID();
             leaderElectionDriver.publishLeaderInformation(
-                    contenderID, LeaderInformation.known(leaderSessionID, leaderAddress));
+                    componentId, LeaderInformation.known(leaderSessionID, leaderAddress));
 
             return leaderSessionID;
         }
@@ -202,7 +202,7 @@ class KubernetesHighAvailabilityTestBase {
                             kubernetesTestFixture.getConfigMapSharedWatcher(),
                             watchCallbackExecutorService,
                             LEADER_CONFIGMAP_NAME,
-                            contenderID);
+                            componentId);
             return factory.createLeaderRetrievalDriver(
                     retrievalEventHandler, retrievalEventHandler::handleError);
         }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -67,7 +67,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
 
     @Test
     void testLeaderElectionAndRetrieval() throws Exception {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final String leaderAddress = "random-address";
         final String configMapName = LEADER_CONFIGMAP_NAME + UUID.randomUUID();
         final FlinkKubeClient flinkKubeClient = KUBERNETES_EXTENSION.getFlinkKubeClient();
@@ -110,7 +110,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
                             configMapSharedWatcher,
                             EXECUTOR_EXTENSION.getExecutor(),
                             configMapName,
-                            contenderID);
+                            componentId);
 
             final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
             final TestingLeaderRetrievalEventHandler firstLeaderRetrievalEventHandler =
@@ -123,7 +123,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
             electionEventHandler.await(LeaderElectionEvent.IsLeaderEvent.class);
             final LeaderInformation leaderInformation =
                     LeaderInformation.known(UUID.randomUUID(), leaderAddress);
-            leaderElectionDriver.publishLeaderInformation(contenderID, leaderInformation);
+            leaderElectionDriver.publishLeaderInformation(componentId, leaderInformation);
 
             // Check if the leader retrieval driver is notified about the leader address
             awaitLeadership(firstLeaderRetrievalEventHandler, leaderInformation);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -174,12 +174,12 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                                             .AllLeaderInformationChangeEvent.class)
                                             .getLeaderInformationRegister();
 
-                            assertThat(leaderInformationRegister.getRegisteredContenderIDs())
+                            assertThat(leaderInformationRegister.getRegisteredComponentIds())
                                     .containsExactly(contenderID);
 
                             final LeaderInformation expectedFaultyLeaderInformation =
                                     LeaderInformation.known(faultySessionID, faultyAddress);
-                            assertThat(leaderInformationRegister.forContenderID(contenderID))
+                            assertThat(leaderInformationRegister.forComponentId(contenderID))
                                     .hasValue(expectedFaultyLeaderInformation);
 
                             leaderElectionDriver.publishLeaderInformation(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -126,7 +126,7 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                 runTest(
                         () -> {
                             leaderElectionDriver.publishLeaderInformation(
-                                    contenderID,
+                                    componentId,
                                     LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
 
                             final String expectedErrorMessage =
@@ -175,15 +175,15 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                                             .getLeaderInformationRegister();
 
                             assertThat(leaderInformationRegister.getRegisteredComponentIds())
-                                    .containsExactly(contenderID);
+                                    .containsExactly(componentId);
 
                             final LeaderInformation expectedFaultyLeaderInformation =
                                     LeaderInformation.known(faultySessionID, faultyAddress);
-                            assertThat(leaderInformationRegister.forComponentId(contenderID))
+                            assertThat(leaderInformationRegister.forComponentId(componentId))
                                     .hasValue(expectedFaultyLeaderInformation);
 
                             leaderElectionDriver.publishLeaderInformation(
-                                    contenderID,
+                                    componentId,
                                     LeaderInformation.known(leaderSessionID, leaderAddress));
 
                             assertThat(getLeaderInformationFromConfigMap())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -313,7 +313,7 @@ public class EmbeddedLeaderService {
 
                 LOG.info(
                         "Proposing leadership to the contender that is registered under component ID '{}'.",
-                        embeddedLeaderElection.contender);
+                        embeddedLeaderElection.componentId);
 
                 return execute(
                         new GrantLeadershipCall(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -154,9 +154,9 @@ public class EmbeddedLeaderService {
     //  creating contenders and listeners
     // ------------------------------------------------------------------------
 
-    public LeaderElection createLeaderElectionService(String contenderID) {
+    public LeaderElection createLeaderElectionService(String componentId) {
         checkState(!shutdown, "leader election service is shut down");
-        return new EmbeddedLeaderElection(contenderID);
+        return new EmbeddedLeaderElection(componentId);
     }
 
     public LeaderRetrievalService createLeaderRetrievalService() {
@@ -440,15 +440,15 @@ public class EmbeddedLeaderService {
 
     private class EmbeddedLeaderElection implements LeaderElection {
 
-        final String contenderID;
+        final String componentId;
         volatile LeaderContender contender;
 
         volatile boolean isLeader;
 
         volatile boolean running;
 
-        EmbeddedLeaderElection(String contenderID) {
-            this.contenderID = contenderID;
+        EmbeddedLeaderElection(String componentId) {
+            this.componentId = componentId;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -311,7 +311,9 @@ public class EmbeddedLeaderService {
                 currentLeaderProposed = embeddedLeaderElection;
                 currentLeaderProposed.isLeader = true;
 
-                LOG.info("Proposing leadership to contender {}", embeddedLeaderElection.contender);
+                LOG.info(
+                        "Proposing leadership to the contender that is registered under component ID '{}'.",
+                        embeddedLeaderElection.contender);
 
                 return execute(
                         new GrantLeadershipCall(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperLeaderElectionHaServices.java
@@ -172,11 +172,11 @@ public class ZooKeeperLeaderElectionHaServices extends AbstractHaServices {
     // ///////////////////////////////////////////////
 
     @Override
-    protected LeaderRetrievalService createLeaderRetrievalService(String contenderID) {
+    protected LeaderRetrievalService createLeaderRetrievalService(String componentId) {
         // Maybe use a single service for leader retrieval
         return ZooKeeperUtils.createLeaderRetrievalService(
                 curatorFrameworkWrapper.asCuratorFramework(),
-                ZooKeeperUtils.getLeaderPath(contenderID),
+                ZooKeeperUtils.getLeaderPath(componentId),
                 configuration);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -29,32 +29,32 @@ import java.util.UUID;
 class DefaultLeaderElection implements LeaderElection {
 
     private final ParentService parentService;
-    private final String contenderID;
+    private final String componentId;
 
-    DefaultLeaderElection(ParentService parentService, String contenderID) {
+    DefaultLeaderElection(ParentService parentService, String componentId) {
         this.parentService = parentService;
-        this.contenderID = contenderID;
+        this.componentId = componentId;
     }
 
     @Override
     public void startLeaderElection(LeaderContender contender) throws Exception {
         Preconditions.checkNotNull(contender);
-        parentService.register(contenderID, contender);
+        parentService.register(componentId, contender);
     }
 
     @Override
     public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
-        parentService.confirmLeadership(contenderID, leaderSessionID, leaderAddress);
+        parentService.confirmLeadership(componentId, leaderSessionID, leaderAddress);
     }
 
     @Override
     public boolean hasLeadership(UUID leaderSessionId) {
-        return parentService.hasLeadership(contenderID, leaderSessionId);
+        return parentService.hasLeadership(componentId, leaderSessionId);
     }
 
     @Override
     public void close() throws Exception {
-        parentService.remove(contenderID);
+        parentService.remove(componentId);
     }
 
     /**
@@ -64,32 +64,32 @@ class DefaultLeaderElection implements LeaderElection {
     abstract static class ParentService {
 
         /**
-         * Registers the {@link LeaderContender} under the {@code contenderID} with the underlying
+         * Registers the {@link LeaderContender} under the {@code componentId} with the underlying
          * {@code ParentService}. Leadership changes are starting to be reported to the {@code
          * LeaderContender}.
          */
-        abstract void register(String contenderID, LeaderContender contender) throws Exception;
+        abstract void register(String componentId, LeaderContender contender) throws Exception;
 
         /**
          * Removes the {@code LeaderContender} from the {@code ParentService} that is associated
-         * with the {@code contenderID}.
+         * with the {@code componentId}.
          */
-        abstract void remove(String contenderID) throws Exception;
+        abstract void remove(String componentId) throws Exception;
 
         /**
          * Confirms the leadership with the {@code leaderSessionID} and {@code leaderAddress} for
-         * the {@link LeaderContender} that is associated with the {@code contenderID}.
+         * the {@link LeaderContender} that is associated with the {@code componentId}.
          */
         abstract void confirmLeadership(
-                String contenderID, UUID leaderSessionID, String leaderAddress);
+                String componentId, UUID leaderSessionID, String leaderAddress);
 
         /**
          * Checks whether the {@code ParentService} has the leadership acquired for the {@code
-         * contenderID} and {@code leaderSessionID}.
+         * componentId} and {@code leaderSessionID}.
          *
          * @return {@code true} if the service has leadership with the passed {@code
          *     leaderSessionID} acquired; {@code false} otherwise.
          */
-        abstract boolean hasLeadership(String contenderID, UUID leaderSessionID);
+        abstract boolean hasLeadership(String componentId, UUID leaderSessionID);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -153,7 +153,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     "The service was already closed and cannot be reused.");
             Preconditions.checkState(
                     !leaderContenderRegistry.containsKey(componentId),
-                    "There is no contender already registered under the passed component ID '%s'.",
+                    "There shouldn't be any contender registered under the passed component ID '%s'.",
                     componentId);
             return new DefaultLeaderElection(this, componentId);
         }
@@ -191,11 +191,11 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
             Preconditions.checkState(
                     leaderContenderRegistry.put(componentId, contender) == null,
-                    "There is no contender already registered under the passed component ID '%s'.",
+                    "There shouldn't be any contender registered under the passed component ID '%s'.",
                     componentId);
 
             LOG.info(
-                    "LeaderContender {} has been registered for {}.",
+                    "LeaderContender has been registered under component ID {} for {}.",
                     componentId,
                     leaderElectionDriver);
 
@@ -225,7 +225,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     "The LeaderElectionDriver should be instantiated.");
 
             LOG.info(
-                    "Deregistering contender with ID '{}' from the DefaultLeaderElectionService.",
+                    "Deregistering contender with component ID '{}' from the DefaultLeaderElectionService.",
                     componentId);
 
             final LeaderContender leaderContender = leaderContenderRegistry.remove(componentId);
@@ -236,13 +236,13 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             if (issuedLeaderSessionID != null) {
                 notifyLeaderContenderOfLeadershipLoss(componentId, leaderContender);
                 LOG.debug(
-                        "The contender registered under component ID '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
+                        "The contender associated with component ID '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
                         componentId);
 
                 if (leaderElectionDriver.hasLeadership()) {
                     leaderElectionDriver.deleteLeaderInformation(componentId);
                     LOG.debug(
-                            "Leader information is cleaned up while deregistering the contender '{}' from the service.",
+                            "Leader information is cleaned up while deregistering the contender for component ID '{}' from the service.",
                             componentId);
                 }
             } else {
@@ -251,7 +251,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                         "The confirmed leader information should have been cleared during leadership revocation.");
 
                 LOG.debug(
-                        "Contender registered under component ID '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
+                        "Contender associated with component ID '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
                         componentId);
             }
 
@@ -345,14 +345,14 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             } else {
                 if (!leaderSessionID.equals(this.issuedLeaderSessionID)) {
                     LOG.debug(
-                            "Received an old confirmation call of leader session ID {} for contender '{}' (current issued session ID is {}).",
+                            "Received an old confirmation call of leader session ID {} for component ID '{}' (current issued session ID is {}).",
                             leaderSessionID,
                             componentId,
                             issuedLeaderSessionID);
                 } else {
                     LOG.warn(
-                            "The leader session ID {} for contender '{}' was confirmed even though the "
-                                    + "corresponding service was not elected as the leader or has been stopped already.",
+                            "The leader session ID {} for component ID '{}' was confirmed even though the corresponding "
+                                    + "service was not elected as the leader or has been stopped already.",
                             componentId,
                             leaderSessionID);
                 }
@@ -435,7 +435,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                 "The leadership should have been granted while not having the leadership acquired.");
 
         LOG.debug(
-                "Granting leadership to contender {} with session ID {}.",
+                "Granting leadership to the contender registered under component ID {} with session ID {}.",
                 componentId,
                 issuedLeaderSessionID);
 
@@ -469,11 +469,11 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
         if (!confirmedLeaderInformation.hasLeaderInformation(componentId)) {
             LOG.debug(
-                    "Revoking leadership to contender {} while a previous leadership grant wasn't confirmed, yet.",
+                    "Revoking leadership for component ID {} while a previous leadership grant wasn't confirmed, yet.",
                     componentId);
         } else {
             LOG.debug(
-                    "Revoking leadership to contender {} for {}.",
+                    "Revoking leadership to component ID {} for previously confirmed leader information {}.",
                     componentId,
                     LeaderElectionUtils.convertToString(
                             confirmedLeaderInformation.forComponentIdOrEmpty(componentId)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -76,7 +76,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
      * Saves the {@link LeaderInformation} for the registered {@link LeaderContender}s. There's no
      * semantic difference between an entry with an empty {@code LeaderInformation} and no entry
      * being present at all here. Both mean that no confirmed {@code LeaderInformation} is available
-     * for the corresponding {@code contenderID}.
+     * for the corresponding {@code componentId}.
      */
     @GuardedBy("lock")
     private LeaderInformationRegister confirmedLeaderInformation;
@@ -146,16 +146,16 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     }
 
     @Override
-    public LeaderElection createLeaderElection(String contenderID) {
+    public LeaderElection createLeaderElection(String componentId) {
         synchronized (lock) {
             Preconditions.checkState(
                     !leadershipOperationExecutor.isShutdown(),
                     "The service was already closed and cannot be reused.");
             Preconditions.checkState(
-                    !leaderContenderRegistry.containsKey(contenderID),
-                    "There is no contender already registered under the passed contender ID '%s'.",
-                    contenderID);
-            return new DefaultLeaderElection(this, contenderID);
+                    !leaderContenderRegistry.containsKey(componentId),
+                    "There is no contender already registered under the passed component ID '%s'.",
+                    componentId);
+            return new DefaultLeaderElection(this, componentId);
         }
     }
 
@@ -176,8 +176,8 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     }
 
     @Override
-    protected void register(String contenderID, LeaderContender contender) throws Exception {
-        checkNotNull(contenderID, "ContenderID must not be null.");
+    protected void register(String componentId, LeaderContender contender) throws Exception {
+        checkNotNull(componentId, "componentId must not be null.");
         checkNotNull(contender, "Contender must not be null.");
 
         synchronized (lock) {
@@ -190,13 +190,13 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             }
 
             Preconditions.checkState(
-                    leaderContenderRegistry.put(contenderID, contender) == null,
-                    "There is no contender already registered under the passed contender ID '%s'.",
-                    contenderID);
+                    leaderContenderRegistry.put(componentId, contender) == null,
+                    "There is no contender already registered under the passed component ID '%s'.",
+                    componentId);
 
             LOG.info(
                     "LeaderContender {} has been registered for {}.",
-                    contenderID,
+                    componentId,
                     leaderElectionDriver);
 
             if (issuedLeaderSessionID != null) {
@@ -205,19 +205,19 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                         LEADER_ACQUISITION_EVENT_LOG_NAME,
                         () ->
                                 notifyLeaderContenderOfLeadership(
-                                        contenderID, issuedLeaderSessionID));
+                                        componentId, issuedLeaderSessionID));
             }
         }
     }
 
     @Override
-    protected final void remove(String contenderID) throws Exception {
+    protected final void remove(String componentId) throws Exception {
         AutoCloseable driverToClose = null;
         synchronized (lock) {
-            if (!leaderContenderRegistry.containsKey(contenderID)) {
+            if (!leaderContenderRegistry.containsKey(componentId)) {
                 LOG.debug(
-                        "There is no contender registered under contenderID '{}' anymore. No action necessary.",
-                        contenderID);
+                        "There is no contender registered under component ID '{}' anymore. No action necessary.",
+                        componentId);
                 return;
             }
             Preconditions.checkState(
@@ -226,24 +226,24 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
             LOG.info(
                     "Deregistering contender with ID '{}' from the DefaultLeaderElectionService.",
-                    contenderID);
+                    componentId);
 
-            final LeaderContender leaderContender = leaderContenderRegistry.remove(contenderID);
+            final LeaderContender leaderContender = leaderContenderRegistry.remove(componentId);
             Preconditions.checkNotNull(
                     leaderContender,
-                    "There should be a LeaderContender registered under the given contenderID '%s'.",
-                    contenderID);
+                    "There should be a LeaderContender registered under the given component ID '%s'.",
+                    componentId);
             if (issuedLeaderSessionID != null) {
-                notifyLeaderContenderOfLeadershipLoss(contenderID, leaderContender);
+                notifyLeaderContenderOfLeadershipLoss(componentId, leaderContender);
                 LOG.debug(
-                        "The contender registered under contenderID '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
-                        contenderID);
+                        "The contender registered under component ID '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
+                        componentId);
 
                 if (leaderElectionDriver.hasLeadership()) {
-                    leaderElectionDriver.deleteLeaderInformation(contenderID);
+                    leaderElectionDriver.deleteLeaderInformation(componentId);
                     LOG.debug(
                             "Leader information is cleaned up while deregistering the contender '{}' from the service.",
-                            contenderID);
+                            componentId);
                 }
             } else {
                 Preconditions.checkState(
@@ -251,8 +251,8 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                         "The confirmed leader information should have been cleared during leadership revocation.");
 
                 LOG.debug(
-                        "Contender registered under contenderID '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
-                        contenderID);
+                        "Contender registered under component ID '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
+                        componentId);
             }
 
             if (leaderContenderRegistry.isEmpty()) {
@@ -314,23 +314,23 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
     @Override
     protected void confirmLeadership(
-            String contenderID, UUID leaderSessionID, String leaderAddress) {
-        Preconditions.checkArgument(leaderContenderRegistry.containsKey(contenderID));
+            String componentId, UUID leaderSessionID, String leaderAddress) {
+        Preconditions.checkArgument(leaderContenderRegistry.containsKey(componentId));
         LOG.debug(
-                "The leader session for contender '{}' is confirmed with session ID {} and address {}.",
-                contenderID,
+                "The leader session for component ID '{}' is confirmed with session ID {} and address {}.",
+                componentId,
                 leaderSessionID,
                 leaderAddress);
 
         checkNotNull(leaderSessionID);
 
         synchronized (lock) {
-            if (hasLeadership(contenderID, leaderSessionID)) {
+            if (hasLeadership(componentId, leaderSessionID)) {
                 Preconditions.checkState(
                         leaderElectionDriver != null,
                         "The leadership check should only return true if a driver is instantiated.");
                 Preconditions.checkState(
-                        !confirmedLeaderInformation.hasLeaderInformation(contenderID),
+                        !confirmedLeaderInformation.hasLeaderInformation(componentId),
                         "No confirmation should have happened, yet.");
 
                 final LeaderInformation newConfirmedLeaderInformation =
@@ -338,22 +338,22 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                 confirmedLeaderInformation =
                         LeaderInformationRegister.merge(
                                 confirmedLeaderInformation,
-                                contenderID,
+                                componentId,
                                 newConfirmedLeaderInformation);
                 leaderElectionDriver.publishLeaderInformation(
-                        contenderID, newConfirmedLeaderInformation);
+                        componentId, newConfirmedLeaderInformation);
             } else {
                 if (!leaderSessionID.equals(this.issuedLeaderSessionID)) {
                     LOG.debug(
                             "Received an old confirmation call of leader session ID {} for contender '{}' (current issued session ID is {}).",
                             leaderSessionID,
-                            contenderID,
+                            componentId,
                             issuedLeaderSessionID);
                 } else {
                     LOG.warn(
                             "The leader session ID {} for contender '{}' was confirmed even though the "
                                     + "corresponding service was not elected as the leader or has been stopped already.",
-                            contenderID,
+                            componentId,
                             leaderSessionID);
                 }
             }
@@ -361,16 +361,16 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     }
 
     @Override
-    protected boolean hasLeadership(String contenderID, UUID leaderSessionId) {
+    protected boolean hasLeadership(String componentId, UUID leaderSessionId) {
         synchronized (lock) {
             if (leaderElectionDriver != null) {
-                if (leaderContenderRegistry.containsKey(contenderID)) {
+                if (leaderContenderRegistry.containsKey(componentId)) {
                     return leaderElectionDriver.hasLeadership()
                             && leaderSessionId.equals(issuedLeaderSessionID);
                 } else {
                     LOG.debug(
-                            "hasLeadership is called for contender ID '{}' while there is no contender registered under that ID in the service, returning false.",
-                            contenderID);
+                            "hasLeadership is called for component ID '{}' while there is no contender registered under that ID in the service, returning false.",
+                            componentId);
                     return false;
                 }
             } else {
@@ -381,16 +381,16 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     }
 
     /**
-     * Returns the current leader session ID for the given {@code contenderID} or {@code null}, if
+     * Returns the current leader session ID for the given {@code componentId} or {@code null}, if
      * the session wasn't confirmed.
      */
     @VisibleForTesting
     @Nullable
-    public UUID getLeaderSessionID(String contenderID) {
+    public UUID getLeaderSessionID(String componentId) {
         synchronized (lock) {
-            return leaderContenderRegistry.containsKey(contenderID)
+            return leaderContenderRegistry.containsKey(componentId)
                     ? confirmedLeaderInformation
-                            .forContenderIdOrEmpty(contenderID)
+                            .forContenderIdOrEmpty(componentId)
                             .getLeaderSessionID()
                     : null;
         }
@@ -409,14 +409,14 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
         leaderContenderRegistry
                 .keySet()
                 .forEach(
-                        contenderID ->
+                        componentId ->
                                 notifyLeaderContenderOfLeadership(
-                                        contenderID, issuedLeaderSessionID));
+                                        componentId, issuedLeaderSessionID));
     }
 
     @GuardedBy("lock")
-    private void notifyLeaderContenderOfLeadership(String contenderID, UUID sessionID) {
-        if (!leaderContenderRegistry.containsKey(contenderID)) {
+    private void notifyLeaderContenderOfLeadership(String componentId, UUID sessionID) {
+        if (!leaderContenderRegistry.containsKey(componentId)) {
             LOG.debug(
                     "The grant leadership notification for session ID {} is not forwarded because the DefaultLeaderElectionService ({}) has no contender registered.",
                     sessionID,
@@ -431,15 +431,15 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
         }
 
         Preconditions.checkState(
-                !confirmedLeaderInformation.hasLeaderInformation(contenderID),
+                !confirmedLeaderInformation.hasLeaderInformation(componentId),
                 "The leadership should have been granted while not having the leadership acquired.");
 
         LOG.debug(
                 "Granting leadership to contender {} with session ID {}.",
-                contenderID,
+                componentId,
                 issuedLeaderSessionID);
 
-        leaderContenderRegistry.get(contenderID).grantLeadership(issuedLeaderSessionID);
+        leaderContenderRegistry.get(componentId).grantLeadership(issuedLeaderSessionID);
     }
 
     @GuardedBy("lock")
@@ -462,31 +462,31 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
     @GuardedBy("lock")
     private void notifyLeaderContenderOfLeadershipLoss(
-            String contenderID, LeaderContender leaderContender) {
+            String componentId, LeaderContender leaderContender) {
         Preconditions.checkState(
                 leaderContender != null,
                 "The LeaderContender should be always set when calling this method.");
 
-        if (!confirmedLeaderInformation.hasLeaderInformation(contenderID)) {
+        if (!confirmedLeaderInformation.hasLeaderInformation(componentId)) {
             LOG.debug(
                     "Revoking leadership to contender {} while a previous leadership grant wasn't confirmed, yet.",
-                    contenderID);
+                    componentId);
         } else {
             LOG.debug(
                     "Revoking leadership to contender {} for {}.",
-                    contenderID,
+                    componentId,
                     LeaderElectionUtils.convertToString(
-                            confirmedLeaderInformation.forContenderIdOrEmpty(contenderID)));
+                            confirmedLeaderInformation.forContenderIdOrEmpty(componentId)));
         }
 
         confirmedLeaderInformation =
-                LeaderInformationRegister.clear(confirmedLeaderInformation, contenderID);
+                LeaderInformationRegister.clear(confirmedLeaderInformation, componentId);
         leaderContender.revokeLeadership();
     }
 
     @GuardedBy("lock")
     private void notifyLeaderInformationChangeInternal(
-            String contenderID,
+            String componentId,
             LeaderInformation externallyChangedLeaderInformation,
             LeaderInformation confirmedLeaderInformation) {
         if (leaderElectionDriver == null) {
@@ -504,24 +504,24 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
         if (confirmedLeaderInformation.isEmpty()) {
             LOG.trace(
-                    "Leader information changed while there's no confirmation available by the contender for contender ID '{}', yet. Changed leader information {} will be reset.",
-                    contenderID,
+                    "Leader information changed while there's no confirmation available by the contender for component ID '{}', yet. Changed leader information {} will be reset.",
+                    componentId,
                     LeaderElectionUtils.convertToString(externallyChangedLeaderInformation));
         } else if (externallyChangedLeaderInformation.isEmpty()) {
             LOG.debug(
-                    "Re-writing leader information ({}) for contender '{}' to overwrite the empty leader information in the external storage.",
+                    "Re-writing leader information ({}) for component ID '{}' to overwrite the empty leader information in the external storage.",
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation),
-                    contenderID);
+                    componentId);
         } else {
             // the changed LeaderInformation does not match the confirmed LeaderInformation
             LOG.debug(
-                    "Correcting leader information for contender '{}' (local: {}, external storage: {}).",
-                    contenderID,
+                    "Correcting leader information for component ID '{}' (local: {}, external storage: {}).",
+                    componentId,
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation),
                     LeaderElectionUtils.convertToString(externallyChangedLeaderInformation));
         }
 
-        leaderElectionDriver.publishLeaderInformation(contenderID, confirmedLeaderInformation);
+        leaderElectionDriver.publishLeaderInformation(componentId, confirmedLeaderInformation);
     }
 
     private void runInLeaderEventThread(String leaderElectionEventName, Runnable callback) {
@@ -593,12 +593,12 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     }
 
     @Override
-    public void onLeaderInformationChange(String contenderID, LeaderInformation leaderInformation) {
+    public void onLeaderInformationChange(String componentId, LeaderInformation leaderInformation) {
         synchronized (lock) {
             notifyLeaderInformationChangeInternal(
-                    contenderID,
+                    componentId,
                     leaderInformation,
-                    confirmedLeaderInformation.forContenderIdOrEmpty(contenderID));
+                    confirmedLeaderInformation.forContenderIdOrEmpty(componentId));
         }
     }
 
@@ -606,16 +606,16 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
     public void onLeaderInformationChange(LeaderInformationRegister changedLeaderInformation) {
         synchronized (lock) {
             leaderContenderRegistry.forEach(
-                    (contenderID, leaderContender) -> {
+                    (componentId, leaderContender) -> {
                         final LeaderInformation externallyChangedLeaderInformationForContender =
                                 changedLeaderInformation
-                                        .forContenderID(contenderID)
+                                        .forContenderID(componentId)
                                         .orElse(LeaderInformation.empty());
                         final LeaderInformation confirmedLeaderInformationForContender =
-                                confirmedLeaderInformation.forContenderIdOrEmpty(contenderID);
+                                confirmedLeaderInformation.forContenderIdOrEmpty(componentId);
 
                         notifyLeaderInformationChangeInternal(
-                                contenderID,
+                                componentId,
                                 externallyChangedLeaderInformationForContender,
                                 confirmedLeaderInformationForContender);
                     });

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -390,7 +390,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
         synchronized (lock) {
             return leaderContenderRegistry.containsKey(componentId)
                     ? confirmedLeaderInformation
-                            .forContenderIdOrEmpty(componentId)
+                            .forComponentIdOrEmpty(componentId)
                             .getLeaderSessionID()
                     : null;
         }
@@ -476,7 +476,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     "Revoking leadership to contender {} for {}.",
                     componentId,
                     LeaderElectionUtils.convertToString(
-                            confirmedLeaderInformation.forContenderIdOrEmpty(componentId)));
+                            confirmedLeaderInformation.forComponentIdOrEmpty(componentId)));
         }
 
         confirmedLeaderInformation =
@@ -598,7 +598,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             notifyLeaderInformationChangeInternal(
                     componentId,
                     leaderInformation,
-                    confirmedLeaderInformation.forContenderIdOrEmpty(componentId));
+                    confirmedLeaderInformation.forComponentIdOrEmpty(componentId));
         }
     }
 
@@ -609,10 +609,10 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     (componentId, leaderContender) -> {
                         final LeaderInformation externallyChangedLeaderInformationForContender =
                                 changedLeaderInformation
-                                        .forContenderID(componentId)
+                                        .forComponentId(componentId)
                                         .orElse(LeaderInformation.empty());
                         final LeaderInformation confirmedLeaderInformationForContender =
-                                confirmedLeaderInformation.forContenderIdOrEmpty(componentId);
+                                confirmedLeaderInformation.forComponentIdOrEmpty(componentId);
 
                         notifyLeaderInformationChangeInternal(
                                 componentId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -153,7 +153,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     "The service was already closed and cannot be reused.");
             Preconditions.checkState(
                     !leaderContenderRegistry.containsKey(componentId),
-                    "There shouldn't be any contender registered under the passed component ID '%s'.",
+                    "There shouldn't be any contender registered under the passed component '%s'.",
                     componentId);
             return new DefaultLeaderElection(this, componentId);
         }
@@ -191,11 +191,11 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
             Preconditions.checkState(
                     leaderContenderRegistry.put(componentId, contender) == null,
-                    "There shouldn't be any contender registered under the passed component ID '%s'.",
+                    "There shouldn't be any contender registered under the passed component '%s'.",
                     componentId);
 
             LOG.info(
-                    "LeaderContender has been registered under component ID {} for {}.",
+                    "LeaderContender has been registered under component '{}' for {}.",
                     componentId,
                     leaderElectionDriver);
 
@@ -216,7 +216,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
         synchronized (lock) {
             if (!leaderContenderRegistry.containsKey(componentId)) {
                 LOG.debug(
-                        "There is no contender registered under component ID '{}' anymore. No action necessary.",
+                        "There is no contender registered under component '{}' anymore. No action necessary.",
                         componentId);
                 return;
             }
@@ -225,24 +225,24 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                     "The LeaderElectionDriver should be instantiated.");
 
             LOG.info(
-                    "Deregistering contender with component ID '{}' from the DefaultLeaderElectionService.",
+                    "Deregistering contender with component '{}' from the DefaultLeaderElectionService.",
                     componentId);
 
             final LeaderContender leaderContender = leaderContenderRegistry.remove(componentId);
             Preconditions.checkNotNull(
                     leaderContender,
-                    "There should be a LeaderContender registered under the given component ID '%s'.",
+                    "There should be a LeaderContender registered under the given component '%s'.",
                     componentId);
             if (issuedLeaderSessionID != null) {
                 notifyLeaderContenderOfLeadershipLoss(componentId, leaderContender);
                 LOG.debug(
-                        "The contender associated with component ID '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
+                        "The contender associated with component '{}' is deregistered while the service has the leadership acquired. The revoke event is forwarded to the LeaderContender.",
                         componentId);
 
                 if (leaderElectionDriver.hasLeadership()) {
                     leaderElectionDriver.deleteLeaderInformation(componentId);
                     LOG.debug(
-                            "Leader information is cleaned up while deregistering the contender for component ID '{}' from the service.",
+                            "Leader information is cleaned up while deregistering the contender for component '{}' from the service.",
                             componentId);
                 }
             } else {
@@ -251,7 +251,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                         "The confirmed leader information should have been cleared during leadership revocation.");
 
                 LOG.debug(
-                        "Contender associated with component ID '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
+                        "Contender associated with component '{}' is deregistered while the service doesn't have the leadership acquired. No cleanup necessary.",
                         componentId);
             }
 
@@ -317,7 +317,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             String componentId, UUID leaderSessionID, String leaderAddress) {
         Preconditions.checkArgument(leaderContenderRegistry.containsKey(componentId));
         LOG.debug(
-                "The leader session for component ID '{}' is confirmed with session ID {} and address {}.",
+                "The leader session for component '{}' is confirmed with session ID {} and address {}.",
                 componentId,
                 leaderSessionID,
                 leaderAddress);
@@ -345,13 +345,13 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
             } else {
                 if (!leaderSessionID.equals(this.issuedLeaderSessionID)) {
                     LOG.debug(
-                            "Received an old confirmation call of leader session ID {} for component ID '{}' (current issued session ID is {}).",
+                            "Received an old confirmation call of leader session ID {} for component '{}' (current issued session ID is {}).",
                             leaderSessionID,
                             componentId,
                             issuedLeaderSessionID);
                 } else {
                     LOG.warn(
-                            "The leader session ID {} for component ID '{}' was confirmed even though the corresponding "
+                            "The leader session ID {} for component '{}' was confirmed even though the corresponding "
                                     + "service was not elected as the leader or has been stopped already.",
                             componentId,
                             leaderSessionID);
@@ -369,7 +369,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                             && leaderSessionId.equals(issuedLeaderSessionID);
                 } else {
                     LOG.debug(
-                            "hasLeadership is called for component ID '{}' while there is no contender registered under that ID in the service, returning false.",
+                            "hasLeadership is called for component '{}' while there is no contender registered under that ID in the service, returning false.",
                             componentId);
                     return false;
                 }
@@ -435,7 +435,7 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
                 "The leadership should have been granted while not having the leadership acquired.");
 
         LOG.debug(
-                "Granting leadership to the contender registered under component ID {} with session ID {}.",
+                "Granting leadership to the contender registered under component '{}' with session ID {}.",
                 componentId,
                 issuedLeaderSessionID);
 
@@ -469,11 +469,11 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
         if (!confirmedLeaderInformation.hasLeaderInformation(componentId)) {
             LOG.debug(
-                    "Revoking leadership for component ID {} while a previous leadership grant wasn't confirmed, yet.",
+                    "Revoking leadership for component '{}' while a previous leadership grant wasn't confirmed, yet.",
                     componentId);
         } else {
             LOG.debug(
-                    "Revoking leadership to component ID {} for previously confirmed leader information {}.",
+                    "Revoking leadership to component '{}' for previously confirmed leader information {}.",
                     componentId,
                     LeaderElectionUtils.convertToString(
                             confirmedLeaderInformation.forComponentIdOrEmpty(componentId)));
@@ -504,18 +504,18 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
 
         if (confirmedLeaderInformation.isEmpty()) {
             LOG.trace(
-                    "Leader information changed while there's no confirmation available by the contender for component ID '{}', yet. Changed leader information {} will be reset.",
+                    "Leader information changed while there's no confirmation available by the contender for component '{}', yet. Changed leader information {} will be reset.",
                     componentId,
                     LeaderElectionUtils.convertToString(externallyChangedLeaderInformation));
         } else if (externallyChangedLeaderInformation.isEmpty()) {
             LOG.debug(
-                    "Re-writing leader information ({}) for component ID '{}' to overwrite the empty leader information in the external storage.",
+                    "Re-writing leader information ({}) for component '{}' to overwrite the empty leader information in the external storage.",
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation),
                     componentId);
         } else {
             // the changed LeaderInformation does not match the confirmed LeaderInformation
             LOG.debug(
-                    "Correcting leader information for component ID '{}' (local: {}, external storage: {}).",
+                    "Correcting leader information for component '{}' (local: {}, external storage: {}).",
                     componentId,
                     LeaderElectionUtils.convertToString(confirmedLeaderInformation),
                     LeaderElectionUtils.convertToString(externallyChangedLeaderInformation));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionDriver.java
@@ -35,17 +35,17 @@ public interface LeaderElectionDriver extends AutoCloseable {
     /**
      * Publishes the leader information for the given component.
      *
-     * @param contenderID identifying the component for which to publish the leader information
+     * @param componentId identifying the component for which to publish the leader information
      * @param leaderInformation leader information of the respective component
      */
-    void publishLeaderInformation(String contenderID, LeaderInformation leaderInformation);
+    void publishLeaderInformation(String componentId, LeaderInformation leaderInformation);
 
     /**
      * Deletes the leader information for the given component.
      *
-     * @param contenderID identifying the component for which to delete the leader information
+     * @param componentId identifying the component for which to delete the leader information
      */
-    void deleteLeaderInformation(String contenderID);
+    void deleteLeaderInformation(String componentId);
 
     /** Listener interface for state changes of the {@link LeaderElectionDriver}. */
     interface Listener {
@@ -59,10 +59,10 @@ public interface LeaderElectionDriver extends AutoCloseable {
         /**
          * Notifies the listener about a changed leader information for the given component.
          *
-         * @param contenderID identifying the component whose leader information has changed
+         * @param componentId identifying the component whose leader information has changed
          * @param leaderInformation new leader information
          */
-        void onLeaderInformationChange(String contenderID, LeaderInformation leaderInformation);
+        void onLeaderInformationChange(String componentId, LeaderInformation leaderInformation);
 
         /** Notifies the listener about all currently known leader information. */
         void onLeaderInformationChange(LeaderInformationRegister leaderInformationRegister);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -39,8 +39,8 @@ public interface LeaderElectionService {
      * Creates a new {@link LeaderElection} instance that is registered to this {@code
      * LeaderElectionService} instance.
      *
-     * @param contenderID a unique identifier that refers to the stored leader information that the
+     * @param componentId a unique identifier that refers to the stored leader information that the
      *     newly created {@link LeaderElection} manages.
      */
-    LeaderElection createLeaderElection(String contenderID);
+    LeaderElection createLeaderElection(String componentId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegister.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 /**
  * A register containing the {@link LeaderInformation} for multiple contenders based on their {@code
- * contenderID}. No empty {@code LeaderInformation} is stored physically. No entry and an entry with
+ * componentId}. No empty {@code LeaderInformation} is stored physically. No entry and an entry with
  * an empty {@code LeaderInformation} are, therefore, semantically the same.
  */
 public class LeaderInformationRegister {
@@ -36,7 +36,7 @@ public class LeaderInformationRegister {
     private static final LeaderInformationRegister EMPTY_REGISTER =
             new LeaderInformationRegister(Collections.emptyMap());
 
-    private final Map<String, LeaderInformation> leaderInformationPerContenderID;
+    private final Map<String, LeaderInformation> leaderInformationPerComponentId;
 
     public static LeaderInformationRegister empty() {
         return EMPTY_REGISTER;
@@ -44,32 +44,32 @@ public class LeaderInformationRegister {
 
     /** Creates a single-entry instance containing only the passed information. */
     public static LeaderInformationRegister of(
-            String contenderID, LeaderInformation leaderInformation) {
+            String componentId, LeaderInformation leaderInformation) {
         return new LeaderInformationRegister(
-                Collections.singletonMap(contenderID, leaderInformation));
+                Collections.singletonMap(componentId, leaderInformation));
     }
 
     /**
      * Merges another {@code LeaderInformationRegister} with additional leader information into a
      * new {@code LeaderInformationRegister} instance. Any existing {@link LeaderInformation} for
-     * the passed {@code contenderID} will be overwritten.
+     * the passed {@code componentId} will be overwritten.
      *
      * <p>Empty {@code LeaderInformation} results in the removal of the corresponding entry (if it
      * exists).
      */
     public static LeaderInformationRegister merge(
             @Nullable LeaderInformationRegister leaderInformationRegister,
-            String contenderID,
+            String componentId,
             LeaderInformation leaderInformation) {
         final Map<String, LeaderInformation> existingLeaderInformation =
                 new HashMap<>(
                         leaderInformationRegister == null
                                 ? Collections.emptyMap()
-                                : leaderInformationRegister.leaderInformationPerContenderID);
+                                : leaderInformationRegister.leaderInformationPerComponentId);
         if (leaderInformation.isEmpty()) {
-            existingLeaderInformation.remove(contenderID);
+            existingLeaderInformation.remove(componentId);
         } else {
-            existingLeaderInformation.put(contenderID, leaderInformation);
+            existingLeaderInformation.put(componentId, leaderInformation);
         }
 
         return new LeaderInformationRegister(existingLeaderInformation);
@@ -77,55 +77,55 @@ public class LeaderInformationRegister {
 
     /**
      * Creates a new {@code LeaderInformationRegister} that matches the passed {@code
-     * LeaderInformationRegister} except for the entry of {@code contenderID} which is removed if it
+     * LeaderInformationRegister} except for the entry of {@code componentId} which is removed if it
      * existed.
      */
     public static LeaderInformationRegister clear(
-            @Nullable LeaderInformationRegister leaderInformationRegister, String contenderID) {
+            @Nullable LeaderInformationRegister leaderInformationRegister, String componentId) {
         if (leaderInformationRegister == null
-                || !leaderInformationRegister.getRegisteredContenderIDs().iterator().hasNext()) {
+                || !leaderInformationRegister.getRegisteredComponentIds().iterator().hasNext()) {
             return LeaderInformationRegister.empty();
         }
 
-        return merge(leaderInformationRegister, contenderID, LeaderInformation.empty());
+        return merge(leaderInformationRegister, componentId, LeaderInformation.empty());
     }
 
     /** Creates a {@code LeaderInformationRegister} based on the passed leader information. */
     public LeaderInformationRegister(
-            Map<String, LeaderInformation> leaderInformationPerContenderID) {
-        this.leaderInformationPerContenderID =
-                leaderInformationPerContenderID.entrySet().stream()
+            Map<String, LeaderInformation> leaderInformationPerComponentId) {
+        this.leaderInformationPerComponentId =
+                leaderInformationPerComponentId.entrySet().stream()
                         .filter(entry -> !entry.getValue().isEmpty())
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
      * Returns the {@link LeaderInformation} that is stored or an empty {@code Optional} if no entry
-     * exists for the passed {@code contenderID}.
+     * exists for the passed {@code componentId}.
      */
-    public Optional<LeaderInformation> forContenderID(String contenderID) {
-        return Optional.ofNullable(leaderInformationPerContenderID.get(contenderID));
+    public Optional<LeaderInformation> forComponentId(String componentId) {
+        return Optional.ofNullable(leaderInformationPerComponentId.get(componentId));
     }
 
     /**
      * Returns a {@link LeaderInformation} which is empty if no {@code LeaderInformation} is stored
-     * for the passed {@code contenderID}.
+     * for the passed {@code componentId}.
      */
-    public LeaderInformation forContenderIdOrEmpty(String contenderID) {
-        return forContenderID(contenderID).orElse(LeaderInformation.empty());
+    public LeaderInformation forComponentIdOrEmpty(String componentId) {
+        return forComponentId(componentId).orElse(LeaderInformation.empty());
     }
 
-    /** Returns the {@code contenderID}s for which leader information is stored. */
-    public Iterable<String> getRegisteredContenderIDs() {
-        return leaderInformationPerContenderID.keySet();
+    /** Returns the {@code componentId}s for which leader information is stored. */
+    public Iterable<String> getRegisteredComponentIds() {
+        return leaderInformationPerComponentId.keySet();
     }
 
     /**
      * Checks whether the register holds non-empty {@link LeaderInformation} for the passed {@code
-     * contenderID}.
+     * componentId}.
      */
-    public boolean hasLeaderInformation(String contenderID) {
-        return leaderInformationPerContenderID.containsKey(contenderID);
+    public boolean hasLeaderInformation(String componentId) {
+        return leaderInformationPerComponentId.containsKey(componentId);
     }
 
     /**
@@ -133,10 +133,10 @@ public class LeaderInformationRegister {
      *
      * @return {@code true}, if there is no entry that refers to a non-empty {@code
      *     LeaderInformation}; otherwise {@code false} (i.e. either no information is stored under
-     *     any {@code contenderID} or there are entries for certain {@code contenderID}s that refer
+     *     any {@code componentId} or there are entries for certain {@code componentId}s that refer
      *     to an empty {@code LeaderInformation} record).
      */
     public boolean hasNoLeaderInformation() {
-        return leaderInformationPerContenderID.isEmpty();
+        return leaderInformationPerComponentId.isEmpty();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -128,7 +128,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
     }
 
     @Override
-    public void publishLeaderInformation(String contenderID, LeaderInformation leaderInformation) {
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation) {
         Preconditions.checkState(running.get());
 
         if (!leaderLatch.hasLeadership()) {
@@ -136,12 +136,12 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
         }
 
         final String connectionInformationPath =
-                ZooKeeperUtils.generateConnectionInformationPath(contenderID);
+                ZooKeeperUtils.generateConnectionInformationPath(componentId);
 
         LOG.debug(
                 "Write leader information {} for {} to {}.",
                 leaderInformation,
-                contenderID,
+                componentId,
                 ZooKeeperUtils.generateZookeeperPath(
                         curatorFramework.getNamespace(), connectionInformationPath));
 
@@ -157,10 +157,10 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
     }
 
     @Override
-    public void deleteLeaderInformation(String contenderID) {
+    public void deleteLeaderInformation(String componentId) {
         try {
             ZooKeeperUtils.deleteZNode(
-                    curatorFramework, ZooKeeperUtils.generateZookeeperPath(contenderID));
+                    curatorFramework, ZooKeeperUtils.generateZookeeperPath(componentId));
         } catch (Exception e) {
             leaderElectionListener.onError(e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderServiceTest.java
@@ -45,7 +45,7 @@ class EmbeddedLeaderServiceTest {
             final TestingLeaderContender contender = new TestingLeaderContender();
 
             final LeaderElection leaderElection =
-                    embeddedLeaderService.createLeaderElectionService("contender_id");
+                    embeddedLeaderService.createLeaderElectionService("component_id");
             leaderElection.startLeaderElection(contender);
             leaderElection.close();
 
@@ -79,7 +79,7 @@ class EmbeddedLeaderServiceTest {
             final TestingLeaderContender contender = new TestingLeaderContender();
 
             final LeaderElection leaderElection =
-                    embeddedLeaderService.createLeaderElectionService("contender_id");
+                    embeddedLeaderService.createLeaderElectionService("component_id");
             leaderElection.startLeaderElection(contender);
 
             // wait for the leadership

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -719,9 +719,9 @@ class JobMasterServiceLeadershipRunnerTest {
                                     return CompletableFuture.completedFuture(null);
                                 })
                         .build();
-        final String contenderID = "random-contender-id";
+        final String componentId = "random-component-id";
         final LeaderElection leaderElection =
-                defaultLeaderElectionService.createLeaderElection(contenderID);
+                defaultLeaderElectionService.createLeaderElection(componentId);
         try (final JobMasterServiceLeadershipRunner jobManagerRunner =
                 newJobMasterServiceLeadershipRunnerBuilder()
                         .setClassLoaderLease(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -69,7 +69,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(ctx.contender.getLeaderSessionID())
                                                 .isEqualTo(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isEqualTo(leaderSessionID);
 
                                         final LeaderInformation
@@ -79,7 +79,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.contenderID))
+                                                                .forContenderID(ctx.componentId))
                                                 .as(
                                                         "The HA backend should have its leader information updated.")
                                                 .hasValue(expectedLeaderInformationInHaBackend);
@@ -93,7 +93,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(ctx.contender.getLeaderSessionID()).isNull();
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isNull();
 
                                         final LeaderInformation
@@ -104,7 +104,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.contenderID))
+                                                                .forContenderID(ctx.componentId))
                                                 .as(
                                                         "External storage is not touched by the leader session because the leadership is already lost.")
                                                 .hasValue(expectedLeaderInformationInHaBackend);
@@ -115,7 +115,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testErrorOnContenderIDReuse() throws Exception {
+    void testErrorOnComponentIdReuse() throws Exception {
         new Context() {
             {
                 runTestWithSynchronousEventHandling(
@@ -123,7 +123,7 @@ class DefaultLeaderElectionServiceTest {
                                 assertThatThrownBy(
                                                 () ->
                                                         leaderElectionService.createLeaderElection(
-                                                                contenderContext0.contenderID))
+                                                                contenderContext0.componentId))
                                         .isInstanceOf(IllegalStateException.class));
             }
         };
@@ -524,18 +524,18 @@ class DefaultLeaderElectionServiceTest {
                                                 .isEqualTo(leaderSessionID);
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isEqualTo(leaderSessionID);
 
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isEqualTo(leaderSessionID);
 
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.contenderID))
+                                                                .forContenderID(ctx.componentId))
                                                 .hasValue(
                                                         LeaderInformation.known(
                                                                 leaderSessionID, ctx.address));
@@ -548,7 +548,7 @@ class DefaultLeaderElectionServiceTest {
                                                 .isNull();
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .as(
                                                         "The LeaderElectionService should have its internal state cleaned.")
                                                 .isNull();
@@ -581,11 +581,11 @@ class DefaultLeaderElectionServiceTest {
                             // corrected.
                             storedLeaderInformation.set(LeaderInformationRegister.empty());
                             leaderElectionService.onLeaderInformationChange(
-                                    contenderContext0.contenderID, LeaderInformation.empty());
+                                    contenderContext0.componentId, LeaderInformation.empty());
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.contenderID))
+                                                    .forContenderID(contenderContext0.componentId))
                                     .as("Removed leader information should have been reset.")
                                     .hasValue(expectedLeaderInformation);
 
@@ -593,14 +593,14 @@ class DefaultLeaderElectionServiceTest {
                                     LeaderInformation.known(UUID.randomUUID(), "faulty-address");
                             storedLeaderInformation.set(
                                     LeaderInformationRegister.of(
-                                            contenderContext0.contenderID,
+                                            contenderContext0.componentId,
                                             faultyLeaderInformation));
                             leaderElectionService.onLeaderInformationChange(
-                                    contenderContext0.contenderID, faultyLeaderInformation);
+                                    contenderContext0.componentId, faultyLeaderInformation);
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.contenderID))
+                                                    .forContenderID(contenderContext0.componentId))
                                     .as("Overwritten leader information should have been reset.")
                                     .hasValue(expectedLeaderInformation);
                         });
@@ -623,17 +623,17 @@ class DefaultLeaderElectionServiceTest {
                                     storedLeaderInformation.get();
                             assertThat(correctLeaderInformationRegister.getRegisteredContenderIDs())
                                     .containsExactlyInAnyOrder(
-                                            contenderContext0.contenderID,
-                                            contenderContext1.contenderID);
+                                            contenderContext0.componentId,
+                                            contenderContext1.componentId);
 
                             // change LeaderInformation partially on external storage
-                            final String contenderIdWithChange = contenderContext0.contenderID;
-                            final String contenderIdWithoutChange = contenderContext1.contenderID;
+                            final String componentIdWithChange = contenderContext0.componentId;
+                            final String componentIdWithoutChange = contenderContext1.componentId;
                             final LeaderInformationRegister
                                     partiallyChangedLeaderInformationRegister =
                                             LeaderInformationRegister.clear(
                                                     correctLeaderInformationRegister,
-                                                    contenderIdWithChange);
+                                                    componentIdWithChange);
                             storedLeaderInformation.set(partiallyChangedLeaderInformationRegister);
                             leaderElectionService.onLeaderInformationChange(
                                     partiallyChangedLeaderInformationRegister);
@@ -641,26 +641,26 @@ class DefaultLeaderElectionServiceTest {
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderIdWithChange))
+                                                    .forContenderID(componentIdWithChange))
                                     .as("Removed leader information should have been reset.")
                                     .hasValue(
                                             correctLeaderInformationRegister.forContenderIdOrEmpty(
-                                                    contenderIdWithChange));
+                                                    componentIdWithChange));
 
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderIdWithoutChange))
+                                                    .forContenderID(componentIdWithoutChange))
                                     .hasValue(
                                             correctLeaderInformationRegister.forContenderIdOrEmpty(
-                                                    contenderIdWithoutChange));
+                                                    componentIdWithoutChange));
                         });
             }
         };
     }
 
     @Test
-    void testAllLeaderInformationChangeEventWithUnknownContenderID() throws Exception {
+    void testAllLeaderInformationChangeEventWithUnknownComponentId() throws Exception {
         final AtomicReference<LeaderInformationRegister> storedLeaderInformation =
                 new AtomicReference<>();
         new Context(storedLeaderInformation) {
@@ -674,19 +674,19 @@ class DefaultLeaderElectionServiceTest {
                                     storedLeaderInformation.get();
                             assertThat(correctLeaderInformationRegister.getRegisteredContenderIDs())
                                     .containsExactlyInAnyOrder(
-                                            contenderContext0.contenderID,
-                                            contenderContext1.contenderID);
+                                            contenderContext0.componentId,
+                                            contenderContext1.componentId);
 
-                            // change LeaderInformation only affects an unregistered contenderID
-                            final String unknownContenderID = createRandomContenderID();
+                            // change LeaderInformation only affects an unregistered componentId
+                            final String unknownComponentId = createRandomContenderID();
                             final LeaderInformationRegister
                                     partiallyChangedLeaderInformationRegister =
                                             LeaderInformationRegister.merge(
                                                     correctLeaderInformationRegister,
-                                                    unknownContenderID,
+                                                    unknownComponentId,
                                                     LeaderInformation.known(
                                                             UUID.randomUUID(),
-                                                            "address-for-" + unknownContenderID));
+                                                            "address-for-" + unknownComponentId));
                             storedLeaderInformation.set(partiallyChangedLeaderInformationRegister);
                             leaderElectionService.onLeaderInformationChange(
                                     partiallyChangedLeaderInformationRegister);
@@ -713,11 +713,11 @@ class DefaultLeaderElectionServiceTest {
                                     ctx -> {
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, expectedSessionID))
+                                                                ctx.componentId, expectedSessionID))
                                                 .isFalse();
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, UUID.randomUUID()))
+                                                                ctx.componentId, UUID.randomUUID()))
                                                 .isFalse();
                                     });
                         });
@@ -746,11 +746,11 @@ class DefaultLeaderElectionServiceTest {
 
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, expectedSessionID))
+                                                                ctx.componentId, expectedSessionID))
                                                 .isTrue();
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, UUID.randomUUID()))
+                                                                ctx.componentId, UUID.randomUUID()))
                                                 .isFalse();
                                     });
                         });
@@ -774,7 +774,7 @@ class DefaultLeaderElectionServiceTest {
                                     ctx -> {
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, expectedSessionID))
+                                                                ctx.componentId, expectedSessionID))
                                                 .as(
                                                         "No operation should be handled anymore after the HA backend "
                                                                 + "indicated leadership loss even if the onRevokeLeadership wasn't "
@@ -784,7 +784,7 @@ class DefaultLeaderElectionServiceTest {
                                                 .isFalse();
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, UUID.randomUUID()))
+                                                                ctx.componentId, UUID.randomUUID()))
                                                 .isFalse();
                                     });
                         });
@@ -806,11 +806,11 @@ class DefaultLeaderElectionServiceTest {
                                     ctx -> {
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, expectedSessionID))
+                                                                ctx.componentId, expectedSessionID))
                                                 .isFalse();
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, UUID.randomUUID()))
+                                                                ctx.componentId, UUID.randomUUID()))
                                                 .isFalse();
                                     });
                         });
@@ -833,7 +833,7 @@ class DefaultLeaderElectionServiceTest {
 
                                         assertThat(
                                                         leaderElectionService.hasLeadership(
-                                                                ctx.contenderID, expectedSessionID))
+                                                                ctx.componentId, expectedSessionID))
                                                 .isFalse();
                                     });
                         });
@@ -853,15 +853,15 @@ class DefaultLeaderElectionServiceTest {
                                     LeaderInformation.known(UUID.randomUUID(), "different-address");
                             storedLeaderInformation.set(
                                     LeaderInformationRegister.of(
-                                            contenderContext0.contenderID,
+                                            contenderContext0.componentId,
                                             differentLeaderInformation));
                             leaderElectionService.onLeaderInformationChange(
-                                    contenderContext0.contenderID, differentLeaderInformation);
+                                    contenderContext0.componentId, differentLeaderInformation);
 
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.contenderID))
+                                                    .forContenderID(contenderContext0.componentId))
                                     .as("The external storage shouldn't have been changed.")
                                     .hasValue(differentLeaderInformation);
                         });
@@ -882,7 +882,7 @@ class DefaultLeaderElectionServiceTest {
                                     ctx -> {
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .as(
                                                         "The grant event shouldn't have been processed by the LeaderElectionService.")
                                                 .isNull();
@@ -899,8 +899,8 @@ class DefaultLeaderElectionServiceTest {
     @Test
     void testOnLeaderInformationChangeIsIgnoredAfterLeaderElectionBeingClosed() throws Exception {
         testLeadershipChangeEventHandlingBeingIgnoredAfterLeaderElectionClose(
-                (listener, contenderIDs, externalStorage) ->
-                        contenderIDs.forEach(
+                (listener, componentIds, externalStorage) ->
+                        componentIds.forEach(
                                 c ->
                                         listener.onLeaderInformationChange(
                                                 c, externalStorage.forContenderIdOrEmpty(c))));
@@ -909,7 +909,7 @@ class DefaultLeaderElectionServiceTest {
     @Test
     void testAllLeaderInformationChangeIsIgnoredAfterLeaderElectionBeingClosed() throws Exception {
         testLeadershipChangeEventHandlingBeingIgnoredAfterLeaderElectionClose(
-                (listener, ignoredContenderIDs, externalStorage) ->
+                (listener, ignoredComponentIds, externalStorage) ->
                         listener.onLeaderInformationChange(externalStorage));
     }
 
@@ -927,8 +927,8 @@ class DefaultLeaderElectionServiceTest {
 
                             assertThat(storedLeaderInformation.get().getRegisteredContenderIDs())
                                     .containsExactlyInAnyOrder(
-                                            contenderContext0.contenderID,
-                                            contenderContext1.contenderID);
+                                            contenderContext0.componentId,
+                                            contenderContext1.componentId);
 
                             contenderContext0.leaderElection.close();
 
@@ -938,19 +938,19 @@ class DefaultLeaderElectionServiceTest {
                             // LeaderInformationRegister is implemented as a singleton which would
                             // prevent us from checking the identity of the external storage at the
                             // end of the test)
-                            final String otherContenderID = createRandomContenderID();
+                            final String otherComponentId = createRandomContenderID();
                             final LeaderInformation otherLeaderInformation =
                                     LeaderInformation.known(
-                                            UUID.randomUUID(), "address-for-" + otherContenderID);
+                                            UUID.randomUUID(), "address-for-" + otherComponentId);
                             final LeaderInformationRegister registerWithUnknownContender =
                                     LeaderInformationRegister.of(
-                                            otherContenderID, otherLeaderInformation);
+                                            otherComponentId, otherLeaderInformation);
                             storedLeaderInformation.set(registerWithUnknownContender);
                             callback.accept(
                                     leaderElectionService,
                                     Arrays.asList(
-                                            contenderContext0.contenderID,
-                                            contenderContext1.contenderID),
+                                            contenderContext0.componentId,
+                                            contenderContext1.componentId),
                                     storedLeaderInformation.get());
 
                             final LeaderInformationRegister correctedExternalStorage =
@@ -959,7 +959,7 @@ class DefaultLeaderElectionServiceTest {
                                     .as(
                                             "Only the still registered contender and the unknown one should have corrected its LeaderInformation.")
                                     .containsExactlyInAnyOrder(
-                                            contenderContext1.contenderID, otherContenderID);
+                                            contenderContext1.componentId, otherComponentId);
 
                             contenderContext1.leaderElection.close();
 
@@ -968,7 +968,7 @@ class DefaultLeaderElectionServiceTest {
 
                             callback.accept(
                                     leaderElectionService,
-                                    Collections.singleton(contenderContext1.contenderID),
+                                    Collections.singleton(contenderContext1.componentId),
                                     leftOverData);
 
                             assertThat(storedLeaderInformation.get().getRegisteredContenderIDs())
@@ -992,7 +992,7 @@ class DefaultLeaderElectionServiceTest {
                             grantLeadership();
                             final UUID oldSessionId =
                                     leaderElectionService.getLeaderSessionID(
-                                            contenderContext0.contenderID);
+                                            contenderContext0.componentId);
 
                             applyToBothContenderContexts(
                                     ctx -> {
@@ -1033,7 +1033,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.contenderID))
+                                                                .forContenderID(ctx.componentId))
                                                 .hasValue(expectedLeaderInformation);
 
                                         // Old confirm call should be ignored.
@@ -1041,7 +1041,7 @@ class DefaultLeaderElectionServiceTest {
                                                 UUID.randomUUID(), ctx.address);
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isEqualTo(currentLeaderSessionId);
                                     });
 
@@ -1073,7 +1073,7 @@ class DefaultLeaderElectionServiceTest {
 
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
-                                                                ctx.contenderID))
+                                                                ctx.componentId))
                                                 .isNull();
                                     });
                         });
@@ -1139,17 +1139,17 @@ class DefaultLeaderElectionServiceTest {
     @Test
     void testGrantDoesNotBlockNotifyLeaderInformationChange() throws Exception {
         testLeaderEventDoesNotBlockLeaderInformationChangeEventHandling(
-                (listener, contenderID, storedLeaderInformation) -> {
+                (listener, componentId, storedLeaderInformation) -> {
                     listener.onLeaderInformationChange(
-                            contenderID,
-                            storedLeaderInformation.forContenderIdOrEmpty(contenderID));
+                            componentId,
+                            storedLeaderInformation.forContenderIdOrEmpty(componentId));
                 });
     }
 
     @Test
     void testGrantDoesNotBlockNotifyAllKnownLeaderInformation() throws Exception {
         testLeaderEventDoesNotBlockLeaderInformationChangeEventHandling(
-                (listener, contenderID, storedLeaderInformation) -> {
+                (listener, componentId, storedLeaderInformation) -> {
                     listener.onLeaderInformationChange(storedLeaderInformation);
                 });
     }
@@ -1170,11 +1170,11 @@ class DefaultLeaderElectionServiceTest {
                                             UUID.randomUUID(), contenderContext0.address);
                             storedLeaderInformation.set(
                                     LeaderInformationRegister.of(
-                                            contenderContext0.contenderID,
+                                            contenderContext0.componentId,
                                             changedLeaderInformation));
                             callback.accept(
                                     leaderElectionService,
-                                    contenderContext0.contenderID,
+                                    contenderContext0.componentId,
                                     storedLeaderInformation.get());
 
                             assertThat(storedLeaderInformation.get().hasNoLeaderInformation())
@@ -1353,7 +1353,7 @@ class DefaultLeaderElectionServiceTest {
     /** Context for holding the per-contender information. */
     private static class ContenderContext implements AutoCloseable {
 
-        private final String contenderID;
+        private final String componentId;
         private final String address;
         private final TestingContender contender;
         private LeaderElection leaderElection;
@@ -1362,23 +1362,23 @@ class DefaultLeaderElectionServiceTest {
                 throws Exception {
             // randomSuffix is added to ensure uniqueness even between tests
             final String randomSuffix = UUID.randomUUID().toString().substring(0, 4);
-            final String contenderID = String.format("contender-id-%d-%s", id, randomSuffix);
+            final String componentId = String.format("component-id-%d-%s", id, randomSuffix);
             final String address = String.format("address-%d-%s", id, randomSuffix);
 
             final LeaderElection leaderElection =
-                    leaderElectionService.createLeaderElection(contenderID);
+                    leaderElectionService.createLeaderElection(componentId);
             final TestingContender contender = new TestingContender(address, leaderElection);
             contender.startLeaderElection();
 
-            return new ContenderContext(contenderID, address, contender, leaderElection);
+            return new ContenderContext(componentId, address, contender, leaderElection);
         }
 
         private ContenderContext(
-                String contenderID,
+                String componentId,
                 String address,
                 TestingContender contender,
                 LeaderElection leaderElection) {
-            this.contenderID = contenderID;
+            this.componentId = componentId;
             this.address = address;
             this.contender = contender;
             this.leaderElection = leaderElection;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -164,7 +164,7 @@ class DefaultLeaderElectionServiceTest {
                         driverFactory, fatalErrorHandlerExtension.getTestingFatalErrorHandler())) {
 
             // creating the LeaderElection is necessary to instantiate the driver
-            final LeaderElection leaderElection = testInstance.createLeaderElection("contender-id");
+            final LeaderElection leaderElection = testInstance.createLeaderElection("component-id");
             leaderElection.startLeaderElection(TestingGenericLeaderContender.newBuilder().build());
 
             final TestingLeaderElectionDriver driver =
@@ -238,7 +238,7 @@ class DefaultLeaderElectionServiceTest {
                     .isFalse();
 
             try (final LeaderElection leaderElection =
-                    testInstance.createLeaderElection("contender-id")) {
+                    testInstance.createLeaderElection("component-id")) {
                 assertThat(driverCreated)
                         .as(
                                 "The driver shouldn't have been created during LeaderElection creation.")
@@ -265,7 +265,7 @@ class DefaultLeaderElectionServiceTest {
         // This results in the close method not having any effect.
         testInstance.close();
 
-        assertThatThrownBy(() -> testInstance.createLeaderElection("contender-id"))
+        assertThatThrownBy(() -> testInstance.createLeaderElection("component-id"))
                 .as(
                         "Registering a contender on a closed service should have resulted in an IllegalStateException.")
                 .isInstanceOf(IllegalStateException.class);
@@ -286,14 +286,14 @@ class DefaultLeaderElectionServiceTest {
         try (final DefaultLeaderElectionService testInstance =
                 new DefaultLeaderElectionService(driverFactory)) {
 
-            final String contenderID = "contender_id";
+            final String componentId = "component_id";
             final int numberOfStartCloseSessions = 2;
             for (int i = 1; i <= numberOfStartCloseSessions; i++) {
                 assertThat(driverFactory.getCreatedDriverCount()).isEqualTo(i - 1);
                 assertThat(closeCount).hasValue(i - 1);
 
                 try (final LeaderElection leaderElection =
-                        testInstance.createLeaderElection(contenderID)) {
+                        testInstance.createLeaderElection(componentId)) {
                     leaderElection.startLeaderElection(
                             TestingGenericLeaderContender.newBuilder().build());
                 }
@@ -383,7 +383,7 @@ class DefaultLeaderElectionServiceTest {
                                     ignoredSessionID -> secondContenderReceivedGrant.set(true))
                             .build();
             try (final LeaderElection firstLeaderElection =
-                    leaderElectionService.createLeaderElection("contender_id_0")) {
+                    leaderElectionService.createLeaderElection("component_id_0")) {
                 firstLeaderElection.startLeaderElection(firstContender);
 
                 assertThat(driverFactory.getCreatedDriverCount())
@@ -394,7 +394,7 @@ class DefaultLeaderElectionServiceTest {
                 assertThat(firstContenderReceivedGrant).isFalse();
 
                 try (final LeaderElection secondLeaderElection =
-                        leaderElectionService.createLeaderElection("contender_id_1")) {
+                        leaderElectionService.createLeaderElection("component_id_1")) {
                     secondLeaderElection.startLeaderElection(secondContender);
 
                     assertThat(secondContenderReceivedGrant).isFalse();
@@ -428,7 +428,7 @@ class DefaultLeaderElectionServiceTest {
                                             leadershipGrantForwardedToContender.set(true))
                             .build();
             try (final LeaderElection leaderElection =
-                    leaderElectionService.createLeaderElection("contender_id")) {
+                    leaderElectionService.createLeaderElection("component_id")) {
                 leaderElection.startLeaderElection(leaderContender);
 
                 assertThat(driverFactory.getCreatedDriverCount())
@@ -454,7 +454,8 @@ class DefaultLeaderElectionServiceTest {
                             executorService.trigger();
 
                             final LeaderElection leaderElection =
-                                    leaderElectionService.createLeaderElection(createRandomComponentId());
+                                    leaderElectionService.createLeaderElection(
+                                            createRandomComponentId());
 
                             final AtomicInteger revokeCallCount = new AtomicInteger();
                             final LeaderContender contender =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -343,7 +343,7 @@ class DefaultLeaderElectionServiceTest {
                         Executors.newDirectExecutorService())) {
 
             final LeaderElection leaderElection =
-                    testInstance.createLeaderElection(createRandomContenderID());
+                    testInstance.createLeaderElection(createRandomComponentId());
             final TestingContender testingContender =
                     new TestingContender("unused-address", leaderElection);
             testingContender.startLeaderElection();
@@ -454,7 +454,7 @@ class DefaultLeaderElectionServiceTest {
                             executorService.trigger();
 
                             final LeaderElection leaderElection =
-                                    leaderElectionService.createLeaderElection("contender_id");
+                                    leaderElectionService.createLeaderElection(createRandomComponentId());
 
                             final AtomicInteger revokeCallCount = new AtomicInteger();
                             final LeaderContender contender =
@@ -678,7 +678,7 @@ class DefaultLeaderElectionServiceTest {
                                             contenderContext1.componentId);
 
                             // change LeaderInformation only affects an unregistered componentId
-                            final String unknownComponentId = createRandomContenderID();
+                            final String unknownComponentId = createRandomComponentId();
                             final LeaderInformationRegister
                                     partiallyChangedLeaderInformationRegister =
                                             LeaderInformationRegister.merge(
@@ -938,7 +938,7 @@ class DefaultLeaderElectionServiceTest {
                             // LeaderInformationRegister is implemented as a singleton which would
                             // prevent us from checking the identity of the external storage at the
                             // end of the test)
-                            final String otherComponentId = createRandomContenderID();
+                            final String otherComponentId = createRandomComponentId();
                             final LeaderInformation otherLeaderInformation =
                                     LeaderInformation.known(
                                             UUID.randomUUID(), "address-for-" + otherComponentId);
@@ -1234,7 +1234,7 @@ class DefaultLeaderElectionServiceTest {
                         driverFactory, fatalErrorHandlerExtension.getTestingFatalErrorHandler());
 
         final LeaderElection leaderElection =
-                testInstance.createLeaderElection(createRandomContenderID());
+                testInstance.createLeaderElection(createRandomComponentId());
         leaderElection.startLeaderElection(contender);
 
         listenerAction.accept(leadershipGranted, testInstance);
@@ -1245,8 +1245,8 @@ class DefaultLeaderElectionServiceTest {
         testInstance.close();
     }
 
-    private static String createRandomContenderID() {
-        return String.format("contender-id-%s", UUID.randomUUID());
+    private static String createRandomComponentId() {
+        return String.format("component-id-%s", UUID.randomUUID());
     }
 
     private class Context {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -79,7 +79,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.componentId))
+                                                                .forComponentId(ctx.componentId))
                                                 .as(
                                                         "The HA backend should have its leader information updated.")
                                                 .hasValue(expectedLeaderInformationInHaBackend);
@@ -104,7 +104,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.componentId))
+                                                                .forComponentId(ctx.componentId))
                                                 .as(
                                                         "External storage is not touched by the leader session because the leadership is already lost.")
                                                 .hasValue(expectedLeaderInformationInHaBackend);
@@ -535,7 +535,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.componentId))
+                                                                .forComponentId(ctx.componentId))
                                                 .hasValue(
                                                         LeaderInformation.known(
                                                                 leaderSessionID, ctx.address));
@@ -554,7 +554,7 @@ class DefaultLeaderElectionServiceTest {
                                                 .isNull();
                                     });
 
-                            assertThat(storedLeaderInformation.get().getRegisteredContenderIDs())
+                            assertThat(storedLeaderInformation.get().getRegisteredComponentIds())
                                     .as("The HA backend's data should have been cleaned.")
                                     .isEmpty();
                         });
@@ -585,7 +585,7 @@ class DefaultLeaderElectionServiceTest {
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.componentId))
+                                                    .forComponentId(contenderContext0.componentId))
                                     .as("Removed leader information should have been reset.")
                                     .hasValue(expectedLeaderInformation);
 
@@ -600,7 +600,7 @@ class DefaultLeaderElectionServiceTest {
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.componentId))
+                                                    .forComponentId(contenderContext0.componentId))
                                     .as("Overwritten leader information should have been reset.")
                                     .hasValue(expectedLeaderInformation);
                         });
@@ -621,7 +621,7 @@ class DefaultLeaderElectionServiceTest {
 
                             final LeaderInformationRegister correctLeaderInformationRegister =
                                     storedLeaderInformation.get();
-                            assertThat(correctLeaderInformationRegister.getRegisteredContenderIDs())
+                            assertThat(correctLeaderInformationRegister.getRegisteredComponentIds())
                                     .containsExactlyInAnyOrder(
                                             contenderContext0.componentId,
                                             contenderContext1.componentId);
@@ -641,18 +641,18 @@ class DefaultLeaderElectionServiceTest {
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(componentIdWithChange))
+                                                    .forComponentId(componentIdWithChange))
                                     .as("Removed leader information should have been reset.")
                                     .hasValue(
-                                            correctLeaderInformationRegister.forContenderIdOrEmpty(
+                                            correctLeaderInformationRegister.forComponentIdOrEmpty(
                                                     componentIdWithChange));
 
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(componentIdWithoutChange))
+                                                    .forComponentId(componentIdWithoutChange))
                                     .hasValue(
-                                            correctLeaderInformationRegister.forContenderIdOrEmpty(
+                                            correctLeaderInformationRegister.forComponentIdOrEmpty(
                                                     componentIdWithoutChange));
                         });
             }
@@ -672,7 +672,7 @@ class DefaultLeaderElectionServiceTest {
 
                             final LeaderInformationRegister correctLeaderInformationRegister =
                                     storedLeaderInformation.get();
-                            assertThat(correctLeaderInformationRegister.getRegisteredContenderIDs())
+                            assertThat(correctLeaderInformationRegister.getRegisteredComponentIds())
                                     .containsExactlyInAnyOrder(
                                             contenderContext0.componentId,
                                             contenderContext1.componentId);
@@ -861,7 +861,7 @@ class DefaultLeaderElectionServiceTest {
                             assertThat(
                                             storedLeaderInformation
                                                     .get()
-                                                    .forContenderID(contenderContext0.componentId))
+                                                    .forComponentId(contenderContext0.componentId))
                                     .as("The external storage shouldn't have been changed.")
                                     .hasValue(differentLeaderInformation);
                         });
@@ -903,7 +903,7 @@ class DefaultLeaderElectionServiceTest {
                         componentIds.forEach(
                                 c ->
                                         listener.onLeaderInformationChange(
-                                                c, externalStorage.forContenderIdOrEmpty(c))));
+                                                c, externalStorage.forComponentIdOrEmpty(c))));
     }
 
     @Test
@@ -925,7 +925,7 @@ class DefaultLeaderElectionServiceTest {
                         () -> {
                             grantLeadership();
 
-                            assertThat(storedLeaderInformation.get().getRegisteredContenderIDs())
+                            assertThat(storedLeaderInformation.get().getRegisteredComponentIds())
                                     .containsExactlyInAnyOrder(
                                             contenderContext0.componentId,
                                             contenderContext1.componentId);
@@ -955,7 +955,7 @@ class DefaultLeaderElectionServiceTest {
 
                             final LeaderInformationRegister correctedExternalStorage =
                                     storedLeaderInformation.get();
-                            assertThat(correctedExternalStorage.getRegisteredContenderIDs())
+                            assertThat(correctedExternalStorage.getRegisteredComponentIds())
                                     .as(
                                             "Only the still registered contender and the unknown one should have corrected its LeaderInformation.")
                                     .containsExactlyInAnyOrder(
@@ -971,7 +971,7 @@ class DefaultLeaderElectionServiceTest {
                                     Collections.singleton(contenderContext1.componentId),
                                     leftOverData);
 
-                            assertThat(storedLeaderInformation.get().getRegisteredContenderIDs())
+                            assertThat(storedLeaderInformation.get().getRegisteredComponentIds())
                                     .as(
                                             "The following identity check does only make sense if we're not using an empty register.")
                                     .hasSize(1);
@@ -1033,7 +1033,7 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(
                                                         storedLeaderInformation
                                                                 .get()
-                                                                .forContenderID(ctx.componentId))
+                                                                .forComponentId(ctx.componentId))
                                                 .hasValue(expectedLeaderInformation);
 
                                         // Old confirm call should be ignored.
@@ -1142,7 +1142,7 @@ class DefaultLeaderElectionServiceTest {
                 (listener, componentId, storedLeaderInformation) -> {
                     listener.onLeaderInformationChange(
                             componentId,
-                            storedLeaderInformation.forContenderIdOrEmpty(componentId));
+                            storedLeaderInformation.forComponentIdOrEmpty(componentId));
                 });
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionTest.java
@@ -35,27 +35,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DefaultLeaderElectionTest {
 
-    private static final String DEFAULT_TEST_CONTENDER_ID = "test-contender-id";
+    private static final String DEFAULT_TEST_COMPONENT_ID = "test-component-id";
 
     @Test
     void testContenderRegistration() throws Exception {
-        final AtomicReference<String> contenderIDRef = new AtomicReference<>();
+        final AtomicReference<String> componentIdRef = new AtomicReference<>();
         final AtomicReference<LeaderContender> contenderRef = new AtomicReference<>();
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
                         .setRegisterConsumer(
-                                (actualContenderID, actualContender) -> {
-                                    contenderIDRef.set(actualContenderID);
+                                (actualComponentId, actualContender) -> {
+                                    componentIdRef.set(actualComponentId);
                                     contenderRef.set(actualContender);
                                 })
                         .build();
         try (final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID)) {
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID)) {
 
             final LeaderContender contender = TestingGenericLeaderContender.newBuilder().build();
             testInstance.startLeaderElection(contender);
 
-            assertThat(contenderIDRef).hasValue(DEFAULT_TEST_CONTENDER_ID);
+            assertThat(componentIdRef).hasValue(DEFAULT_TEST_COMPONENT_ID);
             assertThat(contenderRef.get()).isSameAs(contender);
         }
     }
@@ -65,7 +65,7 @@ class DefaultLeaderElectionTest {
         try (final DefaultLeaderElection testInstance =
                 new DefaultLeaderElection(
                         TestingAbstractLeaderElectionService.newBuilder().build(),
-                        DEFAULT_TEST_CONTENDER_ID)) {
+                        DEFAULT_TEST_COMPONENT_ID)) {
             assertThatThrownBy(() -> testInstance.startLeaderElection(null))
                     .isInstanceOf(NullPointerException.class);
         }
@@ -78,12 +78,12 @@ class DefaultLeaderElectionTest {
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
                         .setRegisterConsumer(
-                                (actualContenderID, actualContender) -> {
+                                (actualComponentId, actualContender) -> {
                                     throw expectedException;
                                 })
                         .build();
         try (final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID)) {
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID)) {
             assertThatThrownBy(
                             () ->
                                     testInstance.startLeaderElection(
@@ -94,26 +94,26 @@ class DefaultLeaderElectionTest {
 
     @Test
     void testLeaderConfirmation() throws Exception {
-        final AtomicReference<String> contenderIDRef = new AtomicReference<>();
+        final AtomicReference<String> componentIdRef = new AtomicReference<>();
         final AtomicReference<UUID> leaderSessionIDRef = new AtomicReference<>();
         final AtomicReference<String> leaderAddressRef = new AtomicReference<>();
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
                         .setConfirmLeadershipConsumer(
-                                (contenderID, leaderSessionID, address) -> {
-                                    contenderIDRef.set(contenderID);
+                                (componentId, leaderSessionID, address) -> {
+                                    componentIdRef.set(componentId);
                                     leaderSessionIDRef.set(leaderSessionID);
                                     leaderAddressRef.set(address);
                                 })
                         .build();
         try (final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID)) {
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID)) {
 
             final UUID expectedLeaderSessionID = UUID.randomUUID();
             final String expectedAddress = "random-address";
             testInstance.confirmLeadership(expectedLeaderSessionID, expectedAddress);
 
-            assertThat(contenderIDRef).hasValue(DEFAULT_TEST_CONTENDER_ID);
+            assertThat(componentIdRef).hasValue(DEFAULT_TEST_COMPONENT_ID);
             assertThat(leaderSessionIDRef).hasValue(expectedLeaderSessionID);
             assertThat(leaderAddressRef).hasValue(expectedAddress);
         }
@@ -121,37 +121,37 @@ class DefaultLeaderElectionTest {
 
     @Test
     void testClose() throws Exception {
-        final CompletableFuture<String> actualContenderID = new CompletableFuture<>();
+        final CompletableFuture<String> actualComponentId = new CompletableFuture<>();
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
-                        .setRegisterConsumer((ignoredContenderID, ignoredContender) -> {})
-                        .setRemoveConsumer(actualContenderID::complete)
+                        .setRegisterConsumer((ignoredComponentId, ignoredContender) -> {})
+                        .setRemoveConsumer(actualComponentId::complete)
                         .build();
 
         final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID);
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID);
 
         testInstance.startLeaderElection(TestingGenericLeaderContender.newBuilder().build());
         testInstance.close();
 
-        assertThat(actualContenderID).isCompletedWithValue(DEFAULT_TEST_CONTENDER_ID);
+        assertThat(actualComponentId).isCompletedWithValue(DEFAULT_TEST_COMPONENT_ID);
     }
 
     @Test
     void testCloseWithoutStart() throws Exception {
-        final CompletableFuture<String> actualContenderID = new CompletableFuture<>();
+        final CompletableFuture<String> actualComponentId = new CompletableFuture<>();
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
-                        .setRemoveConsumer(actualContenderID::complete)
+                        .setRemoveConsumer(actualComponentId::complete)
                         .build();
 
         final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID);
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID);
         testInstance.close();
 
-        assertThatFuture(actualContenderID)
+        assertThatFuture(actualComponentId)
                 .eventuallySucceeds()
-                .isEqualTo(DEFAULT_TEST_CONTENDER_ID);
+                .isEqualTo(DEFAULT_TEST_COMPONENT_ID);
     }
 
     @Test
@@ -165,24 +165,24 @@ class DefaultLeaderElectionTest {
     }
 
     private void testHasLeadership(boolean expectedReturnValue) throws Exception {
-        final AtomicReference<String> contenderIDRef = new AtomicReference<>();
+        final AtomicReference<String> componentIdRef = new AtomicReference<>();
         final AtomicReference<UUID> leaderSessionIDRef = new AtomicReference<>();
         final DefaultLeaderElection.ParentService parentService =
                 TestingAbstractLeaderElectionService.newBuilder()
                         .setHasLeadershipFunction(
-                                (actualContenderID, actualLeaderSessionID) -> {
-                                    contenderIDRef.set(actualContenderID);
+                                (actualComponentId, actualLeaderSessionID) -> {
+                                    componentIdRef.set(actualComponentId);
                                     leaderSessionIDRef.set(actualLeaderSessionID);
                                     return expectedReturnValue;
                                 })
                         .build();
         try (final DefaultLeaderElection testInstance =
-                new DefaultLeaderElection(parentService, DEFAULT_TEST_CONTENDER_ID)) {
+                new DefaultLeaderElection(parentService, DEFAULT_TEST_COMPONENT_ID)) {
 
             final UUID expectedLeaderSessionID = UUID.randomUUID();
             assertThat(testInstance.hasLeadership(expectedLeaderSessionID))
                     .isEqualTo(expectedReturnValue);
-            assertThat(contenderIDRef).hasValue(DEFAULT_TEST_CONTENDER_ID);
+            assertThat(componentIdRef).hasValue(DEFAULT_TEST_COMPONENT_ID);
             assertThat(leaderSessionIDRef).hasValue(expectedLeaderSessionID);
         }
     }
@@ -209,40 +209,40 @@ class DefaultLeaderElectionTest {
         }
 
         @Override
-        protected void register(String contenderID, LeaderContender contender) throws Exception {
-            registerConsumer.accept(contenderID, contender);
+        protected void register(String componentId, LeaderContender contender) throws Exception {
+            registerConsumer.accept(componentId, contender);
         }
 
         @Override
-        protected void remove(String contenderID) {
-            removeConsumer.accept(contenderID);
+        protected void remove(String componentId) {
+            removeConsumer.accept(componentId);
         }
 
         @Override
         protected void confirmLeadership(
-                String contenderID, UUID leaderSessionID, String leaderAddress) {
-            confirmLeadershipConsumer.accept(contenderID, leaderSessionID, leaderAddress);
+                String componentId, UUID leaderSessionID, String leaderAddress) {
+            confirmLeadershipConsumer.accept(componentId, leaderSessionID, leaderAddress);
         }
 
         @Override
-        protected boolean hasLeadership(String contenderID, UUID leaderSessionId) {
-            return hasLeadershipFunction.apply(contenderID, leaderSessionId);
+        protected boolean hasLeadership(String componentId, UUID leaderSessionId) {
+            return hasLeadershipFunction.apply(componentId, leaderSessionId);
         }
 
         public static Builder newBuilder() {
             return new Builder()
                     .setRegisterConsumer(
-                            (contenderID, contender) -> {
+                            (componentId, contender) -> {
                                 throw new UnsupportedOperationException("register not supported");
                             })
-                    .setRemoveConsumer(contenderID -> {})
+                    .setRemoveConsumer(componentId -> {})
                     .setConfirmLeadershipConsumer(
-                            (contenderID, leaderSessionID, address) -> {
+                            (componentId, leaderSessionID, address) -> {
                                 throw new UnsupportedOperationException(
                                         "confirmLeadership not supported");
                             })
                     .setHasLeadershipFunction(
-                            (contenderID, leaderSessionID) -> {
+                            (componentId, leaderSessionID) -> {
                                 throw new UnsupportedOperationException(
                                         "hasLeadership not supported");
                             });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionEvent.java
@@ -80,11 +80,11 @@ public abstract class LeaderElectionEvent {
     }
 
     public static class LeaderInformationChangeEvent extends LeaderElectionEvent {
-        private final String contenderID;
+        private final String componentId;
         private final LeaderInformation leaderInformation;
 
-        LeaderInformationChangeEvent(String contenderID, LeaderInformation leaderInformation) {
-            this.contenderID = contenderID;
+        LeaderInformationChangeEvent(String componentId, LeaderInformation leaderInformation) {
+            this.componentId = componentId;
             this.leaderInformation = leaderInformation;
         }
 
@@ -92,8 +92,8 @@ public abstract class LeaderElectionEvent {
             return leaderInformation;
         }
 
-        public String getContenderID() {
-            return contenderID;
+        public String getComponentId() {
+            return componentId;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -200,7 +200,7 @@ public class LeaderElectionTest {
 
         @Override
         public LeaderElection createLeaderElection() {
-            return leaderElectionService.createLeaderElection("random-contender-id");
+            return leaderElectionService.createLeaderElection("random-component-id");
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderInformationRegisterTest.java
@@ -30,218 +30,218 @@ class LeaderInformationRegisterTest {
 
     @Test
     void testOfWithKnownLeaderInformation() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
         final LeaderInformationRegister testInstance =
-                LeaderInformationRegister.of(contenderID, leaderInformation);
-        assertThat(testInstance.getRegisteredContenderIDs()).containsExactly(contenderID);
-        assertThat(testInstance.forContenderID(contenderID)).hasValue(leaderInformation);
+                LeaderInformationRegister.of(componentId, leaderInformation);
+        assertThat(testInstance.getRegisteredComponentIds()).containsExactly(componentId);
+        assertThat(testInstance.forComponentId(componentId)).hasValue(leaderInformation);
     }
 
     @Test
     void testOfWithEmptyLeaderInformation() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformationRegister testInstance =
-                LeaderInformationRegister.of(contenderID, LeaderInformation.empty());
+                LeaderInformationRegister.of(componentId, LeaderInformation.empty());
 
-        assertThat(testInstance.getRegisteredContenderIDs()).isEmpty();
-        assertThat(testInstance.forContenderID(contenderID)).isNotPresent();
+        assertThat(testInstance.getRegisteredComponentIds()).isEmpty();
+        assertThat(testInstance.forComponentId(componentId)).isNotPresent();
     }
 
     @Test
     void testMerge() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
-        final String newContenderID = "new-contender-id";
+        final String newComponentId = "new-component-id";
         final LeaderInformation newLeaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "new-address");
 
         final LeaderInformationRegister initialRegister =
-                LeaderInformationRegister.of(contenderID, leaderInformation);
+                LeaderInformationRegister.of(componentId, leaderInformation);
 
         final LeaderInformationRegister newRegister =
                 LeaderInformationRegister.merge(
-                        initialRegister, newContenderID, newLeaderInformation);
+                        initialRegister, newComponentId, newLeaderInformation);
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs())
-                .containsExactlyInAnyOrder(contenderID, newContenderID);
-        assertThat(newRegister.forContenderID(contenderID)).hasValue(leaderInformation);
-        assertThat(newRegister.forContenderID(newContenderID)).hasValue(newLeaderInformation);
+        assertThat(newRegister.getRegisteredComponentIds())
+                .containsExactlyInAnyOrder(componentId, newComponentId);
+        assertThat(newRegister.forComponentId(componentId)).hasValue(leaderInformation);
+        assertThat(newRegister.forComponentId(newComponentId)).hasValue(newLeaderInformation);
     }
 
     @Test
     void testMergeEmptyLeaderInformation() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
-        final String newContenderID = "new-contender-id";
+        final String newComponentId = "new-component-id";
 
         final LeaderInformationRegister initialRegister =
-                LeaderInformationRegister.of(contenderID, leaderInformation);
+                LeaderInformationRegister.of(componentId, leaderInformation);
 
         final LeaderInformationRegister newRegister =
                 LeaderInformationRegister.merge(
-                        initialRegister, newContenderID, LeaderInformation.empty());
+                        initialRegister, newComponentId, LeaderInformation.empty());
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
-        assertThat(newRegister.forContenderID(newContenderID)).isNotPresent();
+        assertThat(newRegister.getRegisteredComponentIds()).containsExactly(componentId);
+        assertThat(newRegister.forComponentId(newComponentId)).isNotPresent();
     }
 
     @Test
-    void testMergeEmptyLeaderInformationForExistingContenderID() {
-        final String contenderID = "contender-id";
+    void testMergeEmptyLeaderInformationForExistingComponentId() {
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
         final LeaderInformationRegister initialRegister =
-                LeaderInformationRegister.of(contenderID, leaderInformation);
+                LeaderInformationRegister.of(componentId, leaderInformation);
 
         final LeaderInformationRegister newRegister =
                 LeaderInformationRegister.merge(
-                        initialRegister, contenderID, LeaderInformation.empty());
+                        initialRegister, componentId, LeaderInformation.empty());
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs()).isEmpty();
-        assertThat(newRegister.forContenderID(contenderID)).isNotPresent();
+        assertThat(newRegister.getRegisteredComponentIds()).isEmpty();
+        assertThat(newRegister.forComponentId(componentId)).isNotPresent();
     }
 
     @Test
-    void testMergeKnownLeaderInformationForExistingContenderID() {
-        final String contenderID = "contender-id";
+    void testMergeKnownLeaderInformationForExistingComponentId() {
+        final String componentId = "component-id";
         final LeaderInformation oldLeaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "old-address");
 
         final LeaderInformationRegister initialRegister =
-                LeaderInformationRegister.of(contenderID, oldLeaderInformation);
+                LeaderInformationRegister.of(componentId, oldLeaderInformation);
 
         final LeaderInformation newLeaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "new-address");
         final LeaderInformationRegister newRegister =
-                LeaderInformationRegister.merge(initialRegister, contenderID, newLeaderInformation);
+                LeaderInformationRegister.merge(initialRegister, componentId, newLeaderInformation);
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
-        assertThat(newRegister.forContenderID(contenderID)).hasValue(newLeaderInformation);
+        assertThat(newRegister.getRegisteredComponentIds()).containsExactly(componentId);
+        assertThat(newRegister.forComponentId(componentId)).hasValue(newLeaderInformation);
     }
 
     @Test
     void testClear() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
         final LeaderInformationRegister initialRegister =
-                LeaderInformationRegister.of(contenderID, leaderInformation);
+                LeaderInformationRegister.of(componentId, leaderInformation);
 
         final LeaderInformationRegister newRegister =
-                LeaderInformationRegister.clear(initialRegister, contenderID);
+                LeaderInformationRegister.clear(initialRegister, componentId);
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs()).isEmpty();
-        assertThat(newRegister.forContenderID(contenderID)).isNotPresent();
+        assertThat(newRegister.getRegisteredComponentIds()).isEmpty();
+        assertThat(newRegister.forComponentId(componentId)).isNotPresent();
     }
 
     @Test
-    void testClearNotRegisteredContenderID() {
-        final String contenderID = "contender-id";
+    void testClearNotRegisteredComponentId() {
+        final String componentId = "component-id";
         final LeaderInformationRegister initialRegister =
                 LeaderInformationRegister.of(
-                        contenderID, LeaderInformation.known(UUID.randomUUID(), "address"));
+                        componentId, LeaderInformation.known(UUID.randomUUID(), "address"));
 
         final LeaderInformationRegister newRegister =
-                LeaderInformationRegister.clear(initialRegister, "another-contender-id");
+                LeaderInformationRegister.clear(initialRegister, "another-component-id");
 
         assertThat(newRegister).isNotSameAs(initialRegister);
-        assertThat(newRegister.getRegisteredContenderIDs()).containsExactly(contenderID);
+        assertThat(newRegister.getRegisteredComponentIds()).containsExactly(componentId);
     }
 
     @Test
     void testEmptyLeaderInformationFiltering() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
 
-        final String contenderIDWithEmptyLeaderInformation = "new-contender-id";
+        final String componentIdWithEmptyLeaderInformation = "new-component-id";
 
         final Map<String, LeaderInformation> records = new HashMap<>();
-        records.put(contenderID, leaderInformation);
-        records.put(contenderIDWithEmptyLeaderInformation, LeaderInformation.empty());
+        records.put(componentId, leaderInformation);
+        records.put(componentIdWithEmptyLeaderInformation, LeaderInformation.empty());
 
         final LeaderInformationRegister testInstance = new LeaderInformationRegister(records);
-        assertThat(testInstance.getRegisteredContenderIDs()).containsExactly(contenderID);
-        assertThat(testInstance.forContenderID(contenderIDWithEmptyLeaderInformation))
+        assertThat(testInstance.getRegisteredComponentIds()).containsExactly(componentId);
+        assertThat(testInstance.forComponentId(componentIdWithEmptyLeaderInformation))
                 .isNotPresent();
     }
 
     @Test
     void testEmptyInstance() {
-        assertThat(LeaderInformationRegister.empty().getRegisteredContenderIDs()).isEmpty();
+        assertThat(LeaderInformationRegister.empty().getRegisteredComponentIds()).isEmpty();
     }
 
     @Test
-    void testForContenderID() {
-        final String contenderID = "contender-id";
+    void testForComponentId() {
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
         assertThat(
-                        LeaderInformationRegister.of(contenderID, leaderInformation)
-                                .forContenderID(contenderID))
+                        LeaderInformationRegister.of(componentId, leaderInformation)
+                                .forComponentId(componentId))
                 .hasValue(leaderInformation);
     }
 
     @Test
-    void testForContenderIDOrEmpty() {
-        final String contenderID = "contender-id";
+    void testForComponentIdOrEmpty() {
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
         assertThat(
-                        LeaderInformationRegister.of(contenderID, leaderInformation)
-                                .forContenderIdOrEmpty(contenderID))
+                        LeaderInformationRegister.of(componentId, leaderInformation)
+                                .forComponentIdOrEmpty(componentId))
                 .isEqualTo(leaderInformation);
     }
 
     @Test
-    void testForContenderIDWithEmptyLeaderInformation() {
-        final String contenderID = "contender-id";
+    void testForComponentIdWithEmptyLeaderInformation() {
+        final String componentId = "component-id";
         assertThat(
-                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
-                                .forContenderID(contenderID))
+                        LeaderInformationRegister.of(componentId, LeaderInformation.empty())
+                                .forComponentId(componentId))
                 .isNotPresent();
     }
 
     @Test
-    void testForContenderIDOrEmptyWithEmptyLeaderInformation() {
-        final String contenderID = "contender-id";
+    void testForComponentIdOrEmptyWithEmptyLeaderInformation() {
+        final String componentId = "component-id";
         assertThat(
-                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
-                                .forContenderIdOrEmpty(contenderID))
+                        LeaderInformationRegister.of(componentId, LeaderInformation.empty())
+                                .forComponentIdOrEmpty(componentId))
                 .isEqualTo(LeaderInformation.empty());
     }
 
     @Test
     void testHasLeaderInformation() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         final LeaderInformation leaderInformation =
                 LeaderInformation.known(UUID.randomUUID(), "address");
         assertThat(
-                        LeaderInformationRegister.of(contenderID, leaderInformation)
-                                .hasLeaderInformation(contenderID))
+                        LeaderInformationRegister.of(componentId, leaderInformation)
+                                .hasLeaderInformation(componentId))
                 .isTrue();
     }
 
     @Test
     void testHasLeaderInformationWithEmptyLeaderInformation() {
-        final String contenderID = "contender-id";
+        final String componentId = "component-id";
         assertThat(
-                        LeaderInformationRegister.of(contenderID, LeaderInformation.empty())
-                                .hasLeaderInformation(contenderID))
+                        LeaderInformationRegister.of(componentId, LeaderInformation.empty())
+                                .hasLeaderInformation(componentId))
                 .isFalse();
     }
 
@@ -250,13 +250,13 @@ class LeaderInformationRegisterTest {
         LeaderInformationRegister register = LeaderInformationRegister.empty();
         assertThat(register.hasNoLeaderInformation()).isTrue();
 
-        register = LeaderInformationRegister.of("contender-id", LeaderInformation.empty());
+        register = LeaderInformationRegister.of("component-id", LeaderInformation.empty());
         assertThat(register.hasNoLeaderInformation()).isTrue();
 
         register =
                 LeaderInformationRegister.merge(
                         register,
-                        "other-contender-id",
+                        "other-component-id",
                         LeaderInformation.known(UUID.randomUUID(), "address"));
         assertThat(register.hasNoLeaderInformation()).isFalse();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -62,13 +62,13 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
     }
 
     @Override
-    public void publishLeaderInformation(String contenderID, LeaderInformation leaderInformation) {
-        publishLeaderInformationConsumer.accept(lock, contenderID, leaderInformation);
+    public void publishLeaderInformation(String componentId, LeaderInformation leaderInformation) {
+        publishLeaderInformationConsumer.accept(lock, componentId, leaderInformation);
     }
 
     @Override
-    public void deleteLeaderInformation(String contenderID) {
-        deleteLeaderInformationConsumer.accept(lock, contenderID);
+    public void deleteLeaderInformation(String componentId) {
+        deleteLeaderInformationConsumer.accept(lock, componentId);
     }
 
     @Override
@@ -122,7 +122,7 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
                             }
                         })
                 .setPublishLeaderInformationConsumer(
-                        (lock, contenderID, leaderInformation) -> {
+                        (lock, componentId, leaderInformation) -> {
                             try {
                                 lock.lock();
                                 if (hasLeadership.get()) {
@@ -130,7 +130,7 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
                                             oldData ->
                                                     LeaderInformationRegister.merge(
                                                             oldData,
-                                                            contenderID,
+                                                            componentId,
                                                             leaderInformation));
                                 }
                             } finally {
@@ -138,14 +138,14 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
                             }
                         })
                 .setDeleteLeaderInformationConsumer(
-                        (lock, contenderID) -> {
+                        (lock, componentId) -> {
                             try {
                                 lock.lock();
                                 if (hasLeadership.get()) {
                                     storedLeaderInformation.getAndUpdate(
                                             oldData ->
                                                     LeaderInformationRegister.clear(
-                                                            oldData, contenderID));
+                                                            oldData, componentId));
                                 }
                             } finally {
                                 lock.unlock();
@@ -228,9 +228,9 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
         private Function<ReentrantLock, Boolean> hasLeadershipFunction = ignoredLock -> false;
         private TriConsumer<ReentrantLock, String, LeaderInformation>
                 publishLeaderInformationConsumer =
-                        (ignoredLock, ignoredContenderID, ignoredLeaderInformation) -> {};
+                        (ignoredLock, ignoredComponentId, ignoredLeaderInformation) -> {};
         private BiConsumer<ReentrantLock, String> deleteLeaderInformationConsumer =
-                (ignoredLock, ignoredContenderID) -> {};
+                (ignoredLock, ignoredComponentId) -> {};
 
         private ThrowingConsumer<ReentrantLock, Exception> closeConsumer = (ignoredLock) -> {};
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -106,7 +106,7 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
                 storedLeaderInformation.get() == null
                         || !storedLeaderInformation
                                 .get()
-                                .getRegisteredContenderIDs()
+                                .getRegisteredComponentIds()
                                 .iterator()
                                 .hasNext(),
                 "Initial state check for storedLeaderInformation failed.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionListener.java
@@ -46,8 +46,8 @@ public final class TestingLeaderElectionListener implements LeaderElectionDriver
     }
 
     @Override
-    public void onLeaderInformationChange(String contenderID, LeaderInformation leaderInformation) {
-        put(new LeaderElectionEvent.LeaderInformationChangeEvent(contenderID, leaderInformation));
+    public void onLeaderInformationChange(String componentId, LeaderInformation leaderInformation) {
+        put(new LeaderElectionEvent.LeaderInformationChangeEvent(componentId, leaderInformation));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -146,7 +146,7 @@ class ZooKeeperLeaderElectionConnectionHandlingTest {
 
         final TestingContender contender = new TestingContender();
         try (LeaderElection leaderElection =
-                leaderElectionService.createLeaderElection("random-contender-id")) {
+                leaderElectionService.createLeaderElection("random-component-id")) {
             leaderElection.startLeaderElection(contender);
 
             contender.awaitGrantLeadership();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
@@ -227,7 +227,7 @@ class ZooKeeperLeaderElectionDriverTest {
                                                     LeaderElectionEvent.LeaderInformationChangeEvent
                                                             .class);
 
-                            assertThat(leaderInformationChangeEvent.getContenderID())
+                            assertThat(leaderInformationChangeEvent.getComponentId())
                                     .isEqualTo(componentId);
                             assertThat(leaderInformationChangeEvent.getLeaderInformation())
                                     .isEqualTo(leaderInformation);
@@ -328,7 +328,7 @@ class ZooKeeperLeaderElectionDriverTest {
                                             leaderElectionListener.await(
                                                     LeaderElectionEvent.LeaderInformationChangeEvent
                                                             .class);
-                            assertThat(leaderInformationChangeEvent.getContenderID())
+                            assertThat(leaderInformationChangeEvent.getComponentId())
                                     .isEqualTo(componentId);
                             assertThat(leaderInformationChangeEvent.getLeaderInformation())
                                     .isEqualTo(LeaderInformation.empty());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
@@ -96,12 +96,12 @@ class ZooKeeperLeaderElectionDriverTest {
                         () -> {
                             leaderElectionListener.await(LeaderElectionEvent.IsLeaderEvent.class);
 
-                            final String contenderID = "retrieved-component";
+                            final String componentId = "retrieved-component";
                             final DefaultLeaderRetrievalService defaultLeaderRetrievalService =
                                     new DefaultLeaderRetrievalService(
                                             new ZooKeeperLeaderRetrievalDriverFactory(
                                                     curatorFramework.asCuratorFramework(),
-                                                    contenderID,
+                                                    componentId,
                                                     ZooKeeperLeaderRetrievalDriver
                                                             .LeaderInformationClearancePolicy
                                                             .ON_LOST_CONNECTION));
@@ -112,7 +112,7 @@ class ZooKeeperLeaderElectionDriverTest {
                             final LeaderInformation leaderInformation =
                                     LeaderInformation.known(UUID.randomUUID(), "foobar");
                             leaderElectionDriver.publishLeaderInformation(
-                                    contenderID, leaderInformation);
+                                    componentId, leaderInformation);
 
                             leaderRetrievalListener.waitForNewLeader();
 
@@ -131,12 +131,12 @@ class ZooKeeperLeaderElectionDriverTest {
                         () -> {
                             leaderElectionListener.await(LeaderElectionEvent.IsLeaderEvent.class);
 
-                            final String contenderID = "retrieved-component";
+                            final String componentId = "retrieved-component";
                             final DefaultLeaderRetrievalService defaultLeaderRetrievalService =
                                     new DefaultLeaderRetrievalService(
                                             new ZooKeeperLeaderRetrievalDriverFactory(
                                                     curatorFramework.asCuratorFramework(),
-                                                    contenderID,
+                                                    componentId,
                                                     ZooKeeperLeaderRetrievalDriver
                                                             .LeaderInformationClearancePolicy
                                                             .ON_LOST_CONNECTION));
@@ -145,13 +145,13 @@ class ZooKeeperLeaderElectionDriverTest {
                             defaultLeaderRetrievalService.start(leaderRetrievalListener);
 
                             leaderElectionDriver.publishLeaderInformation(
-                                    contenderID,
+                                    componentId,
                                     LeaderInformation.known(UUID.randomUUID(), "foobar"));
 
                             leaderRetrievalListener.waitForNewLeader();
 
                             leaderElectionDriver.publishLeaderInformation(
-                                    contenderID, LeaderInformation.empty());
+                                    componentId, LeaderInformation.empty());
 
                             leaderRetrievalListener.waitForEmptyLeaderInformation();
 
@@ -182,7 +182,7 @@ class ZooKeeperLeaderElectionDriverTest {
                                 assertThat(otherLeaderElectionDriver.hasLeadership()).isFalse();
 
                                 otherLeaderElectionDriver.publishLeaderInformation(
-                                        "contenderID",
+                                        "component-id",
                                         LeaderInformation.known(UUID.randomUUID(), "localhost"));
 
                                 assertThat(
@@ -211,9 +211,9 @@ class ZooKeeperLeaderElectionDriverTest {
 
                             final LeaderInformation leaderInformation =
                                     LeaderInformation.known(UUID.randomUUID(), "foobar");
-                            final String contenderID = "contenderID";
+                            final String componentId = "componentId";
                             final String path =
-                                    ZooKeeperUtils.generateConnectionInformationPath(contenderID);
+                                    ZooKeeperUtils.generateConnectionInformationPath(componentId);
 
                             ZooKeeperUtils.writeLeaderInformationToZooKeeper(
                                     leaderInformation,
@@ -228,7 +228,7 @@ class ZooKeeperLeaderElectionDriverTest {
                                                             .class);
 
                             assertThat(leaderInformationChangeEvent.getContenderID())
-                                    .isEqualTo(contenderID);
+                                    .isEqualTo(componentId);
                             assertThat(leaderInformationChangeEvent.getLeaderInformation())
                                     .isEqualTo(leaderInformation);
                         });
@@ -306,9 +306,9 @@ class ZooKeeperLeaderElectionDriverTest {
 
                             final LeaderInformation leaderInformation =
                                     LeaderInformation.known(UUID.randomUUID(), "foobar");
-                            final String contenderID = "contenderID";
+                            final String componentId = "componentId";
                             final String path =
-                                    ZooKeeperUtils.generateConnectionInformationPath(contenderID);
+                                    ZooKeeperUtils.generateConnectionInformationPath(componentId);
 
                             ZooKeeperUtils.writeLeaderInformationToZooKeeper(
                                     leaderInformation,
@@ -329,7 +329,7 @@ class ZooKeeperLeaderElectionDriverTest {
                                                     LeaderElectionEvent.LeaderInformationChangeEvent
                                                             .class);
                             assertThat(leaderInformationChangeEvent.getContenderID())
-                                    .isEqualTo(contenderID);
+                                    .isEqualTo(componentId);
                             assertThat(leaderInformationChangeEvent.getLeaderInformation())
                                     .isEqualTo(LeaderInformation.empty());
                         });
@@ -375,9 +375,9 @@ class ZooKeeperLeaderElectionDriverTest {
             return leaderElectionListener.getLeadershipFuture();
         }
 
-        void publishLeaderInformation(String contenderID, LeaderInformation leaderInformation)
+        void publishLeaderInformation(String componentId, LeaderInformation leaderInformation)
                 throws Exception {
-            leaderElectionDriver.publishLeaderInformation(contenderID, leaderInformation);
+            leaderElectionDriver.publishLeaderInformation(componentId, leaderInformation);
         }
     }
 
@@ -405,7 +405,7 @@ class ZooKeeperLeaderElectionDriverTest {
 
         @Override
         public void onLeaderInformationChange(
-                String contenderID, LeaderInformation leaderInformation) {}
+                String componentId, LeaderInformation leaderInformation) {}
 
         @Override
         public void onLeaderInformationChange(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -96,7 +96,7 @@ class ZooKeeperLeaderElectionTest {
 
     private Configuration configuration;
 
-    private static final String CONTENDER_ID = "contender-id";
+    private static final String COMPONENT_ID = "component-id";
     private static final String LEADER_ADDRESS = "akka//user/jobmanager";
     private static final long timeout = 200L * 1000L;
 
@@ -124,7 +124,7 @@ class ZooKeeperLeaderElectionTest {
                                 createZooKeeperClient(), electionEventHandler);
                 LeaderRetrievalDriver leaderRetrievalDriver =
                         ZooKeeperUtils.createLeaderRetrievalDriverFactory(
-                                        createZooKeeperClient(), CONTENDER_ID)
+                                        createZooKeeperClient(), COMPONENT_ID)
                                 .createLeaderRetrievalDriver(
                                         retrievalEventHandler,
                                         retrievalEventHandler::handleError)) {
@@ -133,7 +133,7 @@ class ZooKeeperLeaderElectionTest {
 
             final UUID leaderSessionID = UUID.randomUUID();
             leaderElectionDriver.publishLeaderInformation(
-                    CONTENDER_ID, LeaderInformation.known(leaderSessionID, LEADER_ADDRESS));
+                    COMPONENT_ID, LeaderInformation.known(leaderSessionID, LEADER_ADDRESS));
 
             retrievalEventHandler.waitForNewLeader();
 
@@ -166,7 +166,7 @@ class ZooKeeperLeaderElectionTest {
         try {
             leaderRetrievalService =
                     ZooKeeperUtils.createLeaderRetrievalService(
-                            createZooKeeperClient(), CONTENDER_ID, new Configuration());
+                            createZooKeeperClient(), COMPONENT_ID, new Configuration());
 
             LOG.debug("Start leader retrieval service for the TestingListener.");
 
@@ -176,7 +176,7 @@ class ZooKeeperLeaderElectionTest {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
                 leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
-                leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
+                leaderElections[i] = leaderElectionService[i].createLeaderElection(COMPONENT_ID);
                 contenders[i] = new TestingContender(createAddress(i), leaderElections[i]);
 
                 LOG.debug("Start leader election service for contender #{}.", i);
@@ -268,7 +268,7 @@ class ZooKeeperLeaderElectionTest {
         try {
             leaderRetrievalService =
                     ZooKeeperUtils.createLeaderRetrievalService(
-                            createZooKeeperClient(), CONTENDER_ID, new Configuration());
+                            createZooKeeperClient(), COMPONENT_ID, new Configuration());
 
             leaderRetrievalService.start(listener);
 
@@ -276,7 +276,7 @@ class ZooKeeperLeaderElectionTest {
                 final LeaderElectionDriverFactory driverFactory =
                         new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
                 leaderElectionService[i] = new DefaultLeaderElectionService(driverFactory);
-                leaderElections[i] = leaderElectionService[i].createLeaderElection(CONTENDER_ID);
+                leaderElections[i] = leaderElectionService[i].createLeaderElection(COMPONENT_ID);
                 contenders[i] =
                         new TestingContender(LEADER_ADDRESS + "_" + i + "_0", leaderElections[i]);
 
@@ -311,7 +311,7 @@ class ZooKeeperLeaderElectionTest {
                             new ZooKeeperLeaderElectionDriverFactory(createZooKeeperClient());
                     leaderElectionService[index] = new DefaultLeaderElectionService(driverFactory);
                     leaderElections[index] =
-                            leaderElectionService[index].createLeaderElection(CONTENDER_ID);
+                            leaderElectionService[index].createLeaderElection(COMPONENT_ID);
 
                     contenders[index] =
                             new TestingContender(
@@ -355,7 +355,7 @@ class ZooKeeperLeaderElectionTest {
             electionEventHandler.await(LeaderElectionEvent.IsLeaderEvent.class);
 
             leaderElectionDriver.publishLeaderInformation(
-                    CONTENDER_ID, LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
+                    COMPONENT_ID, LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
 
             // First update will successfully complete.
             electionEventHandler.await(LeaderElectionEvent.LeaderInformationChangeEvent.class);
@@ -402,7 +402,7 @@ class ZooKeeperLeaderElectionTest {
                 electionEventHandler.await(LeaderElectionEvent.IsLeaderEvent.class);
 
                 leaderElectionDriver.publishLeaderInformation(
-                        CONTENDER_ID, LeaderInformation.known(UUID.randomUUID(), "some-address"));
+                        COMPONENT_ID, LeaderInformation.known(UUID.randomUUID(), "some-address"));
 
                 final LeaderElectionEvent.ErrorEvent errorEvent =
                         electionEventHandler.await(LeaderElectionEvent.ErrorEvent.class);
@@ -446,25 +446,25 @@ class ZooKeeperLeaderElectionTest {
                             curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
             leaderRetrievalDriver =
                     ZooKeeperUtils.createLeaderRetrievalDriverFactory(
-                                    curatorFrameworkWrapper2.asCuratorFramework(), CONTENDER_ID)
+                                    curatorFrameworkWrapper2.asCuratorFramework(), COMPONENT_ID)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
             cache =
                     CuratorCache.build(
                             curatorFrameworkWrapper2.asCuratorFramework(),
-                            ZooKeeperUtils.generateConnectionInformationPath(CONTENDER_ID));
+                            ZooKeeperUtils.generateConnectionInformationPath(COMPONENT_ID));
 
             final ExistsCacheListener existsListener =
                     ExistsCacheListener.createWithNodeIsMissingValidation(
-                            cache, ZooKeeperUtils.generateConnectionInformationPath(CONTENDER_ID));
+                            cache, ZooKeeperUtils.generateConnectionInformationPath(COMPONENT_ID));
             cache.listenable().addListener(existsListener);
             cache.start();
 
             electionEventHandler.await(LeaderElectionEvent.IsLeaderEvent.class);
 
             leaderElectionDriver.publishLeaderInformation(
-                    CONTENDER_ID, LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
+                    COMPONENT_ID, LeaderInformation.known(UUID.randomUUID(), LEADER_ADDRESS));
 
             retrievalEventHandler.waitForNewLeader();
 
@@ -474,7 +474,7 @@ class ZooKeeperLeaderElectionTest {
 
             final DeletedCacheListener deletedCacheListener =
                     DeletedCacheListener.createWithNodeExistValidation(
-                            cache, ZooKeeperUtils.generateConnectionInformationPath(CONTENDER_ID));
+                            cache, ZooKeeperUtils.generateConnectionInformationPath(COMPONENT_ID));
             cache.listenable().addListener(deletedCacheListener);
 
             leaderElectionDriver.close();
@@ -519,7 +519,7 @@ class ZooKeeperLeaderElectionTest {
 
             final UUID leaderSessionID = UUID.randomUUID();
             leaderElectionDriver.publishLeaderInformation(
-                    CONTENDER_ID, LeaderInformation.known(leaderSessionID, LEADER_ADDRESS));
+                    COMPONENT_ID, LeaderInformation.known(leaderSessionID, LEADER_ADDRESS));
 
             // Leader is revoked
             leaderElectionDriver.notLeader();
@@ -528,7 +528,7 @@ class ZooKeeperLeaderElectionTest {
             // The data on ZooKeeper has not been cleared
             try (ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver =
                     ZooKeeperUtils.createLeaderRetrievalDriverFactory(
-                                    createZooKeeperClient(), CONTENDER_ID)
+                                    createZooKeeperClient(), COMPONENT_ID)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError)) {
 


### PR DESCRIPTION
## What is the purpose of the change

We introduced contenderID in a lot of places with [FLINK-26522](https://issues.apache.org/jira/browse/FLINK-26522). The original multi-component leader election classes of [FLINK-24038](https://issues.apache.org/jira/browse/FLINK-24038) used componentId.

Revisiting that naming made me realize that it's actually wrong. A contender is a specific instance of a component that participates in the leader election. A component, in this sense, is the more abstract concept. contenderID refers to an ID for the specific contender instance but the IDs we're sharing are actually referring to a Flink component and therefore, are the same between different contenders which compete for leadership for the same component. This contradicts the definition of an identifier.

## Brief change log

Renames of all occurrences that match the case-insensitive regex `contender.?id`.

## Verifying this change

Grep through the code for `contender.?id`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable