### PR TITLE
[FLINK-32457][table-planner] Add test cases of unsupported usage for JSON_OBJECTAGG & JSON_ARRAYAGG and also update docs

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -881,25 +881,6 @@ json:
         )
       )
       ```
-  - sql: JSON_OBJECTAGG([KEY] key VALUE value [ { NULL | ABSENT } ON NULL ])
-    table: jsonObjectAgg(JsonOnNull, keyExpression, valueExpression)
-    description: |
-      Builds a JSON object string by aggregating key-value expressions into a single JSON object.
-
-      The key expression must return a non-nullable character string. Value expressions can be
-      arbitrary, including other JSON functions. If a value is `NULL`, the `ON NULL` behavior
-      defines what to do. If omitted, `NULL ON NULL` is assumed by default.
-
-      Note that keys must be unique. If a key occurs multiple times, an error will be thrown.
-
-      This function is currently not supported in `OVER` windows.
-
-      ```sql
-      -- '{"Apple":2,"Banana":17,"Orange":0}'
-      SELECT
-        JSON_OBJECTAGG(KEY product VALUE cnt)
-      FROM orders
-      ```
   - sql: JSON_ARRAY([value]* [ { NULL | ABSENT } ON NULL ])
     table: jsonArray(JsonOnNull, values...)
     description: |
@@ -928,23 +909,6 @@ json:
 
       -- '[[1]]'
       JSON_ARRAY(JSON_ARRAY(1))
-      ```
-  - sql: JSON_ARRAYAGG(items [ { NULL | ABSENT } ON NULL ])
-    table: jsonArrayAgg(JsonOnNull, itemExpression)
-    description: |
-      Builds a JSON object string by aggregating items into an array.
-
-      Item expressions can be arbitrary, including other JSON functions. If a value is `NULL`, the
-      `ON NULL` behavior defines what to do. If omitted, `ABSENT ON NULL` is assumed by default.
-
-      This function is currently not supported in `OVER` windows, unbounded session windows, or hop
-      windows.
-
-      ```sql
-      -- '["Apple","Banana","Orange"]'
-      SELECT
-        JSON_ARRAYAGG(product)
-      FROM orders
       ```
 
 valueconstruction:
@@ -1092,6 +1056,42 @@ aggregate:
       Divides the rows for each window partition into `n` buckets ranging from 1 to at most `n`.
       If the number of rows in the window partition doesn't divide evenly into the number of buckets, then the remainder values are distributed one per bucket, starting with the first bucket.
       For example, with 6 rows and 4 buckets, the bucket values would be as follows: 1 1 2 2 3 4
