### PR TITLE
[hotfix][streaming] Reactive sanity check for windowOperator's mergeable state.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -240,15 +240,10 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
             // store a typed reference for the state of merging windows - sanity check
             if (windowState instanceof InternalMergingState) {
                 windowMergingState = (InternalMergingState<K, W, IN, ACC, ACC>) windowState;
+            } else if (windowState != null) {
+                throw new IllegalStateException(
+                        "The window uses a merging assigner, but the window state is not mergeable.");
             }
-            // TODO this sanity check should be here, but is prevented by an incorrect test (pending
-            // validation)
-            // TODO see WindowOperatorTest.testCleanupTimerWithEmptyFoldingStateForSessionWindows()
-            // TODO activate the sanity check once resolved
-            //			else if (windowState != null) {
-            //				throw new IllegalStateException(
-            //						"The window uses a merging assigner, but the window state is not mergeable.");
-            //			}
 
             @SuppressWarnings("unchecked")
             final Class<Tuple2<W, W>> typedTuple = (Class<Tuple2<W, W>>) (Class<?>) Tuple2.class;


### PR DESCRIPTION
## What is the purpose of the change

*Reactive sanity check for windowOperator's mergeable state.*


## Brief change log

  - *Remove todo in windowOperator.*
  - *Reactive sanity check for windowOperator's mergeable state.*


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
