### PR TITLE
[FLINK-32568][web] Ensure that all subtasks are sorted by busy ratio at the backpressure tab by default

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -57,8 +57,8 @@
     </tr>
     <tr>
       <th>SubTask</th>
-      <th [nzSortFn]="sortByBackpressureRatio" [nzSortOrder]="'descend'">Backpressure</th>
-      <th [nzSortFn]="sortByIdleRatio" [nzSortOrder]="'descend'">Idle</th>
+      <th [nzSortFn]="sortByBackpressureRatio">Backpressure</th>
+      <th [nzSortFn]="sortByIdleRatio">Idle</th>
       <th [nzSortFn]="sortByBusyRatio" [nzSortOrder]="'descend'">Busy</th>
       <th>Backpressure Status</th>
       <th>Thread Dump</th>


### PR DESCRIPTION
## What is the purpose of the change

Ensure that all subtasks are sorted by busy ratio at the backpressure tab by default

## Brief change log

Remove the default `nzSortOrder`  for backpressure and idle at the backpressure tab.


## Verifying this change

### Before:

![image](https://github.com/apache/flink/assets/38427477/ef1f8890-ccf6-40a8-a2fd-5683697a9d13)

### After: 

<img width="875" alt="image" src="https://github.com/apache/flink/assets/38427477/ce98ae6a-19d3-40cd-b862-d6cdfe7dd97f">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
