### PR TITLE
[FLINK-32584] Make it possible to unset default catalog and/or database

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -33,6 +33,8 @@ import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.table.types.AbstractDataType;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -1110,10 +1112,13 @@ public interface TableEnvironment {
      *     </tbody>
      * </table>
      *
+     * <p>You can unset the current catalog by passing a null value. If the current catalog is
+     * unset, you need to use fully qualified identifiers.
+     *
      * @param catalogName The name of the catalog to set as the current default catalog.
      * @see TableEnvironment#useDatabase(String)
      */
-    void useCatalog(String catalogName);
+    void useCatalog(@Nullable String catalogName);
 
     /**
      * Gets the current default database name of the running session.
@@ -1179,10 +1184,13 @@ public interface TableEnvironment {
      *     </tbody>
      * </table>
      *
+     * <p>You can unset the current database by passing a null value. If the current database is
+     * unset, you need to qualify identifiers at least with the database name.
+     *
      * @param databaseName The name of the database to set as the current database.
      * @see TableEnvironment#useCatalog(String)
      */
-    void useDatabase(String databaseName);
+    void useDatabase(@Nullable String databaseName);
 
     /** Returns the table config that defines the runtime behavior of the Table API. */
     TableConfig getConfig();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.table.procedures.Procedure;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -120,9 +122,13 @@ public interface Catalog {
      * value probably comes from configuration, will not change for the life time of the catalog
      * instance.
      *
+     * <p>If the default database is null, users will need to set a current database themselves or
+     * qualify identifiers at least with the database name when using the catalog.
+     *
      * @return the name of the current database
      * @throws CatalogException in case of any runtime exception
      */
+    @Nullable
     String getDefaultDatabase() throws CatalogException;
 
     /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -478,7 +478,7 @@ abstract class PlannerBase(
       TimeZone.getTimeZone(TableConfigUtils.getLocalTimeZone(tableConfig)).getOffset(epochTime)
     tableConfig.set(TABLE_QUERY_START_LOCAL_TIME, localTime)
 
-    val currentDatabase = catalogManager.getCurrentDatabase
+    val currentDatabase = Option(catalogManager.getCurrentDatabase).getOrElse("")
     tableConfig.set(TABLE_QUERY_CURRENT_DATABASE, currentDatabase)
 
     // We pass only the configuration to avoid reconfiguration with the rootConfiguration

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.catalog;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for no default catalog and/or database. */
+public class UnknownCatalogTest {
+
+    public static final String BUILTIN_CATALOG = "cat";
+    private static final String BUILTIN_DATABASE = "db";
+    public static final EnvironmentSettings ENVIRONMENT_SETTINGS =
+            EnvironmentSettings.newInstance()
+                    .inStreamingMode()
+                    .withBuiltInCatalogName(BUILTIN_CATALOG)
+                    .withBuiltInDatabaseName(BUILTIN_DATABASE)
+                    .build();
+    public static final ResolvedSchema EXPECTED_SCHEMA =
+            ResolvedSchema.of(Column.physical("i", INT()), Column.physical("s", STRING()));
+
+    @Test
+    public void testUnsetCatalogWithFullyQualified() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+
+        tEnv.useCatalog(null);
+        final String tablePath = String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, "tb");
+        registerTable(tEnv, tablePath);
+
+        Table table = tEnv.sqlQuery(String.format("SELECT * FROM %s", tablePath));
+
+        assertThat(table.getResolvedSchema()).isEqualTo(EXPECTED_SCHEMA);
+    }
+
+    @Test
+    public void testUnsetCatalogWithSingleIdentifier() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+
+        tEnv.useCatalog(null);
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        assertThatThrownBy(() -> tEnv.sqlQuery("SELECT * FROM " + tableName))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(String.format("Object '%s' not found", tableName));
+    }
+
+    @Test
+    public void testUsingUnknownDatabaseWithDatabaseQualified() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+        tEnv.useDatabase(null);
+
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        Table table =
+                tEnv.sqlQuery(String.format("SELECT * FROM %s.%s", BUILTIN_DATABASE, tableName));
+
+        assertThat(table.getResolvedSchema()).isEqualTo(EXPECTED_SCHEMA);
+    }
+
+    @Test
+    public void testUsingUnknownDatabaseWithSingleIdentifier() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+        tEnv.useDatabase(null);
+
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        assertThatThrownBy(() -> tEnv.sqlQuery("SELECT * FROM " + tableName))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(String.format("Object '%s' not found", tableName));
+    }
+
+    @Test
+    public void testUnsetCatalogWithAlterTable() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+
+        tEnv.useCatalog(null);
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                        String.format("ALTER TABLE %s ADD (f STRING)", tableName)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A current catalog has not been set. Please use a fully qualified"
+                                + " identifier (such as 'my_catalog.my_database.my_table') or set a"
+                                + " current catalog using 'USE CATALOG my_catalog'.");
+    }
+
+    @Test
+    public void testUnsetDatabaseWithAlterTable() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+
+        tEnv.useDatabase(null);
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", BUILTIN_CATALOG, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                        String.format("ALTER TABLE %s ADD (f STRING)", tableName)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A current database has not been set. Please use a fully qualified"
+                                + " identifier (such as 'my_database.my_table' or"
+                                + " 'my_catalog.my_database.my_table') or set a current database"
+                                + " using 'USE my_database'.");
+    }
+
+    @Test
+    public void testUnsetDatabaseComingFromCatalogWithAlterTable() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
+
+        final String catalogName = "custom";
+        final NullDefaultDatabaseCatalog catalog = new NullDefaultDatabaseCatalog(catalogName);
+        catalog.createDatabase(
+                BUILTIN_DATABASE, new CatalogDatabaseImpl(Collections.emptyMap(), null), false);
+        tEnv.registerCatalog(catalogName, catalog);
+        tEnv.useCatalog(catalogName);
+        final String tableName = "tb";
+        final String tablePath =
+                String.format("%s.%s.%s", catalogName, BUILTIN_DATABASE, tableName);
+        registerTable(tEnv, tablePath);
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                        String.format("ALTER TABLE %s ADD (f STRING)", tableName)))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "A current database has not been set. Please use a fully qualified"
+                                + " identifier (such as 'my_database.my_table' or"
+                                + " 'my_catalog.my_database.my_table') or set a current database"
+                                + " using 'USE my_database'.");
+    }
+
+    private static void registerTable(TableEnvironment tEnv, String tableName) {
+        final String input1DataId =
+                TestValuesTableFactory.registerData(Arrays.asList(Row.of(1, "a"), Row.of(2, "b")));
+        tEnv.createTable(
+                tableName,
+                TableDescriptor.forConnector("values")
+                        .option("data-id", input1DataId)
+                        .schema(Schema.newBuilder().fromResolvedSchema(EXPECTED_SCHEMA).build())
+                        .build());
+    }
+
+    private static class NullDefaultDatabaseCatalog extends GenericInMemoryCatalog {
+
+        public NullDefaultDatabaseCatalog(String name) {
+            super(name);
+        }
+
+        @Override
+        public String getDefaultDatabase() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Make it possible to unset the default catalog and/or database

## Brief change log

* accept `null` in `useCatalog` and `useDatabase`
* adjust `CatalogReader` search paths
* throw an exception if we end up qualifying an identifier without a default catalog and/or database set.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
