### PR TITLE
[FLINK-32496][connectors/common] Fix the bug that source cannot resume after enabling the watermark alignment and idleness

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -181,9 +181,11 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
         Set<Integer> subTaskIds = combinedWatermark.keySet();
         LOG.info(
-                "Distributing maxAllowedWatermark={} to subTaskIds={}",
+                "Distributing maxAllowedWatermark={} of group={} to subTaskIds={} for source {}.",
                 maxAllowedWatermark,
-                subTaskIds);
+                watermarkAlignmentParams.getWatermarkGroup(),
+                subTaskIds,
+                operatorName);
 
         // Subtask maybe during deploying or restarting, so we only send WatermarkAlignmentEvent
         // to ready task to avoid period task fail (Java-ThreadPoolExecutor will not schedule
@@ -611,7 +613,11 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             + "scenario (e.g. if speculative execution is enabled)");
         }
 
-        LOG.debug("New reported watermark={} from subTaskId={}", watermark, subtask);
+        LOG.debug(
+                "New reported watermark={} from subTaskId={} of source {}.",
+                watermark,
+                subtask,
+                operatorName);
 
         checkState(watermarkAlignmentParams.isEnabled());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import java.time.Duration;
 
@@ -46,11 +45,14 @@ public interface TimestampsAndWatermarks<T> {
     /** Lets the owner/creator of the output know about latest emitted watermark. */
     @Internal
     interface WatermarkUpdateListener {
+
+        /** It should be called once the idle is changed. */
+        void updateIdle(boolean isIdle);
+
         /**
-         * Effective watermark covers the {@link WatermarkStatus}. If an output becomes idle, this
-         * method should be called with {@link Long#MAX_VALUE}, but what is more important, once it
-         * becomes active again it should call this method with the last emitted value of the
-         * watermark.
+         * Update the effective watermark. If an output becomes idle, please call {@link
+         * this#updateIdle} instead of update the watermark to {@link Long#MAX_VALUE}. Because the
+         * output needs to distinguish between idle and real watermark.
          */
         void updateCurrentEffectiveWatermark(long watermark);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -42,7 +42,15 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
     @VisibleForTesting
     public WatermarkToDataOutput(PushingAsyncDataInput.DataOutput<?> output) {
-        this(output, watermark -> {});
+        this(
+                output,
+                new TimestampsAndWatermarks.WatermarkUpdateListener() {
+                    @Override
+                    public void updateIdle(boolean isIdle) {}
+
+                    @Override
+                    public void updateCurrentEffectiveWatermark(long watermark) {}
+                });
     }
 
     /** Creates a new WatermarkOutput against the given DataOutput. */
@@ -84,7 +92,7 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
         try {
             output.emitWatermarkStatus(WatermarkStatus.IDLE);
-            watermarkEmitted.updateCurrentEffectiveWatermark(Long.MAX_VALUE);
+            watermarkEmitted.updateIdle(true);
             isIdle = true;
         } catch (ExceptionInChainedOperatorException e) {
             throw e;
@@ -110,7 +118,7 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
         }
 
         output.emitWatermarkStatus(WatermarkStatus.ACTIVE);
-        watermarkEmitted.updateCurrentEffectiveWatermark(maxWatermarkSoFar);
+        watermarkEmitted.updateIdle(false);
         isIdle = false;
         return false;
     }


### PR DESCRIPTION
backport FLINK-32496 to 1.16