### PR TITLE
[FLINK-32586][coordination] Enable input locality in SimpleExecutionSlotAllocator.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
@@ -308,10 +308,4 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
         throw new UnsupportedOperationException(
                 "Method is not supported in SpeculativeExecutionVertex.");
     }
-
-    @Override
-    public CompletableFuture<TaskManagerLocation> getCurrentTaskManagerLocationFuture() {
-        throw new UnsupportedOperationException(
-                "Method is not supported in SpeculativeExecutionVertex.");
-    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SimpleExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SimpleExecutionSlotAllocatorTest.java
@@ -18,18 +18,26 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingPayload;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequest;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.function.BiConsumerWithException;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.InetAddress;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
@@ -232,9 +240,29 @@ class SimpleExecutionSlotAllocatorTest {
         assertThat(context.getSlotProvider().isBatchSlotRequestTimeoutCheckEnabled()).isTrue();
     }
 
+    @Test
+    void testPreferredLocationsOfSlotProfile() {
+        final AllocationContext context = new AllocationContext();
+        List<TaskManagerLocation> taskManagerLocations =
+                Collections.singletonList(
+                        new TaskManagerLocation(
+                                ResourceID.generate(), InetAddress.getLoopbackAddress(), 41));
+        context.getLocations()
+                .put(EXECUTION_ATTEMPT_ID.getExecutionVertexId(), taskManagerLocations);
+        context.allocateSlotsFor(EXECUTION_ATTEMPT_ID);
+        assertThat(context.getSlotProvider().getRequests()).hasSize(1);
+        final PhysicalSlotRequest slotRequest =
+                context.getSlotProvider().getRequests().values().iterator().next();
+
+        assertThat(slotRequest.getSlotProfile().getPreferredLocations()).hasSize(1);
+        assertThat(slotRequest.getSlotProfile().getPreferredLocations())
+                .isEqualTo(taskManagerLocations);
+    }
+
     private static class AllocationContext {
         private final TestingPhysicalSlotProvider slotProvider;
         private final boolean slotWillBeOccupiedIndefinitely;
+        private final Map<ExecutionVertexID, Collection<TaskManagerLocation>> locations;
         private final SimpleExecutionSlotAllocator allocator;
 
         public AllocationContext() {
@@ -245,10 +273,14 @@ class SimpleExecutionSlotAllocatorTest {
                 TestingPhysicalSlotProvider slotProvider, boolean slotWillBeOccupiedIndefinitely) {
             this.slotProvider = slotProvider;
             this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+            this.locations = new HashMap<>();
             this.allocator =
                     new SimpleExecutionSlotAllocator(
                             slotProvider,
                             executionAttemptId -> RESOURCE_PROFILE,
+                            (executionVertexId, producersToIgnore) ->
+                                    locations.getOrDefault(
+                                            executionVertexId, Collections.emptyList()),
                             slotWillBeOccupiedIndefinitely);
         }
 
@@ -266,6 +298,10 @@ class SimpleExecutionSlotAllocatorTest {
 
         public boolean isSlotWillBeOccupiedIndefinitely() {
             return slotWillBeOccupiedIndefinitely;
+        }
+
+        public Map<ExecutionVertexID, Collection<TaskManagerLocation>> getLocations() {
+            return locations;
         }
 
         public SimpleExecutionSlotAllocator getAllocator() {


### PR DESCRIPTION


## What is the purpose of the change

*At present, the AdaptiveBatchScheduler uses the `SimpleExecutionSlotAllocator` to assign slot to execution, but it currently lacks support for the capability of input locality, which may increase unnecessary data transmission overhead. In this issue, we aim to enable the `SimpleExecutionSlotAllocator` to support the input locality.*


## Brief change log

  - *add  `SyncPreferredLocationsRetriever` in `SimpleExecutionSlotAllocator` to compute for preferredLocations to `SlotProfile`*


## Verifying this change
This change added tests and can be verified as follows:
  - *Added test in `SimpleExecutionSlotAllocator.testPreferredLocationsOfSlotProfile()` that validates the `SlotProfile` holds the preferred locations.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
