### PR TITLE
[FLINK-32418][formats-protobuf] Fix ClassNotFoundException when using protobuf in SQL-Client

### DIFF
--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbDecodingFormat.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbDecodingFormat.java
@@ -30,10 +30,10 @@ import org.apache.flink.table.types.logical.RowType;
 
 /** {@link DecodingFormat} for protobuf decoding. */
 public class PbDecodingFormat implements DecodingFormat<DeserializationSchema<RowData>> {
-    private final PbFormatConfig formatConfig;
+    private final PbFormatContext context;
 
-    public PbDecodingFormat(PbFormatConfig formatConfig) {
-        this.formatConfig = formatConfig;
+    public PbDecodingFormat(PbFormatContext context) {
+        this.context = context;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class PbDecodingFormat implements DecodingFormat<DeserializationSchema<Ro
         final RowType rowType = (RowType) producedDataType.getLogicalType();
         final TypeInformation<RowData> rowDataTypeInfo =
                 context.createTypeInformation(producedDataType);
-        return new PbRowDataDeserializationSchema(rowType, rowDataTypeInfo, formatConfig);
+        return new PbRowDataDeserializationSchema(rowType, rowDataTypeInfo, this.context);
     }
 
     @Override

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbEncodingFormat.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbEncodingFormat.java
@@ -29,10 +29,10 @@ import org.apache.flink.table.types.logical.RowType;
 
 /** {@link EncodingFormat} for protobuf encoding. */
 public class PbEncodingFormat implements EncodingFormat<SerializationSchema<RowData>> {
-    private final PbFormatConfig pbFormatConfig;
+    private final PbFormatContext context;
 
-    public PbEncodingFormat(PbFormatConfig pbFormatConfig) {
-        this.pbFormatConfig = pbFormatConfig;
+    public PbEncodingFormat(PbFormatContext context) {
+        this.context = context;
     }
 
     @Override
@@ -44,6 +44,6 @@ public class PbEncodingFormat implements EncodingFormat<SerializationSchema<RowD
     public SerializationSchema<RowData> createRuntimeEncoder(
             DynamicTableSink.Context context, DataType consumedDataType) {
         RowType rowType = (RowType) consumedDataType.getLogicalType();
-        return new PbRowDataSerializationSchema(rowType, pbFormatConfig);
+        return new PbRowDataSerializationSchema(rowType, this.context);
     }
 }

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatContext.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatContext.java
@@ -22,11 +22,18 @@ package org.apache.flink.formats.protobuf;
 public class PbFormatContext {
     private final PbFormatConfig pbFormatConfig;
 
-    public PbFormatContext(PbFormatConfig pbFormatConfig) {
+    private final ClassLoader classLoader;
+
+    public PbFormatContext(PbFormatConfig pbFormatConfig, ClassLoader classLoader) {
         this.pbFormatConfig = pbFormatConfig;
+        this.classLoader = classLoader;
     }
 
     public PbFormatConfig getPbFormatConfig() {
         return pbFormatConfig;
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
     }
 }

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatFactory.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatFactory.java
@@ -45,14 +45,16 @@ public class PbFormatFactory implements DeserializationFormatFactory, Serializat
     public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
-        return new PbDecodingFormat(buildConfig(formatOptions));
+        return new PbDecodingFormat(
+                new PbFormatContext(buildConfig(formatOptions), context.getClassLoader()));
     }
 
     @Override
     public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
-        return new PbEncodingFormat(buildConfig(formatOptions));
+        return new PbEncodingFormat(
+                new PbFormatContext(buildConfig(formatOptions), context.getClassLoader()));
     }
 
     private static PbFormatConfig buildConfig(ReadableConfig formatOptions) {

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbRowDataDeserializationSchema.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbRowDataDeserializationSchema.java
@@ -20,7 +20,7 @@ package org.apache.flink.formats.protobuf.deserialize;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.formats.protobuf.PbFormatConfig;
+import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.formats.protobuf.util.PbSchemaValidationUtils;
 import org.apache.flink.table.data.RowData;
@@ -44,24 +44,27 @@ public class PbRowDataDeserializationSchema implements DeserializationSchema<Row
 
     private final RowType rowType;
     private final TypeInformation<RowData> resultTypeInfo;
-    private final PbFormatConfig formatConfig;
+    private final PbFormatContext context;
     private transient ProtoToRowConverter protoToRowConverter;
 
     public PbRowDataDeserializationSchema(
-            RowType rowType, TypeInformation<RowData> resultTypeInfo, PbFormatConfig formatConfig) {
+            RowType rowType, TypeInformation<RowData> resultTypeInfo, PbFormatContext context) {
         checkNotNull(rowType, "rowType cannot be null");
         this.rowType = rowType;
         this.resultTypeInfo = resultTypeInfo;
-        this.formatConfig = formatConfig;
+        this.context = context;
         // do it in client side to report error in the first place
         PbSchemaValidationUtils.validate(
-                PbFormatUtils.getDescriptor(formatConfig.getMessageClassName()), rowType);
+                PbFormatUtils.getDescriptor(
+                        context.getPbFormatConfig().getMessageClassName(),
+                        context.getClassLoader()),
+                rowType);
         // this step is only used to validate codegen in client side in the first place
     }
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        protoToRowConverter = new ProtoToRowConverter(rowType, formatConfig);
+        protoToRowConverter = new ProtoToRowConverter(rowType, this.context);
     }
 
     @Override
@@ -69,7 +72,7 @@ public class PbRowDataDeserializationSchema implements DeserializationSchema<Row
         try {
             return protoToRowConverter.convertProtoBinaryToRow(message);
         } catch (Throwable t) {
-            if (formatConfig.isIgnoreParseErrors()) {
+            if (context.getPbFormatConfig().isIgnoreParseErrors()) {
                 return null;
             }
             throw new IOException("Failed to deserialize PB object.", t);
@@ -97,11 +100,12 @@ public class PbRowDataDeserializationSchema implements DeserializationSchema<Row
         PbRowDataDeserializationSchema that = (PbRowDataDeserializationSchema) o;
         return Objects.equals(rowType, that.rowType)
                 && Objects.equals(resultTypeInfo, that.resultTypeInfo)
-                && Objects.equals(formatConfig, that.formatConfig);
+                && Objects.equals(
+                        this.context.getPbFormatConfig(), that.context.getPbFormatConfig());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rowType, resultTypeInfo, formatConfig);
+        return Objects.hash(rowType, resultTypeInfo, this.context.getPbFormatConfig());
     }
 }

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.protobuf.serialize;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.protobuf.PbFormatConfig;
 import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.formats.protobuf.util.PbSchemaValidationUtils;
