### PR TITLE
[FLINK-32280][table-runtime] HashAgg support operator fusion codegen

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
@@ -27,6 +27,9 @@ import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.agg.batch.AggWithoutKeysCodeGenerator;
 import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.fusion.OpFusionCodegenSpecGenerator;
+import org.apache.flink.table.planner.plan.fusion.generator.OneInputOpFusionCodegenSpecGenerator;
+import org.apache.flink.table.planner.plan.fusion.spec.HashAggFusionCodegenSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
@@ -158,5 +161,59 @@ public class BatchExecHashAggregate extends ExecNodeBase<RowData>
                 inputTransform.getParallelism(),
                 managedMemory,
                 false);
+    }
+
+    @Override
+    public boolean supportFusionCodegen() {
+        return true;
+    }
+
+    @Override
+    protected OpFusionCodegenSpecGenerator translateToFusionCodegenSpecInternal(
+            PlannerBase planner, ExecNodeConfig config) {
+        OpFusionCodegenSpecGenerator input =
+                getInputEdges().get(0).translateToFusionCodegenSpec(planner);
+
+        final AggregateInfoList aggInfos =
+                AggregateUtil.transformToBatchAggregateInfoList(
+                        planner.getTypeFactory(),
+                        aggInputRowType,
+                        JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
+                        null, // aggCallNeedRetractions
+                        null); // orderKeyIndexes
+        long managedMemory =
+                config.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_HASH_AGG_MEMORY).getBytes();
+        if (grouping.length == 0) {
+            managedMemory = 0L;
+        }
+
+        OpFusionCodegenSpecGenerator hashAggSpecGenerator =
+                new OneInputOpFusionCodegenSpecGenerator(
+                        input,
+                        managedMemory,
+                        (RowType) getOutputType(),
+                        new HashAggFusionCodegenSpec(
+                                new CodeGeneratorContext(
+                                        config, planner.getFlinkContext().getClassLoader()),
+                                planner.createRelBuilder(),
+                                aggInfos,
+                                grouping,
+                                auxGrouping,
+                                isFinal,
+                                isMerge,
+                                supportAdaptiveLocalHashAgg,
+                                config.get(
+                                        ExecutionConfigOptions
+                                                .TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES),
+                                config.get(
+                                        ExecutionConfigOptions
+                                                .TABLE_EXEC_SPILL_COMPRESSION_ENABLED),
+                                (int)
+                                        config.get(
+                                                        ExecutionConfigOptions
+                                                                .TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE)
+                                                .getBytes()));
+        input.addOutput(1, hashAggSpecGenerator);
+        return hashAggSpecGenerator;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
@@ -29,6 +29,9 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecBoundedStreamScan;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecCalc;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecHashAggregate;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecHashJoin;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSourceScan;
@@ -50,6 +53,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_OPERATOR_FUSION_CODEGEN_ENABLED;
 
 /**
  * A {@link ExecNodeGraphProcessor} which organize {@link ExecNode}s into multiple input nodes.
@@ -88,7 +93,7 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
         // sort all nodes in topological order, sinks come first and sources come last
         List<ExecNodeWrapper> orderedWrappers = topologicalSort(rootWrappers);
         // group nodes into multiple input groups
-        createMultipleInputGroups(orderedWrappers);
+        createMultipleInputGroups(context.getPlanner().getTableConfig(), orderedWrappers);
         // apply optimizations to remove unnecessary nodes out of multiple input groups
         optimizeMultipleInputGroups(orderedWrappers, context);
 
@@ -156,7 +161,8 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
     // Multiple Input Groups Creating
     // --------------------------------------------------------------------------------
 
-    private void createMultipleInputGroups(List<ExecNodeWrapper> orderedWrappers) {
+    private void createMultipleInputGroups(
+            ReadableConfig tableConfig, List<ExecNodeWrapper> orderedWrappers) {
         // wrappers are checked in topological order from sinks to sources
         for (ExecNodeWrapper wrapper : orderedWrappers) {
             // we skip nodes which cannot be a member of a multiple input node
@@ -172,7 +178,7 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
             }
 
             // we then try to create a new multiple input group with this node as the root
-            if (canBeRootOfMultipleInputGroup(wrapper)) {
+            if (canBeRootOfMultipleInputGroup(tableConfig, wrapper)) {
                 wrapper.group = new MultipleInputGroup(wrapper);
             }
 
@@ -219,10 +225,33 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
         return outputGroup;
     }
 
-    private boolean canBeRootOfMultipleInputGroup(ExecNodeWrapper wrapper) {
-        // only a node with more than one input can be the root,
-        // as one-input operator chaining are handled by operator chains
-        return wrapper.inputs.size() >= 2;
+    private boolean canBeRootOfMultipleInputGroup(
+            ReadableConfig tableConfig, ExecNodeWrapper wrapper) {
+        // A node with more than one input can be the root, and one-input operator can also be root
+        // if the upstream node only contain Calc&HashJoin&HashAgg and operator fusion codegen
+        // enabled
+        return wrapper.inputs.size() >= 2
+                || (tableConfig.get(TABLE_EXEC_OPERATOR_FUSION_CODEGEN_ENABLED)
+                        && oneInputNodeCanBeRoot(wrapper));
+    }
+
+    private boolean oneInputNodeCanBeRoot(ExecNodeWrapper wrapper) {
+        // The Calc and HashAgg can be the root node of MultipleInputGroup if the upstream node only
+        // contain Calc&HashJoin&HashAgg. This limitation can be removed if all kinds of operator
+        // support OFCG.
+        if (wrapper.inputs.size() == 1) {
+            ExecNodeWrapper inputWrapper = wrapper.inputs.get(0);
+            ExecNode<?> execNode = inputWrapper.execNode;
+            // must have HashJoin which support OFCG as the upstream node
+            if (execNode instanceof BatchExecHashJoin && execNode.supportFusionCodegen()) {
+                return true;
+            } else if (execNode instanceof BatchExecCalc
+                    || execNode instanceof BatchExecHashAggregate) {
+                return oneInputNodeCanBeRoot(inputWrapper);
+            }
+        }
+
+        return false;
     }
 
     // --------------------------------------------------------------------------------
@@ -381,7 +410,20 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
                 }
             } else if (wrapper.inputs.size() == 1) {
                 // optimization 6. operators with only 1 input are not allowed to be the root,
-                // as their chaining will be handled by operator chains.
+                // as their chaining will be handled by operator chains. But Calc and HashAgg can be
+                // the root node for OFCG
+                // TODO If all kinds of one input operator support OFCG, we can remove this
+                // limitation
+                boolean fusionCodegenEnabled =
+                        context.getPlanner()
+                                .getTableConfig()
+                                .get(TABLE_EXEC_OPERATOR_FUSION_CODEGEN_ENABLED);
+                if (fusionCodegenEnabled
+                        && (wrapper.execNode instanceof BatchExecCalc
+                                || wrapper.execNode instanceof BatchExecHashAggregate)) {
+                    continue;
+                }
+
                 wrapper.group.removeRoot();
             }
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -750,7 +750,7 @@ object AggCodeGenHelper {
         }
 
         // apply filter if present
-        if (aggInfo.agg.filterArg >= 0) {
+        if (aggInfo.agg.hasFilter) {
           val expr = getFieldExpr(ctx, inputTerm, inputType, aggCall.filterArg)
           val filterTerm = s"!${expr.nullTerm} && ${expr.resultTerm}"
           s"""

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -45,11 +45,16 @@ import scala.annotation.tailrec
 /** Batch aggregate code generate helper. */
 object AggCodeGenHelper {
 
+  /**
+   * The aggBufferPrefix is used to guarantee the variable name unique in OFCG case, so user should
+   * guarantee the aggBufferPrefix unique in this case.
+   */
   def getAggBufferNames(
+      aggBufferPrefix: String,
       auxGrouping: Array[Int],
       aggInfos: Seq[AggregateInfo]): Array[Array[String]] = {
     val auxGroupingNames = auxGrouping.indices
-      .map(index => Array(s"aux_group$index"))
+      .map(index => Array(s"${aggBufferPrefix}_aux_group$index"))
 
     val aggNames = aggInfos.map {
       aggInfo =>
@@ -59,11 +64,12 @@ object AggCodeGenHelper {
 
           // create one buffer for each attribute in declarative functions
           case function: DeclarativeAggregateFunction =>
-            function.aggBufferAttributes.map(attr => s"agg${aggBufferIdx}_${attr.getName}")
+            function.aggBufferAttributes.map(
+              attr => s"${aggBufferPrefix}_agg${aggBufferIdx}_${attr.getName}")
 
           // create one buffer for imperative functions
           case _: AggregateFunction[_, _] =>
-            Array(s"agg$aggBufferIdx")
+            Array(s"${aggBufferPrefix}_agg$aggBufferIdx")
         }
     }
 
@@ -138,6 +144,7 @@ object AggCodeGenHelper {
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       inputTerm: String,
       inputType: RowType,
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       outputType: RowType,
@@ -158,6 +165,7 @@ object AggCodeGenHelper {
       auxGrouping,
       aggInfos,
       argsMapping,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes)
 
@@ -183,9 +191,11 @@ object AggCodeGenHelper {
       aggInfos,
       functionIdentifiers,
       argsMapping,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
-      aggBufferExprs)
+      aggBufferExprs
+    )
 
     val aggOutputExpr = genSortAggOutputExpr(
       isMerge,
@@ -197,10 +207,12 @@ object AggCodeGenHelper {
       aggInfos,
       functionIdentifiers,
       argsMapping,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
       aggBufferExprs,
-      outputType)
+      outputType
+    )
 
     (initAggBufferCode, doAggregateCode, aggOutputExpr)
   }
@@ -258,6 +270,7 @@ object AggCodeGenHelper {
       agg: DeclarativeAggregateFunction,
       aggIndex: Int,
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferTypes: Array[Array[LogicalType]])
     extends DeclarativeExpressionResolver(relBuilder, agg, isMerge) {
 
@@ -272,7 +285,7 @@ object AggCodeGenHelper {
     }
 
     override def toAggBufferExpr(name: String, localIndex: Int): ResolvedExpression = {
-      val variableName = s"agg${aggIndex}_$name"
+      val variableName = s"${aggBufferPrefix}_agg${aggIndex}_$name"
       newLocalReference(variableName, aggBufferTypes(aggIndex)(localIndex))
     }
   }
@@ -285,6 +298,7 @@ object AggCodeGenHelper {
       auxGrouping: Array[Int],
       aggInfos: Seq[AggregateInfo],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]]): Seq[GeneratedExpression] = {
     val exprCodeGen = new ExprCodeGenerator(ctx, false)
@@ -308,6 +322,7 @@ object AggCodeGenHelper {
               function,
               aggBufferIdx,
               argsMapping,
+              aggBufferPrefix,
               aggBufferTypes)
             function.aggBufferAttributes().map(_.accept(ref))
 
@@ -419,6 +434,7 @@ object AggCodeGenHelper {
       aggInfos: Seq[AggregateInfo],
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       aggBufferExprs: Seq[GeneratedExpression]): String = {
@@ -432,6 +448,7 @@ object AggCodeGenHelper {
         aggInfos,
         functionIdentifiers,
         argsMapping,
+        aggBufferPrefix,
         aggBufferNames,
         aggBufferTypes,
         aggBufferExprs)
@@ -445,6 +462,7 @@ object AggCodeGenHelper {
         aggInfos,
         functionIdentifiers,
         argsMapping,
+        aggBufferPrefix,
         aggBufferNames,
         aggBufferTypes,
         aggBufferExprs)
@@ -461,6 +479,7 @@ object AggCodeGenHelper {
       aggInfos: Seq[AggregateInfo],
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       aggBufferExprs: Seq[GeneratedExpression],
@@ -476,6 +495,7 @@ object AggCodeGenHelper {
         aggInfos,
         functionIdentifiers,
         argsMapping,
+        aggBufferPrefix,
         aggBufferNames,
         aggBufferTypes,
         outputType)
@@ -504,6 +524,7 @@ object AggCodeGenHelper {
       aggInfos: Seq[AggregateInfo],
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       outputType: RowType): Seq[GeneratedExpression] = {
@@ -533,6 +554,7 @@ object AggCodeGenHelper {
               function,
               aggBufferIdx,
               argsMapping,
+              aggBufferPrefix,
               aggBufferTypes)
             val getValueRexNode = function.getValueExpression
               .accept(ref)
@@ -566,6 +588,7 @@ object AggCodeGenHelper {
       aggInfos: Seq[AggregateInfo],
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       aggBufferExprs: Seq[GeneratedExpression]): String = {
@@ -590,6 +613,7 @@ object AggCodeGenHelper {
               function,
               aggBufferIdx,
               argsMapping,
+              aggBufferPrefix,
               aggBufferTypes)
             val mergeExprs = function.mergeExpressions
               .map(_.accept(ref))
@@ -647,6 +671,7 @@ object AggCodeGenHelper {
       aggInfos: Seq[AggregateInfo],
       functionIdentifiers: Map[AggregateFunction[_, _], String],
       argsMapping: Array[Array[(Int, LogicalType)]],
+      aggBufferPrefix: String,
       aggBufferNames: Array[Array[String]],
       aggBufferTypes: Array[Array[LogicalType]],
       aggBufferExprs: Seq[GeneratedExpression]): String = {
@@ -673,6 +698,7 @@ object AggCodeGenHelper {
               function,
               aggBufferIdx,
               argsMapping,
+              aggBufferPrefix,
               aggBufferTypes)
             val accExprs = function.accumulateExpressions
               .map(_.accept(ref))
@@ -725,8 +751,11 @@ object AggCodeGenHelper {
 
         // apply filter if present
         if (aggInfo.agg.filterArg >= 0) {
+          val expr = getFieldExpr(ctx, inputTerm, inputType, aggCall.filterArg)
+          val filterTerm = s"!${expr.nullTerm} && ${expr.resultTerm}"
           s"""
-             |if ($inputTerm.getBoolean(${aggCall.filterArg})) {
+             |${expr.code}
+             |if ($filterTerm) {
              |  $accCode
              |}
         """.stripMargin

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggWithoutKeysCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggWithoutKeysCodeGenerator.scala
@@ -51,7 +51,8 @@ object AggWithoutKeysCodeGenerator {
       .filter(_.isInstanceOf[AggregateFunction[_, _]])
       .map(ctx.addReusableFunction(_))
     val functionIdentifiers = AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
-    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(auxGrouping, aggInfos)
+    val aggBufferPrefix = "hash"
+    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(aggBufferPrefix, auxGrouping, aggInfos)
     val aggBufferTypes = AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggInfos)
 
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
@@ -67,6 +68,7 @@ object AggWithoutKeysCodeGenerator {
       functionIdentifiers,
       inputTerm,
       inputType,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
       outputType)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -112,7 +112,8 @@ object HashAggCodeGenerator {
 
     val aggInfos = aggInfoList.aggInfos
     val functionIdentifiers = AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
-    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(auxGrouping, aggInfos)
+    val aggBufferPrefix = "hash"
+    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(aggBufferPrefix, auxGrouping, aggInfos)
     val aggBufferTypes = AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggInfos)
     val groupKeyRowType = RowTypeUtils.projectRowType(inputType, grouping)
     val aggBufferRowType = RowType.of(aggBufferTypes.flatten, aggBufferNames.flatten)
@@ -219,6 +220,7 @@ object HashAggCodeGenerator {
       aggregateMapTerm,
       (groupKeyTypesTerm, aggBufferTypesTerm),
       (groupKeyRowType, aggBufferRowType),
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
       outputTerm,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortAggCodeGenerator.scala
@@ -56,7 +56,8 @@ object SortAggCodeGenerator {
       .filter(_.isInstanceOf[AggregateFunction[_, _]])
       .map(ctx.addReusableFunction(_))
     val functionIdentifiers = AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
-    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(auxGrouping, aggInfos)
+    val aggBufferPrefix = "sort"
+    val aggBufferNames = AggCodeGenHelper.getAggBufferNames(aggBufferPrefix, auxGrouping, aggInfos)
     val aggBufferTypes = AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggInfos)
 
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
@@ -89,9 +90,11 @@ object SortAggCodeGenerator {
       functionIdentifiers,
       inputTerm,
       inputType,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
-      outputType)
+      outputType
+    )
 
     val joinedRow = "joinedRow"
     ctx.addReusableOutputRecord(outputType, classOf[JoinedRowData], joinedRow)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -76,8 +76,9 @@ abstract class WindowCodeGenerator(
   protected lazy val functionIdentifiers: Map[AggregateFunction[_, _], String] =
     AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
 
+  private lazy val aggBufferPrefix = "window"
   protected lazy val aggBufferNames: Array[Array[String]] =
-    AggCodeGenHelper.getAggBufferNames(auxGrouping, aggInfos)
+    AggCodeGenHelper.getAggBufferNames(aggBufferPrefix, auxGrouping, aggInfos)
 
   protected lazy val aggBufferTypes: Array[Array[LogicalType]] =
     AggCodeGenHelper.getAggBufferTypes(inputRowType, auxGrouping, aggInfos)
@@ -205,6 +206,7 @@ abstract class WindowCodeGenerator(
       auxGrouping,
       aggInfos,
       argsMapping,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes)
     val initAggBufferCode = genInitFlatAggregateBuffer(
@@ -227,9 +229,11 @@ abstract class WindowCodeGenerator(
       aggInfos,
       functionIdentifiers,
       argsMapping,
+      aggBufferPrefix,
       aggBufferNames,
       aggBufferTypes,
-      aggBufferExprs)
+      aggBufferExprs
+    )
 
     // --------------------------------------------------------------------------------------------
     // gen code to set group window aggregate output
@@ -246,6 +250,7 @@ abstract class WindowCodeGenerator(
         aggInfos,
         functionIdentifiers,
         argsMapping,
+        aggBufferPrefix,
         aggBufferNames,
         aggBufferTypes,
         aggBufferExprs,
@@ -443,6 +448,7 @@ abstract class WindowCodeGenerator(
           auxGrouping,
           aggInfos,
           argsMapping,
+          aggBufferPrefix,
           aggBufferNames,
           aggBufferTypes)
         val initAggBufferCode = genInitFlatAggregateBuffer(
@@ -465,9 +471,11 @@ abstract class WindowCodeGenerator(
           aggInfos,
           functionIdentifiers,
           argsMapping,
+          aggBufferPrefix,
           aggBufferNames,
           aggBufferTypes,
-          aggBufferExprs)
+          aggBufferExprs
+        )
 
         // project pre accumulated results into a binary row to fit to WindowsGrouping
         val exprCodegen = new ExprCodeGenerator(ctx, false)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/HashAggFusionCodegenSpec.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/HashAggFusionCodegenSpec.scala
@@ -1,0 +1,681 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.fusion.spec
+
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.data.utils.JoinedRowData
+import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenUtils, GeneratedExpression}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{getReuseRowFieldExprs, newName, newNames}
+import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator.genAdaptiveLocalHashAggValueProjectionExpr
+import org.apache.flink.table.planner.codegen.agg.batch.{AggCodeGenHelper, HashAggCodeGenHelper}
+import org.apache.flink.table.planner.codegen.agg.batch.AggCodeGenHelper.{buildAggregateArgsMapping, genAggregateByFlatAggregateBuffer, genFlatAggBufferExprs, genGetValueFromFlatAggregateBuffer, genInitFlatAggregateBuffer}
+import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenerator.{TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_DISTINCT_VALUE_RATE_THRESHOLD, TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_ENABLED, TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_SAMPLING_THRESHOLD}
+import org.apache.flink.table.planner.codegen.agg.batch.HashAggCodeGenHelper.{buildAggregateAggBuffMapping, genAggregate, genCreateFallbackSorter, genHashAggValueExpr, genRetryAppendToMap, genReusableEmptyAggBuffer, prepareFallbackSorter}
+import org.apache.flink.table.planner.plan.fusion.{OpFusionCodegenSpecBase, OpFusionContext}
+import org.apache.flink.table.planner.plan.fusion.FusionCodegenUtil.{constructDoConsumeCode, constructDoConsumeFunction, evaluateVariables}
+import org.apache.flink.table.planner.plan.utils.AggregateInfoList
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.{toJava, toScala}
+import org.apache.flink.table.runtime.operators.aggregate.BytesHashMapSpillMemorySegmentPool
+import org.apache.flink.table.runtime.util.KeyValueIterator
+import org.apache.flink.table.runtime.util.collections.binary.{BytesHashMap, BytesMap}
+import org.apache.flink.table.types.logical.{LogicalType, RowType}
+
+import org.apache.calcite.tools.RelBuilder
+
+import java.util
+
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+
+/** The operator fusion codegen spec for HashAgg. */
+class HashAggFusionCodegenSpec(
+    opCodegenCtx: CodeGeneratorContext,
+    builder: RelBuilder,
+    aggInfoList: AggregateInfoList,
+    grouping: Array[Int],
+    auxGrouping: Array[Int],
+    isFinal: Boolean,
+    isMerge: Boolean,
+    supportAdaptiveLocalHashAgg: Boolean,
+    maxNumFileHandles: Int,
+    compressionEnabled: Boolean,
+    compressionBlockSize: Int)
+  extends OpFusionCodegenSpecBase(opCodegenCtx) {
+
+  private lazy val aggBufferPrefix: String = if (isFinal) { newName("hash") }
+  else { newName("local_hash") }
+
+  private lazy val aggInfos = aggInfoList.aggInfos
+  private lazy val functionIdentifiers = AggCodeGenHelper.getFunctionIdentifiers(aggInfos)
+  private lazy val aggBufferNames =
+    AggCodeGenHelper.getAggBufferNames(aggBufferPrefix, auxGrouping, aggInfos)
+
+  // The name for BytesMap
+  private lazy val aggregateMapTerm: String = newName("aggregateMap")
+
+  private var inputContext: OpFusionContext = _
+  private var inputType: RowType = _
+  private var aggBufferTypes: Array[Array[LogicalType]] = _
+  private var groupKeyRowType: RowType = _
+  private var aggBufferRowType: RowType = _
+  private var argsMapping: Array[Array[(Int, LogicalType)]] = _
+  private var aggBuffMapping: Array[Array[(Int, LogicalType)]] = _
+
+  private var inputRowTerm: String = _
+  private var outputFromMap: String = _
+  private var aggBufferExprs: Seq[GeneratedExpression] = _
+  private var consumeFunctionName: String = _
+  private var initAggBufferCode: String = _
+  private var hasInput: String = _
+  private var sorterTerm: String = _
+  private var localAggSuppressedTerm: String = _
+
+  override def variablePrefix: String = if (isFinal) { "hashagg" }
+  else { "local_hashagg" }
+
+  override def setup(opFusionContext: OpFusionContext): Unit = {
+    super.setup(opFusionContext)
+    assert(opFusionContext.getInputFusionContexts.size == 1)
+    inputContext = opFusionContext.getInputFusionContexts.head
+
+    inputType = inputContext.getOutputType
+    aggBufferTypes = AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggInfos)
+    groupKeyRowType = RowTypeUtils.projectRowType(inputType, grouping)
+    aggBufferRowType = RowType.of(aggBufferTypes.flatten, aggBufferNames.flatten)
+    argsMapping = buildAggregateArgsMapping(
+      isMerge,
+      grouping.length,
+      inputType,
+      auxGrouping,
+      aggInfos,
+      aggBufferTypes)
+    aggBuffMapping = buildAggregateAggBuffMapping(aggBufferTypes)
+  }
+
+  override def doProcessProduce(fusionCtx: CodeGeneratorContext): Unit = {
+    inputContext.processProduce(fusionCtx)
+  }
+
+  override def doEndInputProduce(fusionCtx: CodeGeneratorContext): Unit = {
+    inputContext.endInputProduce(fusionCtx)
+  }
+
+  override def doProcessConsume(
+      inputId: Int,
+      inputVars: util.List[GeneratedExpression],
+      row: GeneratedExpression): String = {
+    inputRowTerm = row.resultTerm
+    if (grouping.isEmpty) {
+      doProcessConsumeWithoutKeys()
+    } else {
+      doProcessConsumeWithKeys(toScala(inputVars))
+    }
+  }
+
+  override def doEndInputConsume(inputId: Int): String = {
+    if (grouping.isEmpty) {
+      doEndInputConsumeWithoutKeys()
+    } else {
+      doEndInputConsumeWithKeys()
+    }
+  }
+
+  /** Generate the java source code to process the row with group key. */
+  private def doProcessConsumeWithKeys(input: Seq[GeneratedExpression]): String = {
+    // initialize the hashmap related code first
+    val Seq(groupKeyTypesTerm, aggBufferTypesTerm) = newNames("groupKeyTypes", "aggBufferTypes")
+    // gen code to create groupKey, aggBuffer Type array, it will be used in BytesHashMap and BufferedKVExternalSorter if enable fallback
+    HashAggCodeGenHelper.prepareHashAggKVTypes(
+      opCodegenCtx,
+      groupKeyTypesTerm,
+      aggBufferTypesTerm,
+      groupKeyRowType,
+      aggBufferRowType)
+
+    // create aggregate map
+    val memorySizeTerm = newName("memorySize")
+    val mapTypeTerm = classOf[BytesHashMap].getName
+    opCodegenCtx.addReusableMember(s"private transient $mapTypeTerm $aggregateMapTerm;")
+    opCodegenCtx.addReusableOpenStatement(
+      s"""
+         |long $memorySizeTerm = computeMemorySize(${fusionContext.getManagedMemoryFraction});
+         |$aggregateMapTerm = new $mapTypeTerm(
+         |  getContainingTask(),
+         |  getContainingTask().getEnvironment().getMemoryManager(),
+         |  $memorySizeTerm,
+         |  $groupKeyTypesTerm,
+         |  $aggBufferTypesTerm);
+       """.stripMargin)
+
+    // close aggregate map and release memory segments
+    opCodegenCtx.addReusableCloseStatement(s"$aggregateMapTerm.free();")
+
+    val Seq(currentKeyTerm, currentKeyWriterTerm) = newNames("currentKey", "currentKeyWriter")
+    val Seq(lookupInfo, currentAggBufferTerm) = newNames("lookupInfo", "currentAggBuffer")
+    val lookupInfoTypeTerm = classOf[BytesMap.LookupInfo[_, _]].getCanonicalName
+    val binaryRowTypeTerm = classOf[BinaryRowData].getName
+
+    // evaluate input field access for group key projection and aggregate buffer update
+    val inputAccessCode = evaluateVariables(input)
+    // project key row from input
+    val keyExprs = grouping.map(idx => input(idx))
+    val keyProjectionCode = getExprCodeGenerator
+      .generateResultExpression(
+        keyExprs,
+        groupKeyRowType,
+        classOf[BinaryRowData],
+        currentKeyTerm,
+        outRowWriter = Option(currentKeyWriterTerm))
+      .code
+
+    // gen code to create empty agg buffer, here need to consider the auxGrouping is not empty case
+    val initedAggBuffer = genReusableEmptyAggBuffer(
+      opCodegenCtx,
+      builder,
+      inputRowTerm,
+      inputType,
+      auxGrouping,
+      aggInfos,
+      aggBufferRowType)
+    val lazyInitAggBufferCode = if (auxGrouping.isEmpty) {
+      // create an empty agg buffer and initialized make it reusable
+      opCodegenCtx.addReusableOpenStatement(initedAggBuffer.code)
+      ""
+    } else {
+      s"""
+         |// lazy init agg buffer (with auxGrouping)
+         |${initedAggBuffer.code}
+       """.stripMargin
+    }
+
+    // generate code to update agg buffer
+    opCodegenCtx.startNewLocalVariableStatement(currentAggBufferTerm)
+    val aggregateExpr = genAggregate(
+      isMerge,
+      opCodegenCtx,
+      builder,
+      inputType,
+      inputRowTerm,
+      auxGrouping,
+      aggInfos,
+      argsMapping,
+      aggBuffMapping,
+      currentAggBufferTerm,
+      aggBufferRowType
+    )
+
+    // gen code to prepare agg output using agg buffer and key from the aggregate map
+    val Seq(reuseAggMapKeyTerm, reuseAggBufferTerm) = newNames("reuseAggMapKey", "reuseAggBuffer")
+    val rowData = classOf[RowData].getName
+    opCodegenCtx.addReusableMember(s"private transient $rowData $reuseAggMapKeyTerm;")
+    opCodegenCtx.addReusableMember(s"private transient $rowData $reuseAggBufferTerm;")
+    // gen code to prepare agg output using agg buffer and key from the aggregate map
+    val iteratorTerm = CodeGenUtils.newName("iterator")
+    val iteratorType = classOf[KeyValueIterator[_, _]].getCanonicalName
+
+    opCodegenCtx.startNewLocalVariableStatement(reuseAggBufferTerm)
+    val reuseKeyExprs = getReuseRowFieldExprs(opCodegenCtx, groupKeyRowType, reuseAggMapKeyTerm)
+    // get value expr from agg buffer
+    getExprCodeGenerator
+      .bindSecondInput(aggBufferRowType, reuseAggBufferTerm)
+    val reuseValueExprs = genHashAggValueExpr(
+      isMerge,
+      isFinal,
+      opCodegenCtx,
+      getExprCodeGenerator,
+      builder,
+      auxGrouping,
+      aggInfos,
+      argsMapping,
+      aggBuffMapping,
+      inputType,
+      reuseAggBufferTerm,
+      aggBufferRowType
+    )
+    // reuse aggBuffer field access code if isFinal to avoid evaluate more times
+    val reuseAggBufferFieldCode = if (isFinal) {
+      opCodegenCtx.reuseInputUnboxingCode(reuseAggBufferTerm)
+    } else {
+      ""
+    }
+    outputFromMap =
+      s"""
+         |${opCodegenCtx.reuseLocalVariableCode(reuseAggBufferTerm)}
+         |$iteratorType<$rowData, $rowData> $iteratorTerm =
+         |  $aggregateMapTerm.getEntryIterator(false); // reuse key/value during iterating
+         |while ($iteratorTerm.advanceNext()) {
+         |   // set result and output
+         |   $reuseAggMapKeyTerm = ($rowData)$iteratorTerm.getKey();
+         |   $reuseAggBufferTerm = ($rowData)$iteratorTerm.getValue();
+         |   // consume the row of agg produce
+         |   $reuseAggBufferFieldCode
+         |   ${outputResult(fusionContext.getOutputType, reuseKeyExprs ++ reuseValueExprs)}
+         |}
+       """.stripMargin
+
+    val retryAppendCode = genRetryAppendToMap(
+      aggregateMapTerm,
+      currentKeyTerm,
+      initedAggBuffer,
+      lookupInfo,
+      currentAggBufferTerm)
+
+    // gen code to deal with hash map oom, if enable fallback we will use sort agg strategy
+    val dealWithAggHashMapOOM =
+      genHashAggOOMHandling(groupKeyTypesTerm, aggBufferTypesTerm, retryAppendCode)
+
+    // generate the adaptive local hash agg code
+    localAggSuppressedTerm = newName("localAggSuppressed")
+    opCodegenCtx.addReusableMember(s"private transient boolean $localAggSuppressedTerm = false;")
+    val (
+      distinctCountIncCode,
+      totalCountIncCode,
+      adaptiveSamplingCode,
+      adaptiveLocalHashAggCode,
+      flushResultSuppressEnableCode) = genAdaptiveLocalHashAgg(keyExprs)
+
+    // process code
+    s"""
+       |do {
+       |   // input field access
+       |  $inputAccessCode
+       |
+       |  $adaptiveLocalHashAggCode
+       |
+       |  // project key from input
+       |  $keyProjectionCode
+       |
+       |   // lookup output buffer using current group key
+       |  $lookupInfoTypeTerm $lookupInfo = ($lookupInfoTypeTerm) $aggregateMapTerm.lookup($currentKeyTerm);
+       |  $binaryRowTypeTerm $currentAggBufferTerm = ($binaryRowTypeTerm) $lookupInfo.getValue();
+       |  if (!$lookupInfo.isFound()) {
+       |    $distinctCountIncCode
+       |    $lazyInitAggBufferCode
+       |    // append empty agg buffer into aggregate map for current group key
+       |    try {
+       |      $currentAggBufferTerm =
+       |        $aggregateMapTerm.append($lookupInfo, ${initedAggBuffer.resultTerm});
+       |    } catch (java.io.EOFException exp) {
+       |      $dealWithAggHashMapOOM
+       |    }
+       |  }
+       |
+       |  $totalCountIncCode
+       |  $adaptiveSamplingCode
+       |
+       |  // do aggregate and update agg buffer
+       |  ${opCodegenCtx.reuseLocalVariableCode(currentAggBufferTerm)}
+       |  // aggregate buffer fields access
+       |  ${opCodegenCtx.reuseInputUnboxingCode(currentAggBufferTerm)}
+       |  
+       |  ${aggregateExpr.code}
+       |  // flush result form map if suppress is enable.
+       |  $flushResultSuppressEnableCode
+       |} while(false);
+       |""".stripMargin.trim
+  }
+
+  /** Generate the java source code to trigger the clean work with group key. */
+  private def doEndInputConsumeWithKeys(): String = {
+    val endInputCode = if (isFinal) {
+      val fallbackToSortAggCode = genFallbackToSortAgg()
+      val memPoolTypeTerm = classOf[BytesHashMapSpillMemorySegmentPool].getName
+      s"""
+         |if ($sorterTerm == null) {
+         | // no spilling, output by iterating aggregate map.
+         |  $outputFromMap
+         |} else {
+         |  // spill last part of input' aggregation output buffer
+         |  $sorterTerm.sortAndSpill(
+         |    $aggregateMapTerm.getRecordAreaMemorySegments(),
+         |    $aggregateMapTerm.getNumElements(),
+         |    new $memPoolTypeTerm($aggregateMapTerm.getBucketAreaMemorySegments()));
+         |    // only release floating memory in advance.
+         |  $aggregateMapTerm.free(true);
+         |   
+         |  // fall back to sort based aggregation
+         |  $fallbackToSortAggCode
+         |}
+       """.stripMargin
+    } else {
+      s"""
+         |  if (!$localAggSuppressedTerm) {
+         |    $outputFromMap
+         |  }
+         |""".stripMargin
+    }
+
+    val endInputMethodTerm = newName(variablePrefix + "withKeyEndInput")
+    opCodegenCtx.addReusableMember(
+      s"""
+         |private void $endInputMethodTerm() throws Exception {
+         |  $endInputCode
+         |}
+       """.stripMargin
+    )
+    // we also need to call downstream endInput method
+    s"""
+       |$endInputMethodTerm();
+       |  // call downstream endInput
+       |${fusionContext.endInputConsume()}
+       """.stripMargin
+  }
+
+  /** Generate the java source code to process the row without group key. */
+  private def doProcessConsumeWithoutKeys(): String = {
+    val aggregateCode = genFallbackSortAggCode(isMerge, forHashAgg = false)
+    hasInput = newName("hasInput")
+    opCodegenCtx.addReusableMember(s"private boolean $hasInput = false;")
+    s"""
+       |${opCodegenCtx.reuseLocalVariableCode()}
+       |if (!$hasInput) {
+       |  $hasInput = true;
+       |  // init agg buffer
+       |  $initAggBufferCode
+       |}
+       |// update agg buffer to do aggregate
+       |$aggregateCode
+       |""".stripMargin.trim
+  }
+
+  /** Generate the java source code to trigger the clean work without group key. */
+  private def doEndInputConsumeWithoutKeys(): String = {
+    val (localVariables, resultExprs) = if (isFinal) {
+      val endInputOutputRowTerm = newName("endInputOutputRowTerm")
+      opCodegenCtx.startNewLocalVariableStatement(endInputOutputRowTerm)
+      val exprs = genGetValueFromFlatAggregateBuffer(
+        isMerge,
+        opCodegenCtx,
+        builder,
+        auxGrouping,
+        aggInfos,
+        functionIdentifiers,
+        argsMapping,
+        aggBufferPrefix,
+        aggBufferNames,
+        aggBufferTypes,
+        fusionContext.getOutputType
+      )
+      (opCodegenCtx.reuseLocalVariableCode(endInputOutputRowTerm), exprs)
+    } else {
+      ("", aggBufferExprs)
+    }
+
+    val endInputCode = if (isFinal) {
+      s"""
+         |// if the input is empty in final phase, we should output default values
+         |if (!$hasInput) {
+         |  $initAggBufferCode
+         |}
+         |// consume the agg output 
+         |${fusionContext.processConsume(toJava(resultExprs))}
+       """.stripMargin
+    } else {
+      s"""
+         |if ($hasInput) {
+         |  ${fusionContext.processConsume(toJava(resultExprs))}
+         |}
+       """.stripMargin
+    }
+
+    val endInputMethodTerm = newName(variablePrefix + "EndInputWithoutKeys")
+    opCodegenCtx.addReusableMember(
+      s"""
+         |private void $endInputMethodTerm() throws Exception {
+         |  $localVariables
+         |  $endInputCode
+         |}
+       """.stripMargin
+    )
+    // we also need to call downstream endInput method
+    s"""
+       |$endInputMethodTerm();
+       |  // propagate to downstream endInput
+       |${fusionContext.endInputConsume()}
+       """.stripMargin
+  }
+
+  private def outputResult(resultType: RowType, resultVars: Seq[GeneratedExpression]): String = {
+    if (consumeFunctionName == null) {
+      consumeFunctionName =
+        constructDoConsumeFunction(variablePrefix, opCodegenCtx, fusionContext, resultType)
+    }
+    constructDoConsumeCode(consumeFunctionName, resultVars)
+  }
+
+  private def genAdaptiveLocalHashAgg(
+      keyExprs: Seq[GeneratedExpression]): (String, String, String, String, String) = {
+    if (
+      !isFinal && supportAdaptiveLocalHashAgg &&
+      opCodegenCtx.tableConfig.get(TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_ENABLED)
+    ) {
+      val adaptiveLocalAggRowTerm = newName("adaptiveLocalAggRowTerm")
+      opCodegenCtx.startNewLocalVariableStatement(adaptiveLocalAggRowTerm)
+      val projectionExprs =
+        genAdaptiveLocalHashAggValueProjectionExpr(
+          opCodegenCtx,
+          inputType,
+          inputRowTerm,
+          aggInfos,
+          auxGrouping)
+      val adaptiveDistinctCountTerm = CodeGenUtils.newName("distinctCount")
+      val adaptiveTotalCountTerm = CodeGenUtils.newName("totalCount")
+      opCodegenCtx.addReusableMember(s"private transient long $adaptiveDistinctCountTerm = 0;")
+      opCodegenCtx.addReusableMember(s"private transient long $adaptiveTotalCountTerm = 0;")
+
+      val samplingThreshold =
+        opCodegenCtx.tableConfig.get(TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_SAMPLING_THRESHOLD)
+      val distinctValueRateThreshold =
+        opCodegenCtx.tableConfig.get(
+          TABLE_EXEC_LOCAL_HASH_AGG_ADAPTIVE_DISTINCT_VALUE_RATE_THRESHOLD)
+      (
+        s"$adaptiveDistinctCountTerm++;",
+        s"$adaptiveTotalCountTerm++;",
+        s"""
+           |if ($adaptiveTotalCountTerm == $samplingThreshold) {
+           |  LOG.info("Local hash aggregation checkpoint reached, sampling threshold = " +
+           |    $samplingThreshold + ", distinct value count = " + $adaptiveDistinctCountTerm + ", total = " +
+           |    $adaptiveTotalCountTerm + ", distinct value rate threshold = "
+           |    + $distinctValueRateThreshold);
+           |  if ($adaptiveDistinctCountTerm / (1.0 * $adaptiveTotalCountTerm) > $distinctValueRateThreshold) {
+           |    LOG.info("Local hash aggregation is suppressed");
+           |    $localAggSuppressedTerm = true;
+           |  }
+           |}
+           |""".stripMargin,
+        s"""
+           |if ($localAggSuppressedTerm) {
+           |  ${opCodegenCtx.reuseLocalVariableCode(adaptiveLocalAggRowTerm)}
+           |  ${outputResult(fusionContext.getOutputType, keyExprs ++ projectionExprs)}
+           |  continue;
+           |}
+           |""".stripMargin,
+        s"""
+           |if ($localAggSuppressedTerm) {
+           |  $outputFromMap
+           |}
+           |""".stripMargin)
+
+    } else {
+      ("", "", "", "", "")
+    }
+  }
+
+  private def genHashAggOOMHandling(
+      groupKeyTypesTerm: String,
+      aggBufferTypesTerm: String,
+      retryAppendCode: String): String = {
+    if (isFinal) {
+      val memPoolTypeTerm = classOf[BytesHashMapSpillMemorySegmentPool].getName
+      sorterTerm = CodeGenUtils.newName("sorter")
+      prepareFallbackSorter(opCodegenCtx, sorterTerm)
+      val createSorter = genCreateFallbackSorter(
+        opCodegenCtx,
+        groupKeyRowType,
+        groupKeyTypesTerm,
+        aggBufferTypesTerm,
+        sorterTerm,
+        maxNumFileHandles,
+        compressionEnabled,
+        compressionBlockSize)
+      s"""
+         |LOG.info("BytesHashMap out of memory with {} entries, start spilling.", $aggregateMapTerm.getNumElements());
+         | // hash map out of memory, spill to external sorter
+         |if ($sorterTerm == null) {
+         |  $createSorter
+         |}
+         | // sort and spill
+         |$sorterTerm.sortAndSpill(
+         |  $aggregateMapTerm.getRecordAreaMemorySegments(),
+         |  $aggregateMapTerm.getNumElements(),
+         |  new $memPoolTypeTerm($aggregateMapTerm.getBucketAreaMemorySegments()));
+         |$retryAppendCode
+       """.stripMargin
+    } else {
+      s"""
+         |LOG.info("BytesHashMap out of memory with {} entries, output directly.", $aggregateMapTerm.getNumElements());
+         | // hash map out of memory, output directly
+         |$outputFromMap
+         |$retryAppendCode
+          """.stripMargin
+    }
+  }
+
+  private def genFallbackToSortAgg(): String = {
+    val Seq(keyTerm, lastKeyTerm) = newNames("key", "lastKey")
+    val keyNotEquals = AggCodeGenHelper.genGroupKeyChangedCheckCode(keyTerm, lastKeyTerm)
+    val joinedRow = classOf[JoinedRowData].getName
+    inputRowTerm = newName("fallbackInput")
+    inputType = RowType.of(
+      (groupKeyRowType.getChildren ++ aggBufferRowType.getChildren).toArray,
+      (groupKeyRowType.getFieldNames ++ aggBufferRowType.getFieldNames).toArray)
+    opCodegenCtx.startNewLocalVariableStatement(inputRowTerm)
+
+    argsMapping = buildAggregateArgsMapping(
+      true,
+      grouping.length,
+      inputType,
+      auxGrouping,
+      aggInfos,
+      aggBufferTypes)
+    val updateAggBufferCode = genFallbackSortAggCode(true, true)
+
+    val keyExprs = getReuseRowFieldExprs(opCodegenCtx, groupKeyRowType, lastKeyTerm)
+    val valueExprs = genGetValueFromFlatAggregateBuffer(
+      isMerge,
+      opCodegenCtx,
+      builder,
+      auxGrouping,
+      aggInfos,
+      functionIdentifiers,
+      argsMapping,
+      aggBufferPrefix,
+      aggBufferNames,
+      aggBufferTypes,
+      fusionContext.getOutputType
+    )
+    val outputCode = outputResult(fusionContext.getOutputType, keyExprs ++ valueExprs)
+    val kvPairTerm = CodeGenUtils.newName("kvPair")
+    val kvPairTypeTerm = classOf[JTuple2[BinaryRowData, BinaryRowData]].getName
+    val aggBuffTerm = CodeGenUtils.newName("val")
+    val binaryRow = classOf[BinaryRowData].getName
+
+    s"""
+       |  $binaryRow $lastKeyTerm = null;
+       |  $kvPairTypeTerm<$binaryRow, $binaryRow> $kvPairTerm = null;
+       |  $binaryRow $keyTerm = null;
+       |  $binaryRow $aggBuffTerm = null;
+       |  $joinedRow $inputRowTerm = new $joinedRow();
+       |  ${opCodegenCtx.reuseLocalVariableCode(inputRowTerm)}
+       |  // free hash map memory, but not release back to memory manager
+       |  org.apache.flink.util.MutableObjectIterator<$kvPairTypeTerm<$binaryRow, $binaryRow>>
+       |    iterator = $sorterTerm.getKVIterator();
+       |  while (
+       |    ($kvPairTerm = ($kvPairTypeTerm<$binaryRow, $binaryRow>) iterator.next()) != null) {
+       |    $keyTerm = ($binaryRow) $kvPairTerm.f0;
+       |    $aggBuffTerm = ($binaryRow) $kvPairTerm.f1;
+       |    // prepare input
+       |    $inputRowTerm.replace($keyTerm, $aggBuffTerm);
+       |    if ($lastKeyTerm == null) {
+       |      // found first key group
+       |      $lastKeyTerm = $keyTerm.copy();
+       |      $initAggBufferCode
+       |    } else if ($keyNotEquals) {
+       |      // output current group aggregate result
+       |      $outputCode
+       |      // found new group
+       |      $lastKeyTerm = $keyTerm.copy();
+       |      $initAggBufferCode
+       |    }
+       |    // reusable field access codes for agg buffer merge
+       |    ${opCodegenCtx.reuseInputUnboxingCode(inputRowTerm)}
+       |    // merge aggregate map's value into aggregate buffer fields
+       |    $updateAggBufferCode
+       |  }
+       |
+       |  // output last key group aggregate result
+       |  $outputCode
+       """.stripMargin
+  }
+
+  private def genFallbackSortAggCode(isMerge: Boolean, forHashAgg: Boolean): String = {
+    // The agg buffer field is member variable when without key
+    aggBufferExprs = genFlatAggBufferExprs(
+      isMerge,
+      opCodegenCtx,
+      builder,
+      auxGrouping,
+      aggInfos,
+      argsMapping,
+      aggBufferPrefix,
+      aggBufferNames,
+      aggBufferTypes
+    )
+
+    initAggBufferCode = genInitFlatAggregateBuffer(
+      opCodegenCtx,
+      builder,
+      inputType,
+      inputRowTerm,
+      grouping,
+      auxGrouping,
+      aggInfos,
+      functionIdentifiers,
+      aggBufferExprs,
+      forHashAgg = forHashAgg
+    )
+
+    genAggregateByFlatAggregateBuffer(
+      isMerge,
+      opCodegenCtx,
+      builder,
+      inputType,
+      inputRowTerm,
+      auxGrouping,
+      aggInfos,
+      functionIdentifiers,
+      argsMapping,
+      aggBufferPrefix,
+      aggBufferNames,
+      aggBufferTypes,
+      aggBufferExprs
+    )
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/HashJoinFusionCodegenSpec.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/HashJoinFusionCodegenSpec.scala
@@ -415,7 +415,7 @@ class HashJoinFusionCodegenSpec(
           var expr = GenerateUtils.generateFieldAccess(opCodegenCtx, buildType, buildRow, index)
 
           if (hashJoinType == HashJoinType.PROBE_OUTER) {
-            val fieldType = buildType.getTypeAt(index)
+            val fieldType = buildType.getTypeAt(index).copy(true)
             val resultTypeTerm = primitiveTypeTermForType(fieldType)
             val defaultValue = primitiveDefaultValue(fieldType)
             val Seq(fieldTerm, nullTerm) =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/AggTestBase.scala
@@ -69,6 +69,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     val call = mock(classOf[AggregateCall])
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg1")
+    when(call.hasFilter).thenReturn(false)
     when(aggInfo.function).thenReturn(new LongAvgAggFunction)
     when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.BIGINT))
     when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
@@ -83,6 +84,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     val call = mock(classOf[AggregateCall])
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg2")
+    when(call.hasFilter).thenReturn(false)
     when(aggInfo.function).thenReturn(new DoubleAvgAggFunction)
     when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.DOUBLE()))
     when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.DOUBLE, DataTypes.BIGINT))
@@ -98,6 +100,7 @@ abstract class AggTestBase(isBatchMode: Boolean) {
     val call = mock(classOf[AggregateCall])
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg3")
+    when(call.hasFilter).thenReturn(false)
     when(aggInfo.function).thenReturn(imperativeAggFunc)
     when(aggInfo.externalArgTypes).thenReturn(Array(DataTypes.BIGINT()))
     when(aggInfo.externalAccTypes).thenReturn(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGeneratorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGeneratorTest.scala
@@ -59,6 +59,7 @@ class HashAggCodeGeneratorTest extends BatchAggTestBase {
     val call = mock(classOf[AggregateCall])
     when(aggInfo.agg).thenReturn(call)
     when(call.getName).thenReturn("avg3")
+    when(call.hasFilter).thenReturn(false)
     when(aggInfo.function).thenReturn(new LongAvgAggFunction)
     when(aggInfo.externalAccTypes).thenReturn(Array(DataTypes.BIGINT, DataTypes.BIGINT))
     when(aggInfo.argIndexes).thenReturn(Array(3))


### PR DESCRIPTION
## What is the purpose of the change

*HashAgg support operator fusion code generator, include without key and with key case, also include one phase and two phase case. Please attention, we only support multiple input operator fusion codegen, so the hashagg must be fused with HashJoin operator.*


## Brief change log

  - *HashAgg support operator fusion codegen*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added related integration tests in OperatorFusionCodegenITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
