### PR TITLE
[FLINK-32660][table] Introduce external FS compatible FileCatalogStore implementation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
@@ -19,23 +19,26 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
-import org.apache.flink.util.FileUtils;
 
-import org.apache.flink.shaded.jackson2.org.yaml.snakeyaml.Yaml;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link CatalogStore} that stores all catalog configuration to a directory. Configuration of
@@ -46,42 +49,56 @@ public class FileCatalogStore extends AbstractCatalogStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileCatalogStore.class);
 
-    private static final String FILE_EXTENSION = ".yaml";
+    static final String FILE_EXTENSION = ".yaml";
+
+    /** The YAML mapper to use when reading and writing catalog files. */
+    private static final YAMLMapper YAML_MAPPER =
+            new YAMLMapper().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
 
     /** The directory path where catalog configurations will be stored. */
-    private final String catalogStoreDirectory;
-
-    /** The character set to use when reading and writing catalog files. */
-    private final String charset;
-
-    /** The YAML parser to use when reading and writing catalog files. */
-    private final Yaml yaml = new Yaml();
+    private final Path catalogStorePath;
 
     /**
      * Creates a new {@link FileCatalogStore} instance with the specified directory path.
      *
-     * @param catalogStoreDirectory the directory path where catalog configurations will be stored
+     * @param catalogStorePath the directory path where catalog configurations will be stored
      */
