### PR TITLE
[FLINK-32625][tests] MiniClusterTestEnvironment supports customized MiniClusterResourceConfiguration

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
@@ -60,22 +60,28 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
     private boolean isStarted = false;
 
     public MiniClusterTestEnvironment() {
-        Configuration conf = new Configuration();
-        conf.set(METRIC_FETCHER_UPDATE_INTERVAL, METRIC_FETCHER_UPDATE_INTERVAL_MS);
-        this.miniCluster =
-                new MiniClusterWithClientResource(
-                        new MiniClusterResourceConfiguration.Builder()
-                                .setConfiguration(conf)
-                                .setNumberTaskManagers(1)
-                                .setNumberSlotsPerTaskManager(6)
-                                .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
-                                .withHaLeadershipControl()
-                                .build());
+        this(defaultMiniClusterResourceConfiguration());
+    }
+
+    public MiniClusterTestEnvironment(MiniClusterResourceConfiguration conf) {
+        this.miniCluster = new MiniClusterWithClientResource(conf);
         try {
             this.checkpointPath = Files.createTempDirectory("minicluster-environment-checkpoint-");
         } catch (IOException e) {
             throw new RuntimeException("Failed to create temporary checkpoint directory", e);
         }
+    }
+
+    private static MiniClusterResourceConfiguration defaultMiniClusterResourceConfiguration() {
+        Configuration conf = new Configuration();
+        conf.set(METRIC_FETCHER_UPDATE_INTERVAL, METRIC_FETCHER_UPDATE_INTERVAL_MS);
+        return new MiniClusterResourceConfiguration.Builder()
+                .setConfiguration(conf)
+                .setNumberTaskManagers(1)
+                .setNumberSlotsPerTaskManager(6)
+                .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+                .withHaLeadershipControl()
+                .build();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Connector tests can need to set a different configuration from the default one.

## Brief change log

TRIVIAL. See the diff.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
