### PR TITLE
[FLINK-32560][Scala] Deprecate all Scala API

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopInputFormat.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopInputFormat.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.java.hadoop.mapred.HadoopInputFormatBase
 
 import org.apache.hadoop.mapred.{InputFormat, JobConf}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class HadoopInputFormat[K, V](
     mapredInputFormat: InputFormat[K, V],

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopOutputFormat.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapred/HadoopOutputFormat.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormatBase
 
 import org.apache.hadoop.mapred.{JobConf, OutputCommitter, OutputFormat}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class HadoopOutputFormat[K, V](mapredOutputFormat: OutputFormat[K, V], job: JobConf)
   extends HadoopOutputFormatBase[K, V, (K, V)](mapredOutputFormat, job) {

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopInputFormat.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopInputFormat.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.java.hadoop.mapreduce.HadoopInputFormatBase
 
 import org.apache.hadoop.mapreduce.{InputFormat, Job}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class HadoopInputFormat[K, V](
     mapredInputFormat: InputFormat[K, V],

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopOutputFormat.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/api/scala/hadoop/mapreduce/HadoopOutputFormat.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.java.hadoop.mapreduce.HadoopOutputFormatBase
 
 import org.apache.hadoop.mapreduce.{Job, OutputFormat}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class HadoopOutputFormat[K, V](mapredOutputFormat: OutputFormat[K, V], job: Job)
   extends HadoopOutputFormatBase[K, V, (K, V)](mapredOutputFormat, job) {

--- a/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/scala/org/apache/flink/hadoopcompatibility/scala/HadoopInputs.scala
@@ -33,7 +33,15 @@ import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => MapreduceFileIn
  *
  * Key value pairs produced by the Hadoop InputFormats are converted into [[Tuple2]] where the first
  * field is the key and the second field is the value.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 object HadoopInputs {
 
   /**

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/CEP.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/CEP.scala
@@ -21,8 +21,17 @@ import org.apache.flink.cep.{CEP => JCEP, EventComparator}
 import org.apache.flink.cep.scala.pattern.Pattern
 import org.apache.flink.streaming.api.scala.DataStream
 
-/** Utility method to transform a [[DataStream]] into a [[PatternStream]] to do CEP. */
-
+/**
+ * Utility method to transform a [[DataStream]] into a [[PatternStream]] to do CEP.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 object CEP {
 
   /**

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
@@ -37,7 +37,14 @@ import scala.collection.Map
  *   Underlying pattern stream from Java API
  * @tparam T
  *   Type of the events
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class PatternStream[T](jPatternStream: JPatternStream[T]) {
 
   private[flink] def wrappedPatternStream = jPatternStream

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/GroupPattern.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/GroupPattern.scala
@@ -29,7 +29,14 @@ import org.apache.flink.cep.pattern.conditions.IterativeCondition
  *   Base type of the elements appearing in the pattern
  * @tparam F
  *   Subtype of T to which the current pattern operator is constrained
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class GroupPattern[T, F <: T](jGroupPattern: JGroupPattern[T, F])
   extends Pattern[T, F](jGroupPattern) {
 

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
@@ -43,7 +43,14 @@ import org.apache.flink.streaming.api.windowing.time.Time
  *   Base type of the elements appearing in the pattern
  * @tparam F
  *   Subtype of T to which the current pattern operator is constrained
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class Pattern[T, F <: T](jPattern: JPattern[T, F]) {
 
   private[flink] def wrappedPattern = jPattern

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaAggregateOperator.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaAggregateOperator.java
@@ -51,7 +51,12 @@ import scala.Product;
  * data set produced by the function.
  *
  * @param <IN> The type of the data set aggregated by the operator.
+ * @deprecated All Flink Scala APIs are deprecated and will be removed in a future Flink major
+ *     version. You can still build your application in Scala, but you should move to the Java
+ *     version of either the DataStream and/or Table API.
+ * @see <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@Deprecated
 @Public
 public class ScalaAggregateOperator<IN>
         extends SingleInputOperator<IN, IN, ScalaAggregateOperator<IN>> {

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/operators/ScalaCsvOutputFormat.java
@@ -42,7 +42,13 @@ import scala.Product;
  * This is an OutputFormat to serialize Scala Tuples to text. The output is structured by record
  * delimiters and field delimiters as common in CSV files. Record delimiter separate records from
  * each other ('\n' is common). Field delimiters separate fields within a record.
+ *
+ * @deprecated All Flink Scala APIs are deprecated and will be removed in a future Flink major
+ *     version. You can still build your application in Scala, but you should move to the Java
+ *     version of either the DataStream and/or Table API.
+ * @see <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@Deprecated
 @PublicEvolving
 public class ScalaCsvOutputFormat<T extends Product> extends FileOutputFormat<T>
         implements InputTypeConfigurable {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/AggregateDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/AggregateDataSet.scala
@@ -29,7 +29,14 @@ import scala.reflect.ClassTag
  *
  * @tparam T
  *   The type of the DataSet, i.e., the type of the elements of the DataSet.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class AggregateDataSet[T: ClassTag](set: ScalaAggregateOperator[T]) extends DataSet[T](set) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -61,7 +61,14 @@ import scala.reflect.ClassTag
  *   Type of the left input of the coGroup.
  * @tparam R
  *   Type of the right input of the coGroup.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class CoGroupDataSet[L, R](
     defaultCoGroup: CoGroupOperator[L, R, (Array[L], Array[R])],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
@@ -45,7 +45,14 @@ import scala.reflect.ClassTag
  *   Type of the left input of the cross.
  * @tparam R
  *   Type of the right input of the cross.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class CrossDataSet[L, R](
     defaultCross: CrossOperator[L, R, (L, R)],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -86,7 +86,14 @@ import scala.reflect.ClassTag
  *
  * @tparam T
  *   The type of the DataSet, i.e., the type of the elements of the DataSet.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   require(set != null, "Java DataSet must not be null.")

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -62,11 +62,9 @@ import scala.reflect.ClassTag
  *   still build your application in Scala, but you should move to the Java version of either the
  *   DataStream and/or Table API.
  * @see
- *   <a
- *   href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">
- *   FLIP-265 Deprecate and remove Scala API support</a>
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
-@Deprecated
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.17.0")
 @Public
 class ExecutionEnvironment(javaEnv: JavaEnv) {
 
@@ -605,6 +603,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   }
 }
 
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.17.0")
 @Public
 object ExecutionEnvironment {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -42,7 +42,15 @@ import scala.reflect.ClassTag
  *
  * A secondary sort order can be added with sortGroup, but this is only used when using one of the
  * group-at-a-time operations, i.e. `reduceGroup`.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class GroupedDataSet[T: ClassTag](private val set: DataSet[T], private val keys: Keys[T]) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/PartitionSortedDataSet.scala
@@ -31,7 +31,14 @@ import scala.reflect.ClassTag
  *
  * @tparam T
  *   The type of the DataSet, i.e., the type of the elements of the DataSet.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class PartitionSortedDataSet[T: ClassTag](set: SortPartitionOperator[T]) extends DataSet[T](set) {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/UnfinishedCoGroupOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/UnfinishedCoGroupOperation.scala
@@ -42,7 +42,14 @@ import scala.reflect.ClassTag
  *   The type of the left input of the coGroup.
  * @tparam R
  *   The type of the right input of the coGroup.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class UnfinishedCoGroupOperation[L: ClassTag, R: ClassTag](
     leftInput: DataSet[L],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnCoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnCoGroupDataSet.scala
@@ -33,7 +33,14 @@ import scala.reflect.ClassTag
  *   The type of the left data set items
  * @tparam R
  *   The type of the right data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnCoGroupDataSet[L, R](ds: CoGroupDataSet[L, R]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnCrossDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnCrossDataSet.scala
@@ -33,7 +33,14 @@ import scala.reflect.ClassTag
  *   The type of the left data set items
  * @tparam R
  *   The type of the right data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnCrossDataSet[L, R](ds: CrossDataSet[L, R]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnDataSet.scala
@@ -32,7 +32,14 @@ import scala.reflect.ClassTag
  *   The wrapped data set
  * @tparam T
  *   The type of the data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnDataSet[T](ds: DataSet[T]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnGroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnGroupedDataSet.scala
@@ -33,7 +33,14 @@ import scala.reflect.ClassTag
  *   The wrapped grouped data set
  * @tparam T
  *   The type of the grouped data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnGroupedDataSet[T](ds: GroupedDataSet[T]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnHalfUnfinishedKeyPairOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnHalfUnfinishedKeyPairOperation.scala
@@ -33,7 +33,14 @@ import org.apache.flink.api.scala.HalfUnfinishedKeyPairOperation
  *   The type of the right data set items
  * @tparam O
  *   The type of the output data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnHalfUnfinishedKeyPairOperation[L, R, O](ds: HalfUnfinishedKeyPairOperation[L, R, O]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnJoinFunctionAssigner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnJoinFunctionAssigner.scala
@@ -33,7 +33,14 @@ import scala.reflect.ClassTag
  *   The type of the left data set items
  * @tparam R
  *   The type of the right data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnJoinFunctionAssigner[L, R](ds: JoinFunctionAssigner[L, R]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnUnfinishedKeyPairOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnUnfinishedKeyPairOperation.scala
@@ -33,7 +33,14 @@ import org.apache.flink.api.scala.{HalfUnfinishedKeyPairOperation, UnfinishedKey
  *   The type of the right data set items
  * @tparam O
  *   The type of the output data set items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnUnfinishedKeyPairOperation[L, R, O](ds: UnfinishedKeyPairOperation[L, R, O]) {
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/package.scala
@@ -57,6 +57,13 @@ import org.apache.flink.api.scala.extensions.impl.acceptPartialFunctions._
  * opt-in by importing `org.apache.flink.api.scala.extensions.acceptPartialFunctions`.
  *
  * For more information and usage examples please consult the Apache Flink official documentation.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
 package object extensions {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
@@ -58,7 +58,14 @@ import scala.reflect.ClassTag
  *   Type of the left input of the join.
  * @tparam R
  *   Type of the right input of the join.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class JoinDataSet[L, R](
     defaultJoin: EquiJoin[L, R, (L, R)],
@@ -267,6 +274,7 @@ abstract private[flink] class UnfinishedJoinOperationBase[L, R, O <: JoinFunctio
  * @tparam R
  *   The type of the right input of the join.
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class UnfinishedJoinOperation[L, R](leftSet: DataSet[L], rightSet: DataSet[R], joinHint: JoinHint)
   extends UnfinishedJoinOperationBase[L, R, JoinDataSet[L, R]](
@@ -303,6 +311,7 @@ class UnfinishedJoinOperation[L, R](leftSet: DataSet[L], rightSet: DataSet[R], j
  * @tparam R
  *   The type of the right input of the join.
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class UnfinishedOuterJoinOperation[L, R](
     leftSet: DataSet[L],
@@ -343,6 +352,7 @@ class UnfinishedOuterJoinOperation[L, R](
 
 }
 
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 trait JoinFunctionAssigner[L, R] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
@@ -45,11 +45,14 @@ import language.experimental.macros
  *   still build your application in Scala, but you should move to the Java version of either the
  *   DataStream and/or Table API.
  * @see
- *   <a
- *   href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">
- *   FLIP-265 Deprecate and remove Scala API support</a>
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
 package object scala {
+
+  val FLIP_265_WARNING: String = "All Flink Scala APIs are deprecated and will be removed in a " +
+    "future Flink version. You can still build your application in Scala, but you should move " +
+    "to the Java version of either the DataStream and/or Table API."
+
   // We have this here so that we always have generated TypeInformationS when
   // using the Scala API
   implicit def createTypeInformation[T]: TypeInformation[T] = macro TypeUtils.createTypeInfo[T]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
@@ -36,7 +36,15 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * TypeInformation for Case Classes. Creation and access is different from our Java Tuples so we
  * have to treat them differently.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 abstract class CaseClassTypeInfo[T <: Product](
     clazz: Class[T],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
@@ -24,7 +24,17 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 
 import scala.collection.JavaConverters._
 
-/** TypeInformation [[Either]]. */
+/**
+ * TypeInformation [[Either]].
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class EitherTypeInfo[A, B, T <: Either[A, B]](
     val clazz: Class[T],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
@@ -24,7 +24,17 @@ import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
 
 import scala.collection.JavaConverters._
 
-/** TypeInformation for [[Enumeration]] values. */
+/**
+ * TypeInformation for [[Enumeration]] values.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class EnumValueTypeInfo[E <: Enumeration](val enum: E, val clazz: Class[E#Value])
   extends TypeInformation[E#Value]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
@@ -24,7 +24,17 @@ import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
 
 import scala.collection.JavaConverters._
 
-/** TypeInformation for [[Option]]. */
+/**
+ * TypeInformation for [[Option]].
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class OptionTypeInfo[A, T <: Option[A]](private val elemTypeInfo: TypeInformation[A])
   extends TypeInformation[T]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class ScalaNothingTypeInfo extends TypeInformation[Nothing] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfo.scala
@@ -24,7 +24,17 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 
 import scala.collection.JavaConverters._
 
-/** TypeInformation for Scala Collections. */
+/**
+ * TypeInformation for Scala Collections.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 abstract class TraversableTypeInfo[T <: TraversableOnce[E], E](
     val clazz: Class[T],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
@@ -25,7 +25,17 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-/** TypeInformation for [[scala.util.Try]]. */
+/**
+ * TypeInformation for [[scala.util.Try]].
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class TryTypeInfo[A, T <: Try[A]](val elemTypeInfo: TypeInformation[A]) extends TypeInformation[T] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/Types.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/Types.scala
@@ -38,7 +38,15 @@ import _root_.scala.util.{Either, Try}
  *
  * Scala macros allow to determine type information of classes and type parameters. You can use
  * [[Types.of]] to let type information be determined automatically.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 object Types {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class UnitTypeInfo extends TypeInformation[Unit] {
   @PublicEvolving

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
@@ -40,7 +40,14 @@ package object utils {
    *
    * @param self
    *   Data Set
+   * @deprecated
+   *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+   *   can still build your application in Scala, but you should move to the Java version of either
+   *   the DataStream and/or Table API.
+   * @see
+   *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
    */
+  @deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
   @PublicEvolving
   implicit class DataSetUtils[T: TypeInformation: ClassTag](val self: DataSet[T]) {
 

--- a/flink-streaming-scala/src/main/java/org/apache/flink/streaming/util/typeutils/DefaultScalaProductFieldAccessorFactory.java
+++ b/flink-streaming-scala/src/main/java/org/apache/flink/streaming/util/typeutils/DefaultScalaProductFieldAccessorFactory.java
@@ -32,7 +32,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>There are two versions of ProductFieldAccessor, differing in whether there is another
  * FieldAccessor nested inside. The no inner accessor version is probably a little faster.
+ *
+ * @deprecated All Flink Scala APIs are deprecated and will be removed in a future Flink major
+ *     version. You can still build your application in Scala, but you should move to the Java
+ *     version of either the DataStream and/or Table API.
+ * @see <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@Deprecated
 public class DefaultScalaProductFieldAccessorFactory implements ScalaProductFieldAccessorFactory {
 
     public <T, F> FieldAccessor<T, F> createSimpleProductFieldAccessor(

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -51,7 +51,14 @@ import org.apache.flink.util.Preconditions.checkNotNull
  * @tparam W
  *   The type of [[Window]] that the
  *   [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]] assigns the elements to.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
@@ -40,7 +40,15 @@ import scala.concurrent.duration.TimeUnit
  *
  *   AsyncDataStream.orderedWait(input, asyncFunction, timeout, TimeUnit.MILLISECONDS, 100)
  * }}}
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 object AsyncDataStream {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/BroadcastConnectedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/BroadcastConnectedStream.scala
@@ -22,6 +22,15 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{BroadcastConnectedStream => JavaBCStream}
 import org.apache.flink.streaming.api.functions.co.{BroadcastProcessFunction, KeyedBroadcastProcessFunction}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class BroadcastConnectedStream[IN1, IN2](javaStream: JavaBCStream[IN1, IN2]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CachedDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CachedDataStream.scala
@@ -20,6 +20,15 @@ package org.apache.flink.streaming.api.scala
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.streaming.api.datastream.{CachedDataStream => JavaCachedDataStream}
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 class CachedDataStream[T](javaStream: JavaCachedDataStream[T])
   extends DataStream[T](javaStream: JavaCachedDataStream[T]) {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CloseableIterator.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CloseableIterator.scala
@@ -23,7 +23,15 @@ import org.apache.flink.util.{CloseableIterator => JCloseableIterator}
  * This interface represents an [[Iterator]] that is also [[AutoCloseable]]. A typical use-case for
  * this interface are iterators that are based on native-resources such as files, network, or
  * database connections. Clients must call close after using the iterator.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 trait CloseableIterator[T] extends Iterator[T] with AutoCloseable {}
 
 object CloseableIterator {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
@@ -55,7 +55,15 @@ import scala.collection.JavaConverters._
  *     .apply(new MyCoGroupFunction())
  * }
  * }}}
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -38,7 +38,15 @@ import org.apache.flink.util.Collector
  *
  * The connected stream can be conceptually viewed as a union stream of an Either type, that holds
  * either the first stream's type or the second stream's type.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -44,6 +44,15 @@ import org.apache.flink.util.{CloseableIterator, Collector}
 
 import scala.collection.JavaConverters._
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class DataStream[T](stream: JavaStream[T]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamUtils.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamUtils.scala
@@ -33,7 +33,14 @@ import scala.reflect.ClassTag
  *
  * @param self
  *   DataStream
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Experimental
 class DataStreamUtils[T: TypeInformation: ClassTag](val self: DataStream[T]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
@@ -53,7 +53,15 @@ import org.apache.flink.util.Collector
  *     .apply(new MyJoinFunction())
  * }
  * }}}
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -34,6 +34,15 @@ import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.windows.{GlobalWindow, TimeWindow, Window}
 import org.apache.flink.util.Collector
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T](javaStream) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/OutputTag.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/OutputTag.scala
@@ -31,7 +31,15 @@ import org.apache.flink.util.{OutputTag => JOutputTag}
  *
  * @tparam T
  *   the type of elements in the side-output stream.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 class OutputTag[T: TypeInformation](id: String)
   extends JOutputTag[T](id, implicitly[TypeInformation[T]])

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -48,6 +48,15 @@ import java.net.URI
 
 import scala.collection.JavaConverters._
 
+/**
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class StreamExecutionEnvironment(javaEnv: JavaEnv) extends AutoCloseable {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -56,7 +56,14 @@ import org.apache.flink.util.Collector
  * @tparam W
  *   The type of [[Window]] that the
  *   [[org.apache.flink.streaming.api.windowing.assigners.WindowAssigner]] assigns the elements to.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
@@ -37,7 +37,15 @@ import java.util.concurrent.TimeoutException
  *   The type of the input element
  * @tparam OUT
  *   The type of the output elements
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait AsyncFunction[IN, OUT] extends Function {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryPredicate.scala
@@ -22,7 +22,17 @@ import org.apache.flink.annotation.PublicEvolving
 import java.util
 import java.util.function.Predicate
 
-/** Interface encapsulates an asynchronous retry predicate. */
+/**
+ * Interface encapsulates an asynchronous retry predicate.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait AsyncRetryPredicate[OUT] {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -25,7 +25,17 @@ import org.apache.flink.streaming.util.retryable.{AsyncRetryStrategies => JAsync
 import java.{util => ju}
 import java.util.function.Predicate
 
-/** Utility class to create concrete {@link AsyncRetryStrategy}. */
+/**
+ * Utility class to create concrete {@link AsyncRetryStrategy}.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 object AsyncRetryStrategies {
 
   final private class JavaToScalaRetryStrategy[T](retryStrategy: JAsyncRetryStrategy[T])
@@ -70,6 +80,7 @@ object AsyncRetryStrategies {
    * FixedDelayRetryStrategyBuilder for building an {@link AsyncRetryStrategy} with fixed delay
    * retrying behaviours.
    */
+  @deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
   @PublicEvolving
   @SerialVersionUID(1L)
   class FixedDelayRetryStrategyBuilder[OUT](
@@ -98,6 +109,7 @@ object AsyncRetryStrategies {
    * ExponentialBackoffDelayRetryStrategyBuilder for building an {@link AsyncRetryStrategy} with
    * exponential delay retrying behaviours.
    */
+  @deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
   @PublicEvolving
   @SerialVersionUID(1L)
   class ExponentialBackoffDelayRetryStrategyBuilder[OUT](

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategy.scala
@@ -19,7 +19,17 @@ package org.apache.flink.streaming.api.scala.async
 
 import org.apache.flink.annotation.PublicEvolving
 
-/** Interface encapsulates an asynchronous retry strategy. */
+/**
+ * Interface encapsulates an asynchronous retry strategy.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait AsyncRetryStrategy[OUT] extends Serializable {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/ResultFuture.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/ResultFuture.scala
@@ -25,7 +25,14 @@ import org.apache.flink.annotation.PublicEvolving
  *
  * @tparam OUT
  *   type of the output element
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait ResultFuture[OUT] {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
@@ -23,7 +23,17 @@ import org.apache.flink.streaming.util.retryable.{RetryPredicates => JRetryPredi
 import java.util
 import java.util.function.Predicate
 
-/** Utility class to create concrete retry predicates. */
+/**
+ * Utility class to create concrete retry predicates.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 object RetryPredicates {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RichAsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RichAsyncFunction.scala
@@ -34,7 +34,14 @@ import org.apache.flink.api.common.functions.AbstractRichFunction
  *   The type of the input value.
  * @tparam OUT
  *   The type of the output value.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 abstract class RichAsyncFunction[IN, OUT]
   extends AbstractRichFunction
   with AsyncFunction[IN, OUT] {}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/ScalaRichAsyncFunctionWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/ScalaRichAsyncFunctionWrapper.scala
@@ -27,7 +27,14 @@ import org.apache.flink.streaming.api.functions.async.{ResultFuture => JResultFu
  * The Scala and Java RichAsyncFunctions differ in their type of "ResultFuture"
  *   - Scala RichAsyncFunction: [[org.apache.flink.streaming.api.scala.async.ResultFuture]]
  *   - Java RichAsyncFunction: [[org.apache.flink.streaming.api.functions.async.ResultFuture]]
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaRichAsyncFunctionWrapper[IN, OUT](func: RichAsyncFunction[IN, OUT])
   extends JRichAsyncFunction[IN, OUT] {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnConnectedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnConnectedStream.scala
@@ -31,7 +31,14 @@ import org.apache.flink.streaming.api.scala.{ConnectedStreams, DataStream}
  *   The type of the data stream items coming from the first connection
  * @tparam IN2
  *   The type of the data stream items coming from the second connection
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnConnectedStream[IN1, IN2](stream: ConnectedStreams[IN1, IN2]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnDataStream.scala
@@ -29,7 +29,14 @@ import org.apache.flink.streaming.api.scala.{DataStream, KeyedStream}
  *   The wrapped data stream
  * @tparam T
  *   The type of the data stream items
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnDataStream[T](stream: DataStream[T]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnJoinedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnJoinedStream.scala
@@ -36,7 +36,14 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  *   The type of key
  * @tparam W
  *   The type of the window
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnJoinedStream[L, R, K, W <: Window](
     stream: JoinedStreams[L, R]#Where[K]#EqualTo#WithWindow[W]) {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnKeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnKeyedStream.scala
@@ -31,7 +31,14 @@ import org.apache.flink.streaming.api.scala.{DataStream, KeyedStream}
  *   The type of the data stream items
  * @tparam K
  *   The type of key
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnKeyedStream[T, K](stream: KeyedStream[T, K]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnWindowedStream.scala
@@ -35,7 +35,14 @@ import org.apache.flink.util.Collector
  *   The type of key
  * @tparam W
  *   The type of the window
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 class OnWindowedStream[T, K, W <: Window](stream: WindowedStream[T, K, W]) {
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/package.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/extensions/package.scala
@@ -59,6 +59,13 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  * `org.apache.flink.streaming.api.scala.extensions.acceptPartialFunctions`.
  *
  * For more information and usage examples please consult the Apache Flink official documentation.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
 package object extensions {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/AllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/AllWindowFunction.scala
@@ -32,7 +32,14 @@ import java.io.Serializable
  *   The type of the input value.
  * @tparam OUT
  *   The type of the output value.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 trait AllWindowFunction[IN, OUT, W <: Window] extends Function with Serializable {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessAllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessAllWindowFunction.scala
@@ -34,7 +34,14 @@ import org.apache.flink.util.Collector
  *   The type of the output value.
  * @tparam W
  *   The type of the window.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 abstract class ProcessAllWindowFunction[IN, OUT, W <: Window] extends AbstractRichFunction {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
@@ -36,7 +36,14 @@ import org.apache.flink.util.Collector
  *   The type of the key.
  * @tparam W
  *   The type of the window.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 abstract class ProcessWindowFunction[IN, OUT, KEY, W <: Window] extends AbstractRichFunction {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichAllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichAllWindowFunction.scala
@@ -33,7 +33,14 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  *   The type of the output value.
  * @tparam W
  *   The type of Window that this window function can be applied on.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 abstract class RichAllWindowFunction[IN, OUT, W <: Window]
   extends AbstractRichFunction
   with AllWindowFunction[IN, OUT, W] {}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichProcessAllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichProcessAllWindowFunction.scala
@@ -31,7 +31,7 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  * @tparam W
  *   The type of the window.
  */
-@Public
 @deprecated("use [[ProcessAllWindowFunction]] instead")
+@Public
 abstract class RichProcessAllWindowFunction[IN, OUT, W <: Window]
   extends ProcessAllWindowFunction[IN, OUT, W] {}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichProcessWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichProcessWindowFunction.scala
@@ -32,8 +32,14 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  *   The type of the key.
  * @tparam W
  *   The type of the window.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
-@Public
 @deprecated("use [[ProcessWindowFunction]] instead")
+@Public
 abstract class RichProcessWindowFunction[IN, OUT, KEY, W <: Window]
   extends ProcessWindowFunction[IN, OUT, KEY, W] {}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/RichWindowFunction.scala
@@ -35,7 +35,14 @@ import org.apache.flink.streaming.api.windowing.windows.Window
  *   The type of the key.
  * @tparam W
  *   The type of Window that this window function can be applied on.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 abstract class RichWindowFunction[IN, OUT, KEY, W <: Window]
   extends AbstractRichFunction
   with WindowFunction[IN, OUT, KEY, W] {}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -27,7 +27,15 @@ import org.apache.flink.configuration.Configuration
  * Trait implementing the functionality necessary to apply stateful functions in RichFunctions
  * without exposing the OperatorStates to the user. The user should call the applyWithState method
  * in his own RichFunction implementation.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 trait StatefulFunction[I, O, S] extends RichFunction {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/WindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/WindowFunction.scala
@@ -33,7 +33,14 @@ import java.io.Serializable
  *   The type of the output value.
  * @tparam KEY
  *   The type of the key.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @Public
 trait WindowFunction[IN, OUT, KEY, W <: Window] extends Function with Serializable {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaAllWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaAllWindowFunction.scala
@@ -23,7 +23,17 @@ import org.apache.flink.util.Collector
 
 import scala.collection.JavaConverters._
 
-/** A wrapper function that exposes a Scala Function3 as a Java AllWindowFunction. */
+/**
+ * A wrapper function that exposes a Scala Function3 as a Java AllWindowFunction.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaAllWindowFunction[IN, OUT, W <: Window](
     private[this] val function: (W, Iterable[IN], Collector[OUT]) => Unit)
   extends JAllWindowFunction[IN, OUT, W] {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaAllWindowFunctionWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaAllWindowFunctionWrapper.scala
@@ -32,7 +32,14 @@ import scala.collection.JavaConverters._
  * The Scala and Java Window functions differ in their type of "Iterable":
  *   - Scala WindowFunction: scala.Iterable
  *   - Java WindowFunction: java.lang.Iterable
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaAllWindowFunctionWrapper[IN, OUT, W <: Window](func: AllWindowFunction[IN, OUT, W])
   extends WrappingFunction[AllWindowFunction[IN, OUT, W]](func)
   with JAllWindowFunction[IN, OUT, W]

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaProcessWindowFunctionWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaProcessWindowFunctionWrapper.scala
@@ -36,7 +36,14 @@ import scala.collection.JavaConverters._
  * The Scala and Java Window functions differ in their type of "Iterable":
  *   - Scala WindowFunction: scala.Iterable
  *   - Java WindowFunction: java.lang.Iterable
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaProcessWindowFunctionWrapper[IN, OUT, KEY, W <: Window](
     private[this] val func: ScalaProcessWindowFunction[IN, OUT, KEY, W])
   extends JProcessWindowFunction[IN, OUT, KEY, W] {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaReduceFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaReduceFunction.scala
@@ -19,7 +19,16 @@ package org.apache.flink.streaming.api.scala.function.util
 
 import org.apache.flink.api.common.functions.ReduceFunction
 
-/** A wrapper function that exposes a Scala Function2 as a [[ReduceFunction]]. */
+/**
+ * A wrapper function that exposes a Scala Function2 as a [[ReduceFunction]]. * @deprecated All
+ * Flink Scala APIs are deprecated and will be removed in a future Flink major version. You can
+ * still build your application in Scala, but you should move to the Java version of either the
+ * DataStream and/or Table API.
+ *
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaReduceFunction[T](private[this] val function: (T, T) => T)
   extends ReduceFunction[T] {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaWindowFunction.scala
@@ -23,7 +23,17 @@ import org.apache.flink.util.Collector
 
 import scala.collection.JavaConverters._
 
-/** A wrapper function that exposes a Scala Function4 as a Java WindowFunction. */
+/**
+ * A wrapper function that exposes a Scala Function4 as a Java WindowFunction.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
+ */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaWindowFunction[IN, OUT, KEY, W <: Window](
     private[this] val function: (KEY, W, Iterable[IN], Collector[OUT]) => Unit)
   extends JWindowFunction[IN, OUT, KEY, W] {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaWindowFunctionWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaWindowFunctionWrapper.scala
@@ -32,7 +32,14 @@ import scala.collection.JavaConverters._
  * The Scala and Java Window functions differ in their type of "Iterable":
  *   - Scala WindowFunction: scala.Iterable
  *   - Java WindowFunction: java.lang.Iterable
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 final class ScalaWindowFunctionWrapper[IN, OUT, KEY, W <: Window](
     func: WindowFunction[IN, OUT, KEY, W])
   extends WrappingFunction[WindowFunction[IN, OUT, KEY, W]](func)

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/DataStreamConversions.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/DataStreamConversions.scala
@@ -32,7 +32,14 @@ import org.apache.flink.util.Preconditions
  *   The [[DataStream]] to convert.
  * @tparam T
  *   The external type of the [[DataStream]].
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 class DataStreamConversions[T](dataStream: DataStream[T]) {
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamStatementSet.scala
@@ -30,7 +30,15 @@ import org.apache.flink.table.api.{ExplainDetail, StatementSet, Table, TableDesc
  *
  * The added statements will be cleared when calling the `execute()` or `attachAsDataStream()`
  * method.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait StreamStatementSet extends StatementSet {
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -47,7 +47,15 @@ import org.apache.flink.types.{Row, RowKind}
  *
  * Note: If you don't intend to use the [[DataStream]] API, [[TableEnvironment]] is meant for pure
  * table programs.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 trait StreamTableEnvironment extends TableEnvironment {
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/TableConversions.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/TableConversions.scala
@@ -31,7 +31,14 @@ import org.apache.flink.types.Row
  *
  * @param table
  *   The [[Table]] to convert.
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(org.apache.flink.api.scala.FLIP_265_WARNING, since = "1.18.0")
 @PublicEvolving
 class TableConversions(table: Table) {
 

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -38,7 +38,15 @@ import scala.language.implicitConversions
 /**
  * Implicit conversions from Scala literals to [[Expression]] and from [[Expression]] to
  * [[ImplicitExpressionOperations]].
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(since = "1.18.0")
 @PublicEvolving
 trait ImplicitExpressionConversions {
 

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionOperations.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionOperations.scala
@@ -28,7 +28,15 @@ import scala.language.implicitConversions
 /**
  * These are all the operations that can be used to construct an [[Expression]] AST for expression
  * operations.
+ *
+ * @deprecated
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink major version. You
+ *   can still build your application in Scala, but you should move to the Java version of either
+ *   the DataStream and/or Table API.
+ * @see
+ *   <a href="https://s.apache.org/flip-265">FLIP-265 Deprecate and remove Scala API support</a>
  */
+@deprecated(since = "1.18.0")
 @PublicEvolving
 trait ImplicitExpressionOperations extends BaseExpressions[Expression, Expression] {
   private[flink] def expr: Expression


### PR DESCRIPTION
## What is the purpose of the change

* The entry points for using the Scala API were deprecated in https://github.com/apache/flink/pull/21176.  This PR ensures that all `@Public`, `@PublicEvolving` and `@Experimental` APIs are also marked as `@Deprecated`.
* This PR doesn't have any code changes outside of deprecating these classes. Classes that are *not* scheduled for removal might still need to be migrated.

## Brief change log

* All classes that contain one of those methods are also marked as deprecated with a link to [FLIP-265](https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support).
* The `flink-table`  modules have not been deprecated except for those dealing with a user-facing scala API (`flink-table-api-scala` and `flink-table-api-scala-bridge`)
* The hadoop connector Scala classes were also `@Deprecated`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (but it does prepare for the next major release as described in FLIP-265)
