### PR TITLE
Revert "[FLINK-28046][connectors] Mark SourceFunction interface as @deprecated"

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -94,11 +94,7 @@ import java.io.Serializable;
  * SourceContext#emitWatermark(Watermark)}.
  *
  * @param <T> The type of the elements produced by this source.
- * @deprecated This interface will be removed in future versions. Use the new {@link
- *     org.apache.flink.api.connector.source.Source} interface instead. NOTE: All sub-tasks from
- *     FLINK-28045 must be closed before this API can be completely removed.
  */
-@Deprecated
 @Public
 public interface SourceFunction<T> extends Function, Serializable {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR reverts commit 07bf511a32b525f94d258daec347cf777b31bebb, which marks SourceFunction interface as @deprecated.

We need to resolve all subtasks in FLINK-28045 and then deprecated SourceFunction interface.

## Brief change log

reverts commit 07bf511a32b525f94d258daec347cf777b31bebb

## Verifying this change

This change is a revert without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
