### PR TITLE
[FLINK-32610][json] JSON format supports nested type projection pushdown

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/json.md
+++ b/docs/content.zh/docs/connectors/table/formats/json.md
@@ -135,6 +135,13 @@ Format 参数
       <td>Boolean</td>
       <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
     </tr>
+    <tr>
+      <td><h5>decode.json-parser.enabled</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td><code>JsonParser</code> 是 Jackson 提供的流式读取 JSON 数据的 API。与 <code>JsonNode</code> 方式相比，这种方式读取速度更快，内存消耗更少。同时，<code>JsonParser</code> 在读取数据时还支持嵌套字段的投影下推。该参数默认启用。如果遇到任何不兼容性问题，可以禁用并回退到 <code>JsonNode</code> 方式。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -146,6 +146,14 @@ Format Options
       <td>Boolean</td>
       <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
     </tr>
+    <tr>
+      <td><h5>decode.json-parser.enabled</h5></td>
+      <td>optional</td>
+      <td></td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>Whether to use the Jackson <code>JsonParser</code> to decode json. <code>JsonParser</code> is the Jackson JSON streaming API to read JSON data. This is much faster and consumes less memory compared to the previous <code>JsonNode</code> approach. Meanwhile, <code>JsonParser</code> also supports nested projection pushdown when reading data. This option is enabled by default. You can disable and fallback to the previous <code>JsonNode</code> approach when encountering any incompatibility issues.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/AbstractJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/AbstractJsonDeserializationSchema.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.json.JsonReadFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Deserialization schema from JSON to Flink Table/SQL internal data structure {@link RowData}. This
+ * is the abstract base class which has different implementation.
+ *
+ * <p>Failures during deserialization are forwarded as wrapped IOExceptions.
+ */
+public abstract class AbstractJsonDeserializationSchema implements DeserializationSchema<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Flag indicating whether to fail if a field is missing. */
+    protected final boolean failOnMissingField;
+
+    /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
+    protected final boolean ignoreParseErrors;
+
+    /** TypeInformation of the produced {@link RowData}. */
+    private final TypeInformation<RowData> resultTypeInfo;
+
+    /** Object mapper for parsing the JSON. */
+    protected transient ObjectMapper objectMapper;
+
+    /** Timestamp format specification which is used to parse timestamp. */
+    private final TimestampFormat timestampFormat;
+
+    private final boolean hasDecimalType;
+
+    public AbstractJsonDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> resultTypeInfo,
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat) {
+        if (ignoreParseErrors && failOnMissingField) {
+            throw new IllegalArgumentException(
+                    "JSON format doesn't support failOnMissingField and ignoreParseErrors are both enabled.");
+        }
+        this.resultTypeInfo = checkNotNull(resultTypeInfo);
+        this.failOnMissingField = failOnMissingField;
+        this.ignoreParseErrors = ignoreParseErrors;
+        this.timestampFormat = timestampFormat;
+        this.hasDecimalType = LogicalTypeChecks.hasNested(rowType, t -> t instanceof DecimalType);
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        objectMapper =
+                JacksonMapperFactory.createObjectMapper()
+                        .configure(
+                                JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(),
+                                true);
+        if (hasDecimalType) {
+            objectMapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return resultTypeInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractJsonDeserializationSchema that = (AbstractJsonDeserializationSchema) o;
+        return failOnMissingField == that.failOnMissingField
+                && ignoreParseErrors == that.ignoreParseErrors
+                && resultTypeInfo.equals(that.resultTypeInfo)
+                && timestampFormat.equals(that.timestampFormat);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(failOnMissingField, ignoreParseErrors, resultTypeInfo, timestampFormat);
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
@@ -73,6 +73,13 @@ public class JsonFormatOptions {
                     .withDescription(
                             "Optional flag to specify whether to encode all decimals as plain numbers instead of possible scientific notations, false by default.");
 
+    public static final ConfigOption<Boolean> DECODE_JSON_PARSER_ENABLED =
+            ConfigOptions.key("decode.json-parser.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Optional flag to specify whether to use the Jackson JsonParser to decode json with better performance, true by default.");
+
     // --------------------------------------------------------------------------------------------
     // Enums
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParseException.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParseException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+/** Exception which refers to parse errors in converters. */
+public class JsonParseException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public JsonParseException(String message) {
+        super(message);
+    }
+
+    public JsonParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Tool class used to convert fields from {@link JsonParser} to {@link RowData} which has a higher
+ * parsing efficiency.
+ */
+@Internal
+public class JsonParserRowDataDeserializationSchema extends AbstractJsonDeserializationSchema {
+
+    /**
+     * Runtime converter that converts {@link JsonParser}s into objects of Flink SQL internal data
+     * structures.
+     */
+    private final JsonParserToRowDataConverters.JsonParserToRowDataConverter runtimeConverter;
+
+    public JsonParserRowDataDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> resultTypeInfo,
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat) {
+        this(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat, null);
+    }
+
+    public JsonParserRowDataDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> resultTypeInfo,
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat,
+            @Nullable String[][] projectedFields) {
+        super(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat);
+        this.runtimeConverter =
+                new JsonParserToRowDataConverters(
+                                failOnMissingField, ignoreParseErrors, timestampFormat)
+                        .createConverter(projectedFields, checkNotNull(rowType));
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        // return null when there is no token
+        if (message == null || message.length == 0) {
+            return null;
+        }
+        try (JsonParser root = objectMapper.getFactory().createParser(message)) {
+            /* First: must point to a token; if not pointing to one, advance.
+             * This occurs before first read from JsonParser, as well as
+             * after clearing of current token.
+             */
+            if (root.currentToken() == null) {
+                root.nextToken();
+            }
+            if (root.currentToken() != JsonToken.START_OBJECT) {
+                throw JsonMappingException.from(root, "No content to map due to end-of-input");
+            }
+            return (RowData) runtimeConverter.convert(root);
+        } catch (Throwable t) {
+            if (ignoreParseErrors) {
+                return null;
+            }
+            throw new IOException(
+                    format("Failed to deserialize JSON '%s'.", new String(message)), t);
+        }
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -1,0 +1,626 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.SQL_TIME_FORMAT;
+
+/** Tool class used to convert fields from {@link JsonParser} to {@link RowData}. */
+@Internal
+public class JsonParserToRowDataConverters implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Flag indicating whether to fail if a field is missing. */
+    private final boolean failOnMissingField;
+
+    /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
+    private final boolean ignoreParseErrors;
+
+    /** Timestamp format specification which is used to parse timestamp. */
+    private final TimestampFormat timestampFormat;
+
+    public JsonParserToRowDataConverters(
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat) {
+        this.failOnMissingField = failOnMissingField;
+        this.ignoreParseErrors = ignoreParseErrors;
+        this.timestampFormat = timestampFormat;
+    }
+
+    /**
+     * Runtime converter that converts {@link JsonParser}s into objects of Flink Table & SQL
+     * internal data structures. Unlike {@link JsonToRowDataConverters.JsonToRowDataConverter}, this
+     * interface also supports projection pushdown of nested fields.
+     */
+    @FunctionalInterface
+    public interface JsonParserToRowDataConverter extends Serializable {
+        Object convert(JsonParser jsonParser) throws IOException;
+    }
+
+    /** Creates a runtime nested converter which is null safe. */
+    public JsonParserToRowDataConverter createConverter(
+            String[][] projectedFields, RowType rowType) {
+        // If projectedFields is null or doesn't contain nested fields, fallback to origin way
+        if (projectedFields == null
+                || Arrays.stream(projectedFields).allMatch(arr -> arr.length == 1)) {
+            return createConverter(rowType);
+        }
+
+        RowNestedConverter rowConverter = new RowNestedConverter();
+        for (int i = 0; i < projectedFields.length; i++) {
+            addFieldConverter(
+                    rowConverter.fieldConverters, projectedFields[i], 0, i, rowType.getTypeAt(i));
+        }
+
+        // DO NOT USE Lambda,it has shade problem.
+        return new JsonParserToRowDataConverter() {
+
+            @Override
+            public Object convert(JsonParser jp) throws IOException {
+                GenericRowData row = new GenericRowData(rowType.getFieldCount());
+                rowConverter.convert(jp, row);
+                return row;
+            }
+        };
+    }
+
+    /** Creates a runtime converter which is null safe. */
+    private JsonParserToRowDataConverter createConverter(LogicalType type) {
+        return wrapIntoNullableConverter(createNotNullConverter(type));
+    }
+
+    /** Creates a runtime converter which assuming input object is not null. */
+    private JsonParserToRowDataConverter createNotNullConverter(LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case NULL:
+                return jsonNode -> null;
+            case BOOLEAN:
+                return this::convertToBoolean;
+            case TINYINT:
+                return this::convertToByte;
+            case SMALLINT:
+                return this::convertToShort;
+            case INTEGER:
+            case INTERVAL_YEAR_MONTH:
+                return this::convertToInt;
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return this::convertToLong;
+            case DATE:
+                return this::convertToDate;
+            case TIME_WITHOUT_TIME_ZONE:
+                return this::convertToTime;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return this::convertToTimestamp;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return this::convertToTimestampWithLocalZone;
+            case FLOAT:
+                return this::convertToFloat;
+            case DOUBLE:
+                return this::convertToDouble;
+            case CHAR:
+            case VARCHAR:
+                return this::convertToString;
+            case BINARY:
+            case VARBINARY:
+                return JsonParser::getBinaryValue;
+            case DECIMAL:
+                return createDecimalConverter((DecimalType) type);
+            case ARRAY:
+                return createArrayConverter((ArrayType) type);
+            case MAP:
+                MapType mapType = (MapType) type;
+                return createMapConverter(
+                        mapType.asSummaryString(), mapType.getKeyType(), mapType.getValueType());
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) type;
+                return createMapConverter(
+                        multisetType.asSummaryString(),
+                        multisetType.getElementType(),
+                        new IntType());
+            case ROW:
+                return createRowConverter((RowType) type);
+            case RAW:
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    private boolean convertToBoolean(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_TRUE) {
+            return true;
+        } else if (jp.currentToken() == JsonToken.VALUE_FALSE) {
+            return false;
+        } else {
+            return Boolean.parseBoolean(jp.getText().trim());
+        }
+    }
+
+    private byte convertToByte(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_INT) {
+            // DON'T use jp.getByteValue() whose value is from -128 to 255 because of the unsigned
+            // value.
+            int value = jp.getIntValue();
+            if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                throw new JsonParseException(
+                        String.format("Numeric value (%s) out of range of Java byte.", value));
+            }
+            return (byte) value;
+        } else {
+            return Byte.parseByte(jp.getText().trim());
+        }
+    }
+
+    private short convertToShort(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_INT) {
+            return jp.getShortValue();
+        } else {
+            return Short.parseShort(jp.getText().trim());
+        }
+    }
+
+    private int convertToInt(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || jp.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+            return jp.getIntValue();
+        } else {
+            return Integer.parseInt(jp.getText().trim());
+        }
+    }
+
+    private long convertToLong(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || jp.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+            return jp.getLongValue();
+        } else {
+            return Long.parseLong(jp.getText().trim());
+        }
+    }
+
+    private double convertToDouble(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+            return jp.getDoubleValue();
+        } else {
+            return Double.parseDouble(jp.getText().trim());
+        }
+    }
+
+    private float convertToFloat(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+            return jp.getFloatValue();
+        } else {
+            return Float.parseFloat(jp.getText().trim());
+        }
+    }
+
+    private int convertToDate(JsonParser jp) throws IOException {
+        LocalDate date = ISO_LOCAL_DATE.parse(jp.getText()).query(TemporalQueries.localDate());
+        return (int) date.toEpochDay();
+    }
+
+    private int convertToTime(JsonParser jsonNode) throws IOException {
+        TemporalAccessor parsedTime = SQL_TIME_FORMAT.parse(jsonNode.getText());
+        LocalTime localTime = parsedTime.query(TemporalQueries.localTime());
+
+        // get number of milliseconds of the day
+        return localTime.toSecondOfDay() * 1000;
+    }
+
+    private TimestampData convertToTimestamp(JsonParser jp) throws IOException {
+        TemporalAccessor parsedTimestamp;
+        switch (timestampFormat) {
+            case SQL:
+                parsedTimestamp = SQL_TIMESTAMP_FORMAT.parse(jp.getText());
+                break;
+            case ISO_8601:
+                parsedTimestamp = ISO8601_TIMESTAMP_FORMAT.parse(jp.getText());
+                break;
+            default:
+                throw new TableException(
+                        String.format(
+                                "Unsupported timestamp format '%s'. Validator should have checked that.",
+                                timestampFormat));
+        }
+        LocalTime localTime = parsedTimestamp.query(TemporalQueries.localTime());
+        LocalDate localDate = parsedTimestamp.query(TemporalQueries.localDate());
+
+        return TimestampData.fromLocalDateTime(LocalDateTime.of(localDate, localTime));
+    }
+
+    private TimestampData convertToTimestampWithLocalZone(JsonParser jp) throws IOException {
+        TemporalAccessor parsedTimestampWithLocalZone;
+        switch (timestampFormat) {
+            case SQL:
+                parsedTimestampWithLocalZone =
+                        SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.parse(jp.getText());
+                break;
+            case ISO_8601:
+                parsedTimestampWithLocalZone =
+                        ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.parse(jp.getText());
+                break;
+            default:
+                throw new TableException(
+                        String.format(
+                                "Unsupported timestamp format '%s'. Validator should have checked that.",
+                                timestampFormat));
+        }
+        LocalTime localTime = parsedTimestampWithLocalZone.query(TemporalQueries.localTime());
+        LocalDate localDate = parsedTimestampWithLocalZone.query(TemporalQueries.localDate());
+
+        return TimestampData.fromInstant(
+                LocalDateTime.of(localDate, localTime).toInstant(ZoneOffset.UTC));
+    }
+
+    private StringData convertToString(JsonParser jp) throws IOException {
+        if (jp.currentToken() == JsonToken.START_OBJECT
+                || jp.currentToken() == JsonToken.START_ARRAY) {
+            return StringData.fromString(jp.readValueAsTree().toString());
+        } else {
+            return StringData.fromString(jp.getText());
+        }
+    }
+
+    private JsonParserToRowDataConverter createDecimalConverter(DecimalType decimalType) {
+        final int precision = decimalType.getPrecision();
+        final int scale = decimalType.getScale();
+        return jp -> {
+            BigDecimal bigDecimal;
+            if (jp.currentToken() == JsonToken.VALUE_STRING) {
+                bigDecimal = new BigDecimal(jp.getText().trim());
+            } else {
+                bigDecimal = jp.getDecimalValue();
+            }
+            return DecimalData.fromBigDecimal(bigDecimal, precision, scale);
+        };
+    }
+
+    private JsonParserToRowDataConverter createArrayConverter(ArrayType arrayType) {
+        JsonParserToRowDataConverter elementConverter = createConverter(arrayType.getElementType());
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+        return jp -> {
+            if (jp.currentToken() != JsonToken.START_ARRAY) {
+                throw new IllegalStateException("Illegal JSON array data...");
+            }
+            List<Object> result = new ArrayList<>();
+            while (jp.nextToken() != JsonToken.END_ARRAY) {
+                Object convertField = elementConverter.convert(jp);
+                result.add(convertField);
+            }
+            final Object[] array = (Object[]) Array.newInstance(elementClass, result.size());
+            return new GenericArrayData(result.toArray(array));
+        };
+    }
+
+    private JsonParserToRowDataConverter createMapConverter(
+            String typeSummary, LogicalType keyType, LogicalType valueType) {
+        if (!keyType.is(LogicalTypeFamily.CHARACTER_STRING)) {
+            throw new UnsupportedOperationException(
+                    "JSON format doesn't support non-string as key type of map. "
+                            + "The type is: "
+                            + typeSummary);
+        }
+        final JsonParserToRowDataConverter keyConverter = createConverter(keyType);
+        final JsonParserToRowDataConverter valueConverter = createConverter(valueType);
+
+        return jp -> {
+            if (jp.currentToken() != JsonToken.START_OBJECT) {
+                throw new IllegalStateException("Illegal JSON map data...");
+            }
+            Map<Object, Object> result = new HashMap<>();
+            while (jp.nextToken() != JsonToken.END_OBJECT) {
+                Object key = keyConverter.convert(jp);
+                jp.nextToken();
+                Object value = valueConverter.convert(jp);
+                result.put(key, value);
+            }
+            return new GenericMapData(result);
+        };
+    }
+
+    public JsonParserToRowDataConverter createRowConverter(RowType rowType) {
+        final JsonParserToRowDataConverter[] fieldConverters =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .map(this::createConverter)
+                        .toArray(JsonParserToRowDataConverter[]::new);
+        final String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
+
+        Map<String, Integer> nameIdxMap = new HashMap<>();
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            nameIdxMap.put(fieldNames[i], i);
+        }
+
+        return jp -> {
+            if (jp.currentToken() != JsonToken.START_OBJECT) {
+                throw new IllegalStateException("Illegal JSON object data...");
+            }
+            int arity = nameIdxMap.size();
+            GenericRowData row = new GenericRowData(arity);
+            int cnt = 0;
+            jp.nextToken();
+            while (jp.currentToken() != JsonToken.END_OBJECT) {
+                if (cnt >= arity) {
+                    skipToNextField(jp);
+                    continue;
+                }
+                String fieldName = jp.getText();
+                jp.nextToken();
+                Integer idx = nameIdxMap.get(fieldName);
+                if (idx != null) {
+                    try {
+                        Object convertField = fieldConverters[idx].convert(jp);
+                        row.setField(idx, convertField);
+                    } catch (Throwable t) {
+                        throw new JsonParseException(
+                                String.format("Fail to deserialize at field: %s.", fieldName));
+                    }
+                    jp.nextToken();
+                    cnt++;
+                } else {
+                    skipToNextField(jp);
+                }
+            }
+            if (cnt < arity && failOnMissingField) {
+                throw new JsonParseException("Some field is missing in the JSON data.");
+            }
+            return row;
+        };
+    }
+
+    public static void skipToNextField(JsonParser jp) throws IOException {
+        switch (jp.currentToken()) {
+            case START_OBJECT:
+            case START_ARRAY:
+                int match = 1;
+                JsonToken token;
+                while (match > 0) {
+                    token = jp.nextToken();
+                    if (token == JsonToken.END_ARRAY || token == JsonToken.END_OBJECT) {
+                        match--;
+                    } else if (token == JsonToken.START_ARRAY || token == JsonToken.START_OBJECT) {
+                        match++;
+                    }
+                }
+                break;
+            default:
+        }
+        jp.nextToken();
+    }
+
+    private JsonParserToRowDataConverter wrapIntoNullableConverter(
+            JsonParserToRowDataConverter converter) {
+        return jp -> {
+            if (jp == null
+                    || jp.currentToken() == null
+                    || jp.getCurrentToken() == JsonToken.VALUE_NULL) {
+                return null;
+            }
+            try {
+                return converter.convert(jp);
+            } catch (Throwable t) {
+                if (!ignoreParseErrors) {
+                    throw t;
+                }
+                return null;
+            }
+        };
+    }
+
+    private void addFieldConverter(
+            Map<String, ProjectedConverter> converters,
+            String[] nestedField,
+            int depth,
+            int outputPos,
+            LogicalType type) {
+        String name = nestedField[depth];
+        if (depth == nestedField.length - 1) {
+            FieldConverter fieldConverter = new FieldConverter(outputPos, type);
+            ProjectedConverter converter = converters.get(name);
+            if (converter instanceof RowNestedConverter) {
+                // Has RowNestedConverter, fallback to get nested field from a converted row field.
+                for (Map.Entry<Integer, String[]> entry :
+                        ((RowNestedConverter) converter).outputPosToPath.entrySet()) {
+                    fieldConverter.addNestedFieldPath(entry.getKey(), entry.getValue());
+                }
+            } else if (converter instanceof FieldConverter) {
+                throw new RuntimeException("This is a bug, contains duplicated fields.");
+            }
+            converters.put(name, fieldConverter);
+        } else {
+            ProjectedConverter converter =
+                    converters.computeIfAbsent(name, k -> new RowNestedConverter());
+            String[] namePath = ArrayUtils.subarray(nestedField, depth + 1, nestedField.length);
+            if (converter instanceof FieldConverter) {
+                // Already converted this row field, just get nested field from it.
+                ((FieldConverter) converter).addNestedFieldPath(outputPos, namePath);
+            } else {
+                RowNestedConverter rowConverter = (RowNestedConverter) converter;
+                rowConverter.outputPosToPath.put(outputPos, namePath);
+                addFieldConverter(
+                        rowConverter.fieldConverters, nestedField, depth + 1, outputPos, type);
+            }
+        }
+    }
+
+    /**
+     * Runtime converter that converts {@link JsonParser}s into objects of Flink Table & SQL
+     * internal data structures.
+     */
+    private abstract static class ProjectedConverter implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public final void convert(JsonParser jp, GenericRowData outputRow) throws IOException {
+            if (jp != null
+                    && jp.currentToken() != null
+                    && jp.getCurrentToken() != JsonToken.VALUE_NULL) {
+                convertNotNull(jp, outputRow);
+            }
+        }
+
+        public abstract void convertNotNull(JsonParser jp, GenericRowData outputRow)
+                throws IOException;
+    }
+
+    private class FieldConverter extends ProjectedConverter {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int outputPos;
+
+        private final JsonParserToRowDataConverter converter;
+
+        private final LogicalType type;
+
+        private final Map<Integer, int[]> outputPosToPath = new HashMap<>();
+
+        public FieldConverter(int outputPos, LogicalType type) {
+            this.outputPos = outputPos;
+            this.converter = createConverter(type);
+            this.type = type;
+        }
+
+        @Override
+        public void convertNotNull(JsonParser jp, GenericRowData outputRow) throws IOException {
+            Object field = converter.convert(jp);
+            outputRow.setField(outputPos, field);
+            if (field != null && !outputPosToPath.isEmpty()) {
+                outNestedFields(field, outputRow);
+            }
+        }
+
+        private void outNestedFields(Object field, GenericRowData outputRow) {
+            outputLoop:
+            for (Map.Entry<Integer, int[]> entry : outputPosToPath.entrySet()) {
+                Object currentField = field;
+                for (int i : entry.getValue()) {
+                    if (currentField == null) {
+                        continue outputLoop;
+                    }
+                    currentField = ((GenericRowData) currentField).getField(i);
+                }
+                outputRow.setField(entry.getKey(), currentField);
+            }
+        }
+
+        public void addNestedFieldPath(int pos, String[] namePath) {
+            int[] path = new int[namePath.length];
+            LogicalType currentType = type;
+            for (int i = 0; i < path.length; i++) {
+                if (!(currentType instanceof RowType)) {
+                    throw new RuntimeException(
+                            "This is a bug, currentType should be row type, but is: "
+                                    + currentType);
+                }
+
+                int fieldIndex = ((RowType) currentType).getFieldNames().indexOf(namePath[i]);
+                currentType = currentType.getChildren().get(fieldIndex);
+                path[i] = fieldIndex;
+            }
+            outputPosToPath.put(pos, path);
+        }
+    }
+
+    private class RowNestedConverter extends ProjectedConverter {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Map<String, ProjectedConverter> fieldConverters = new HashMap<>();
+
+        // Keep path here for fallback to get nested field from a converted row field.
+        private final Map<Integer, String[]> outputPosToPath = new HashMap<>();
+
+        @Override
+        public void convertNotNull(JsonParser jp, GenericRowData outputRow) throws IOException {
+            if (jp.currentToken() != JsonToken.START_OBJECT) {
+                throw new IllegalStateException("Illegal Json Data...");
+            }
+            int arity = fieldConverters.size();
+            int cnt = 0;
+            jp.nextToken();
+            while (jp.currentToken() != JsonToken.END_OBJECT) {
+                if (cnt >= arity) {
+                    skipToNextField(jp);
+                    continue;
+                }
+                String fieldName = jp.getText();
+                jp.nextToken();
+                ProjectedConverter converter = fieldConverters.get(fieldName);
+                if (converter != null) {
+                    converter.convert(jp, outputRow);
+                    jp.nextToken();
+                    cnt++;
+                } else {
+                    skipToNextField(jp);
+                }
+            }
+            if (cnt < arity && failOnMissingField) {
+                throw new JsonParseException("Some field is missing in the Json data.");
+            }
+        }
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * <p>Serializes the input Flink object into a JSON string and converts it into <code>byte[]</code>.
  *
  * <p>Result <code>byte[]</code> messages can be deserialized using {@link
- * JsonRowDataDeserializationSchema}.
+ * JsonRowDataDeserializationSchema} or {@link JsonParserRowDataDeserializationSchema}.
  */
 @Internal
 public class JsonRowDataSerializationSchema implements SerializationSchema<RowData> {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -386,17 +386,4 @@ public class JsonToRowDataConverters implements Serializable {
             }
         };
     }
