### PR TITLE
[FLINK-32168] RM logs missing and current resources

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -801,12 +801,9 @@ public class FineGrainedSlotManager implements SlotManager {
 
     @Override
     public Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID) {
-        return taskManagerTracker
-                .getRegisteredTaskManager(instanceID)
-                .map(TaskManagerInfo::getAllocatedSlots)
-                .map(Map::values)
-                .orElse(Collections.emptyList())
-                .stream()
+        return taskManagerTracker.getRegisteredTaskManager(instanceID)
+                .map(TaskManagerInfo::getAllocatedSlots).map(Map::values)
+                .orElse(Collections.emptyList()).stream()
                 .map(slot -> new SlotInfo(slot.getJobId(), slot.getResourceProfile()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
```
2023-07-24 15:27:05,558 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - Received resource requirements from job 525d55a98516a8918aa77bef5b8e4e64: [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=1}]
2023-07-24 15:27:05,621 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - Matching resource requirements against available resources.
2023-07-24 15:27:05,621 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - Missing resources:
2023-07-24 15:27:05,621 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - 	Job 525d55a98516a8918aa77bef5b8e4e64 requires [ResourceRequirement{resourceProfile=ResourceProfile{UNKNOWN}, numberOfRequiredSlots=1}].
2023-07-24 15:27:05,621 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - Current resources:
2023-07-24 15:27:05,621 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - 	TaskManager localhost:35187-06ac90
2023-07-24 15:27:05,622 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - 		Available: ResourceProfile{cpuCores=1, taskHeapMemory=384.000mb (402653174 bytes), taskOffHeapMemory=0 bytes, managedMemory=512.000mb (536870920 bytes), networkMemory=128.000mb (134217730 bytes)}
2023-07-24 15:27:05,622 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.FineGrainedSlotManager [] - 		Total:     ResourceProfile{cpuCores=1, taskHeapMemory=384.000mb (402653174 bytes), taskOffHeapMemory=0 bytes, managedMemory=512.000mb (536870920 bytes), networkMemory=128.000mb (134217730 bytes)}
```