### PR TITLE
[FLINK-32564][table] Support Cast From BYTES to NUMBER

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -156,38 +156,62 @@ public final class LogicalTypeCasts {
 
         castTo(TINYINT)
                 .implicitFrom(TINYINT)
-                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(SMALLINT)
                 .implicitFrom(TINYINT, SMALLINT)
-                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(INTEGER)
                 .implicitFrom(TINYINT, SMALLINT, INTEGER)
-                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(BIGINT)
                 .implicitFrom(TINYINT, SMALLINT, INTEGER, BIGINT)
-                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(NUMERIC, CHARACTER_STRING, INTERVAL, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(FLOAT)
                 .implicitFrom(TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT, DECIMAL)
-                .explicitFromFamily(NUMERIC, CHARACTER_STRING)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(NUMERIC, CHARACTER_STRING, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(DOUBLE)
                 .implicitFromFamily(NUMERIC)
-                .explicitFromFamily(CHARACTER_STRING)
-                .explicitFrom(BOOLEAN, TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .explicitFromFamily(CHARACTER_STRING, BINARY_STRING)
+                .explicitFrom(
+                        BOOLEAN,
+                        TIMESTAMP_WITHOUT_TIME_ZONE,
+                        TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        VARBINARY)
                 .build();
 
         castTo(DATE)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -167,6 +167,14 @@ public class SqlCastFunction extends SqlFunction {
             case MULTISET:
             case STRUCTURED:
             case ROW:
+            case BINARY:
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case VARBINARY:
+            case FLOAT:
+            case DOUBLE:
             case OTHER:
                 // We use our casting checker logic only for these types,
                 //  as the differences with calcite casting checker logic generates issues

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToNumericCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToNumericCastRule.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_BYTE;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_DOUBLE;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_FLOAT;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_INT;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_LONG;
+import static org.apache.flink.table.planner.codegen.calls.BuiltInMethods.STRING_DATA_TO_SHORT;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
+
+/** {@link LogicalTypeFamily#BINARY_STRING} to {@link LogicalTypeFamily#NUMERIC} cast rule. */
+class BinaryToNumericCastRule extends AbstractExpressionCodeGeneratorCastRule<byte[], Number> {
+
+    static final BinaryToNumericCastRule INSTANCE = new BinaryToNumericCastRule();
+
+    protected BinaryToNumericCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeFamily.BINARY_STRING)
+                        .target(LogicalTypeFamily.INTEGER_NUMERIC)
+                        .target(LogicalTypeFamily.APPROXIMATE_NUMERIC)
+                        .build());
+    }
+
+    @Override
+    public String generateExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        final String inputstr = staticCall(BinaryStringData.class, "fromBytes", inputTerm);
+        switch (targetLogicalType.getTypeRoot()) {
+            case TINYINT:
+                return staticCall(STRING_DATA_TO_BYTE(), inputstr);
+            case SMALLINT:
+                return staticCall(STRING_DATA_TO_SHORT(), inputstr);
+            case INTEGER:
+                return staticCall(STRING_DATA_TO_INT(), inputstr);
+            case BIGINT:
+                return staticCall(STRING_DATA_TO_LONG(), inputstr);
+            case FLOAT:
+                return staticCall(STRING_DATA_TO_FLOAT(), inputstr);
+            case DOUBLE:
+                return staticCall(STRING_DATA_TO_DOUBLE(), inputstr);
+        }
+        throw new IllegalArgumentException("This is a bug. Please file an issue.");
+    }
+
+    @Override
+    public boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        return super.canFail(inputLogicalType, targetLogicalType);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -53,6 +53,7 @@ public class CastRuleProvider {
                 .addRule(NumericPrimitiveToDecimalCastRule.INSTANCE)
                 .addRule(DecimalToNumericPrimitiveCastRule.INSTANCE)
                 .addRule(NumericPrimitiveCastRule.INSTANCE)
+                .addRule(BinaryToNumericCastRule.INSTANCE)
                 // Boolean <-> numeric rules
                 .addRule(BooleanToNumericCastRule.INSTANCE)
                 .addRule(NumericToBooleanCastRule.INSTANCE)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -323,6 +323,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(TINYINT())
+                        .fromCase(VARBINARY(1), new byte[] {5}, (byte) 5)
+                        .fromCase(BINARY(1), new byte[] {5}, (byte) 5)
                         .fromCase(TINYINT(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -332,11 +334,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "-130", NumberFormatException.class)
                         .fromCase(BOOLEAN(), true, (byte) 1)
                         .fromCase(BOOLEAN(), false, (byte) 0)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, (byte) 1)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, (byte) 12)
+                        .failRuntime(BYTES(), DEFAULT_BYTES, NumberFormatException.class)
                         .fromCase(DECIMAL(4, 3), 9.87, (byte) 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
@@ -370,6 +370,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(SMALLINT())
+                        .fromCase(VARBINARY(1), new byte[] {5}, (short) 5)
+                        .fromCase(BINARY(1), new byte[] {54, 54}, (short) 6)
                         .fromCase(SMALLINT(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -379,11 +381,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "-32769", NumberFormatException.class)
                         .fromCase(BOOLEAN(), true, (short) 1)
                         .fromCase(BOOLEAN(), false, (short) 0)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, (short) 1)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, (short) 12)
+                        .fromCase(BYTES(), DEFAULT_BYTES, (short) 1234)
                         .fromCase(DECIMAL(4, 3), 9.87, (short) 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
@@ -428,6 +428,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(INT())
+                        .fromCase(VARBINARY(1), new byte[] {5}, (int) 5)
+                        .fromCase(BINARY(2), new byte[] {54}, (int) 60)
                         .fromCase(INT(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -437,11 +439,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failRuntime(STRING(), "-3276913443134", NumberFormatException.class)
                         .fromCase(BOOLEAN(), true, 1)
                         .fromCase(BOOLEAN(), false, 0)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, 1)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, 12)
+                        .fromCase(BYTES(), DEFAULT_BYTES, 1234)
                         .fromCase(DECIMAL(4, 3), 9.87, 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
@@ -488,6 +488,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(BIGINT())
+                        .fromCase(VARBINARY(2147483647), new byte[] {50, 51, 52, 53}, (Long) 2345L)
+                        .fromCase(BINARY(2), new byte[] {54}, (Long) 60L)
                         .fromCase(BIGINT(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -497,11 +499,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "-3276913443134", -3276913443134L)
                         .fromCase(BOOLEAN(), true, 1L)
                         .fromCase(BOOLEAN(), false, 0L)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, 1L)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, 12L)
+                        .fromCase(BYTES(), DEFAULT_BYTES, 1234L)
                         .fromCase(DECIMAL(4, 3), 9.87, 9L)
                         .fromCase(DECIMAL(20, 3), 3276913443134.87, 3276913443134L)
                         .fromCase(
@@ -545,6 +545,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(FLOAT())
+                        .fromCase(VARBINARY(2), new byte[] {5}, 5.0f)
+                        .fromCase(BINARY(2), new byte[] {5}, 50.0f)
                         .fromCase(FLOAT(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -554,11 +556,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "-3276913443134", -3.27691403E12f)
                         .fromCase(BOOLEAN(), true, 1.0f)
                         .fromCase(BOOLEAN(), false, 0.0f)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, 1.0f)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, 12.0f)
+                        .fromCase(BYTES(), DEFAULT_BYTES, 1234.0f)
                         .fromCase(DECIMAL(4, 3), 9.87, 9.87f)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
@@ -607,6 +607,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         // RAW
                         .build(),
                 CastTestSpecBuilder.testCastTo(DOUBLE())
+                        .fromCase(VARBINARY(2), new byte[] {54}, 6.0d)
+                        .fromCase(BINARY(2), new byte[] {54}, 60.0d)
                         .fromCase(DOUBLE(), null, null)
                         .failRuntime(CHAR(3), "foo", NumberFormatException.class)
                         .failRuntime(VARCHAR(5), "Flink", NumberFormatException.class)
@@ -616,11 +618,9 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "-3276913443134", -3.276913443134E12)
                         .fromCase(BOOLEAN(), true, 1.0d)
                         .fromCase(BOOLEAN(), false, 0.0d)
-                        // Not supported - no fix
-                        .failValidation(BINARY(2), DEFAULT_BINARY)
-                        .failValidation(VARBINARY(5), DEFAULT_VARBINARY)
-                        .failValidation(BYTES(), DEFAULT_BYTES)
-                        //
+                        .fromCase(BINARY(2), DEFAULT_BINARY, 1.0d)
+                        .fromCase(VARBINARY(5), DEFAULT_VARBINARY, 12.0d)
+                        .fromCase(BYTES(), DEFAULT_BYTES, 1234.0d)
                         .fromCase(DECIMAL(4, 3), 9.87, 9.87d)
                         .fromCase(DECIMAL(20, 3), 3276913443134.87, 3.27691344313487E12d)
                         .fromCase(
@@ -988,6 +988,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "Apache Flink", "Apache Flink")
                         .fromCase(STRING(), null, null)
                         .fromCase(BOOLEAN(), true, "TRUE")
+                        .fromCase(BINARY(1), new byte[] {5}, "\u0005")
                         .fromCase(BINARY(2), DEFAULT_BINARY, "\u0000\u0001")
                         .fromCase(BINARY(3), DEFAULT_BINARY, "\u0000\u0001\u0000")
                         .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "\u0000\u0001\u0002")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -393,6 +393,7 @@ public class BinaryStringDataUtil {
      * <p>This code is mostly copied from LazyLong.parseLong in Hive.
      */
     public static long toLong(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         int sizeInBytes = str.getSizeInBytes();
         byte[] tmpBytes = getTmpBytes(str, sizeInBytes);
         if (sizeInBytes == 0) {
@@ -481,6 +482,8 @@ public class BinaryStringDataUtil {
      * performance reasons, like Hive does.
      */
     public static int toInt(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
+
         int sizeInBytes = str.getSizeInBytes();
         byte[] tmpBytes = getTmpBytes(str, sizeInBytes);
         if (sizeInBytes == 0) {
@@ -574,10 +577,12 @@ public class BinaryStringDataUtil {
     }
 
     public static double toDouble(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         return Double.parseDouble(str.toString());
     }
 
     public static float toFloat(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         return Float.parseFloat(str.toString());
     }
 
@@ -1191,5 +1196,17 @@ public class BinaryStringDataUtil {
         } else {
             return str.toString();
         }
+    }
+
+    public static BinaryStringData transformer(BinaryStringData str) {
+        StringBuilder std = new StringBuilder();
+        for (int i = 0; i < (str.toString()).length(); i++) {
+            if (Character.isIdentifierIgnorable((str.toString()).charAt(i))) {
+                std.append((int) ((str.toString()).charAt(i)) + "");
+            } else {
+                std.append(str.toString().charAt(i) + "");
+            }
+        }
+        return new BinaryStringData(std.toString());
     }
 }


### PR DESCRIPTION
### What is the purpose of the change
Implement` CAST` from `BINARY`/`VARBINART`/`BYTES `to `NUMBER`

### Brief change log
` CAST` from `BINARY`/`VARBINART`/`BYTES `to `NUMBER` for Table API and SQL

Syntax:
`
CAST(NUMBER AS BYTES)
`

Examples:
```
Flink SQL> select cast(cast('1234' as BYTES) as BIGINT);;
res: 1234

Flink SQL> select cast(cast('1234' as BYTES) as DOUBLE);
res: 1234.0

select cast(cast('123' as BYTES) as TINYINT);
res: 123

Flink SQL> select cast(cast('123' as BYTES) as INT);
res:123

Flink SQL> select cast(cast('123' as BYTES) as FLOAT);
res:123.0

Flink SQL> select cast(cast('123' as BYTES) as SMALLINT);
res:123
```

### Verifying this change

- This change added tests in CastFunctionITCase.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)