-
-    /** Exception which refers to parse errors in converters. */
-    private static final class JsonParseException extends RuntimeException {
-        private static final long serialVersionUID = 1L;
-
-        public JsonParseException(String message) {
-            super(message);
-        }
-
-        public JsonParseException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -151,8 +151,8 @@ class JsonFormatFactoryTest {
     }
 
     private void testSchemaDeserializationSchema(Map<String, String> options) {
-        final JsonRowDataDeserializationSchema expectedDeser =
-                new JsonRowDataDeserializationSchema(
+        final JsonParserRowDataDeserializationSchema expectedDeser =
+                new JsonParserRowDataDeserializationSchema(
                         PHYSICAL_TYPE,
                         InternalTypeInfo.of(PHYSICAL_TYPE),
                         false,

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.connector.testutils.formats.SchemaTestUtils.open;
+import static org.apache.flink.formats.json.JsonRowDataSerDeSchemaTest.convertToExternal;
+import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.MAP;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.SMALLINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JsonParserRowDataDeserializationSchema}. */
+public class JsonParserRowDataDeSerSchemaTest {
+
+    /**
+     * Tests parsing partial fields in actual json data, sometimes we can skip some complex field
+     * parsing, e.g., field with Row/Array type.
+     */
+    @Test
+    public void testParsePartialJson() throws Exception {
+        byte tinyint = 'c';
+        short smallint = 128;
+        int intValue = 45536;
+        float floatValue = 33.333F;
+        long bigint = 1238123899121L;
+        String name = "asdlkjasjkdla998y1122";
+        byte[] bytes = new byte[1024];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        BigDecimal decimal = new BigDecimal("123.456789");
+
+        Map<String, Long> map = new HashMap<>();
+        map.put("flink", 123L);
+
+        Map<String, Map<String, Integer>> nestedMap = new HashMap<>();
+        Map<String, Integer> innerMap = new HashMap<>();
+        innerMap.put("key", 234);
+        nestedMap.put("inner_map", innerMap);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ArrayNode doubleNode = objectMapper.createArrayNode().add(1.1D).add(2.2D).add(3.3D);
+
+        // Root
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("bool", true);
+        root.put("tinyint", tinyint);
+        root.put("smallint", smallint);
+        root.put("int", intValue);
+        root.put("bigint", bigint);
+        root.put("float", floatValue);
+        root.put("name", name);
+        root.put("bytes", bytes);
+        root.put("decimal", decimal);
+        root.set("doubles", doubleNode);
+        root.put("date", "1990-10-14");
+        root.put("time", "12:12:43");
+        root.put("timestamp3", "1990-10-14T12:12:43.123");
+        root.put("timestamp9", "1990-10-14T12:12:43.123456789");
+        root.putObject("map").put("flink", 123);
+        root.putObject("map2map").putObject("inner_map").put("key", 234);
+
+        byte[] serializedJson = objectMapper.writeValueAsBytes(root);
+
+        DataType dataType =
+                ROW(
+                        FIELD("bool", BOOLEAN()),
+                        FIELD("tinyint", TINYINT()),
+                        FIELD("smallint", SMALLINT()),
+                        FIELD("int", INT()),
+                        FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))));
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        DeserializationSchema<RowData> deserializationSchema =
+                new JsonParserRowDataDeserializationSchema(
+                        schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+
+        Row expected = new Row(5);
+        expected.setField(0, true);
+        expected.setField(1, tinyint);
+        expected.setField(2, smallint);
+        expected.setField(3, intValue);
+        expected.setField(4, nestedMap);
+
+        RowData rowData = deserializationSchema.deserialize(serializedJson);
+        Row actual = convertToExternal(rowData, dataType);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testProjected() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("f0", 0);
+        root.put("f1", 1);
+        root.put("f2", 2);
+        root.put("f3", 3);
+        root.put("f4", 4);
+        innerTestProjected(objectMapper.writeValueAsBytes(root), GenericRowData.of(1, 4, 0, 2));
+    }
+
+    @Test
+    public void testProjectedNullable() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("f0", 0);
+        root.put("f1", 1);
+        root.putNull("f2");
+        root.put("f3", 3);
+        root.putNull("f4");
+        innerTestProjected(
+                objectMapper.writeValueAsBytes(root), GenericRowData.of(1, null, 0, null));
+    }
+
+    private void innerTestProjected(byte[] serializedJson, GenericRowData expected)
+            throws Exception {
+        DataType dataType =
+                ROW(FIELD("f1", INT()), FIELD("f4", INT()), FIELD("f0", INT()), FIELD("f2", INT()));
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        JsonParserRowDataDeserializationSchema deserializationSchema =
+                new JsonParserRowDataDeserializationSchema(
+                        schema,
+                        resultTypeInfo,
+                        false,
+                        false,
+                        TimestampFormat.ISO_8601,
+                        new String[][] {
+                            new String[] {"f1"},
+                            new String[] {"f4"},
+                            new String[] {"f0"},
+                            new String[] {"f2"}
+                        });
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(serializedJson);
+        assertThat(rowData).isEqualTo(expected);
+    }
+
+    private byte[] prepareNestedRow() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // Root
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("f0", 0);
+        root.put("f1", 1);
+        root.put("f2", 2);
+        ObjectNode f3 = root.putObject("f3");
+        f3.put("f0", 30);
+        f3.put("f1", 31);
+        f3.put("f2", 32);
+        ObjectNode f4 = root.putObject("f4");
+        f4.put("f0", 40);
+        f4.put("f1", 41);
+
+        ObjectNode f5 = root.putObject("f5");
+        f5.put("f0", 50);
+        ObjectNode f51 = f5.putObject("f1");
+        f51.put("f0", 510);
+        f51.put("f1", 511);
+
+        return objectMapper.writeValueAsBytes(root);
+    }
+
+    private byte[] prepareNullableNestedRow() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // Root
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("f0", 0);
+        root.put("f1", 1);
+        root.put("f2", 2);
+        ObjectNode f3 = root.putObject("f3");
+        f3.put("f0", 30);
+        f3.put("f1", 31);
+        f3.put("f2", 32);
+        ObjectNode f4 = root.putObject("f4");
+        f4.putNull("f0");
+        f4.put("f1", 41);
+
+        ObjectNode f5 = root.putObject("f5");
+        f5.put("f0", 50);
+        f5.putNull("f1");
+
+        return objectMapper.writeValueAsBytes(root);
+    }
+
+    @Test
+    public void testProjectNestedField() throws Exception {
+        GenericRowData expected = GenericRowData.of(1, 31, 32, 510, 0, GenericRowData.of(40, 41));
+        innerTestProjectNestedField(prepareNestedRow(), expected);
+    }
+
+    @Test
+    public void testProjectNestedFieldNullable() throws Exception {
+        GenericRowData expected =
+                GenericRowData.of(1, 31, 32, null, 0, GenericRowData.of(null, 41));
+        innerTestProjectNestedField(prepareNullableNestedRow(), expected);
+    }
+
+    private void innerTestProjectNestedField(byte[] serializedJson, GenericRowData expected)
+            throws Exception {
+        DataType dataType =
+                ROW(
+                        FIELD("f1", INT()),
+                        FIELD("f3_1", INT()),
+                        FIELD("f3_2", INT()),
+                        FIELD("f5_1_0", INT()),
+                        FIELD("f0", INT()),
+                        FIELD("f4", ROW(FIELD("f0", INT()), FIELD("f1", INT()))));
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        JsonParserRowDataDeserializationSchema deserializationSchema =
+                new JsonParserRowDataDeserializationSchema(
+                        schema,
+                        resultTypeInfo,
+                        false,
+                        false,
+                        TimestampFormat.ISO_8601,
+                        new String[][] {
+                            new String[] {"f1"},
+                            new String[] {"f3", "f1"},
+                            new String[] {"f3", "f2"},
+                            new String[] {"f5", "f1", "f0"},
+                            new String[] {"f0"},
+                            new String[] {"f4"}
+                        });
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(serializedJson);
+        assertThat(rowData).isEqualTo(expected);
+    }
+
+    @Test
+    public void testProjectBothRowAndNestedField() throws Exception {
+        GenericRowData expected =
+                GenericRowData.of(
+                        1,
+                        32,
+                        GenericRowData.of(40, 41),
+                        40,
+                        511,
+                        GenericRowData.of(510, 511),
+                        GenericRowData.of(50, GenericRowData.of(510, 511)));
+        innerTestProjectBothRowAndNestedField(prepareNestedRow(), expected);
+    }
+
+    @Test
+    public void testProjectBothRowAndNestedFieldNullable() throws Exception {
+        GenericRowData expected =
+                GenericRowData.of(
+                        1,
+                        32,
+                        GenericRowData.of(null, 41),
+                        null,
+                        null,
+                        null,
+                        GenericRowData.of(50, null));
+        innerTestProjectBothRowAndNestedField(prepareNullableNestedRow(), expected);
+    }
+
+    private void innerTestProjectBothRowAndNestedField(
+            byte[] serializedJson, GenericRowData expected) throws Exception {
+        DataType dataType =
+                ROW(
+                        FIELD("f1", INT()),
+                        FIELD("f3_2", INT()),
+                        FIELD("f4", ROW(FIELD("f0", INT()), FIELD("f1", INT()))),
+                        FIELD("f4_0", INT()),
+                        FIELD("f5_1_1", INT()),
+                        FIELD("f5_1", ROW(FIELD("f0", INT()), FIELD("f1", INT()))),
+                        FIELD(
+                                "f5",
+                                ROW(
+                                        FIELD("f0", INT()),
+                                        FIELD("f1", ROW(FIELD("f0", INT()), FIELD("f1", INT()))))));
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        JsonParserRowDataDeserializationSchema deserializationSchema =
+                new JsonParserRowDataDeserializationSchema(
+                        schema,
+                        resultTypeInfo,
+                        false,
+                        false,
+                        TimestampFormat.ISO_8601,
+                        new String[][] {
+                            new String[] {"f1"},
+                            new String[] {"f3", "f2"},
+                            new String[] {"f4"},
+                            new String[] {"f4", "f0"},
+                            new String[] {"f5", "f1", "f1"},
+                            new String[] {"f5", "f1"},
+                            new String[] {"f5"}
+                        });
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(serializedJson);
+        assertThat(rowData).isEqualTo(expected);
+    }
+}

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.formats.json;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.formats.common.TimestampFormat;
@@ -30,6 +30,9 @@ import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
@@ -38,6 +41,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Arra
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -47,6 +52,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -80,13 +86,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Tests for {@link JsonRowDataDeserializationSchema} and {@link JsonRowDataSerializationSchema}.
+ * Tests for {@link JsonRowDataDeserializationSchema}, {@link
+ * JsonParserRowDataDeserializationSchema} and {@link JsonRowDataSerializationSchema}.
  */
