### PR TITLE
[FLINK-32279][table-runtime] Shuffle HashJoin support spill to disk when enable operator fusion codegen

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/CalcFusionCodegenSpec.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/CalcFusionCodegenSpec.scala
@@ -78,6 +78,7 @@ class CalcFusionCodegenSpec(
       if (onlyFilter) {
         s"""
            |$filterAccessCode
+           |${opCodegenCtx.reuseLocalVariableCode()}
            |${filterExpr.code}
            |if (${filterExpr.resultTerm}) {
            |  ${fusionContext.processConsume(inputVars)}
@@ -88,6 +89,7 @@ class CalcFusionCodegenSpec(
         val projectionExprs = projection.map(getExprCodeGenerator.generateExpression)
         s"""
            |$filterAccessCode
+           |${opCodegenCtx.reuseLocalVariableCode()}
            |${filterExpr.code}
            |if (${filterExpr.resultTerm}) {
            |  ${evaluateRequiredVariables(toScala(inputVars), projectionUsedColumns)}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/OperatorFusionCodegenTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/OperatorFusionCodegenTest.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCalcAsMutltipleInputRoot[fusionCodegenEnabled=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, b1, a2, b2, a3, b3, COUNT(c1) FROM (SELECT * FROM T1, T2, T3 WHERE a1 = b2 AND a1 = a3) t GROUP BY a1, b1, a2, b2, a3, b3]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3, 4, 5}], EXPR$6=[COUNT($6)])
