### PR TITLE
[FLINK-32569][table] Fix the incomplete serialization of ResolvedCatalogTable caused by the newly introduced time travel interface

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -249,6 +249,7 @@ class CatalogBaseTableResolutionTest {
         properties.put("version", "12");
         properties.put("connector", "custom");
         properties.put("comment", "This is an example table.");
+        properties.put("snapshot", "1688918400000");
         return properties;
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,6 +78,11 @@ public final class CatalogPropertiesUtil {
             final String comment = resolvedTable.getComment();
             if (comment != null && comment.length() > 0) {
                 properties.put(COMMENT, comment);
+            }
+
+            final Optional<Long> snapshot = resolvedTable.getSnapshot();
+            if (snapshot.isPresent()) {
+                properties.put(SNAPSHOT, Long.toString(snapshot.get()));
             }
 
             serializePartitionKeys(properties, resolvedTable.getPartitionKeys());
@@ -139,11 +145,16 @@ public final class CatalogPropertiesUtil {
 
             final @Nullable String comment = properties.get(COMMENT);
 
+            final @Nullable Long snapshot =
+                    properties.containsKey(SNAPSHOT)
+                            ? getValue(properties, SNAPSHOT, Long::parseLong)
+                            : null;
+
             final List<String> partitionKeys = deserializePartitionKeys(properties);
 
             final Map<String, String> options = deserializeOptions(properties, schemaKey);
 
-            return CatalogTable.of(schema, comment, partitionKeys, options);
+            return CatalogTable.of(schema, comment, partitionKeys, options, snapshot);
         } catch (Exception e) {
             throw new CatalogException("Error in deserializing catalog table.", e);
         }
@@ -194,6 +205,8 @@ public final class CatalogPropertiesUtil {
 
     private static final String COMMENT = "comment";
 
+    private static final String SNAPSHOT = "snapshot";
+
     private static Map<String, String> deserializeOptions(
             Map<String, String> map, String schemaKey) {
         return map.entrySet().stream()
@@ -202,7 +215,8 @@ public final class CatalogPropertiesUtil {
                             final String key = e.getKey();
                             return !key.startsWith(schemaKey + SEPARATOR)
                                     && !key.startsWith(PARTITION_KEYS + SEPARATOR)
-                                    && !key.equals(COMMENT);
+                                    && !key.equals(COMMENT)
+                                    && !key.equals(SNAPSHOT);
                         })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -81,9 +81,7 @@ public final class CatalogPropertiesUtil {
             }
 
             final Optional<Long> snapshot = resolvedTable.getSnapshot();
-            if (snapshot.isPresent()) {
-                properties.put(SNAPSHOT, Long.toString(snapshot.get()));
-            }
+            snapshot.ifPresent(snapshotId -> properties.put(SNAPSHOT, Long.toString(snapshotId)));
 
             serializePartitionKeys(properties, resolvedTable.getPartitionKeys());
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
@@ -131,12 +131,13 @@ public class DefaultCatalogTable implements CatalogTable {
         return schema.equals(that.schema)
                 && Objects.equals(comment, that.comment)
                 && partitionKeys.equals(that.partitionKeys)
-                && options.equals(that.options);
+                && options.equals(that.options)
+                && Objects.equals(snapshot, that.snapshot);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, comment, partitionKeys, options);
+        return Objects.hash(schema, comment, partitionKeys, options, snapshot);
     }
 
     @Override
@@ -151,6 +152,8 @@ public class DefaultCatalogTable implements CatalogTable {
                 + partitionKeys
                 + ", options="
                 + options
+                + ", snapshot="
+                + snapshot
                 + '}';
     }
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the incomplete serialization of ResolvedCatalogTable caused by the newly introduced time travel interface

In order to implement time travel, we added Snapshot information to DefaultCatalogTable, but Snapshot is not used when ResolvedCatalogTable is serialized and deserialized, we break the contract that ResolvedCatalogTable is fully serializable.

So, we should change CatalogPropertiesUtil to fix this.

## Brief change log

  -  Fix the de/serialization in CatalogPropertiesUtil::serializeCatalogTable and  CatalogPropertiesUtil:: deserializeCatalogTable
  - Fix the equals and hashCode method of DefaultCatalogTable


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.table.catalog.CatalogBaseTableResolutionTest#testPropertyDeSerialization*.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