-class JsonRowDataSerDeSchemaTest {
+@ExtendWith(ParameterizedTestExtension.class)
+public class JsonRowDataSerDeSchemaTest {
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
-    @Test
+    @Parameter public boolean isJsonParser;
+
+    @Parameters(name = "isJsonParser={0}")
+    public static Collection<Boolean> parameters() throws Exception {
+        return Arrays.asList(true, false);
+    }
+
+    @TestTemplate
     void testSerDe() throws Exception {
         byte tinyint = 'c';
         short smallint = 128;
@@ -164,11 +179,10 @@ class JsonRowDataSerDeSchemaTest {
                         FIELD("multiSet", MULTISET(STRING())),
                         FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))));
         RowType schema = (RowType) dataType.getLogicalType();
-        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, schema, false, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
         Row expected = new Row(18);
@@ -213,7 +227,7 @@ class JsonRowDataSerDeSchemaTest {
      * Tests the deserialization slow path, e.g. convert into string and use {@link
      * Double#parseDouble(String)}.
      */
-    @Test
+    @TestTemplate
     void testSlowDeserialization() throws Exception {
         Random random = new Random();
         boolean bool = random.nextBoolean();
@@ -244,13 +258,9 @@ class JsonRowDataSerDeSchemaTest {
                         FIELD("float2", FLOAT()));
         RowType rowType = (RowType) dataType.getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        rowType,
-                        InternalTypeInfo.of(rowType),
-                        false,
-                        false,
-                        TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
         Row expected = new Row(7);
@@ -267,7 +277,7 @@ class JsonRowDataSerDeSchemaTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    @Test
+    @TestTemplate
     void testSerDeMultiRows() throws Exception {
         RowType rowType =
                 (RowType)
@@ -280,13 +290,9 @@ class JsonRowDataSerDeSchemaTest {
                                         FIELD("f6", ROW(FIELD("f1", STRING()), FIELD("f2", INT()))))
                                 .getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        rowType,
-                        InternalTypeInfo.of(rowType),
-                        false,
-                        false,
-                        TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
         JsonRowDataSerializationSchema serializationSchema =
                 new JsonRowDataSerializationSchema(
@@ -338,7 +344,7 @@ class JsonRowDataSerDeSchemaTest {
         }
     }
 
-    @Test
+    @TestTemplate
     void testSerDeMultiRowsWithNullValues() throws Exception {
         String[] jsons =
                 new String[] {
@@ -365,13 +371,9 @@ class JsonRowDataSerDeSchemaTest {
                                         FIELD("metrics", MAP(STRING(), DOUBLE())))
                                 .getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        rowType,
-                        InternalTypeInfo.of(rowType),
-                        false,
-                        true,
-                        TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, true, TimestampFormat.ISO_8601);
         open(deserializationSchema);
         JsonRowDataSerializationSchema serializationSchema =
                 new JsonRowDataSerializationSchema(
@@ -390,33 +392,33 @@ class JsonRowDataSerDeSchemaTest {
         }
     }
 
-    @Test
+    @TestTemplate
     void testDeserializationNullRow() throws Exception {
         DataType dataType = ROW(FIELD("name", STRING()));
         RowType schema = (RowType) dataType.getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, schema, true, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
         assertThat(deserializationSchema.deserialize(null)).isNull();
     }
 
-    @Test
+    @TestTemplate
     void testDeserializationMissingNode() throws Exception {
         DataType dataType = ROW(FIELD("name", STRING()));
         RowType schema = (RowType) dataType.getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, schema, true, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
         RowData rowData = deserializationSchema.deserialize("".getBytes());
         assertThat(rowData).isNull();
     }
 
-    @Test
+    @TestTemplate
     void testDeserializationMissingField() throws Exception {
         // Root
         ObjectNode root = OBJECT_MAPPER.createObjectNode();
@@ -427,13 +429,9 @@ class JsonRowDataSerDeSchemaTest {
         RowType schema = (RowType) dataType.getLogicalType();
 
         // pass on missing field
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema,
-                        InternalTypeInfo.of(schema),
-                        false,
-                        false,
-                        TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, schema, false, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
         Row expected = new Row(1);
@@ -442,20 +440,20 @@ class JsonRowDataSerDeSchemaTest {
 
         // fail on missing field
         deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
+                createDeserializationSchema(
+                        isJsonParser, schema, true, false, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
         String errorMessage = "Failed to deserialize JSON '{\"id\":123123123}'.";
 
-        JsonRowDataDeserializationSchema finalDeserializationSchema = deserializationSchema;
+        DeserializationSchema<RowData> finalDeserializationSchema = deserializationSchema;
         assertThatThrownBy(() -> finalDeserializationSchema.deserialize(serializedJson))
                 .hasMessage(errorMessage);
 
         // ignore on parse error
         deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        schema, InternalTypeInfo.of(schema), false, true, TimestampFormat.ISO_8601);
+                createDeserializationSchema(
+                        isJsonParser, schema, false, true, TimestampFormat.ISO_8601);
         open(deserializationSchema);
         actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
         assertThat(actual).isEqualTo(expected);
@@ -473,7 +471,7 @@ class JsonRowDataSerDeSchemaTest {
                 .hasMessage(errorMessage);
     }
 
-    @Test
+    @TestTemplate
     void testSerDeSQLTimestampFormat() throws Exception {
         RowType rowType =
                 (RowType)
@@ -488,9 +486,9 @@ class JsonRowDataSerDeSchemaTest {
                                                 TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)))
                                 .getLogicalType();
 
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        rowType, InternalTypeInfo.of(rowType), false, false, TimestampFormat.SQL);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.SQL);
         open(deserializationSchema);
         JsonRowDataSerializationSchema serializationSchema =
                 new JsonRowDataSerializationSchema(
@@ -582,7 +580,7 @@ class JsonRowDataSerDeSchemaTest {
         assertThat(new String(actual3)).isEqualTo(expectResult3);
     }
 
-    @Test
+    @TestTemplate
     void testSerializationDecimalEncode() throws Exception {
         RowType schema =
                 (RowType)
@@ -592,11 +590,9 @@ class JsonRowDataSerDeSchemaTest {
                                         FIELD("decimal3", DECIMAL(11, 9)))
                                 .getLogicalType();
 
-        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
-
-        JsonRowDataDeserializationSchema deserializer =
-                new JsonRowDataDeserializationSchema(
-                        schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
+        DeserializationSchema<RowData> deserializer =
+                createDeserializationSchema(
+                        isJsonParser, schema, false, false, TimestampFormat.ISO_8601);
         deserializer.open(new DummyInitializationContext());
 
         JsonRowDataSerializationSchema plainDecimalSerializer =
@@ -630,7 +626,7 @@ class JsonRowDataSerDeSchemaTest {
         assertThat(scientificDecimalResult).isEqualTo(scientificDecimalJson);
     }
 
-    @Test
+    @TestTemplate
     void testJsonParse() throws Exception {
         for (TestSpec spec : testData) {
             testIgnoreParseErrors(spec);
@@ -660,13 +656,13 @@ class JsonRowDataSerDeSchemaTest {
                 .satisfies(anyCauseMatches(RuntimeException.class, errorMessage));
     }
 
-    @Test
+    @TestTemplate
     void testDeserializationWithTypesMismatch() {
         RowType rowType = (RowType) ROW(FIELD("f0", STRING()), FIELD("f1", INT())).getLogicalType();
         String json = "{\"f0\":\"abc\", \"f1\": \"abc\"}";
-        JsonRowDataDeserializationSchema deserializationSchema =
-                new JsonRowDataDeserializationSchema(
-                        rowType, InternalTypeInfo.of(rowType), false, false, TimestampFormat.SQL);
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.SQL);
         open(deserializationSchema);
         String errorMessage = "Fail to deserialize at field: f1.";
 
@@ -676,13 +672,9 @@ class JsonRowDataSerDeSchemaTest {
 
     private void testIgnoreParseErrors(TestSpec spec) throws Exception {
         // the parsing field should be null and no exception is thrown
-        JsonRowDataDeserializationSchema ignoreErrorsSchema =
-                new JsonRowDataDeserializationSchema(
-                        spec.rowType,
-                        InternalTypeInfo.of(spec.rowType),
-                        false,
-                        true,
-                        spec.timestampFormat);
+        DeserializationSchema<RowData> ignoreErrorsSchema =
+                createDeserializationSchema(
+                        isJsonParser, spec.rowType, false, true, spec.timestampFormat);
         ignoreErrorsSchema.open(new DummyInitializationContext());
 
         Row expected;
@@ -700,13 +692,9 @@ class JsonRowDataSerDeSchemaTest {
 
     private void testParseErrors(TestSpec spec) {
         // expect exception if parse error is not ignored
-        JsonRowDataDeserializationSchema failingSchema =
-                new JsonRowDataDeserializationSchema(
-                        spec.rowType,
-                        InternalTypeInfo.of(spec.rowType),
-                        false,
-                        false,
-                        spec.timestampFormat);
+        DeserializationSchema<RowData> failingSchema =
+                createDeserializationSchema(
+                        isJsonParser, spec.rowType, false, false, spec.timestampFormat);
         open(failingSchema);
 
         assertThatThrownBy(() -> failingSchema.deserialize(spec.json.getBytes()))
@@ -724,6 +712,12 @@ class JsonRowDataSerDeSchemaTest {
                     TestSpec.json("{\"id\":\"abc\"}")
                             .rowType(ROW(FIELD("id", INT())))
                             .expectErrorMessage("Failed to deserialize JSON '{\"id\":\"abc\"}'."),
+                    TestSpec.json("{\"id\":11211111111.013}")
+                            .rowType(ROW(FIELD("id", INT())))
+                            .expect(null),
+                    TestSpec.json("{\"id\":112.013}")
+                            .rowType(ROW(FIELD("id", INT())))
+                            .expect(Row.of(112)),
                     TestSpec.json("{\"id\":112.013}")
                             .rowType(ROW(FIELD("id", BIGINT())))
                             .expect(Row.of(112L)),
@@ -830,8 +824,31 @@ class JsonRowDataSerDeSchemaTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static Row convertToExternal(RowData rowData, DataType dataType) {
+    static Row convertToExternal(RowData rowData, DataType dataType) {
         return (Row) DataFormatConverters.getConverterForDataType(dataType).toExternal(rowData);
+    }
+
+    private DeserializationSchema<RowData> createDeserializationSchema(
+            boolean isJsonParser,
+            RowType rowType,
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat) {
+        if (isJsonParser) {
+            return new JsonParserRowDataDeserializationSchema(
+                    rowType,
+                    InternalTypeInfo.of(rowType),
+                    failOnMissingField,
+                    ignoreParseErrors,
+                    timestampFormat);
+        } else {
+            return new JsonRowDataDeserializationSchema(
+                    rowType,
+                    InternalTypeInfo.of(rowType),
+                    failOnMissingField,
+                    ignoreParseErrors,
+                    timestampFormat);
+        }
     }
 
     private static class TestSpec {


### PR DESCRIPTION

## What is the purpose of the change

*This PR mainly do two aspects of work, the first is the use of Jackson streamig api parsing json, which can improve the parsing efficiency; the second is to support nested types of projection pushdown*


## Brief change log

  - *Optimize JSON schema data deserialization using jackson streaming api*
  - *JSON format supports nested type projection push down*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in JsonRowDataDeSerSchemaProjectedTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