++- LogicalProject(a1=[$0], b1=[$1], a2=[$4], b2=[$5], a3=[$7], b3=[$8], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], a3=[$7], b3=[$8], c3=[$9], d3=[$10])
+      +- LogicalFilter(condition=[AND(=($0, $5), =($0, $7))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalJoin(condition=[true], joinType=[inner])
+            :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1, b1, a2, b2, a3, b3, ($f4 * $f2) AS $f8])
++- MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(a1 = a3)], select=[a1, b1, a2, b2, $f4, a3, b3, $f2], isBroadcast=[true], build=[right])\n:- Calc(select=[a1, b1, a2, b2, CASE(c1 IS NOT NULL, 1, 0) AS $f4])\n:  +- HashJoin(joinType=[InnerJoin], where=[(a1 = b2)], select=[a1, b1, c1, a2, b2], build=[right])\n:     :- [#2] Exchange(distribution=[hash[a1]])\n:     +- [#3] Exchange(distribution=[hash[b2]])\n+- [#1] Exchange(distribution=[broadcast])\n])
+   :- Exchange(distribution=[broadcast])
+   :  +- HashAggregate(isMerge=[true], groupBy=[a3, b3], select=[a3, b3, Final_COUNT(count1$0) AS $f2])
+   :     +- Exchange(distribution=[hash[a3, b3]])
+   :        +- LocalHashAggregate(groupBy=[a3, b3], select=[a3, b3, Partial_COUNT(*) AS count1$0])
+   :           +- Calc(select=[a3, b3])
+   :              +- LegacyTableSourceScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]], fields=[a3, b3, c3, d3])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1, b1, c1])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+   +- Exchange(distribution=[hash[b2]])
+      +- Calc(select=[a2, b2])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHashAggAsMutltipleInputRoot[fusionCodegenEnabled=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, b1, a2, b2, COUNT(c1) FROM (SELECT * FROM T1, T2 WHERE a1 = b2) t GROUP BY a1, b1, a2, b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$4=[COUNT($4)])
++- LogicalProject(a1=[$0], b1=[$1], a2=[$4], b2=[$5], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6])
+      +- LogicalFilter(condition=[=($0, $5)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+MultipleInput(readOrder=[1,0], members=[\nHashAggregate(isMerge=[false], groupBy=[a1], auxGrouping=[b1, a2, b2], select=[a1, b1, a2, b2, COUNT(c1) AS EXPR$4])\n+- HashJoin(joinType=[InnerJoin], where=[(a1 = b2)], select=[a1, b1, c1, a2, b2], build=[right])\n   :- [#1] Exchange(distribution=[hash[a1]])\n   +- [#2] Exchange(distribution=[hash[b2]])\n])
+:- Exchange(distribution=[hash[a1]])
+:  +- Calc(select=[a1, b1, c1])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[b2]])
+   +- Calc(select=[a2, b2])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcAsMutltipleInputRoot[fusionCodegenEnabled=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, b1, a2, b2, a3, b3, COUNT(c1) FROM (SELECT * FROM T1, T2, T3 WHERE a1 = b2 AND a1 = a3) t GROUP BY a1, b1, a2, b2, a3, b3]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3, 4, 5}], EXPR$6=[COUNT($6)])
++- LogicalProject(a1=[$0], b1=[$1], a2=[$4], b2=[$5], a3=[$7], b3=[$8], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], a3=[$7], b3=[$8], c3=[$9], d3=[$10])
+      +- LogicalFilter(condition=[AND(=($0, $5), =($0, $7))])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalJoin(condition=[true], joinType=[inner])
+            :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+MultipleInput(readOrder=[0,1,0], members=[\nCalc(select=[a1, b1, a2, b2, a3, b3, ($f4 * $f2) AS $f8])\n+- HashJoin(joinType=[InnerJoin], where=[(a1 = a3)], select=[a1, b1, a2, b2, $f4, a3, b3, $f2], isBroadcast=[true], build=[right])\n   :- Calc(select=[a1, b1, a2, b2, CASE(c1 IS NOT NULL, 1, 0) AS $f4])\n   :  +- HashJoin(joinType=[InnerJoin], where=[(a1 = b2)], select=[a1, b1, c1, a2, b2], build=[right])\n   :     :- [#2] Exchange(distribution=[hash[a1]])\n   :     +- [#3] Exchange(distribution=[hash[b2]])\n   +- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- HashAggregate(isMerge=[true], groupBy=[a3, b3], select=[a3, b3, Final_COUNT(count1$0) AS $f2])
+:     +- Exchange(distribution=[hash[a3, b3]])
+:        +- LocalHashAggregate(groupBy=[a3, b3], select=[a3, b3, Partial_COUNT(*) AS count1$0])
+:           +- Calc(select=[a3, b3])
+:              +- LegacyTableSourceScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]], fields=[a3, b3, c3, d3])
+:- Exchange(distribution=[hash[a1]])
+:  +- Calc(select=[a1, b1, c1])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[b2]])
+   +- Calc(select=[a2, b2])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLocalHashAggAsMutltipleInputRoot[fusionCodegenEnabled=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT a2, b2, a3, b3, COUNT(c2), AVG(d3) FROM (SELECT * FROM T2, T3 WHERE b2 = a3) t GROUP BY a2, b2, a3, b3]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$4=[COUNT($4)], EXPR$5=[AVG($5)])
++- LogicalProject(a2=[$0], b2=[$1], a3=[$3], b3=[$4], c2=[$2], d3=[$6])
+   +- LogicalProject(a2=[$0], b2=[$1], c2=[$2], a3=[$3], b3=[$4], c3=[$5], d3=[$6])
+      +- LogicalFilter(condition=[=($1, $3)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a2, b2, a3, b3, EXPR$4, EXPR$5])
++- HashAggregate(isMerge=[true], groupBy=[a3, b3], auxGrouping=[a2, b2], select=[a3, b3, a2, b2, Final_COUNT(count$0) AS EXPR$4, Final_AVG(sum$1, count$2) AS EXPR$5])
+   +- Exchange(distribution=[hash[a3, b3]])
+      +- MultipleInput(readOrder=[1,0], members=[\nLocalHashAggregate(groupBy=[a3, b3], auxGrouping=[a2, b2], select=[a3, b3, a2, b2, Partial_COUNT(c2) AS count$0, Partial_AVG(d3) AS (sum$1, count$2)])\n+- HashJoin(joinType=[InnerJoin], where=[(b2 = a3)], select=[a2, b2, c2, a3, b3, d3], isBroadcast=[true], build=[right])\n   :- [#1] LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])\n   +- [#2] Exchange(distribution=[broadcast])\n])
+         :- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+         +- Exchange(distribution=[broadcast])
+            +- Calc(select=[a3, b3, d3])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]], fields=[a3, b3, c3, d3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testHashAggAsMutltipleInputRoot[fusionCodegenEnabled=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT a1, b1, a2, b2, COUNT(c1) FROM (SELECT * FROM T1, T2 WHERE a1 = b2) t GROUP BY a1, b1, a2, b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$4=[COUNT($4)])
++- LogicalProject(a1=[$0], b1=[$1], a2=[$4], b2=[$5], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6])
+      +- LogicalFilter(condition=[=($0, $5)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a1], auxGrouping=[b1, a2, b2], select=[a1, b1, a2, b2, COUNT(c1) AS EXPR$4])
++- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+   +- HashJoin(joinType=[InnerJoin], where=[(a1 = b2)], select=[a1, b1, c1, a2, b2], build=[right])
+      :- Exchange(distribution=[hash[a1]])
+      :  +- Calc(select=[a1, b1, c1])
+      :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+      +- Exchange(distribution=[hash[b2]])
+         +- Calc(select=[a2, b2])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLocalHashAggAsMutltipleInputRoot[fusionCodegenEnabled=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT a2, b2, a3, b3, COUNT(c2), AVG(d3) FROM (SELECT * FROM T2, T3 WHERE b2 = a3) t GROUP BY a2, b2, a3, b3]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$4=[COUNT($4)], EXPR$5=[AVG($5)])
++- LogicalProject(a2=[$0], b2=[$1], a3=[$3], b3=[$4], c2=[$2], d3=[$6])
+   +- LogicalProject(a2=[$0], b2=[$1], c2=[$2], a3=[$3], b3=[$4], c3=[$5], d3=[$6])
+      +- LogicalFilter(condition=[=($1, $3)])
+         +- LogicalJoin(condition=[true], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a2, b2, a3, b3, EXPR$4, EXPR$5])
++- HashAggregate(isMerge=[true], groupBy=[a3, b3], auxGrouping=[a2, b2], select=[a3, b3, a2, b2, Final_COUNT(count$0) AS EXPR$4, Final_AVG(sum$1, count$2) AS EXPR$5])
+   +- Exchange(distribution=[hash[a3, b3]])
+      +- LocalHashAggregate(groupBy=[a3, b3], auxGrouping=[a2, b2], select=[a3, b3, a2, b2, Partial_COUNT(c2) AS count$0, Partial_AVG(d3) AS (sum$1, count$2)])
+         +- HashJoin(joinType=[InnerJoin], where=[(b2 = a3)], select=[a2, b2, c2, a3, b3, d3], isBroadcast=[true], build=[right])
+            :- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2)]]], fields=[a2, b2, c2])
+            +- Exchange(distribution=[broadcast])
+               +- Calc(select=[a3, b3, d3])
+                  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]], fields=[a3, b3, c3, d3])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/OperatorFusionCodegenTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/OperatorFusionCodegenTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.batch.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.plan.stats.TableStats
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import com.google.common.collect.ImmutableSet
+import org.junit.{Before, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.util
+
+/** Tests for operator fusion codegen. */
+@RunWith(classOf[Parameterized])
+class OperatorFusionCodegenTest(fusionCodegenEnabled: Boolean) extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    util.addTableSource(
+      "T1",
+      Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.STRING),
+      Array("a1", "b1", "c1", "d1"),
+      FlinkStatistic
+        .builder()
+        .tableStats(new TableStats(100000000))
+        .uniqueKeys(ImmutableSet.of(ImmutableSet.of("a1")))
+        .build()
+    )
+    util.addTableSource(
+      "T2",
+      Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING),
+      Array("a2", "b2", "c2"),
+      FlinkStatistic
+        .builder()
+        .tableStats(new TableStats(100000000))
+        .uniqueKeys(ImmutableSet.of(ImmutableSet.of("b2"), ImmutableSet.of("a2", "b2")))
+        .build()
+    )
+    util.addTableSource(
+      "T3",
+      Array[TypeInformation[_]](Types.INT, Types.INT, Types.STRING, Types.LONG),
+      Array("a3", "b3", "c3", "d3"),
+      FlinkStatistic
+        .builder()
+        .tableStats(new TableStats(1000))
+        .build()
+    )
+
+    util.tableEnv.getConfig
+      .set(
+        ExecutionConfigOptions.TABLE_EXEC_OPERATOR_FUSION_CODEGEN_ENABLED,
+        Boolean.box(fusionCodegenEnabled))
+  }
+
+  @Test
+  def testHashAggAsMutltipleInputRoot(): Unit = {
+    util.verifyExecPlan(
+      "SELECT a1, b1, a2, b2, COUNT(c1) FROM " +
+        "(SELECT * FROM T1, T2 WHERE a1 = b2) t GROUP BY a1, b1, a2, b2")
+  }
+
+  @Test
+  def testLocalHashAggAsMutltipleInputRoot(): Unit = {
+    util.verifyExecPlan(
+      "SELECT a2, b2, a3, b3, COUNT(c2), AVG(d3) FROM " +
+        "(SELECT * FROM T2, T3 WHERE b2 = a3) t GROUP BY a2, b2, a3, b3")
+  }
+
+  @Test
+  def testCalcAsMutltipleInputRoot(): Unit = {
+    util.verifyExecPlan(
+      "SELECT a1, b1, a2, b2, a3, b3, COUNT(c1) FROM " +
+        "(SELECT * FROM T1, T2, T3 WHERE a1 = b2 AND a1 = a3) t GROUP BY a1, b1, a2, b2, a3, b3")
+  }
+}
+
+object OperatorFusionCodegenTest {
+  @Parameterized.Parameters(name = "fusionCodegenEnabled={0}")
+  def parameters(): util.Collection[Boolean] = {
+    util.Arrays.asList(true, false)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*For shuffle hash join, we don't support spill to disk currently if operator fusion codegen, so this PR main purpose is to fix the problem.*


## Brief change log

  - *Shuffle hash join support spill to disk if operator fusion codegen enabled*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Integration tests in OperatorFusionCodegenITCase can verify it*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
