### PR TITLE
[FLINK-28743][table-planner] Supports validating the determinism for StreamPhysicalMatchRecognize

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
@@ -3161,4 +3161,84 @@ Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMatchRecognizeSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+SELECT T1.a, T1.b, cast(T1.matchProctime as varchar)
+FROM v1
+MATCH_RECOGNIZE (
+PARTITION BY c
+ORDER BY proctime
+MEASURES
+  A.a as a,
+  A.b as b,
+  MATCH_PROCTIME() as matchProctime
+ONE ROW PER MATCH
+PATTERN (A)
+DEFINE
+  A AS A.a > 1
+) AS T1
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$1], b=[$2], EXPR$2=[CAST($3):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalMatch(partition=[[2]], order=[[4 ASC-nulls-first]], outputFields=[[c, a, b, matchProctime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$0, 0), 1)]], inputFields=[[a, b, c, d, proctime]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, EXPR$2])
++- Calc(select=[a, b, CAST(PROCTIME_MATERIALIZE(matchProctime) AS VARCHAR(2147483647)) AS EXPR$2])
+   +- Match(partitionBy=[c], orderBy=[proctime ASC], measures=[FINAL(A.a) AS a, FINAL(A.b) AS b, FINAL(MATCH_PROCTIME()) AS matchProctime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$0, 0), 1)}])
+      +- Exchange(distribution=[hash[c]])
+         +- Calc(select=[a, b, c, d, PROCTIME() AS proctime])
+            +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMatchRecognizeSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+SELECT T1.a, T1.b, cast(T1.matchProctime as varchar)
+FROM v1
+MATCH_RECOGNIZE (
+PARTITION BY c
+ORDER BY proctime
+MEASURES
+  A.a as a,
+  A.b as b,
+  MATCH_PROCTIME() as matchProctime
+ONE ROW PER MATCH
+PATTERN (A)
+DEFINE
+  A AS A.a > 1
+) AS T1
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, EXPR$2])
++- LogicalProject(a=[$1], b=[$2], EXPR$2=[CAST($3):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalMatch(partition=[[2]], order=[[4 ASC-nulls-first]], outputFields=[[c, a, b, matchProctime]], allRows=[false], after=[FLAG(SKIP TO NEXT ROW)], pattern=[_UTF-16LE'A'], isStrictStarts=[false], isStrictEnds=[false], subsets=[[]], patternDefinitions=[[>(PREV(A.$0, 0), 1)]], inputFields=[[a, b, c, d, proctime]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, EXPR$2])
++- Calc(select=[a, b, CAST(PROCTIME_MATERIALIZE(matchProctime) AS VARCHAR(2147483647)) AS EXPR$2])
+   +- Match(partitionBy=[c], orderBy=[proctime ASC], measures=[FINAL(A.a) AS a, FINAL(A.b) AS b, FINAL(MATCH_PROCTIME()) AS matchProctime], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[_UTF-16LE'A'], define=[{A=>(PREV(A.$0, 0), 1)}])
+      +- Exchange(distribution=[hash[c]])
+         +- Calc(select=[a, b, c, d, PROCTIME() AS proctime])
+            +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -1584,11 +1584,10 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
 
   @Test
   def testMatchRecognizeSinkWithPk(): Unit = {
-    util.tableEnv.executeSql(
-      s"""
-         |create temporary view v1 as
-         |select *, PROCTIME() as proctime from src
-         |""".stripMargin)
+    util.tableEnv.executeSql(s"""
+                                |create temporary view v1 as
+                                |select *, PROCTIME() as proctime from src
+                                |""".stripMargin)
 
     util.verifyExecPlanInsert(
       """
@@ -1614,8 +1613,7 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
   @Test
   def testMatchRecognizeWithNonDeterministicConditionOnCdcSinkWithPk(): Unit = {
     // TODO this should be updated after StreamPhysicalMatch supports consuming updates
-    thrown.expectMessage(
-      "Match Recognize doesn't support consuming update and delete changes")
+    thrown.expectMessage("Match Recognize doesn't support consuming update and delete changes")
     thrown.expect(classOf[TableException])
     util.verifyExecPlanInsert(
       """
@@ -1641,8 +1639,7 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
   @Test
   def testMatchRecognizeOnCdcWithMetaDataSinkWithPk(): Unit = {
     // TODO this should be updated after StreamPhysicalMatch supports consuming updates
-    thrown.expectMessage(
-      "Match Recognize doesn't support consuming update and delete changes")
+    thrown.expectMessage("Match Recognize doesn't support consuming update and delete changes")
     thrown.expect(classOf[TableException])
     util.verifyExecPlanInsert(
       """

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -1582,6 +1582,90 @@ class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUp
     util.verifyExecPlan(stmtSet)
   }
 
+  @Test
+  def testMatchRecognizeSinkWithPk(): Unit = {
+    util.tableEnv.executeSql(
+      s"""
+         |create temporary view v1 as
+         |select *, PROCTIME() as proctime from src
+         |""".stripMargin)
+
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT T1.a, T1.b, cast(T1.matchProctime as varchar)
+        |FROM v1
+        |MATCH_RECOGNIZE (
+        |PARTITION BY c
+        |ORDER BY proctime
+        |MEASURES
+        |  A.a as a,
+        |  A.b as b,
+        |  MATCH_PROCTIME() as matchProctime
+        |ONE ROW PER MATCH
+        |PATTERN (A)
+        |DEFINE
+        |  A AS A.a > 1
+        |) AS T1
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testMatchRecognizeWithNonDeterministicConditionOnCdcSinkWithPk(): Unit = {
+    // TODO this should be updated after StreamPhysicalMatch supports consuming updates
+    thrown.expectMessage(
+      "Match Recognize doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT T.a, T.b, cast(T.matchRowtime as varchar)
+        |FROM cdc_with_meta_and_wm
+        |MATCH_RECOGNIZE (
+        |PARTITION BY c
+        |ORDER BY op_ts
+        |MEASURES
+        |  A.a as a,
+        |  A.b as b,
+        |  MATCH_ROWTIME(op_ts) as matchRowtime
+        |ONE ROW PER MATCH
+        |PATTERN (A)
+        |DEFINE
+        |  A AS A.op_ts >= CURRENT_TIMESTAMP
+        |) AS T
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testMatchRecognizeOnCdcWithMetaDataSinkWithPk(): Unit = {
+    // TODO this should be updated after StreamPhysicalMatch supports consuming updates
+    thrown.expectMessage(
+      "Match Recognize doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT T.a, T.b, cast(T.ts as varchar)
+        |FROM cdc_with_meta_and_wm
+        |MATCH_RECOGNIZE (
+        |PARTITION BY c
+        |ORDER BY op_ts
+        |MEASURES
+        |  A.a as a,
+        |  A.b as b,
+        |  A.op_ts as ts,
+        |  MATCH_ROWTIME(op_ts) as matchRowtime
+        |ONE ROW PER MATCH
+        |PATTERN (A)
+        |DEFINE
+        |  A AS A.a > 0
+        |) AS T
+      """.stripMargin
+    )
+  }
+
   /**
    * This upsert test sink does support getting primary key from table schema. We defined a similar
    * test sink here not using existing {@link TestingUpsertTableSink} in {@link StreamTestSink}


### PR DESCRIPTION
## What is the purpose of the change
This is an minor addition to the FLINK-27849 implementation to support the analysis of the `MatchRecognize` node.
Since the `MatchRecognize` will not support updating inputs in the foreseeable future, here we keep the analytic logic as a relatively simple one.

## Brief change log
add the analytic logic of `MatchRecognize` node in `StreamNonDeterministicUpdatePlanVisitor`

## Verifying this change
added test cases into `NonDeterministicDagTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)