### PR TITLE
[FLINK-32616][jdbc-driver] Close result for non-query in executeQuery

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
@@ -68,6 +68,13 @@ public class FlinkConnection extends BaseConnection {
         driverUri.getDatabase().ifPresent(this::setSessionSchema);
     }
 
+    @VisibleForTesting
+    FlinkConnection(Executor executor) {
+        this.url = null;
+        this.statements = new ArrayList<>();
+        this.executor = executor;
+    }
+
     @Override
     public Statement createStatement() throws SQLException {
         ensureOpen();

--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkStatement.java
@@ -57,6 +57,7 @@ public class FlinkStatement extends BaseStatement {
     public ResultSet executeQuery(String sql) throws SQLException {
         StatementResult result = executeInternal(sql);
         if (!result.isQueryResult()) {
+            result.close();
             throw new SQLException(String.format("Statement[%s] is not a query.", sql));
         }
         currentResults = new FlinkResultSet(this, result);

--- a/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
+++ b/flink-table/flink-sql-jdbc-driver/src/test/java/org/apache/flink/table/jdbc/FlinkStatementTest.java
@@ -18,6 +18,14 @@
 
 package org.apache.flink.table.jdbc;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.StatementResult;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.CloseableIterator;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,6 +36,9 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -141,5 +152,74 @@ public class FlinkStatementTest extends FlinkJdbcDriverTestBase {
         assertTrue(statement1.isClosed());
         assertTrue(statement2.isClosed());
         assertTrue(statement3.isClosed());
+    }
+
+    @Test
+    public void testCloseNonQuery() throws Exception {
+        CompletableFuture<Void> closedFuture = new CompletableFuture<>();
+        try (FlinkConnection connection = new FlinkConnection(new TestingExecutor(closedFuture))) {
+            try (Statement statement = connection.createStatement()) {
+                assertThatThrownBy(() -> statement.executeQuery("INSERT"))
+                        .hasMessage(String.format("Statement[%s] is not a query.", "INSERT"));
+                closedFuture.get(10, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /** Testing executor. */
+    static class TestingExecutor implements Executor {
+        private final CompletableFuture<Void> closedFuture;
+
+        TestingExecutor(CompletableFuture<Void> closedFuture) {
+            this.closedFuture = closedFuture;
+        }
+
+        @Override
+        public void configureSession(String statement) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ReadableConfig getSessionConfig() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getSessionConfigMap() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StatementResult executeStatement(String statement) {
+            return new StatementResult(
+                    null,
+                    new CloseableIterator<RowData>() {
+                        @Override
+                        public void close() throws Exception {
+                            closedFuture.complete(null);
+                        }
+
+                        @Override
+                        public boolean hasNext() {
+                            return false;
+                        }
+
+                        @Override
+                        public RowData next() {
+                            throw new UnsupportedOperationException();
+                        }
+                    },
+                    false,
+                    ResultKind.SUCCESS_WITH_CONTENT,
+                    JobID.generate());
+        }
+
+        @Override
+        public List<String> completeStatement(String statement, int position) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {}
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pr aims to close statement result in FlinkStatement.executeQuery when the statement is not a query sql.

## Brief change log
  - Close statement result when the sql is not query for FlinkStatement.executeQuery

## Verifying this change

This change added tests and can be verified as follows:

  - Added FlinkStatementTest.testCloseNonQuery to validate the statement result is closed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
