### PR TITLE
[FLINK-32654][configuration] Deprecate ExecutionConfig#canEqual(obj)

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -941,8 +941,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         if (obj instanceof ExecutionConfig) {
             ExecutionConfig other = (ExecutionConfig) obj;
 
-            return other.canEqual(this)
-                    && Objects.equals(configuration, other.configuration)
+            return Objects.equals(configuration, other.configuration)
                     && ((restartStrategyConfiguration == null
                                     && other.restartStrategyConfiguration == null)
                             || (null != restartStrategyConfiguration
@@ -998,6 +997,12 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
                 + '}';
     }
 
+    /**
+     * This method simply checks whether the object is an {@link ExecutionConfig} instance.
+     *
+     * @deprecated It is not intended to be used by users.
+     */
+    @Deprecated
     public boolean canEqual(Object obj) {
         return obj instanceof ExecutionConfig;
     }


### PR DESCRIPTION
## What is the purpose of the change

ExecutionConfig#canEqual(obj) checks whether the object is an instance of ExecutionConfig.
It is not intended to be used by users but was used for internal comparison. Unfortunately, is was exposed as `@Public` because ExecutionConfig is `@Public`.
We should deprecate it so that we can remove it in Flink 2.0.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
