### PR TITLE
[FLINK-32649][runtime/Metrics] fix the dimension order for promethues reporter

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -100,11 +100,15 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
         List<String> dimensionKeys = new LinkedList<>();
         List<String> dimensionValues = new LinkedList<>();
-        for (final Map.Entry<String, String> dimension : group.getAllVariables().entrySet()) {
-            final String key = dimension.getKey();
+        Map<String, String> allVariables = group.getAllVariables();
+        List<String> keys = new ArrayList<>(allVariables.keySet());
+        keys.sort(String::compareTo);
+
+        for (String key : keys) {
+            String dimensionValue = allVariables.get(key);
             dimensionKeys.add(
                     CHARACTER_FILTER.filterCharacters(key.substring(1, key.length() - 1)));
-            dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimension.getValue()));
+            dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimensionValue));
         }
 
         final String scopedMetricName = getScopedName(metricName, group);

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -100,15 +100,11 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
         List<String> dimensionKeys = new LinkedList<>();
         List<String> dimensionValues = new LinkedList<>();
-        Map<String, String> allVariables = group.getAllVariables();
-        List<String> keys = new ArrayList<>(allVariables.keySet());
-        keys.sort(String::compareTo);
-
-        for (String key : keys) {
-            String dimensionValue = allVariables.get(key);
+        for (final Map.Entry<String, String> dimension : group.getAllVariables().entrySet()) {
+            final String key = dimension.getKey();
             dimensionKeys.add(
                     CHARACTER_FILTER.filterCharacters(key.substring(1, key.length() - 1)));
-            dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimensionValue));
+            dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimension.getValue()));
         }
 
         final String scopedMetricName = getScopedName(metricName, group);

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.curator5.com.google.common.collect.Iterators;
+import org.apache.flink.shaded.guava31.com.google.common.base.Joiner;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
@@ -38,10 +39,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -174,6 +178,39 @@ class PrometheusReporterTest {
         String response = pollMetrics(reporter.getPort()).getBody();
 
         assertThat(response).contains("some_value").doesNotContain(labelValueThatShouldBeRemoved);
+    }
+
+    @Test
+    void metricWithSameNameAndDiffOrderDimension() throws UnirestException {
+        String metricName = "metric";
+
+        Counter metric1 = new SimpleCounter();
+        Counter metric2 = new SimpleCounter();
+
+        final Map<String, String> variables2 = new LinkedHashMap<>();
+        // reverse the order of keys
+        for (int i = LABEL_NAMES.length - 1; i >= 0; i--) {
+            String value = "some_value" + i;
+            String key = LABEL_NAMES[i];
+            variables2.put(key, value);
+        }
+
+        List<String> dimensionPairs = new ArrayList<>();
+        // build the correct order of key-value
+        for (int i = 0; i < LABEL_NAMES.length; i++) {
+            String key = LABEL_NAMES[i];
+            String value = variables2.get(key);
+            dimensionPairs.add(String.format("%s=\"%s\"", key, value));
+        }
+
+        String dimensions2 = Joiner.on(",").join(dimensionPairs);
+
+        final MetricGroup metricGroup2 = TestUtils.createTestMetricGroup(LOGICAL_SCOPE, variables2);
+        reporter.notifyOfAddedMetric(metric1, metricName, metricGroup);
+        reporter.notifyOfAddedMetric(metric2, metricName, metricGroup2);
+        String response = pollMetrics(reporter.getPort()).getBody();
+
+        assertThat(response).contains(DIMENSIONS).contains(dimensions2);
     }
 
     @Test


### PR DESCRIPTION

## What is the purpose of the change

 Fix promethues reporter mismatch dimension key&value,  with different order of  keys in variables as input.


## Brief change log

  - Sort the keys of `MetricGroup.variables` when add a metric


## Verifying this change



This change is already covered by a new test in `org.apache.flink.metrics.prometheus.PrometheusReporterTest#metricWithSameNameAndDiffOrderDimension`.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