-    public FileCatalogStore(String catalogStoreDirectory, String charset) {
-        this.catalogStoreDirectory = catalogStoreDirectory;
-        this.charset = charset;
+    public FileCatalogStore(String catalogStorePath) {
+        this.catalogStorePath = new Path(catalogStorePath);
     }
 
     /**
      * Opens the catalog store and initializes the catalog file map.
      *
-     * @throws CatalogException if the catalog store directory does not exist or if there is an
-     *     error reading the directory
+     * @throws CatalogException if the catalog store directory does not exist, not a directory, or
+     *     if there is an error reading the directory
      */
     @Override
     public void open() throws CatalogException {
-        super.open();
-
         try {
+            FileSystem fs = catalogStorePath.getFileSystem();
+            if (!fs.exists(catalogStorePath)) {
+                throw new CatalogException(
+                        String.format(
+                                "Failed to open catalog store. The catalog store directory %s does not exist.",
+                                catalogStorePath));
+            }
 
-        } catch (Throwable e) {
-            throw new CatalogException("Failed to open file catalog store directory", e);
+            if (!fs.getFileStatus(catalogStorePath).isDir()) {
+                throw new CatalogException(
+                        String.format(
+                                "Failed to open catalog store. The given catalog store path %s is not a directory.",
+                                catalogStorePath));
+            }
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CatalogException(
+                    String.format(
+                            "Failed to open file catalog store directory %s.", catalogStorePath),
+                    e);
         }
+        super.open();
     }
 
     /**
@@ -97,25 +114,29 @@ public class FileCatalogStore extends AbstractCatalogStore {
             throws CatalogException {
         checkOpenState();
 
-        Path filePath = getCatalogPath(catalogName);
+        Path catalogPath = getCatalogPath(catalogName);
         try {
-            File file = filePath.toFile();
-            if (file.exists()) {
+            FileSystem fs = catalogPath.getFileSystem();
+
+            if (fs.exists(catalogPath)) {
                 throw new CatalogException(
                         String.format(
                                 "Catalog %s's store file %s is already exist.",
-                                catalogName, filePath));
+                                catalogName, catalogPath));
             }
-            // create a new file
-            file.createNewFile();
-            String yamlString = yaml.dumpAsMap(catalog.getConfiguration().toMap());
-            FileUtils.writeFile(file, yamlString, charset);
-            LOG.info("Catalog {}'s configuration saved to file {}", catalogName, filePath);
-        } catch (Throwable e) {
+
+            try (FSDataOutputStream os = fs.create(catalogPath, WriteMode.NO_OVERWRITE)) {
+                YAML_MAPPER.writeValue(os, catalog.getConfiguration().toMap());
+            }
+
+            LOG.info("Catalog {}'s configuration saved to file {}", catalogName, catalogPath);
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
             throw new CatalogException(
                     String.format(
-                            "Failed to save catalog %s's configuration to file %s : %s",
-                            catalogName, filePath, e.getMessage()),
+                            "Failed to store catalog %s's configuration to file %s",
+                            catalogName, catalogPath),
                     e);
         }
     }
@@ -132,31 +153,23 @@ public class FileCatalogStore extends AbstractCatalogStore {
     public void removeCatalog(String catalogName, boolean ignoreIfNotExists)
             throws CatalogException {
         checkOpenState();
-
-        Path path = getCatalogPath(catalogName);
+        Path catalogPath = getCatalogPath(catalogName);
         try {
-            File file = path.toFile();
-            if (file.exists()) {
-                if (!file.isFile()) {
-                    throw new CatalogException(
-                            String.format(
-                                    "Catalog %s's store file %s is not a regular file",
-                                    catalogName, path.getFileName()));
-                }
-                Files.deleteIfExists(path);
-            } else {
-                if (!ignoreIfNotExists) {
-                    throw new CatalogException(
-                            String.format(
-                                    "Catalog %s's store file %s is not exist", catalogName, path));
-                }
+            FileSystem fs = catalogPath.getFileSystem();
+
+            if (fs.exists(catalogPath)) {
+                fs.delete(catalogPath, false);
+            } else if (!ignoreIfNotExists) {
+                throw new CatalogException(
+                        String.format(
+                                "Catalog %s's store file %s does not exist.",
+                                catalogName, catalogPath));
             }
-        } catch (Throwable e) {
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
             throw new CatalogException(
-                    String.format(
-                            "Failed to delete catalog %s's store file: %s",
-                            catalogName, e.getMessage()),
-                    e);
+                    String.format("Failed to remove catalog %s's store file.", catalogName), e);
         }
     }
 
@@ -172,22 +185,30 @@ public class FileCatalogStore extends AbstractCatalogStore {
     @Override
     public Optional<CatalogDescriptor> getCatalog(String catalogName) throws CatalogException {
         checkOpenState();
-
-        Path path = getCatalogPath(catalogName);
+        Path catalogPath = getCatalogPath(catalogName);
         try {
-            File file = path.toFile();
-            if (!file.exists()) {
-                LOG.warn("Catalog {}'s store file %s does not exist.", catalogName, path);
+            FileSystem fs = catalogPath.getFileSystem();
+
+            if (!fs.exists(catalogPath)) {
                 return Optional.empty();
             }
-            String content = FileUtils.readFile(file, charset);
-            Map<String, String> options = yaml.load(content);
-            return Optional.of(CatalogDescriptor.of(catalogName, Configuration.fromMap(options)));
-        } catch (Throwable t) {
+
+            try (FSDataInputStream is = fs.open(catalogPath)) {
+                Map<String, String> configMap =
+                        YAML_MAPPER.readValue(is, new TypeReference<Map<String, String>>() {});
+
+                CatalogDescriptor catalog =
+                        CatalogDescriptor.of(catalogName, Configuration.fromMap(configMap));
+
+                return Optional.of(catalog);
+            }
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
             throw new CatalogException(
                     String.format(
                             "Failed to load catalog %s's configuration from file", catalogName),
-                    t);
+                    e);
         }
     }
 
@@ -201,8 +222,23 @@ public class FileCatalogStore extends AbstractCatalogStore {
     @Override
     public Set<String> listCatalogs() throws CatalogException {
         checkOpenState();
+        try {
+            FileStatus[] statusArr = catalogStorePath.getFileSystem().listStatus(catalogStorePath);
 
-        return Collections.unmodifiableSet(listAllCatalogFiles().keySet());
+            return Arrays.stream(statusArr)
+                    .filter(status -> !status.isDir())
+                    .map(FileStatus::getPath)
+                    .map(Path::getName)
+                    .map(filename -> filename.replace(FILE_EXTENSION, ""))
+                    .collect(Collectors.toSet());
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CatalogException(
+                    String.format(
+                            "Failed to list file catalog store directory %s.", catalogStorePath),
+                    e);
+        }
     }
 
     /**
@@ -217,32 +253,10 @@ public class FileCatalogStore extends AbstractCatalogStore {
     public boolean contains(String catalogName) throws CatalogException {
         checkOpenState();
 
-        return listAllCatalogFiles().containsKey(catalogName);
-    }
-
-    private Map<String, Path> listAllCatalogFiles() throws CatalogException {
-        Map<String, Path> files = new HashMap<>();
-        File directoryFile = new File(catalogStoreDirectory);
-        if (!directoryFile.isDirectory()) {
-            throw new CatalogException("File catalog store only support local directory");
-        }
-
-        try {
-            Files.list(directoryFile.toPath())
-                    .filter(file -> file.getFileName().toString().endsWith(FILE_EXTENSION))
-                    .filter(Files::isRegularFile)
-                    .forEach(
-                            p ->
-                                    files.put(
-                                            p.getFileName().toString().replace(FILE_EXTENSION, ""),
-                                            p));
-        } catch (Throwable t) {
-            throw new CatalogException("Failed to list file catalog store directory", t);
-        }
-        return files;
+        return listCatalogs().contains(catalogName);
     }
 
     private Path getCatalogPath(String catalogName) {
-        return Paths.get(catalogStoreDirectory, catalogName + FILE_EXTENSION);
+        return new Path(catalogStorePath, catalogName + FILE_EXTENSION);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactory.java
@@ -20,42 +20,39 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.factories.CatalogStoreFactory;
-import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.FactoryHelper;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.CHARSET;
 import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.IDENTIFIER;
 import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.PATH;
 import static org.apache.flink.table.factories.FactoryUtil.createCatalogStoreFactoryHelper;
 
-/** CatalogStore factory for {@link FileCatalogStore}. */
+/** Catalog store factory for {@link FileCatalogStore}. */
 public class FileCatalogStoreFactory implements CatalogStoreFactory {
 
     private String path;
 
-    private String charset;
-
     @Override
     public CatalogStore createCatalogStore() {
-        return new FileCatalogStore(path, charset);
+        return new FileCatalogStore(path);
     }
 
     @Override
-    public void open(Context context) throws CatalogException {
-        FactoryUtil.FactoryHelper factoryHelper = createCatalogStoreFactoryHelper(this, context);
+    public void open(Context context) {
+        FactoryHelper<CatalogStoreFactory> factoryHelper =
+                createCatalogStoreFactoryHelper(this, context);
         factoryHelper.validate();
-        ReadableConfig options = factoryHelper.getOptions();
 
+        ReadableConfig options = factoryHelper.getOptions();
         path = options.get(PATH);
-        charset = options.get(CHARSET);
     }
 
     @Override
-    public void close() throws CatalogException {}
+    public void close() {}
 
     @Override
     public String factoryIdentifier() {
@@ -66,13 +63,12 @@ public class FileCatalogStoreFactory implements CatalogStoreFactory {
     public Set<ConfigOption<?>> requiredOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(PATH);
-        return options;
+
+        return Collections.unmodifiableSet(options);
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(CHARSET);
-        return options;
+        return Collections.emptySet();
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryOptions.java
@@ -21,8 +21,6 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
-import java.nio.charset.StandardCharsets;
-
 /** {@link ConfigOption}s for {@link FileCatalogStoreFactory}. */
 public class FileCatalogStoreFactoryOptions {
 
@@ -34,13 +32,6 @@ public class FileCatalogStoreFactoryOptions {
                     .noDefaultValue()
                     .withDescription(
                             "The configuration option for specifying the path to the file catalog store.");
-
-    public static final ConfigOption<String> CHARSET =
-            ConfigOptions.key("charset")
-                    .stringType()
-                    .defaultValue(StandardCharsets.UTF_8.displayName())
-                    .withDescription(
-                            "The charset used for storing/reading the catalog configuration.");
 
     private FileCatalogStoreFactoryOptions() {}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.factories.CatalogStoreFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Tests for {@link FileCatalogStoreFactory}. */
+class FileCatalogStoreFactoryTest {
+
+    @Test
+    void testFileCatalogStoreFactoryDiscovery(@TempDir File tempFolder) {
+
+        String factoryIdentifier = FileCatalogStoreFactoryOptions.IDENTIFIER;
+        Map<String, String> options = new HashMap<>();
+        options.put("path", tempFolder.getAbsolutePath());
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final FactoryUtil.DefaultCatalogStoreContext discoveryContext =
+                new FactoryUtil.DefaultCatalogStoreContext(options, null, classLoader);
+        final CatalogStoreFactory factory =
+                FactoryUtil.discoverFactory(
+                        classLoader, CatalogStoreFactory.class, factoryIdentifier);
+        factory.open(discoveryContext);
+
+        CatalogStore catalogStore = factory.createCatalogStore();
+        assertThat(catalogStore instanceof FileCatalogStore).isTrue();
+
+        factory.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduces a file catalog store implementation that supports external file systems.

## Brief change log

- Use `org.apache.flink.core.fs.Path` instead of standard Java local FS file utils.
- Use `FSDataOutputStream` and `FSDataInputStream` to read/write the catalog store file.
- Validate the given catalog store file exists in `FileCatalogStore#open()`, as automatic directory creation may fail on external file systems. (Permission problems or unsupported API)

## Verifying this change

This change is already covered by existing tests, such as:
- `FileCatalogStoreTest`
- `FileCatalogStoreFactoryTest`

Will add a test case with an external FS.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