+  - sql: JSON_OBJECTAGG([KEY] key VALUE value [ { NULL | ABSENT } ON NULL ])
+    table: jsonObjectAgg(JsonOnNull, keyExpression, valueExpression)
+    description: |
+      Builds a JSON object string by aggregating key-value expressions into a single JSON object.
+
+      The key expression must return a non-nullable character string. Value expressions can be
+      arbitrary, including other JSON functions. If a value is `NULL`, the `ON NULL` behavior
+      defines what to do. If omitted, `NULL ON NULL` is assumed by default.
+
+      Note that keys must be unique. If a key occurs multiple times, an error will be thrown.
+
+      This function is currently not supported in `OVER` windows and is not supported for use with other aggregate functions.
+
+      ```sql
+      -- '{"Apple":2,"Banana":17,"Orange":0}'
+      SELECT
+        JSON_OBJECTAGG(KEY product VALUE cnt)
+      FROM orders
+      ```
+  - sql: JSON_ARRAYAGG(items [ { NULL | ABSENT } ON NULL ])
+    table: jsonArrayAgg(JsonOnNull, itemExpression)
+    description: |
+      Builds a JSON object string by aggregating items into an array.
+
+      Item expressions can be arbitrary, including other JSON functions. If a value is `NULL`, the
+      `ON NULL` behavior defines what to do. If omitted, `ABSENT ON NULL` is assumed by default.
+
+      This function is currently not supported in `OVER` windows, unbounded session windows, or hop
+      windows. And it is not supported for use with other aggregate functions.
+
+      ```sql
+      -- '["Apple","Banana","Orange"]'
+      SELECT
+        JSON_ARRAYAGG(product)
+      FROM orders
+      ```
 
 catalog:
   - sql: CURRENT_DATABASE()

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -963,24 +963,6 @@ json:
         )
       )
       ```
-  - sql: JSON_OBJECTAGG([KEY] key VALUE value [ { NULL | ABSENT } ON NULL ])
-    table: jsonObjectAgg(JsonOnNull, keyExpression, valueExpression)
-    description: |
-      通过将 key-value 聚合到单个 JSON 对象中，构建 JSON 对象字符串。
-
-      键表达式必须返回不为空的字符串。值表达式可以是任意的，包括其他 JSON 函数。
-      如果值为 `NULL`，则 `ON NULL` 行为定义了要执行的操作。如果省略，默认情况下假定为 `NULL ON NULL`。
-
-      请注意，键必须是唯一的。如果一个键出现多次，将抛出一个错误。
-
-      目前在 `OVER` windows 中不支持此函数。
-
-      ```sql
-      -- '{"Apple":2,"Banana":17,"Orange":0}'
-      SELECT
-        JSON_OBJECTAGG(KEY product VALUE cnt)
-      FROM orders
-      ```
   - sql: JSON_ARRAY([value]* [ { NULL | ABSENT } ON NULL ])
     table: jsonArray(JsonOnNull, values...)
     description: |
@@ -1005,21 +987,6 @@ json:
 
       -- '[[1]]'
       JSON_ARRAY(JSON_ARRAY(1))
-      ```
-  - sql: JSON_ARRAYAGG(items [ { NULL | ABSENT } ON NULL ])
-    table: jsonArrayAgg(JsonOnNull, itemExpression)
-    description: |
-      通过将字段聚合到数组中构建 JSON 对象字符串。
-
-      项目表达式可以是任意的，包括其他 JSON 函数。如果值为 `NULL`，则 `ON NULL` 行为定义了要执行的操作。如果省略，默认情况下假定为 `ABSENT ON NULL`。
-
-      此函数目前不支持 `OVER` windows、未绑定的 session windows 或 hop windows。
-
-      ```sql
-      -- '["Apple","Banana","Orange"]'
-      SELECT
-        JSON_ARRAYAGG(product)
-      FROM orders
       ```
 
 valueconstruction:
@@ -1166,6 +1133,39 @@ aggregate:
       将窗口分区中的所有数据按照顺序划分为 n 个分组，返回分配给各行数据的分组编号（从 1 开始）。
       如果不能均匀划分为 n 个分组，则从第 1 个分组开始，为每一分组分配一个剩余值。
       比如某个窗口分区有 6 行数据，划分为 4 个分组，则各行的分组编号为：1，1，2，2，3，4。
