### PR TITLE
[FLINK-32583][rest] Fix deadlock in RestClient

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -140,7 +140,7 @@ public class RestClient implements AutoCloseableAsync {
     private final Collection<CompletableFuture<Channel>> responseChannelFutures =
             ConcurrentHashMap.newKeySet();
 
-    @VisibleForTesting List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
+    private final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
 
     /**
      * Creates a new RestClient for the provided root URL. If the protocol of the URL is "https",
@@ -287,6 +287,11 @@ public class RestClient implements AutoCloseableAsync {
     @VisibleForTesting
     Collection<CompletableFuture<Channel>> getResponseChannelFutures() {
         return responseChannelFutures;
+    }
+
+    @VisibleForTesting
+    List<OutboundChannelHandlerFactory> getOutboundChannelHandlerFactories() {
+        return outboundChannelHandlerFactories;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -109,7 +109,7 @@ public abstract class RestServerEndpoint implements RestService {
 
     private State state = State.CREATED;
 
-    @VisibleForTesting List<InboundChannelHandlerFactory> inboundChannelHandlerFactories;
+    private final List<InboundChannelHandlerFactory> inboundChannelHandlerFactories;
 
     public RestServerEndpoint(Configuration configuration)
             throws IOException, ConfigurationException {
@@ -150,6 +150,11 @@ public abstract class RestServerEndpoint implements RestService {
         }
         inboundChannelHandlerFactories.sort(
                 Comparator.comparingInt(InboundChannelHandlerFactory::priority).reversed());
+    }
+
+    @VisibleForTesting
+    List<InboundChannelHandlerFactory> getInboundChannelHandlerFactories() {
+        return inboundChannelHandlerFactories;
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -124,21 +125,23 @@ class RestExternalHandlersITCase {
     }
 
     @Test
-    void testHandlersMustBeLoaded() throws Exception {
-        assertEquals(serverEndpoint.inboundChannelHandlerFactories.size(), 2);
+    void testHandlersMustBeLoaded() {
+        final List<InboundChannelHandlerFactory> inboundChannelHandlerFactories =
+                serverEndpoint.getInboundChannelHandlerFactories();
+        assertEquals(inboundChannelHandlerFactories.size(), 2);
         assertTrue(
-                serverEndpoint.inboundChannelHandlerFactories.get(0)
-                        instanceof Prio1InboundChannelHandlerFactory);
+                inboundChannelHandlerFactories.get(0) instanceof Prio1InboundChannelHandlerFactory);
         assertTrue(
-                serverEndpoint.inboundChannelHandlerFactories.get(1)
-                        instanceof Prio0InboundChannelHandlerFactory);
+                inboundChannelHandlerFactories.get(1) instanceof Prio0InboundChannelHandlerFactory);
 
-        assertEquals(restClient.outboundChannelHandlerFactories.size(), 2);
+        final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories =
+                restClient.getOutboundChannelHandlerFactories();
+        assertEquals(outboundChannelHandlerFactories.size(), 2);
         assertTrue(
-                restClient.outboundChannelHandlerFactories.get(0)
+                outboundChannelHandlerFactories.get(0)
                         instanceof Prio1OutboundChannelHandlerFactory);
         assertTrue(
-                restClient.outboundChannelHandlerFactories.get(1)
+                outboundChannelHandlerFactories.get(1)
                         instanceof Prio0OutboundChannelHandlerFactory);
 
         try {


### PR DESCRIPTION
## What is the purpose of the change

Fix the issue described in FLINK-32583 wherein a request made to a RestClient that has already been shutdown can deadlock due to the returned future never resolving.


## Brief change log

- Add check if the Netty channel future has already failed after attempting to add a listener to it


## Verifying this change

This change added tests and can be verified as follows:

- Added test for this behavior in RestClientTest, `testCloseClientBeforeRequest`
  - This test calls `restClient.close()` and then attempts to make a request that would eventually fail with a connection timeout
  - The test blocks on the future returned by the call with a timeout of 0 so it can test that the expected exception (and not TimeoutException) is thrown


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
