### PR TITLE
[FLINK-32634][table-api] Deprecate StreamRecordTimestamp and ExistingField

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/ExistingField.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/ExistingField.java
@@ -42,7 +42,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Converts an existing {@link Long}, {@link java.sql.Timestamp}, or timestamp formatted
  * java.lang.String field (e.g., "2018-05-28 12:34:56.000") into a rowtime attribute.
+ *
+ * @deprecated This class will not be supported in the new source design around {@link
+ *     org.apache.flink.table.connector.source.DynamicTableSource}. See FLIP-95 for more
+ *     information.
  */
+@Deprecated
 @PublicEvolving
 public final class ExistingField extends TimestampExtractor {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/StreamRecordTimestamp.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/sources/tsextractors/StreamRecordTimestamp.java
@@ -34,7 +34,12 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STREAM
  * Extracts the timestamp of a StreamRecord into a rowtime attribute.
  *
  * <p>Note: This extractor only works for StreamTableSources.
+ *
+ * @deprecated This class will not be supported in the new source design around {@link
+ *     org.apache.flink.table.connector.source.DynamicTableSource}. See FLIP-95 for more
+ *     information.
  */
+@Deprecated
 @PublicEvolving
 public final class StreamRecordTimestamp extends TimestampExtractor {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR marks `StreamRecordTimestamp` and `ExistingField` as `@Deprecated` since they are `@PublicEvolving` and are subclasses of the deprecated `TimestampExtractor`.


## Brief change log

- Deprecate `StreamRecordTimestamp` and `ExistingField`


## Verifying this change

This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
