### PR TITLE
[FLINK-32660][table] Introduce external FS compatible FileCatalogStore implementation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactory.java
@@ -20,42 +20,39 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.factories.CatalogStoreFactory;
-import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.FactoryHelper;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.CHARSET;
 import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.IDENTIFIER;
 import static org.apache.flink.table.catalog.FileCatalogStoreFactoryOptions.PATH;
 import static org.apache.flink.table.factories.FactoryUtil.createCatalogStoreFactoryHelper;
 
-/** CatalogStore factory for {@link FileCatalogStore}. */
+/** Catalog store factory for {@link FileCatalogStore}. */
 public class FileCatalogStoreFactory implements CatalogStoreFactory {
 
     private String path;
 
-    private String charset;
-
     @Override
     public CatalogStore createCatalogStore() {
-        return new FileCatalogStore(path, charset);
+        return new FileCatalogStore(path);
     }
 
     @Override
-    public void open(Context context) throws CatalogException {
-        FactoryUtil.FactoryHelper factoryHelper = createCatalogStoreFactoryHelper(this, context);
+    public void open(Context context) {
+        FactoryHelper<CatalogStoreFactory> factoryHelper =
+                createCatalogStoreFactoryHelper(this, context);
         factoryHelper.validate();
-        ReadableConfig options = factoryHelper.getOptions();
 
+        ReadableConfig options = factoryHelper.getOptions();
         path = options.get(PATH);
-        charset = options.get(CHARSET);
     }
 
     @Override
-    public void close() throws CatalogException {}
+    public void close() {}
 
     @Override
     public String factoryIdentifier() {
@@ -66,13 +63,12 @@ public class FileCatalogStoreFactory implements CatalogStoreFactory {
     public Set<ConfigOption<?>> requiredOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(PATH);
-        return options;
+
+        return Collections.unmodifiableSet(options);
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(CHARSET);
-        return options;
+        return Collections.emptySet();
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryOptions.java
@@ -21,8 +21,6 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
-import java.nio.charset.StandardCharsets;
-
 /** {@link ConfigOption}s for {@link FileCatalogStoreFactory}. */
 public class FileCatalogStoreFactoryOptions {
 
@@ -34,13 +32,6 @@ public class FileCatalogStoreFactoryOptions {
                     .noDefaultValue()
                     .withDescription(
                             "The configuration option for specifying the path to the file catalog store.");
-
-    public static final ConfigOption<String> CHARSET =
-            ConfigOptions.key("charset")
-                    .stringType()
-                    .defaultValue(StandardCharsets.UTF_8.displayName())
-                    .withDescription(
-                            "The charset used for storing/reading the catalog configuration.");
 
     private FileCatalogStoreFactoryOptions() {}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.factories.CatalogStoreFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Tests for {@link FileCatalogStoreFactory}. */
+class FileCatalogStoreFactoryTest {
+
+    @Test
+    void testFileCatalogStoreFactoryDiscovery(@TempDir File tempFolder) {
+
+        String factoryIdentifier = FileCatalogStoreFactoryOptions.IDENTIFIER;
+        Map<String, String> options = new HashMap<>();
+        options.put("path", tempFolder.getAbsolutePath());
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final FactoryUtil.DefaultCatalogStoreContext discoveryContext =
+                new FactoryUtil.DefaultCatalogStoreContext(options, null, classLoader);
+        final CatalogStoreFactory factory =
+                FactoryUtil.discoverFactory(
+                        classLoader, CatalogStoreFactory.class, factoryIdentifier);
+        factory.open(discoveryContext);
+
+        CatalogStore catalogStore = factory.createCatalogStore();
+        assertThat(catalogStore instanceof FileCatalogStore).isTrue();
+
+        factory.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduces a file catalog store implementation that supports external file systems.

## Brief change log

- Use `org.apache.flink.core.fs.Path` instead of standard Java local FS file utils.
- Use `FSDataOutputStream` and `FSDataInputStream` to read/write the catalog store file.
- Validate the given catalog store file exists in `FileCatalogStore#open()`, as automatic directory creation may fail on external file systems. (Permission problems or unsupported API)

## Verifying this change

This change is already covered by existing tests, such as:
- `FileCatalogStoreTest`
- `FileCatalogStoreFactoryTest`

Will add a test case with an external FS.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