@@ -39,12 +40,12 @@ public class PbRowDataSerializationSchema implements SerializationSchema<RowData
     public static final long serialVersionUID = 1L;
 
     private final RowType rowType;
-    private final PbFormatContext context;
+    private final PbFormatConfig formatConfig;
     private transient RowToProtoConverter rowToProtoConverter;
 
     public PbRowDataSerializationSchema(RowType rowType, PbFormatContext context) {
         this.rowType = rowType;
-        this.context = context;
+        this.formatConfig = context.getPbFormatConfig();
         Descriptors.Descriptor descriptor =
                 PbFormatUtils.getDescriptor(
                         context.getPbFormatConfig().getMessageClassName(),
@@ -54,7 +55,11 @@ public class PbRowDataSerializationSchema implements SerializationSchema<RowData
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        rowToProtoConverter = new RowToProtoConverter(rowType, this.context);
+        rowToProtoConverter =
+                new RowToProtoConverter(
+                        rowType,
+                        new PbFormatContext(
+                                formatConfig, context.getUserCodeClassLoader().asClassLoader()));
     }
 
     @Override

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
@@ -19,7 +19,7 @@
 package org.apache.flink.formats.protobuf.serialize;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.formats.protobuf.PbFormatConfig;
+import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.formats.protobuf.util.PbSchemaValidationUtils;
 import org.apache.flink.table.data.RowData;
@@ -39,20 +39,22 @@ public class PbRowDataSerializationSchema implements SerializationSchema<RowData
     public static final long serialVersionUID = 1L;
 
     private final RowType rowType;
-    private final PbFormatConfig pbFormatConfig;
+    private final PbFormatContext context;
     private transient RowToProtoConverter rowToProtoConverter;
 
-    public PbRowDataSerializationSchema(RowType rowType, PbFormatConfig pbFormatConfig) {
+    public PbRowDataSerializationSchema(RowType rowType, PbFormatContext context) {
         this.rowType = rowType;
-        this.pbFormatConfig = pbFormatConfig;
+        this.context = context;
         Descriptors.Descriptor descriptor =
-                PbFormatUtils.getDescriptor(pbFormatConfig.getMessageClassName());
+                PbFormatUtils.getDescriptor(
+                        context.getPbFormatConfig().getMessageClassName(),
+                        context.getClassLoader());
         PbSchemaValidationUtils.validate(descriptor, rowType);
     }
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        rowToProtoConverter = new RowToProtoConverter(rowType, pbFormatConfig);
+        rowToProtoConverter = new RowToProtoConverter(rowType, this.context);
     }
 
     @Override

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
@@ -52,12 +52,14 @@ public class RowToProtoConverter {
     private static final Logger LOG = LoggerFactory.getLogger(ProtoToRowConverter.class);
     private final Method encodeMethod;
 
-    public RowToProtoConverter(RowType rowType, PbFormatConfig formatConfig)
-            throws PbCodegenException {
+    public RowToProtoConverter(RowType rowType, PbFormatContext context) throws PbCodegenException {
         try {
+            PbFormatConfig formatConfig = context.getPbFormatConfig();
             Descriptors.Descriptor descriptor =
-                    PbFormatUtils.getDescriptor(formatConfig.getMessageClassName());
-            PbFormatContext formatContext = new PbFormatContext(formatConfig);
+                    PbFormatUtils.getDescriptor(
+                            formatConfig.getMessageClassName(), context.getClassLoader());
+            PbFormatContext formatContext =
+                    new PbFormatContext(formatConfig, context.getClassLoader());
 
             PbCodegenAppender codegenAppender = new PbCodegenAppender(0);
             String uuid = UUID.randomUUID().toString().replaceAll("\\-", "");
@@ -95,7 +97,7 @@ public class RowToProtoConverter {
             LOG.debug("Protobuf encode codegen: \n" + printCode);
             Class generatedClass =
                     PbCodegenUtils.compileClass(
-                            Thread.currentThread().getContextClassLoader(),
+                            context.getClassLoader(),
                             generatedPackageName + "." + generatedClassName,
                             codegenAppender.code());
             encodeMethod =

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbFormatUtils.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbFormatUtils.java
@@ -115,10 +115,10 @@ public class PbFormatUtils {
         }
     }
 
-    public static Descriptors.Descriptor getDescriptor(String className) {
+    public static Descriptors.Descriptor getDescriptor(
+            String className, ClassLoader userClassLoader) {
         try {
-            Class<?> pbClass =
-                    Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+            Class<?> pbClass = Class.forName(className, true, userClassLoader);
             return (Descriptors.Descriptor)
                     pbClass.getMethod(PbConstant.PB_METHOD_GET_DESCRIPTOR).invoke(null);
         } catch (Exception e) {

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaNoMultiProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaNoMultiProtoToRowTest.java
@@ -48,10 +48,12 @@ public class MetaNoMultiProtoToRowTest {
         PbFormatConfig formatConfig =
                 new PbFormatConfig(
                         TestSimpleNomulti.SimpleTestNoMulti.class.getName(), false, false, "");
-        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), formatConfig)
+        PbFormatContext context =
+                new PbFormatContext(formatConfig, Thread.currentThread().getContextClassLoader());
+        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), context)
                 .open(null);
 
-        new PbRowDataSerializationSchema(rowType, formatConfig).open(null);
+        new PbRowDataSerializationSchema(rowType, context).open(null);
         // validation success
     }
 
@@ -63,9 +65,12 @@ public class MetaNoMultiProtoToRowTest {
         PbFormatConfig formatConfig =
                 new PbFormatConfig(
                         TestSimpleNomulti.SimpleTestNoMulti.class.getName(), false, false, "");
-        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), formatConfig)
+
+        PbFormatContext context =
+                new PbFormatContext(formatConfig, Thread.currentThread().getContextClassLoader());
+        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), context)
                 .open(null);
-        new PbRowDataSerializationSchema(rowType, formatConfig).open(null);
+        new PbRowDataSerializationSchema(rowType, context).open(null);
         // validation success
     }
 }

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaOuterMultiTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaOuterMultiTest.java
@@ -47,10 +47,12 @@ public class MetaOuterMultiTest {
         RowType rowType = PbToRowTypeUtil.generateRowType(SimpleTestOuterMulti.getDescriptor());
         PbFormatConfig formatConfig =
                 new PbFormatConfig(SimpleTestOuterMulti.class.getName(), false, false, "");
-        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), formatConfig)
+        PbFormatContext context =
+                new PbFormatContext(formatConfig, Thread.currentThread().getContextClassLoader());
+        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), context)
                 .open(null);
 
