### PR TITLE
[FLINK-7129]Support dynamically changing CEP patterns

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/PatternProcessFunction.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/functions/PatternProcessFunction.java
@@ -20,6 +20,8 @@ package org.apache.flink.cep.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.cep.listen.CepListener;
+import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.time.TimeContext;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
@@ -43,6 +45,36 @@ import java.util.Map;
  */
 @PublicEvolving
 public abstract class PatternProcessFunction<IN, OUT> extends AbstractRichFunction {
+
+    //	--------------------
+    private Boolean flagNeedListern = false;
+
+    private CepListener<IN> listerner = null;
+
+    public Boolean getFlagNeedListern() {
+        return flagNeedListern;
+    }
+    /**
+     * @Description: 用于注册一个监听对象，需要实现，什么数据触发规则改变，以及规则如何改变方法
+     *
+     * @param: [listern]
+     * @return: void
+     * @auther: greenday
+     * @date: 2019/9/9 10:28
+     */
+    public void registerListener(CepListener<IN> listerner) {
+        flagNeedListern = true;
+        this.listerner = listerner;
+    }
+
+    public Pattern getNewPattern(IN flagElement) {
+        return listerner.returnPattern(flagElement);
+    }
+
+    public Boolean needchange(IN element) {
+        return listerner.needChange(element);
+    }
+    //	----------------------
 
     /**
      * Generates resulting elements given a map of detected pattern events. The events are

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/listen/CepListener.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/listen/CepListener.java
@@ -1,0 +1,29 @@
+package org.apache.flink.cep.listen;
+
+import org.apache.flink.cep.pattern.Pattern;
+
+import java.io.Serializable;
+
+/**
+ * @title:
+ * @author: zhangyf
+ * @date: 2023/7/19 15:50
+ */
+public interface CepListener<T> extends Serializable {
+
+    /**
+     * @Description: 留给用户判断当接受到元素的时候，是否需要更新CEP逻辑
+     *
+     * @param element
+     * @return java.lang.Boolean
+     */
+    Boolean needChange(T element);
+
+    /**
+     * @Description: 当needChange为true时会被调用，留给用户实现返回一个新逻辑生成的pattern对象
+     *
+     * @param flagElement
+     * @return org.apache.flink.cep.pattern.Pattern
+     */
+    Pattern<T, ?> returnPattern(T flagElement);
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -87,7 +87,9 @@ public class NFA<T> {
      * A set of all the valid NFA states, as returned by the {@link NFACompiler NFACompiler}. These
      * are directly derived from the user-specified pattern.
      */
-    private final Map<String, State<T>> states;
+    //	因为需要动态修改所以改为 去掉final ->
+    private Map<String, State<T>> states;
+    // private final Map<String, State<T>> states;
 
     /**
      * The lengths of a windowed pattern, as specified using the {@link

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -139,7 +139,8 @@ public class NFACompiler {
      *
      * @param <T>
      */
-    static class NFAFactoryCompiler<T> {
+    //	修改default->public
+    public static class NFAFactoryCompiler<T> {
 
         private final NFAStateNameHandler stateNameHandler = new NFAStateNameHandler();
         private final Map<String, State<T>> stopStates = new HashMap<>();
@@ -154,7 +155,8 @@ public class NFACompiler {
         private final AfterMatchSkipStrategy afterMatchSkipStrategy;
         private Map<String, State<T>> originalStateMap = new HashMap<>();
 
-        NFAFactoryCompiler(final Pattern<T, ?> pattern) {
+        //	修改default->public
+        public NFAFactoryCompiler(final Pattern<T, ?> pattern) {
             this.currentPattern = pattern;
             afterMatchSkipStrategy = pattern.getAfterMatchSkipStrategy();
             windowTime = Optional.empty();
@@ -164,7 +166,8 @@ public class NFACompiler {
          * Compiles the given pattern into a {@link NFAFactory}. The NFA factory can be used to
          * create multiple NFAs.
          */
-        void compileFactory() {
+        //	修改default->public
+        public void compileFactory() {
 
             Pattern<T, ?> lastPattern = currentPattern;
 
@@ -197,15 +200,17 @@ public class NFACompiler {
             return afterMatchSkipStrategy;
         }
 
-        List<State<T>> getStates() {
+        //  修改default->public
+        public List<State<T>> getStates() {
             return states;
         }
 
-        long getWindowTime() {
+        // 修改default->public
+        public long getWindowTime() {
             return windowTime.orElse(0L);
         }
 
-        Map<String, Long> getWindowTimes() {
+        public Map<String, Long> getWindowTimes() {
             return windowTimes;
         }
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
@@ -92,6 +92,22 @@ public class SharedBuffer<V> {
 
     private final Timer cacheStatisticsTimer;
 
+    /**
+     * @Description: 用于清理以前的状态
+     *
+     * @param: []
+     * @return: void
+     * @auther: zhangyf
+     * @date: 2023/7/17 10:42
+     */
+    public void clean() {
+        eventsBuffer.clear();
+        eventsBufferCache.cleanUp();
+        entryCache.cleanUp();
+        eventsCount.clear();
+        entries.clear();
+    }
+
     @VisibleForTesting
     public SharedBuffer(KeyedStateStore stateStore, TypeSerializer<V> valueSerializer) {
         this(stateStore, valueSerializer, new SharedBufferCacheConfig());

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPTest.java
@@ -1,0 +1,183 @@
+package org.apache.flink.cep;
+
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.cep.listen.CepListener;
+import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
+import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.time.Time;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * @title:
+ * @author: zhangyf
+ * @date: 2023/7/19 16:09
+ */
+public class CEPTest {
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        //		数据源
+        SingleOutputStreamOperator<Tuple3<String, Long, String>> source =
+                env.fromElements(
+                                new Tuple3<String, Long, String>("a", 1000000001000L, "22"),
+                                new Tuple3<String, Long, String>("b", 1000000002000L, "23"),
+                                new Tuple3<String, Long, String>("c", 1000000003000L, "23"),
+                                new Tuple3<String, Long, String>("d", 1000000003000L, "23"),
+                                new Tuple3<String, Long, String>("change", 1000000003001L, "23"),
+                                new Tuple3<String, Long, String>("e", 1000000004000L, "24"),
+                                new Tuple3<String, Long, String>("f", 1000000005000L, "23"),
+                                new Tuple3<String, Long, String>("g", 1000000006000L, "23"))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy
+                                        .<Tuple3<String, Long, String>>forMonotonousTimestamps()
+                                        .withTimestampAssigner(
+                                                new SerializableTimestampAssigner<
+                                                        Tuple3<String, Long, String>>() {
+                                                    @Override
+                                                    public long extractTimestamp(
+                                                            Tuple3<String, Long, String> element,
+                                                            long recordTimestamp) {
+                                                        return element.f1;
+                                                    }
+                                                }));
+
+        Pattern<Tuple3<String, Long, String>, Tuple3<String, Long, String>> initPattern =
+                Pattern.<Tuple3<String, Long, String>>begin("start")
+                        .where(
+                                new RichIterativeCondition<Tuple3<String, Long, String>>() {
+                                    @Override
+                                    public boolean filter(
+                                            Tuple3<String, Long, String> value,
+                                            IterativeCondition.Context<Tuple3<String, Long, String>>
+                                                    ctx)
+                                            throws Exception {
+                                        return value.f0.equals("a");
+                                    }
+                                })
+                        .next("middle")
+                        .where(
+                                new RichIterativeCondition<Tuple3<String, Long, String>>() {
+                                    @Override
+                                    public boolean filter(
+                                            Tuple3<String, Long, String> value,
+                                            IterativeCondition.Context<Tuple3<String, Long, String>>
+                                                    ctx)
+                                            throws Exception {
+                                        return value.f0.equals("b");
+                                    }
+                                })
+                        .within(Time.minutes(5));
+
+        PatternStream patternStream = CEP.pattern(source, initPattern);
+
+        PatternStream patternstream =
+                patternStream
+                        //	Pattern 更新逻辑
+                        .registerListener(
+                        new CepListener<Tuple3<String, Long, String>>() {
+                            @Override
+                            public Boolean needChange(Tuple3<String, Long, String> element) {
+                                return element.f0.equals("change");
+                            }
+
+                            @Override
+                            public Pattern returnPattern(Tuple3<String, Long, String> flagElement) {
+                                System.out.println("接收到更新数据:" + flagElement.toString() + "感知到切换逻辑");
+                                Pattern<Tuple3<String, Long, String>, ?> pattern =
+                                        Pattern.<Tuple3<String, Long, String>>begin("start")
+                                                .where(
+                                                        new RichIterativeCondition<
+                                                                Tuple3<String, Long, String>>() {
+                                                            @Override
+                                                            public boolean filter(
+                                                                    Tuple3<String, Long, String>
+                                                                            value,
+                                                                    IterativeCondition.Context<
+                                                                                    Tuple3<
+                                                                                            String,
+                                                                                            Long,
+                                                                                            String>>
+                                                                            ctx)
+                                                                    throws Exception {
+                                                                return value.f0.equals("e");
+                                                            }
+                                                        })
+                                                .next("middle")
+                                                .where(
+                                                        new RichIterativeCondition<
+                                                                Tuple3<String, Long, String>>() {
+                                                            @Override
+                                                            public boolean filter(
+                                                                    Tuple3<String, Long, String>
+                                                                            value,
+                                                                    IterativeCondition.Context<
+                                                                                    Tuple3<
+                                                                                            String,
+                                                                                            Long,
+                                                                                            String>>
+                                                                            ctx)
+                                                                    throws Exception {
+                                                                return value.f0.equals("f");
+                                                            }
+                                                        })
+                                                .next("end")
+                                                .where(
+                                                        new RichIterativeCondition<
+                                                                Tuple3<String, Long, String>>() {
+                                                            @Override
+                                                            public boolean filter(
+                                                                    Tuple3<String, Long, String>
+                                                                            value,
+                                                                    IterativeCondition.Context<
+                                                                                    Tuple3<
+                                                                                            String,
+                                                                                            Long,
+                                                                                            String>>
+                                                                            ctx)
+                                                                    throws Exception {
+                                                                return value.f0.equals("g");
+                                                            }
+                                                        })
+                                                .within(Time.minutes(5));
+                                return pattern;
+                            }
+                        });
+
+        patternstream
+                .select(
+                        new RichPatternSelectFunction<
+                                Tuple3<String, Long, String>, Tuple3<String, String, String>>() {
+                            @Override
+                            public Tuple3 select(Map pattern) throws Exception {
+                                String start =
+                                        pattern.containsKey("start")
+                                                ? ((ArrayList) pattern.get("start"))
+                                                        .get(0)
+                                                        .toString()
+                                                : "";
+                                String middle =
+                                        pattern.containsKey("middle")
+                                                ? ((ArrayList) pattern.get("middle"))
+                                                        .get(0)
+                                                        .toString()
+                                                : "";
+                                String end =
+                                        pattern.containsKey("end")
+                                                ? ((ArrayList) pattern.get("end")).get(0).toString()
+                                                : "";
+                                System.out.println("end" + end);
+                                return new Tuple3<String, String, String>(start, middle, end);
+                            }
+                        })
+                .print();
+
+        env.execute("dynamic cep pattern");
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/DynamicSlidingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/DynamicSlidingEventTimeWindows.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.DynamicEventTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link WindowAssigner} that windows elements into sliding windows based on the timestamp of the
+ * elements. Windows can possibly overlap.
+ *
+ * <p>For example, in order to window into windows of 1 minute, every 10 seconds:
+ *
+ * <pre>{@code
+ * DataStream<Tuple2<String, Integer>> in = ...;
+ * KeyedStream<Tuple2<String, Integer>, String> keyed = in.keyBy(...);
+ * WindowedStream<Tuple2<String, Integer>, String, TimeWindow> windowed =
+ *   keyed.window(SlidingEventTimeWindows.of(Time.minutes(1), Time.seconds(10)));
+ * }</pre>
+ */
+@PublicEvolving
+public class DynamicSlidingEventTimeWindows<T> extends WindowAssigner<T, TimeWindow> {
+    private static final long serialVersionUID = 1L;
+
+    private final long size;
+
+    private final long slide;
+
+    private final long offset;
+
+    // 从原始数据中获取窗口长度
+    private final TimeAdjustExtractor<T> sizeTimeAdjustExtractor;
+    // 从原始数据中获取窗口步长
+    private final TimeAdjustExtractor<T> slideTimeAdjustExtractor;
+
+    protected DynamicSlidingEventTimeWindows(long size, long slide, long offset) {
+        if (Math.abs(offset) >= slide || size <= 0) {
+            throw new IllegalArgumentException(
+                    "DynamicSlidingEventTimeWindows parameters must satisfy "
+                            + "abs(offset) < slide and size > 0");
+        }
+
+        this.size = size;
+        this.slide = slide;
+        this.offset = offset;
+        this.sizeTimeAdjustExtractor = (element) -> 0;
+        this.slideTimeAdjustExtractor = (element) -> 0;
+    }
+
+    public DynamicSlidingEventTimeWindows(
+            long size,
+            long offset,
+            long slide,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        if (Math.abs(offset) >= slide || size <= 0) {
+            throw new IllegalArgumentException(
+                    "DynamicSlidingEventTimeWindows parameters must satisfy "
+                            + "abs(offset) < slide and size > 0");
+        }
+        this.size = size;
+        this.offset = offset;
+        this.slide = slide;
+        this.sizeTimeAdjustExtractor = sizeTimeAdjustExtractor;
+        this.slideTimeAdjustExtractor = slideTimeAdjustExtractor;
+    }
+
+    @Override
+    public Collection<TimeWindow> assignWindows(
+            T element, long timestamp, WindowAssignerContext context) {
+        long realSize = this.sizeTimeAdjustExtractor.extract(element);
+        long realSlide = this.slideTimeAdjustExtractor.extract(element);
+        if (timestamp > Long.MIN_VALUE) {
+            List<TimeWindow> windows =
+                    new ArrayList(
+                            (int)
+                                    ((realSize == 0 ? size : realSize)
+                                            / (realSlide == 0 ? slide : realSlide)));
+            long lastStart =
+                    TimeWindow.getWindowStartWithOffset(
+                            timestamp, this.offset, (realSlide == 0 ? slide : realSlide));
+            for (long start = lastStart;
+                    start > timestamp - (realSize == 0 ? size : realSize);
+                    start -= (realSlide == 0 ? slide : realSlide)) {
+                windows.add(new TimeWindow(start, start + (realSize == 0 ? size : realSize)));
+            }
+            return windows;
+        } else {
+            throw new RuntimeException(
+                    "Record has Long.MIN_VALUE timestamp (= no timestamp marker). "
+                            + "Is the time characteristic set to 'ProcessingTime', or did you forget to call "
+                            + "'DataStream.assignTimestampsAndWatermarks(...)'?");
+        }
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getSlide() {
+        return slide;
+    }
+
+    @Override
+    public Trigger<T, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+        return DynamicEventTimeTrigger.<T>create();
+    }
+
+    @Override
+    public String toString() {
+        return "DynamicSlidingEventTimeWindows(" + size + ", " + slide + ")";
+    }
+
+    /**
+     * Creates a new {@code SlidingEventTimeWindows} {@link WindowAssigner} that assigns elements to
+     * sliding time windows based on the element timestamp.
+     *
+     * @param size The size of the generated windows.
+     * @param slide The slide interval of the generated windows.
+     * @return The time policy.
+     */
+    public static DynamicSlidingEventTimeWindows of(Time size, Time slide) {
+        return new DynamicSlidingEventTimeWindows(size.toMilliseconds(), slide.toMilliseconds(), 0);
+    }
+
+    /**
+     * Creates a new {@code SlidingEventTimeWindows} {@link WindowAssigner} that assigns elements to
+     * time windows based on the element timestamp and offset.
+     *
+     * <p>For example, if you want window a stream by hour,but window begins at the 15th minutes of
+     * each hour, you can use {@code of(Time.hours(1),Time.minutes(15))},then you will get time
+     * windows start at 0:15:00,1:15:00,2:15:00,etc.
+     *
+     * <p>Rather than that,if you are living in somewhere which is not using UTC±00:00 time, such as
+     * China which is using UTC+08:00,and you want a time window with size of one day, and window
+     * begins at every 00:00:00 of local time,you may use {@code of(Time.days(1),Time.hours(-8))}.
+     * The parameter of offset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than
+     * UTC time.
+     *
+     * @param size The size of the generated windows.
+     * @param slide The slide interval of the generated windows.
+     * @param offset The offset which window start would be shifted by.
+     * @return The time policy.
+     */
+    public static DynamicSlidingEventTimeWindows of(Time size, Time slide, Time offset) {
+        return new DynamicSlidingEventTimeWindows(
+                size.toMilliseconds(), slide.toMilliseconds(), offset.toMilliseconds());
+    }
+
+    public static <T> DynamicSlidingEventTimeWindows<T> of(
+            Time size,
+            Time slide,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        return new DynamicSlidingEventTimeWindows<T>(
+                size.toMilliseconds(),
+                slide.toMilliseconds(),
+                0,
+                sizeTimeAdjustExtractor,
+                slideTimeAdjustExtractor);
+    }
+
+    public static <T> DynamicSlidingEventTimeWindows<T> of(
+            Time size,
+            Time slide,
+            Time offset,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        return new DynamicSlidingEventTimeWindows<T>(
+                size.toMilliseconds(),
+                slide.toMilliseconds(),
+                offset.toMilliseconds(),
+                sizeTimeAdjustExtractor,
+                slideTimeAdjustExtractor);
+    }
+
+    @Override
+    public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+        return new TimeWindow.Serializer();
+    }
+
+    @Override
+    public boolean isEventTime() {
+        return true;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/DynamicSlidingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/DynamicSlidingProcessingTimeWindows.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.triggers.DynamicProcessingTimeTrigger;
+import org.apache.flink.streaming.api.windowing.triggers.Trigger;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link WindowAssigner} that windows elements into sliding windows based on the current system
+ * time of the machine the operation is running on. Windows can possibly overlap.
+ *
+ * <p>For example, in order to window into windows of 1 minute, every 10 seconds:
+ *
+ * <pre>{@code
+ * DataStream<Tuple2<String, Integer>> in = ...;
+ * KeyedStream<String, Tuple2<String, Integer>> keyed = in.keyBy(...);
+ * WindowedStream<Tuple2<String, Integer>, String, TimeWindows> windowed =
+ *   keyed.window(SlidingProcessingTimeWindows.of(Time.of(1, MINUTES), Time.of(10, SECONDS));
+ * }</pre>
+ */
+public class DynamicSlidingProcessingTimeWindows<T> extends WindowAssigner<T, TimeWindow> {
+    private static final long serialVersionUID = 1L;
+
+    private final long size;
+
+    private final long offset;
+
+    private final long slide;
+
+    // 从原始数据中获取窗口长度
+    private final TimeAdjustExtractor<T> sizeTimeAdjustExtractor;
+    // 从原始数据中获取窗口步长
+    private final TimeAdjustExtractor<T> slideTimeAdjustExtractor;
+
+    private DynamicSlidingProcessingTimeWindows(long size, long slide, long offset) {
+        if (Math.abs(offset) >= slide || size <= 0) {
+            throw new IllegalArgumentException(
+                    "DynamicSlidingProcessingTimeWindows parameters must satisfy "
+                            + "abs(offset) < slide and size > 0");
+        }
+
+        this.size = size;
+        this.slide = slide;
+        this.offset = offset;
+        this.sizeTimeAdjustExtractor = (element) -> 0;
+        this.slideTimeAdjustExtractor = (element) -> 0;
+    }
+
+    public DynamicSlidingProcessingTimeWindows(
+            long size,
+            long offset,
+            long slide,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        if (Math.abs(offset) >= slide || size <= 0) {
+            throw new IllegalArgumentException(
+                    "DynamicSlidingProcessingTimeWindows parameters must satisfy "
+                            + "abs(offset) < slide and size > 0");
+        }
+
+        this.size = size;
+        this.offset = offset;
+        this.slide = slide;
+        this.sizeTimeAdjustExtractor = sizeTimeAdjustExtractor;
+        this.slideTimeAdjustExtractor = slideTimeAdjustExtractor;
+    }
+
+    @Override
+    public Collection<TimeWindow> assignWindows(
+            T element, long timestamp, WindowAssignerContext context) {
+        timestamp = context.getCurrentProcessingTime();
+        long realSize = this.sizeTimeAdjustExtractor.extract(element);
+        long realSlide = this.slideTimeAdjustExtractor.extract(element);
+        List<TimeWindow> windows =
+                new ArrayList(
+                        (int)
+                                ((realSize == 0 ? size : realSize)
+                                        / (realSlide == 0 ? slide : realSlide)));
+        long lastStart =
+                TimeWindow.getWindowStartWithOffset(
+                        timestamp, this.offset, (realSlide == 0 ? slide : realSlide));
+        for (long start = lastStart;
+                start > timestamp - (realSize == 0 ? size : realSize);
+                start -= (realSlide == 0 ? slide : realSlide)) {
+            windows.add(new TimeWindow(start, start + (realSize == 0 ? size : realSize)));
+        }
+        return windows;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getSlide() {
+        return slide;
+    }
+
+    @Override
+    public Trigger<T, TimeWindow> getDefaultTrigger(StreamExecutionEnvironment env) {
+        return DynamicProcessingTimeTrigger.<T>create();
+    }
+
+    @Override
+    public String toString() {
+        return "DynamicSlidingProcessingTimeWindows(" + size + ", " + slide + ")";
+    }
+
+    /**
+     * Creates a new {@code SlidingProcessingTimeWindows} {@link WindowAssigner} that assigns
+     * elements to sliding time windows based on the element timestamp.
+     *
+     * @param size The size of the generated windows.
+     * @param slide The slide interval of the generated windows.
+     * @return The time policy.
+     */
+    public static DynamicSlidingProcessingTimeWindows of(Time size, Time slide) {
+        return new DynamicSlidingProcessingTimeWindows(
+                size.toMilliseconds(), slide.toMilliseconds(), 0);
+    }
+
+    /**
+     * Creates a new {@code SlidingProcessingTimeWindows} {@link WindowAssigner} that assigns
+     * elements to time windows based on the element timestamp and offset.
+     *
+     * <p>For example, if you want window a stream by hour,but window begins at the 15th minutes of
+     * each hour, you can use {@code of(Time.hours(1),Time.minutes(15))},then you will get time
+     * windows start at 0:15:00,1:15:00,2:15:00,etc.
+     *
+     * <p>Rather than that,if you are living in somewhere which is not using UTC±00:00 time, such as
+     * China which is using UTC+08:00,and you want a time window with size of one day, and window
+     * begins at every 00:00:00 of local time,you may use {@code of(Time.days(1),Time.hours(-8))}.
+     * The parameter of offset is {@code Time.hours(-8))} since UTC+08:00 is 8 hours earlier than
+     * UTC time.
+     *
+     * @param size The size of the generated windows.
+     * @param slide The slide interval of the generated windows.
+     * @param offset The offset which window start would be shifted by.
+     * @return The time policy.
+     */
+    public static DynamicSlidingProcessingTimeWindows of(Time size, Time slide, Time offset) {
+        return new DynamicSlidingProcessingTimeWindows(
+                size.toMilliseconds(), slide.toMilliseconds(), offset.toMilliseconds());
+    }
+
+    public static <T> DynamicSlidingProcessingTimeWindows<T> of(
+            Time size,
+            Time slide,
+            Time offset,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        return new DynamicSlidingProcessingTimeWindows<T>(
+                size.toMilliseconds(),
+                slide.toMilliseconds(),
+                offset.toMilliseconds(),
+                sizeTimeAdjustExtractor,
+                slideTimeAdjustExtractor);
+    }
+
+    public static <T> DynamicSlidingProcessingTimeWindows<T> of(
+            Time size,
+            Time slide,
+            TimeAdjustExtractor<T> sizeTimeAdjustExtractor,
+            TimeAdjustExtractor<T> slideTimeAdjustExtractor) {
+        return new DynamicSlidingProcessingTimeWindows<T>(
+                size.toMilliseconds(),
+                slide.toMilliseconds(),
+                0,
+                sizeTimeAdjustExtractor,
+                slideTimeAdjustExtractor);
+    }
+
+    @Override
+    public TypeSerializer<TimeWindow> getWindowSerializer(ExecutionConfig executionConfig) {
+        return new TimeWindow.Serializer();
+    }
+
+    @Override
+    public boolean isEventTime() {
+        return false;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TimeAdjustExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TimeAdjustExtractor.java
@@ -1,0 +1,12 @@
+package org.apache.flink.streaming.api.windowing.assigners;
+
+import java.io.Serializable;
+
+/**
+ * @title:
+ * @author: zhangyf
+ * @date: 2023/7/19 13:24
+ */
+public interface TimeAdjustExtractor<T> extends Serializable {
+    long extract(T element);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DynamicEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DynamicEventTimeTrigger.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.triggers;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+/**
+ * A {@link Trigger} that fires once the watermark passes the end of the window to which a pane
+ * belongs.
+ *
+ * @see org.apache.flink.streaming.api.watermark.Watermark
+ */
+@PublicEvolving
+public class DynamicEventTimeTrigger<T> extends Trigger<T, TimeWindow> {
+    private static final long serialVersionUID = 1L;
+
+    private DynamicEventTimeTrigger() {}
+
+    @Override
+    public TriggerResult onElement(T element, long timestamp, TimeWindow window, TriggerContext ctx)
+            throws Exception {
+        if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
+            // if the watermark is already past the window fire immediately
+            return TriggerResult.FIRE;
+        } else {
+            ctx.registerEventTimeTimer(window.maxTimestamp());
+            return TriggerResult.CONTINUE;
+        }
+    }
+
+    @Override
+    public TriggerResult onEventTime(long time, TimeWindow window, TriggerContext ctx) {
+        return time == window.maxTimestamp() ? TriggerResult.FIRE : TriggerResult.CONTINUE;
+    }
+
+    @Override
+    public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx)
+            throws Exception {
+        return TriggerResult.CONTINUE;
+    }
+
+    @Override
+    public void clear(TimeWindow window, TriggerContext ctx) throws Exception {
+        ctx.deleteEventTimeTimer(window.maxTimestamp());
+    }
+
+    @Override
+    public boolean canMerge() {
+        return true;
+    }
+
+    @Override
+    public void onMerge(TimeWindow window, OnMergeContext ctx) {
+        // only register a timer if the watermark is not yet past the end of the merged window
+        // this is in line with the logic in onElement(). If the watermark is past the end of
+        // the window onElement() will fire and setting a timer here would fire the window twice.
+        long windowMaxTimestamp = window.maxTimestamp();
+        if (windowMaxTimestamp > ctx.getCurrentWatermark()) {
+            ctx.registerEventTimeTimer(windowMaxTimestamp);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "EventTimeTrigger()";
+    }
+
+    /**
+     * Creates an event-time trigger that fires once the watermark passes the end of the window.
+     *
+     * <p>Once the trigger fires all elements are discarded. Elements that arrive late immediately
+     * trigger window evaluation with just this one element.
+     */
+    public static <T> DynamicEventTimeTrigger<T> create() {
+        return new DynamicEventTimeTrigger<>();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DynamicProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DynamicProcessingTimeTrigger.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.triggers;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+/**
+ * A {@link Trigger} that fires once the current system time passes the end of the window to which a
+ * pane belongs.
+ */
+@PublicEvolving
+public class DynamicProcessingTimeTrigger<T> extends Trigger<T, TimeWindow> {
+    private static final long serialVersionUID = 1L;
+
+    private DynamicProcessingTimeTrigger() {}
+
+    @Override
+    public TriggerResult onElement(
+            T element, long timestamp, TimeWindow window, TriggerContext ctx) {
+        ctx.registerProcessingTimeTimer(window.maxTimestamp());
+        return TriggerResult.CONTINUE;
+    }
+
+    @Override
+    public TriggerResult onEventTime(long time, TimeWindow window, TriggerContext ctx)
+            throws Exception {
+        return TriggerResult.CONTINUE;
+    }
+
+    @Override
+    public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx) {
+        return TriggerResult.FIRE;
+    }
+
+    @Override
+    public void clear(TimeWindow window, TriggerContext ctx) throws Exception {
+        ctx.deleteProcessingTimeTimer(window.maxTimestamp());
+    }
+
+    @Override
+    public boolean canMerge() {
+        return true;
+    }
+
+    @Override
+    public void onMerge(TimeWindow window, OnMergeContext ctx) {
+        // only register a timer if the time is not yet past the end of the merged window
+        // this is in line with the logic in onElement(). If the time is past the end of
+        // the window onElement() will fire and setting a timer here would fire the window twice.
+        long windowMaxTimestamp = window.maxTimestamp();
+        if (windowMaxTimestamp > ctx.getCurrentProcessingTime()) {
+            ctx.registerProcessingTimeTimer(windowMaxTimestamp);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ProcessingTimeTrigger()";
+    }
+
+    /** Creates a new trigger that fires once system time passes the end of the window. */
+    public static <T> DynamicProcessingTimeTrigger<T> create() {
+        return new DynamicProcessingTimeTrigger<>();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When using CEP as a complex event processing engine, when the logic is frequently modified and the threshold is frequently adjusted, the entire program needs to be stopped, the code should be modified, the program should be repackaged, and then submitted to the cluster. Dynamic logic modification and external dynamic injection cannot be realized. Currently, Realized the dynamic injection of CEP logic, based on message-driven logic modification, you can manually inject specific messages into the source end to achieve fine-grained control of logic injection perception


## Verifying this change

-

*(example:)*
```java
    public static void main(String[] args) throws Exception {
        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
        env.setParallelism(1);
        //		数据源
        SingleOutputStreamOperator<Tuple3<String, Long, String>> source =
                env.fromElements(
                                new Tuple3<String, Long, String>("a", 1000000001000L, "22"),
                                new Tuple3<String, Long, String>("b", 1000000002000L, "23"),
                                new Tuple3<String, Long, String>("c", 1000000003000L, "23"),
                                new Tuple3<String, Long, String>("d", 1000000003000L, "23"),
                                new Tuple3<String, Long, String>("change", 1000000003001L, "23"),
                                new Tuple3<String, Long, String>("e", 1000000004000L, "24"),
                                new Tuple3<String, Long, String>("f", 1000000005000L, "23"),
                                new Tuple3<String, Long, String>("g", 1000000006000L, "23"))
                        .assignTimestampsAndWatermarks(
                                WatermarkStrategy
                                        .<Tuple3<String, Long, String>>forMonotonousTimestamps()
                                        .withTimestampAssigner(
                                                new SerializableTimestampAssigner<
                                                        Tuple3<String, Long, String>>() {
                                                    @Override
                                                    public long extractTimestamp(
                                                            Tuple3<String, Long, String> element,
                                                            long recordTimestamp) {
                                                        return element.f1;
                                                    }
                                                }));

        Pattern<Tuple3<String, Long, String>, Tuple3<String, Long, String>> initPattern =
                Pattern.<Tuple3<String, Long, String>>begin("start")
                        .where(
                                new RichIterativeCondition<Tuple3<String, Long, String>>() {
                                    @Override
                                    public boolean filter(
                                            Tuple3<String, Long, String> value,
                                            IterativeCondition.Context<Tuple3<String, Long, String>>
                                                    ctx)
                                            throws Exception {
                                        return value.f0.equals("a");
                                    }
                                })
                        .next("middle")
                        .where(
                                new RichIterativeCondition<Tuple3<String, Long, String>>() {
                                    @Override
                                    public boolean filter(
                                            Tuple3<String, Long, String> value,
                                            IterativeCondition.Context<Tuple3<String, Long, String>>
                                                    ctx)
                                            throws Exception {
                                        return value.f0.equals("b");
                                    }
                                })
                        .within(Time.minutes(5));

        PatternStream patternStream = CEP.pattern(source, initPattern);

        PatternStream patternstream =
                patternStream
                        //	Pattern 更新逻辑
                        .registerListener(
                        new CepListener<Tuple3<String, Long, String>>() {
                            @Override
                            public Boolean needChange(Tuple3<String, Long, String> element) {
                                return element.f0.equals("change");
                            }

                            @Override
                            public Pattern returnPattern(Tuple3<String, Long, String> flagElement) {
                                System.out.println("接收到更新数据:" + flagElement.toString() + "感知到切换逻辑");
                                Pattern<Tuple3<String, Long, String>, ?> pattern =
                                        Pattern.<Tuple3<String, Long, String>>begin("start")
                                                .where(
                                                        new RichIterativeCondition<
                                                                Tuple3<String, Long, String>>() {
                                                            @Override
                                                            public boolean filter(
                                                                    Tuple3<String, Long, String>
                                                                            value,
                                                                    IterativeCondition.Context<
                                                                                    Tuple3<
                                                                                            String,
                                                                                            Long,
                                                                                            String>>
                                                                            ctx)
                                                                    throws Exception {
                                                                return value.f0.equals("e");
                                                            }
                                                        })
                                                .next("middle")
                                                .where(
                                                        new RichIterativeCondition<
                                                                Tuple3<String, Long, String>>() {
                                                            @Override
                                                            public boolean filter(
                                                                    Tuple3<String, Long, String>
                                                                            value,
                                                                    IterativeCondition.Context<
                                                                                    Tuple3<
                                                                                            String,
                                                                                            Long,
                                                                                            String>>
                                                                            ctx)
                                                                    throws Exception {
                                                                return value.f0.equals("f");
                                                            }
                                                        })
                                                .next("end")
                                                .where(
                                                        new RichIterativeCondition<
                                                                Tuple3<String, Long, String>>() {
                                                            @Override
                                                            public boolean filter(
                                                                    Tuple3<String, Long, String>
                                                                            value,
                                                                    IterativeCondition.Context<
                                                                                    Tuple3<
                                                                                            String,
                                                                                            Long,
                                                                                            String>>
                                                                            ctx)
                                                                    throws Exception {
                                                                return value.f0.equals("g");
                                                            }
                                                        })
                                                .within(Time.minutes(5));
                                return pattern;
                            }
                        });

        patternstream
                .select(
                        new RichPatternSelectFunction<
                                Tuple3<String, Long, String>, Tuple3<String, String, String>>() {
                            @Override
                            public Tuple3 select(Map pattern) throws Exception {
                                String start =
                                        pattern.containsKey("start")
                                                ? ((ArrayList) pattern.get("start"))
                                                        .get(0)
                                                        .toString()
                                                : "";
                                String middle =
                                        pattern.containsKey("middle")
                                                ? ((ArrayList) pattern.get("middle"))
                                                        .get(0)
                                                        .toString()
                                                : "";
                                String end =
                                        pattern.containsKey("end")
                                                ? ((ArrayList) pattern.get("end")).get(0).toString()
                                                : "";
                                System.out.println("end" + end);
                                return new Tuple3<String, String, String>(start, middle, end);
                            }
                        })
                .print();

        env.execute("dynamic cep pattern");
    }
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)