+  - sql: JSON_OBJECTAGG([KEY] key VALUE value [ { NULL | ABSENT } ON NULL ])
+    table: jsonObjectAgg(JsonOnNull, keyExpression, valueExpression)
+    description: |
+      通过将 key-value 聚合到单个 JSON 对象中，构建 JSON 对象字符串。
+
+      键表达式必须返回不为空的字符串。值表达式可以是任意的，包括其他 JSON 函数。
+      如果值为 `NULL`，则 `ON NULL` 行为定义了要执行的操作。如果省略，默认情况下假定为 `NULL ON NULL`。
+
+      请注意，键必须是唯一的。如果一个键出现多次，将抛出一个错误。
+
+      目前在 `OVER` windows 中不支持此函数。同时，此函数不支持与其他聚合函数一起使用。
+
+      ```sql
+      -- '{"Apple":2,"Banana":17,"Orange":0}'
+      SELECT
+        JSON_OBJECTAGG(KEY product VALUE cnt)
+      FROM orders
+      ```
+  - sql: JSON_ARRAYAGG(items [ { NULL | ABSENT } ON NULL ])
+    table: jsonArrayAgg(JsonOnNull, itemExpression)
+    description: |
+      通过将字段聚合到数组中构建 JSON 对象字符串。
+
+      项目表达式可以是任意的，包括其他 JSON 函数。如果值为 `NULL`，则 `ON NULL` 行为定义了要执行的操作。如果省略，默认情况下假定为 `ABSENT ON NULL`。
+
+      此函数目前不支持 `OVER` windows、未绑定的 session windows 或 hop windows。同时，此函数不支持与其他聚合函数一起使用。
+
+      ```sql
+      -- '["Apple","Banana","Orange"]'
+      SELECT
+        JSON_ARRAYAGG(product)
+      FROM orders
+      ```
 
 catalog:
   - sql: CURRENT_DATABASE()

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/WrapJsonAggFunctionArgumentsRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/WrapJsonAggFunctionArgumentsRuleTest.xml
@@ -16,33 +16,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testJsonArrayAgg">
+  <TestCase name="testJsonArrayAgg[batchMode = false]">
     <Resource name="sql">
       <![CDATA[SELECT JSON_ARRAYAGG(f0) FROM T]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
++- LogicalProject(f0=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-GroupAggregate(select=[JSON_ARRAYAGG_ABSENT_ON_NULL_RETRACT($f1) AS EXPR$0])
+GroupAggregate(select=[JSON_ARRAYAGG_ABSENT_ON_NULL($f1) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- Calc(select=[f0, JSON_STRING(f0) AS $f1])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0], metadata=[]]], fields=[f0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJsonArrayAggInGroupWindow">
+  <TestCase name="testJsonArrayAgg[batchMode = true]">
+    <Resource name="sql">
+      <![CDATA[SELECT JSON_ARRAYAGG(f0) FROM T]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
++- LogicalProject(f0=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[JSON_ARRAYAGG_ABSENT_ON_NULL($f1) AS EXPR$0])
++- Calc(select=[f0, JSON_STRING(f0) AS $f1])
+   +- Exchange(distribution=[single])
+      +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0], metadata=[]]], fields=[f0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonArrayAggInGroupWindow[batchMode = false]">
     <Resource name="sql">
       <![CDATA[SELECT f0, JSON_ARRAYAGG(f0) FROM T GROUP BY f0]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalAggregate(group=[{0}], EXPR$1=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
++- LogicalProject(f0=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -50,18 +72,104 @@ LogicalAggregate(group=[{0}], EXPR$1=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
 GroupAggregate(groupBy=[f0], select=[f0, JSON_ARRAYAGG_ABSENT_ON_NULL($f1) AS EXPR$1])
 +- Exchange(distribution=[hash[f0]])
    +- Calc(select=[f0, JSON_STRING(f0) AS $f1])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0], metadata=[]]], fields=[f0])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJsonObjectAggInGroupWindow">
+  <TestCase name="testJsonArrayAggInGroupWindow[batchMode = true]">
+    <Resource name="sql">
+      <![CDATA[SELECT f0, JSON_ARRAYAGG(f0) FROM T GROUP BY f0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[JSON_ARRAYAGG_ABSENT_ON_NULL($0)])
++- LogicalProject(f0=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[f0], select=[f0, JSON_ARRAYAGG_ABSENT_ON_NULL($f1) AS EXPR$1])
++- Calc(select=[f0, JSON_STRING(f0) AS $f1])
+   +- Sort(orderBy=[f0 ASC])
+      +- Exchange(distribution=[hash[f0]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0], metadata=[]]], fields=[f0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonObjectAgg[batchMode = false]">
+    <Resource name="sql">
+      <![CDATA[SELECT JSON_OBJECTAGG(f1 VALUE f1) FROM T]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[JSON_OBJECTAGG_NULL_ON_NULL($0, $0)])
++- LogicalProject(f1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(select=[JSON_OBJECTAGG_NULL_ON_NULL($f1, $f1) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[f1, JSON_STRING(f1) AS $f1])
+      +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f1], metadata=[]]], fields=[f1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonObjectAggInGroupWindow[batchMode = true]">
     <Resource name="sql">
       <![CDATA[SELECT f0, JSON_OBJECTAGG(f1 VALUE f0) FROM T GROUP BY f0]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalAggregate(group=[{0}], EXPR$1=[JSON_OBJECTAGG_NULL_ON_NULL($1, $0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
++- LogicalProject(f0=[$0], f1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[true], groupBy=[f0], select=[f0, Final_JSON_OBJECTAGG_NULL_ON_NULL(EXPR$1) AS EXPR$1])
++- Sort(orderBy=[f0 ASC])
+   +- Exchange(distribution=[hash[f0]])
+      +- LocalSortAggregate(groupBy=[f0], select=[f0, Partial_JSON_OBJECTAGG_NULL_ON_NULL(f1, $f2) AS EXPR$1])
+         +- Calc(select=[f0, f1, JSON_STRING(f0) AS $f2])
+            +- Sort(orderBy=[f0 ASC])
+               +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0, f1], metadata=[]]], fields=[f0, f1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonObjectAgg[batchMode = true]">
+    <Resource name="sql">
+      <![CDATA[SELECT JSON_OBJECTAGG(f1 VALUE f1) FROM T]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[JSON_OBJECTAGG_NULL_ON_NULL($0, $0)])
++- LogicalProject(f1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_JSON_OBJECTAGG_NULL_ON_NULL(EXPR$0) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- LocalSortAggregate(select=[Partial_JSON_OBJECTAGG_NULL_ON_NULL($f1, $f1) AS EXPR$0])
+      +- Calc(select=[f1, JSON_STRING(f1) AS $f1])
+         +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f1], metadata=[]]], fields=[f1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJsonObjectAggInGroupWindow[batchMode = false]">
+    <Resource name="sql">
+      <![CDATA[SELECT f0, JSON_OBJECTAGG(f1 VALUE f0) FROM T GROUP BY f0]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[JSON_OBJECTAGG_NULL_ON_NULL($1, $0)])
++- LogicalProject(f0=[$0], f1=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -69,26 +177,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[JSON_OBJECTAGG_NULL_ON_NULL($1, $0)])
 GroupAggregate(groupBy=[f0], select=[f0, JSON_OBJECTAGG_NULL_ON_NULL(f1, $f2) AS EXPR$1])
 +- Exchange(distribution=[hash[f0]])
    +- Calc(select=[f0, f1, JSON_STRING(f0) AS $f2])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0, f1])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJsonObjectAgg">
-    <Resource name="sql">
-      <![CDATA[SELECT JSON_OBJECTAGG(f0 VALUE f0) FROM T]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalAggregate(group=[{}], EXPR$0=[JSON_OBJECTAGG_NULL_ON_NULL($0, $0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-GroupAggregate(select=[JSON_OBJECTAGG_NULL_ON_NULL_RETRACT($f1, $f1) AS EXPR$0])
-+- Exchange(distribution=[single])
-   +- Calc(select=[f0, JSON_STRING(f0) AS $f1])
-      +- TableSourceScan(table=[[default_catalog, default_database, T]], fields=[f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, T, project=[f0, f1], metadata=[]]], fields=[f0, f1])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## What is the purpose of the change
This is a subtask of FLINK-32457, it added test cases of unsupported usage for JSON_OBJECTAGG & JSON_ARRAYAGG and also update the related docs(expand the implementation to support mixed use with other aggregate functions will be addressed in another pr).

## Brief change log
- added test cases of unsupported usage for JSON_OBJECTAGG & JSON_ARRAYAGG
- update function documentation to clarify the limitation

## Verifying this change
 added test cases into `WrapJsonAggFunctionArgumentsRuleTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)