-        new PbRowDataSerializationSchema(rowType, formatConfig).open(null);
+        new PbRowDataSerializationSchema(rowType, context).open(null);
         // validation success
     }
 }

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaOuterNoMultiTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/MetaOuterNoMultiTest.java
@@ -52,10 +52,12 @@ public class MetaOuterNoMultiTest {
                         false,
                         false,
                         "");
-        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), formatConfig)
+        PbFormatContext context =
+                new PbFormatContext(formatConfig, Thread.currentThread().getContextClassLoader());
+        new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), context)
                 .open(null);
 
-        new PbRowDataSerializationSchema(rowType, formatConfig).open(null);
+        new PbRowDataSerializationSchema(rowType, context).open(null);
         // validation success
     }
 }

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/NullValueToProtoTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/NullValueToProtoTest.java
@@ -86,7 +86,9 @@ public class NullValueToProtoTest {
                 ProtobufTestHelper.rowToPbBytes(
                         row,
                         NullTest.class,
-                        new PbFormatConfig(NullTest.class.getName(), false, false, ""),
+                        new PbFormatContext(
+                                new PbFormatConfig(NullTest.class.getName(), false, false, ""),
+                                Thread.currentThread().getContextClassLoader()),
                         false);
         NullTest nullTest = NullTest.parseFrom(bytes);
         // string map
@@ -211,7 +213,9 @@ public class NullValueToProtoTest {
                 ProtobufTestHelper.rowToPbBytes(
                         row,
                         NullTest.class,
-                        new PbFormatConfig(NullTest.class.getName(), false, false, "NULL"),
+                        new PbFormatContext(
+                                new PbFormatConfig(NullTest.class.getName(), false, false, "NULL"),
+                                Thread.currentThread().getContextClassLoader()),
                         false);
         NullTest nullTest = NullTest.parseFrom(bytes);
         assertEquals("NULL", nullTest.getStringMapMap().get("key"));

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
@@ -75,19 +75,23 @@ public class ProtobufTestHelper {
         return rowToPbBytes(
                 row,
                 messageClass,
-                new PbFormatConfig(messageClass.getName(), false, false, ""),
+                new PbFormatContext(
+                        new PbFormatConfig(messageClass.getName(), false, false, ""),
+                        Thread.currentThread().getContextClassLoader()),
                 enumAsInt);
     }
 
     public static byte[] rowToPbBytes(
-            RowData row, Class messageClass, PbFormatConfig formatConfig, boolean enumAsInt)
+            RowData row, Class messageClass, PbFormatContext context, boolean enumAsInt)
             throws Exception {
         RowType rowType =
                 PbToRowTypeUtil.generateRowType(
-                        PbFormatUtils.getDescriptor(messageClass.getName()), enumAsInt);
+                        PbFormatUtils.getDescriptor(
+                                messageClass.getName(), context.getClassLoader()),
+                        enumAsInt);
         row = validateRow(row, rowType);
         PbRowDataSerializationSchema serializationSchema =
-                new PbRowDataSerializationSchema(rowType, formatConfig);
+                new PbRowDataSerializationSchema(rowType, context);
         serializationSchema.open(null);
         byte[] bytes = serializationSchema.serialize(row);
         return bytes;
@@ -102,19 +106,22 @@ public class ProtobufTestHelper {
         return pbBytesToRow(
                 messageClass,
                 bytes,
-                new PbFormatConfig(messageClass.getName(), false, false, ""),
+                new PbFormatContext(
+                        new PbFormatConfig(messageClass.getName(), false, false, ""),
+                        Thread.currentThread().getContextClassLoader()),
                 enumAsInt);
     }
 
     public static RowData pbBytesToRow(
-            Class messageClass, byte[] bytes, PbFormatConfig formatConfig, boolean enumAsInt)
+            Class messageClass, byte[] bytes, PbFormatContext context, boolean enumAsInt)
             throws Exception {
         RowType rowType =
                 PbToRowTypeUtil.generateRowType(
-                        PbFormatUtils.getDescriptor(messageClass.getName()), enumAsInt);
+                        PbFormatUtils.getDescriptor(
+                                messageClass.getName(), context.getClassLoader()),
+                        enumAsInt);
         PbRowDataDeserializationSchema deserializationSchema =
