### PR TITLE
[FLINK-32585] Use flink-connector-pulsar shade pattern

### DIFF
--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -210,6 +210,10 @@ public class JarFileChecker {
                     .filter(
                             path ->
                                     !pathStartsWith(
+                                            path, "/org/apache/pulsar/shade/javax/xml/bind/"))
+                    .filter(
+                            path ->
+                                    !pathStartsWith(
                                             path,
                                             "/org/apache/flink/connector/pulsar/shade/javax/xml/bind/"))
                     // dual-licensed under GPL 2 and EPL 2.0
@@ -217,6 +221,10 @@ public class JarFileChecker {
                     .filter(path -> !pathStartsWith(path, "/org/glassfish/jersey/internal"))
                     // contained in sql-connector-pulsar
                     // while the Pulsar connector is externalized, this is still needed for PyFlink
+                    .filter(
+                            path ->
+                                    !pathStartsWith(
+                                            path, "/org/apache/pulsar/shade/org/glassfish/jersey/"))
                     .filter(
                             path ->
                                     !pathStartsWith(

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -210,7 +210,8 @@ public class JarFileChecker {
                     .filter(
                             path ->
                                     !pathStartsWith(
-                                            path, "/org/apache/flink/connector/pulsar/shade/javax/xml/bind/"))
+                                            path,
+                                            "/org/apache/flink/connector/pulsar/shade/javax/xml/bind/"))
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry
                     .filter(path -> !pathStartsWith(path, "/org/glassfish/jersey/internal"))
@@ -219,7 +220,8 @@ public class JarFileChecker {
                     .filter(
                             path ->
                                     !pathStartsWith(
-                                            path, "/org/apache/flink/connector/pulsar/shade/org/glassfish/jersey/"))
+                                            path,
+                                            "/org/apache/flink/connector/pulsar/shade/org/glassfish/jersey/"))
                     .map(
                             path -> {
                                 try {

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/JarFileChecker.java
@@ -210,7 +210,7 @@ public class JarFileChecker {
                     .filter(
                             path ->
                                     !pathStartsWith(
-                                            path, "/org/apache/pulsar/shade/javax/xml/bind/"))
+                                            path, "/org/apache/flink/connector/pulsar/shade/javax/xml/bind/"))
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry
                     .filter(path -> !pathStartsWith(path, "/org/glassfish/jersey/internal"))
@@ -219,7 +219,7 @@ public class JarFileChecker {
                     .filter(
                             path ->
                                     !pathStartsWith(
-                                            path, "/org/apache/pulsar/shade/org/glassfish/jersey/"))
+                                            path, "/org/apache/flink/connector/pulsar/shade/org/glassfish/jersey/"))
                     .map(
                             path -> {
                                 try {


### PR DESCRIPTION
This commit https://github.com/apache/flink-connector-pulsar/pull/54/commits/c78689c4ea62b17e99e2353f9e05967558e09465 change the relocation strategy for flink-connector-pulsar to try to resolve class loading issue. As it doesn't introduce regression, I'd prefer to apply the new shade pattern to all the deps there for consistency.

If we have a suppression file for these checks it can be more smooth, but I'm OK with cross repo updating as long as it's temporary traffic and we can finally converge.

cc @zentol 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
