### PR TITLE
[FLINK-32406][table] Notify catalog modification listener for database ddl in CatalogManager

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterDatabaseEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog.listener;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogDatabase;
 
 import javax.annotation.Nullable;
@@ -26,6 +27,7 @@ import javax.annotation.Nullable;
  * When a database is altered, an {@link AlterDatabaseEvent} event will be created and fired which
  * has the old database and new database.
  */
+@PublicEvolving
 public interface AlterDatabaseEvent extends DatabaseModificationEvent {
     CatalogDatabase newDatabase();
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/AlterDatabaseEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+
+import javax.annotation.Nullable;
+
+/**
+ * When a database is altered, an {@link AlterDatabaseEvent} event will be created and fired which
+ * has the old database and new database.
+ */
+public interface AlterDatabaseEvent extends DatabaseModificationEvent {
+    CatalogDatabase newDatabase();
+
+    boolean ignoreIfNotExists();
+
+    static CatalogModificationEvent createEvent(
+            final CatalogContext context,
+            final String databaseName,
+            final CatalogDatabase newDatabase,
+            final boolean ignoreIfNotExists) {
+        return new AlterDatabaseEvent() {
+            @Override
+            public CatalogDatabase newDatabase() {
+                return newDatabase;
+            }
+
+            @Override
+            public boolean ignoreIfNotExists() {
+                return ignoreIfNotExists;
+            }
+
+            @Nullable
+            @Override
+            public CatalogDatabase database() {
+                throw new IllegalStateException(
+                        "There is no database in AlterDatabaseEvent, use database name instead.");
+            }
+
+            @Override
+            public String databaseName() {
+                return databaseName;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateDatabaseEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+
+/** When a database is created, a {@link CreateDatabaseEvent} event will be created and fired. */
+public interface CreateDatabaseEvent extends DatabaseModificationEvent {
+    boolean ignoreIfExists();
+
+    static CreateDatabaseEvent createEvent(
+            final CatalogContext context,
+            final String databaseName,
+            final CatalogDatabase database,
+            final boolean ignoreIfExists) {
+        return new CreateDatabaseEvent() {
+            @Override
+            public boolean ignoreIfExists() {
+                return ignoreIfExists;
+            }
+
+            @Override
+            public CatalogDatabase database() {
+                return database;
+            }
+
+            @Override
+            public String databaseName() {
+                return databaseName;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/CreateDatabaseEvent.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.catalog.listener;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogDatabase;
 
 /** When a database is created, a {@link CreateDatabaseEvent} event will be created and fired. */
+@PublicEvolving
 public interface CreateDatabaseEvent extends DatabaseModificationEvent {
     boolean ignoreIfExists();
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DatabaseModificationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DatabaseModificationEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+
+import javax.annotation.Nullable;
+
+/**
+ * Basic event for database modification such as create, alter and drop, it has the database name
+ * and {@link CatalogDatabase}.
+ */
+public interface DatabaseModificationEvent extends CatalogModificationEvent {
+    @Nullable
+    CatalogDatabase database();
+
+    String databaseName();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DatabaseModificationEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DatabaseModificationEvent.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog.listener;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogDatabase;
 
 import javax.annotation.Nullable;
@@ -26,6 +27,7 @@ import javax.annotation.Nullable;
  * Basic event for database modification such as create, alter and drop, it has the database name
  * and {@link CatalogDatabase}.
  */
+@PublicEvolving
 public interface DatabaseModificationEvent extends CatalogModificationEvent {
     @Nullable
     CatalogDatabase database();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropDatabaseEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.listener;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+
+/** When a database is dropped, a {@link DropDatabaseEvent} event will be created and fired. */
+public interface DropDatabaseEvent extends DatabaseModificationEvent {
+
+    boolean ignoreIfNotExists();
+
+    boolean cascade();
+
+    static CatalogModificationEvent createEvent(
+            final CatalogContext context,
+            final String databaseName,
+            final boolean ignoreIfNotExists,
+            final boolean cascade) {
+        return new DropDatabaseEvent() {
+            @Override
+            public boolean ignoreIfNotExists() {
+                return ignoreIfNotExists;
+            }
+
+            @Override
+            public boolean cascade() {
+                return cascade;
+            }
+
+            @Override
+            public CatalogDatabase database() {
+                throw new IllegalStateException(
+                        "There is no database in DropDatabaseEvent, use database name instead.");
+            }
+
+            @Override
+            public String databaseName() {
+                return databaseName;
+            }
+
+            @Override
+            public CatalogContext context() {
+                return context;
+            }
+        };
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropDatabaseEvent.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/listener/DropDatabaseEvent.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.catalog.listener;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogDatabase;
 
 /** When a database is dropped, a {@link DropDatabaseEvent} event will be created and fired. */
+@PublicEvolving
 public interface DropDatabaseEvent extends DatabaseModificationEvent {
 
     boolean ignoreIfNotExists();

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.listener.AlterDatabaseEvent;
+import org.apache.flink.table.catalog.listener.CatalogModificationEvent;
+import org.apache.flink.table.catalog.listener.CatalogModificationListener;
+import org.apache.flink.table.catalog.listener.CreateDatabaseEvent;
+import org.apache.flink.table.catalog.listener.DropDatabaseEvent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link CatalogManager}. */
+class CatalogManagerTest {
+    @Test
+    void testDatabaseModificationEvent() throws Exception {
+        CompletableFuture<CreateDatabaseEvent> createFuture = new CompletableFuture<>();
+        CompletableFuture<AlterDatabaseEvent> alterFuture = new CompletableFuture<>();
+        CompletableFuture<DropDatabaseEvent> dropFuture = new CompletableFuture<>();
+        CatalogManager catalogManager =
+                createCatalogManager(
+                        new TestingCatalogModificationListener(
+                                createFuture, alterFuture, dropFuture));
+
+        // Validate create a database
+        catalogManager.createDatabase(
+                catalogManager.getCurrentCatalog(),
+                "database1",
+                new CatalogDatabaseImpl(
+                        Collections.singletonMap("key1", "val1"), "database1 comment"),
+                true);
+        CreateDatabaseEvent createDatabaseEvent = createFuture.get(10, TimeUnit.SECONDS);
+        assertThat(createDatabaseEvent.context().getCatalogName())
+                .isEqualTo(catalogManager.getCurrentCatalog());
+        assertThat(createDatabaseEvent.ignoreIfExists()).isTrue();
+        assertThat(createDatabaseEvent.databaseName()).isEqualTo("database1");
+        assertThat(createDatabaseEvent.database().getComment()).isEqualTo("database1 comment");
+        assertThat(createDatabaseEvent.database().getProperties())
+                .isEqualTo(Collections.singletonMap("key1", "val1"));
+        assertThat(alterFuture.isDone()).isFalse();
+        assertThat(dropFuture.isDone()).isFalse();
+
+        // Validate alter a database
+        catalogManager.alterDatabase(
+                catalogManager.getCurrentCatalog(),
+                "database1",
+                new CatalogDatabaseImpl(
+                        Collections.singletonMap("key1", "val_val1"), "database1 comment modified"),
+                false);
+        AlterDatabaseEvent alterDatabaseEvent = alterFuture.get(10, TimeUnit.SECONDS);
+        assertThat(alterDatabaseEvent.context().getCatalogName())
+                .isEqualTo(catalogManager.getCurrentCatalog());
+        assertThat(alterDatabaseEvent.ignoreIfNotExists()).isFalse();
+        assertThat(alterDatabaseEvent.databaseName()).isEqualTo("database1");
+        assertThatThrownBy(alterDatabaseEvent::database)
+                .hasMessage(
+                        "There is no database in AlterDatabaseEvent, use database name instead.");
+        assertThat(alterDatabaseEvent.newDatabase().getComment())
+                .isEqualTo("database1 comment modified");
+        assertThat(alterDatabaseEvent.newDatabase().getProperties())
+                .isEqualTo(Collections.singletonMap("key1", "val_val1"));
+
+        // Validate drop a database
+        catalogManager.dropDatabase(catalogManager.getCurrentCatalog(), "database1", true, true);
+        DropDatabaseEvent dropDatabaseEvent = dropFuture.get(10, TimeUnit.SECONDS);
+        assertThat(dropDatabaseEvent.context().getCatalogName())
+                .isEqualTo(catalogManager.getCurrentCatalog());
+        assertThat(dropDatabaseEvent.ignoreIfNotExists()).isTrue();
+        assertThat(dropDatabaseEvent.databaseName()).isEqualTo("database1");
+        assertThatThrownBy(dropDatabaseEvent::database)
+                .hasMessage(
+                        "There is no database in DropDatabaseEvent, use database name instead.");
+        assertThat(dropDatabaseEvent.cascade()).isTrue();
+    }
+
+    private CatalogManager createCatalogManager(CatalogModificationListener listener) {
+        return CatalogManager.newBuilder()
+                .classLoader(CatalogManagerTest.class.getClassLoader())
+                .config(new Configuration())
+                .defaultCatalog("default", new GenericInMemoryCatalog("default"))
+                .catalogModificationListeners(Collections.singletonList(listener))
+                .build();
+    }
+
+    /** Testing catalog modification listener. */
+    static class TestingCatalogModificationListener implements CatalogModificationListener {
+        private final CompletableFuture<CreateDatabaseEvent> createFuture;
+        private final CompletableFuture<AlterDatabaseEvent> alterFuture;
+        private final CompletableFuture<DropDatabaseEvent> dropFuture;
+
+        TestingCatalogModificationListener(
+                CompletableFuture<CreateDatabaseEvent> createFuture,
+                CompletableFuture<AlterDatabaseEvent> alterFuture,
+                CompletableFuture<DropDatabaseEvent> dropFuture) {
+            this.createFuture = createFuture;
+            this.alterFuture = alterFuture;
+            this.dropFuture = dropFuture;
+        }
+
+        @Override
+        public void onEvent(CatalogModificationEvent event) {
+            if (event instanceof CreateDatabaseEvent) {
+                createFuture.complete((CreateDatabaseEvent) event);
+            } else if (event instanceof AlterDatabaseEvent) {
+                alterFuture.complete((AlterDatabaseEvent) event);
+            } else if (event instanceof DropDatabaseEvent) {
+                dropFuture.complete((DropDatabaseEvent) event);
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to create event for database ddl and notify customized listener.

## Brief change log
  - Create database modification event for database ddl
  - Notify customized listener for the above events in CatalogManager

## Verifying this change

This change added tests and can be verified as follows:

  - Added CatalogManagerTest to check the listener is notified for database ddl

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
