### PR TITLE
[FLINK-32613] Add ConfigOption for disabling TimestampInserter

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -113,6 +113,12 @@ By default no operator is disabled.</td>
             <td>Determines how Flink enforces NOT NULL column constraints when inserting null values.<br /><br />Possible values:<ul><li>"ERROR": Throw a runtime exception when writing null values into NOT NULL column.</li><li>"DROP": Drop records silently if a null value would have to be inserted into a NOT NULL column.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>table.exec.sink.rowtime-inserter</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">ENABLED</td>
+            <td><p>Enum</p></td>
+            <td>Some sink implementations require a single rowtime attribute in the input that can be inserted into the underlying stream record. This option allows disabling the timestamp insertion and avoids errors around multiple time attributes being present in the query schema.<br /><br />Possible values:<ul><li>"ENABLED": Insert a rowtime attribute (if available) into the underlying stream record. This requires at most one time attribute in the input for the sink.</li><li>"DISABLED": Do not insert the rowtime attribute into the underlying stream record.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.sink.type-length-enforcer</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">IGNORE</td>
             <td><p>Enum</p></td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -170,6 +170,17 @@ public class ExecutionConfigOptions {
                                                     + "You can set to no shuffle(NONE) or force shuffle(FORCE).")
                                     .build());
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<RowtimeInserter> TABLE_EXEC_SINK_ROWTIME_INSERTER =
+            key("table.exec.sink.rowtime-inserter")
+                    .enumType(RowtimeInserter.class)
+                    .defaultValue(RowtimeInserter.ENABLED)
+                    .withDescription(
+                            "Some sink implementations require a single rowtime attribute in the input "
+                                    + "that can be inserted into the underlying stream record. This option "
+                                    + "allows disabling the timestamp insertion and avoids errors around "
+                                    + "multiple time attributes being present in the query schema.");
+
     // ------------------------------------------------------------------------
     //  Sort Options
     // ------------------------------------------------------------------------
@@ -642,6 +653,28 @@ public class ExecutionConfigOptions {
 
         /** Add keyed shuffle in any case except single parallelism. */
         FORCE
+    }
+
+    /** Rowtime attribute insertion strategy for the sink. */
+    @PublicEvolving
+    public enum RowtimeInserter implements DescribedEnum {
+        ENABLED(
+                text(
+                        "Insert a rowtime attribute (if available) into the underlying stream record. "
+                                + "This requires at most one time attribute in the input for the sink.")),
+        DISABLED(text("Do not insert the rowtime attribute into the underlying stream record."));
+
+        private final InlineElement description;
+
+        RowtimeInserter(InlineElement description) {
+            this.description = description;
+        }
+
+        @Internal
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
     }
 
     /** Output mode for asynchronous operations, equivalent to {@see AsyncDataStream.OutputMode}. */


### PR DESCRIPTION
## What is the purpose of the change

This allows disabling the TimestampInserter and also avoids the error message of multiple rowtime attributes in the schema.


## Brief change log

- Add ExecutionConfigOption `table.exec.sink.rowtime-inserter`.

## Verifying this change

This change added tests and can be verified as follows:
- `TableSinkITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
