### PR TITLE
[FLINK-32632][test] Fixes Minikube/cri-dockerd issue

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -58,7 +58,7 @@ function setup_kubernetes_for_linux {
     sudo apt-get install conntrack
     # crictl is required for cri-dockerd
     VERSION="v1.24.2"
-    wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+    wget -nv https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
     sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
     rm -f crictl-$VERSION-linux-amd64.tar.gz
     # cri-dockerd is required to use Kubernetes 1.24+ and the none driver

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -57,18 +57,22 @@ function setup_kubernetes_for_linux {
     # conntrack is required for minikube 1.9 and later
     sudo apt-get install conntrack
     # crictl is required for cri-dockerd
-    VERSION="v1.24.2"
-    wget -nv https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
-    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-    rm -f crictl-$VERSION-linux-amd64.tar.gz
+    local crictl_version crictl_archive
+    crictl_version="v1.24.2"
+    crictl_archive="crictl-$crictl_version-linux-amd64.tar.gz"
+    wget -nv "https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictl_version}/crictl-${crictl_version}-linux-amd64.tar.gz"
+    sudo tar zxvf ${crictl_archive} -C /usr/local/bin
+    rm -f ${crictl_archive}
+
     # cri-dockerd is required to use Kubernetes 1.24+ and the none driver
+    local cri_dockerd_version
+    cri_dockerd_version="v0.2.3"
     if [ -e cri-dockerd ];
      then rm -r cri-dockerd
     fi
     git clone https://github.com/Mirantis/cri-dockerd.git
     cd cri-dockerd
-    # Checkout version 0.2.3
-    git checkout tags/v0.2.3 -b v0.2.3
+    git checkout tags/${cri_dockerd_version} -b ${cri_dockerd_version}
     mkdir bin
     go get && go build -o bin/cri-dockerd
     mkdir -p /usr/local/bin

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -33,7 +33,7 @@ export -f run_mvn
 function setup_maven {
 	set -e # fail if there was an error setting up maven
 	if [ ! -d "${MAVEN_VERSIONED_DIR}" ]; then
-	  wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.zip
+	  wget -nv https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.zip
 	  unzip -d "${MAVEN_CACHE_DIR}" -qq "apache-maven-${MAVEN_VERSION}-bin.zip"
 	  rm "apache-maven-${MAVEN_VERSION}-bin.zip"
 	fi


### PR DESCRIPTION
## What is the purpose of the change

Looking at the error message `error: Internal error occurred: error executing command in container: http: invalid Host header` pointed to several issues that indicated that the actual problem appears when building `cri-dockerd` with go-lang 1.20.6 (e.g. https://github.com/moby/moby/issues/45935 or https://github.com/kubernetes/minikube/issues/16909).

## Brief change log

Instead of building `cri-dockerd` manually, we can rely on the binaries which are provided on github.

## Verifying this change

* `Run Kubernetes test` succeeds again.
* Verification that go 1.20.6 was installed in the CI machine

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable