### PR TITLE
[FLINK-21883][scheduler] Implement cooldown period for adaptive scheduler

### DIFF
--- a/docs/content/docs/deployment/elastic_scaling.md
+++ b/docs/content/docs/deployment/elastic_scaling.md
@@ -100,6 +100,11 @@ With Reactive Mode enabled, the [`jobmanager.adaptive-scheduler.resource-stabili
 In scenarios where TaskManagers are not connecting at the same time, but slowly one after another, this behavior leads to a job restart whenever a TaskManager connects. Increase this configuration value if you want to wait for the resources to stabilize before scheduling the job.
 Additionally, one can configure [`jobmanager.adaptive-scheduler.min-parallelism-increase`]({{< ref "docs/deployment/config">}}#jobmanager-adaptive-scheduler-min-parallelism-increase): This configuration option specifics the minimum amount of additional, aggregate parallelism increase before triggering a scale-up. For example if you have a job with a source (parallelism=2) and a sink (parallelism=2), the aggregate parallelism is 4. By default, the configuration key is set to 1, so any increase in the aggregate parallelism will trigger a restart.
 
+One can force scaling operations to happen by setting [`jobmanager.adaptive-scheduler.scaling-interval.max`]({{< ref "docs/deployment/config">}}#jobmanager-adaptive-scheduler-scaling-interval-max). It is disabled by default. If set, then when new resources are added to the cluster, a rescale is scheduled after [`jobmanager.adaptive-scheduler.scaling-interval.max`]({{< ref "docs/deployment/config">}}#jobmanager-adaptive-scheduler-scaling-interval-max) even if [`jobmanager.adaptive-scheduler.min-parallelism-increase`]({{< ref "docs/deployment/config">}}#jobmanager-adaptive-scheduler-min-parallelism-increase) is not satisfied.
+
+To avoid too frequent scaling operations, one can configure [`jobmanager.adaptive-scheduler.scaling-interval.min`]({{< ref "docs/deployment/config">}}#jobmanager-adaptive-scheduler-scaling-interval-min) to set the minimum time between 2 scaling operations. The default is 30s.
+
+
 #### Recommendations
 
 - **Configure periodic checkpointing for stateful jobs**: Reactive mode restores from the latest completed checkpoint on a rescale event. If no periodic checkpointing is enabled, your program will lose its state. Checkpointing also configures a **restart strategy**. Reactive Mode will respect the configured restarting strategy: If no restarting strategy is configured, reactive mode will fail your job, instead of scaling it.

--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -27,6 +27,18 @@
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Determines the maximum interval time after which a scaling operation is forced even if the <code class="highlighter-rouge">jobmanager.adaptive-scheduler.min-parallelism-increase</code> aren't met. The scaling operation will be ignored when the resource hasn't changed. This option is disabled by default.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -87,6 +87,18 @@
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Determines the maximum interval time after which a scaling operation is forced even if the <code class="highlighter-rouge">jobmanager.adaptive-scheduler.min-parallelism-increase</code> aren't met. The scaling operation will be ignored when the resource hasn't changed. This option is disabled by default.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.partition.hybrid.partition-data-consume-constraint</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -27,6 +27,18 @@
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Determines the maximum interval time after which a scaling operation is forced even if the <code class="highlighter-rouge">jobmanager.adaptive-scheduler.min-parallelism-increase</code> aren't met. The scaling operation will be ignored when the resource hasn't changed. This option is disabled by default.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -511,6 +511,32 @@ public class JobManagerOptions {
         Documentation.Sections.EXPERT_SCHEDULING,
         Documentation.Sections.ALL_JOB_MANAGER
     })
+    public static final ConfigOption<Duration> SCHEDULER_SCALING_INTERVAL_MIN =
+            key("jobmanager.adaptive-scheduler.scaling-interval.min")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    // rescaling and let the user increase the value for high workloads
+                    .withDescription("Determines the minimum time between scaling operations.");
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Duration> SCHEDULER_SCALING_INTERVAL_MAX =
+            key("jobmanager.adaptive-scheduler.scaling-interval.max")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Determines the maximum interval time after which a scaling operation is forced even if the %s aren't met. The scaling operation will be ignored when the resource hasn't changed. This option is disabled by default.",
+                                            code(MIN_PARALLELISM_INCREASE.key()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
     public static final ConfigOption<Duration> RESOURCE_WAIT_TIMEOUT =
             key("jobmanager.adaptive-scheduler.resource-wait-timeout")
                     .durationType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
@@ -39,6 +41,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -47,6 +50,11 @@ import java.util.concurrent.ScheduledFuture;
 class Executing extends StateWithExecutionGraph implements ResourceListener {
 
     private final Context context;
+    private final Instant lastRescale;
+    // only one schedule at the time
+    private boolean rescaleScheduled = false;
+    private final Duration scalingIntervalMin;
+    @Nullable private final Duration scalingIntervalMax;
 
     Executing(
             ExecutionGraph executionGraph,
@@ -55,7 +63,10 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
             Logger logger,
             Context context,
             ClassLoader userCodeClassLoader,
-            List<ExceptionHistoryEntry> failureCollection) {
+            List<ExceptionHistoryEntry> failureCollection,
+            Duration scalingIntervalMin,
+            @Nullable Duration scalingIntervalMax,
+            Instant lastRescale) {
         super(
                 context,
                 executionGraph,
@@ -67,11 +78,29 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
         this.context = context;
         Preconditions.checkState(
                 executionGraph.getState() == JobStatus.RUNNING, "Assuming running execution graph");
+        this.scalingIntervalMin = scalingIntervalMin;
+        this.scalingIntervalMax = scalingIntervalMax;
+        // Executing is recreated with each restart (when we rescale)
+        // we consider the first execution of the pipeline as a rescale event
+        this.lastRescale = lastRescale;
+        Preconditions.checkState(
+                !scalingIntervalMin.isNegative(),
+                "%s must be positive integer or 0",
+                JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN.key());
+        if (scalingIntervalMax != null) {
+            Preconditions.checkState(
+                    scalingIntervalMax.compareTo(scalingIntervalMin) > 0,
+                    "%s(%d) must be greater than %s(%d)",
+                    JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX.key(),
+                    scalingIntervalMax,
+                    JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN.key(),
+                    scalingIntervalMin);
+        }
 
         deploy();
 
         // check if new resources have come available in the meantime
-        context.runIfState(this, this::maybeRescale, Duration.ZERO);
+        rescaleWhenCooldownPeriodIsOver();
     }
 
     @Override
@@ -124,23 +153,74 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
 
     @Override
     public void onNewResourcesAvailable() {
-        maybeRescale();
+        rescaleWhenCooldownPeriodIsOver();
     }
 
     @Override
     public void onNewResourceRequirements() {
-        maybeRescale();
+        rescaleWhenCooldownPeriodIsOver();
     }
 
-    private void maybeRescale() {
-        if (context.shouldRescale(getExecutionGraph())) {
-            getLogger().info("Can change the parallelism of job. Restarting job.");
+    /** Force rescaling as long as the target parallelism is different from the current one. */
+    private void forceRescale() {
+        if (context.shouldRescale(getExecutionGraph(), true)) {
+            getLogger()
+                    .info(
+                            "Added resources are still there after {} time({}), force a rescale.",
+                            JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX.key(),
+                            scalingIntervalMax);
             context.goToRestarting(
                     getExecutionGraph(),
                     getExecutionGraphHandler(),
                     getOperatorCoordinatorHandler(),
                     Duration.ofMillis(0L),
                     getFailures());
+        }
+    }
+
+    /**
+     * Rescale the job if {@link Context#shouldRescale} is true. Otherwise, force a rescale using
+     * {@link Executing#forceRescale()} after {@link
+     * JobManagerOptions#SCHEDULER_SCALING_INTERVAL_MAX}.
+     */
+    private void maybeRescale() {
+        rescaleScheduled = false;
+        if (context.shouldRescale(getExecutionGraph(), false)) {
+            getLogger().info("Can change the parallelism of the job. Restarting the job.");
+            context.goToRestarting(
+                    getExecutionGraph(),
+                    getExecutionGraphHandler(),
+                    getOperatorCoordinatorHandler(),
+                    Duration.ofMillis(0L),
+                    getFailures());
+        } else if (scalingIntervalMax != null) {
+            getLogger()
+                    .info(
+                            "The longer the pipeline runs, the more the (small) resource gain is worth the restarting time. "
+                                    + "Last resource added does not meet {}, force a rescale after {} time({}) if the resource is still there.",
+                            JobManagerOptions.MIN_PARALLELISM_INCREASE,
+                            JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX.key(),
+                            scalingIntervalMax);
+            if (timeSinceLastRescale().compareTo(scalingIntervalMax) > 0) {
+                forceRescale();
+            } else {
+                // schedule a force rescale in JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX time
+                context.runIfState(this, this::forceRescale, scalingIntervalMax);
+            }
+        }
+    }
+
+    private Duration timeSinceLastRescale() {
+        return Duration.between(lastRescale, Instant.now());
+    }
+
+    private void rescaleWhenCooldownPeriodIsOver() {
+        if (timeSinceLastRescale().compareTo(scalingIntervalMin) > 0) {
+            maybeRescale();
+        } else if (!rescaleScheduled) {
+            rescaleScheduled = true;
+            // schedule maybeRescale resetting the cooldown period
+            context.runIfState(this, this::maybeRescale, scalingIntervalMin);
         }
     }
 
@@ -196,9 +276,10 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
          * Asks if we should rescale the currently executing job.
          *
          * @param executionGraph executionGraph for making the scaling decision.
+         * @param forceRescale should we force rescaling
          * @return true, if we should rescale
          */
-        boolean shouldRescale(ExecutionGraph executionGraph);
+        boolean shouldRescale(ExecutionGraph executionGraph, boolean forceRescale);
 
         /**
          * Runs the given action after a delay if the state at this time equals the expected state.
@@ -244,6 +325,7 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
         }
 
         public Executing getState() {
+            final Configuration jobConfiguration = executionGraph.getJobConfiguration();
             return new Executing(
                     executionGraph,
                     executionGraphHandler,
@@ -251,7 +333,10 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
                     log,
                     context,
                     userCodeClassLoader,
-                    failureCollection);
+                    failureCollection,
+                    jobConfiguration.get(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN),
+                    jobConfiguration.get(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX),
+                    Instant.now());
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceParallelismChangeRescalingController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceParallelismChangeRescalingController.java
@@ -17,24 +17,14 @@
 
 package org.apache.flink.runtime.scheduler.adaptive.scalingpolicy;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 
-import static org.apache.flink.configuration.JobManagerOptions.MIN_PARALLELISM_INCREASE;
-
 /**
- * Simple scaling policy. The user can configure a minimum cumulative parallelism increase to allow
- * a scale up.
+ * Simple scaling policy. It just checks that the new parallelism is different (either increase or
+ * decrease) from the current parallelism.
  */
-public class EnforceMinimalIncreaseRescalingController implements RescalingController {
-
-    private final int minParallelismIncrease;
-
-    public EnforceMinimalIncreaseRescalingController(Configuration configuration) {
-        minParallelismIncrease = configuration.get(MIN_PARALLELISM_INCREASE);
-    }
-
+public class EnforceParallelismChangeRescalingController implements RescalingController {
     @Override
     public boolean shouldRescale(
             VertexParallelism currentParallelism, VertexParallelism newParallelism) {
@@ -42,7 +32,7 @@ public class EnforceMinimalIncreaseRescalingController implements RescalingContr
             int parallelismChange =
                     newParallelism.getParallelism(vertex)
                             - currentParallelism.getParallelism(vertex);
-            if (parallelismChange < 0 || parallelismChange >= minParallelismIncrease) {
+            if (parallelismChange != 0) {
                 return true;
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceParallelismChangeRescalingControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceParallelismChangeRescalingControllerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive.scalingpolicy;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link RescalingController}. */
+class EnforceParallelismChangeRescalingControllerTest {
+
+    private static final JobVertexID jobVertexId = new JobVertexID();
+
+    @Test
+    void testScaleUp() {
+        final RescalingController rescalingController =
+                new EnforceParallelismChangeRescalingController();
+        assertThat(rescalingController.shouldRescale(forParallelism(1), forParallelism(2)))
+                .isTrue();
+    }
+
+    @Test
+    void testAlwaysScaleDown() {
+        final RescalingController rescalingController =
+                new EnforceParallelismChangeRescalingController();
+        assertThat(rescalingController.shouldRescale(forParallelism(2), forParallelism(1)))
+                .isTrue();
+    }
+
+    @Test
+    void testNoScaleOnSameParallelism() {
+        final RescalingController rescalingController =
+                new EnforceParallelismChangeRescalingController();
+        assertThat(rescalingController.shouldRescale(forParallelism(2), forParallelism(2)))
+                .isFalse();
+    }
+
+    private static VertexParallelism forParallelism(int parallelism) {
+        return new VertexParallelism(Collections.singletonMap(jobVertexId, parallelism));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce the cooldown period in the adaptive scheduler ([FLIP-322](https://cwiki.apache.org/confluence/display/FLINK/FLIP-322+Cooldown+period+for+adaptive+scheduler))

## Brief change log
Change Executing state, when new slots arrive:

-  schedule a rescale when last rescale was done less than interval-min seconds ago, rescale immediately otherwise.
-  Add the ability to force a rescale when last rescale was done more than interval-max seconds ago regardless if the requirements are met (context#shouldRescale)


## Verifying this change

Added 3 tests to ExecutingTest test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: adding to parameters related to timing
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes: adaptive scheduler in JobManager
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? javadoc