-                new PbRowDataDeserializationSchema(
-                        rowType, InternalTypeInfo.of(rowType), formatConfig);
+                new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), context);
         deserializationSchema.open(null);
         RowData row = deserializationSchema.deserialize(bytes);
         return ProtobufTestHelper.validateRow(row, rowType);

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/SimpleProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/SimpleProtoToRowTest.java
@@ -90,7 +90,10 @@ public class SimpleProtoToRowTest {
                 ProtobufTestHelper.pbBytesToRow(
                         SimpleTestMulti.class,
                         simple.toByteArray(),
-                        new PbFormatConfig(SimpleTestMulti.class.getName(), false, true, ""),
+                        new PbFormatContext(
+                                new PbFormatConfig(
+                                        SimpleTestMulti.class.getName(), false, true, ""),
+                                Thread.currentThread().getContextClassLoader()),
                         false);
 
         assertFalse(row.isNullAt(0));


### PR DESCRIPTION
## Purpose of the change

This pull request changes protobuf format to always use the classloader which is passed on creation for the `DynamicTableFactory.Context` instead of using the thread local classloader as proposed in [FLINK-32418](https://issues.apache.org/jira/browse/FLINK-32418). This is needed to load generated protobuf classes when using the protobuf format in SQL-Client.


## Change log

  - The classloader passed in `DynamicTableFactory.Context` is stored in a `PbFormatContext`which is then passed further down the components
  - `PbFormatUtils.getDescriptor` has an additional parameter where the classloader from the PbFormatContaxt has to be passed to resolve generated Protobuf classes correctly.


## Verifying this change

This change is already covered by existing tests, such as `SimpleProtoToRowTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
