### PR TITLE
[FLINK-32656][table] Deprecate ManagedTable related APIs

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalogLock.java
@@ -46,7 +46,12 @@ import java.util.concurrent.Callable;
 import static org.apache.flink.table.catalog.hive.HiveConfOptions.LOCK_ACQUIRE_TIMEOUT;
 import static org.apache.flink.table.catalog.hive.HiveConfOptions.LOCK_CHECK_MAX_SLEEP;
 
-/** Hive {@link CatalogLock}. */
+/**
+ * Hive {@link CatalogLock}.
+ *
+ * @deprecated This class will be removed soon. Please see FLIP-346 for more details.
+ */
+@Deprecated
 public class HiveCatalogLock implements CatalogLock {
 
     private final HiveMetastoreClientWrapper client;
@@ -123,6 +128,7 @@ public class HiveCatalogLock implements CatalogLock {
         return new HiveCatalogLockFactory(hiveConf);
     }
 
+    @Deprecated
     private static class HiveCatalogLockFactory implements CatalogLock.Factory {
 
         private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
@@ -81,7 +81,12 @@ public class TableDescriptor {
         return descriptorBuilder;
     }
 
-    /** Creates a new {@link Builder} for a managed table. */
+    /**
+     * Creates a new {@link Builder} for a managed table.
+     *
+     * @deprecated This method will be removed soon. Please see FLIP-346 for more details.
+     */
+    @Deprecated
     public static Builder forManaged() {
         return new Builder();
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ManagedTableListener.java
@@ -37,7 +37,12 @@ import java.util.Map;
 
 import static org.apache.flink.table.factories.ManagedTableFactory.discoverManagedTableFactory;
 
-/** The listener for managed table operations. */
+/**
+ * The listener for managed table operations.
+ *
+ * @deprecated This interface will be removed soon. Please see FLIP-346 for more details.
+ */
+@Deprecated
 @Internal
 public class ManagedTableListener {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -367,7 +367,12 @@ public interface Catalog {
         alterTable(tablePath, newTable, ignoreIfNotExists);
     }
 
-    /** If true, tables which do not specify a connector will be translated to managed tables. */
+    /**
+     * If true, tables which do not specify a connector will be translated to managed tables.
+     *
+     * @deprecated This method will be removed soon. Please see FLIP-346 for more details.
+     */
+    @Deprecated
     default boolean supportsManagedTable() {
         return false;
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogLock.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogLock.java
@@ -26,14 +26,22 @@ import java.util.concurrent.Callable;
 
 /**
  * An interface that allows source and sink to use global lock to some transaction-related things.
+ *
+ * @deprecated This interface will be removed soon. Please see FLIP-346 for more details.
  */
+@Deprecated
 @Internal
 public interface CatalogLock extends Closeable {
 
     /** Run with catalog lock. The caller should tell catalog the database and table name. */
     <T> T runWithLock(String database, String table, Callable<T> callable) throws Exception;
 
-    /** Factory to create {@link CatalogLock}. */
+    /**
+     * Factory to create {@link CatalogLock}.
+     *
+     * @deprecated This interface will be removed soon. Please see FLIP-346 for more details.
+     */
+    @Deprecated
     interface Factory extends Serializable {
         CatalogLock create();
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RequireCatalogLock.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RequireCatalogLock.java
@@ -21,7 +21,12 @@ package org.apache.flink.table.connector;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.CatalogLock;
 
-/** Source and sink implement this interface if they require {@link CatalogLock}. */
+/**
+ * Source and sink implement this interface if they require {@link CatalogLock}.
+ *
+ * @deprecated This interface will be removed soon. Please see FLIP-346 for more details.
+ */
+@Deprecated
 @Internal
 public interface RequireCatalogLock {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ManagedTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/ManagedTableFactory.java
@@ -26,7 +26,10 @@ import java.util.Map;
 /**
  * Base interface for configuring a managed dynamic table connector. The managed table factory is
  * used when there is no {@link FactoryUtil#CONNECTOR} option.
+ *
+ * @deprecated This interface will be removed soon. Please see FLIP-346 for more details.
  */
+@Deprecated
 @Internal
 public interface ManagedTableFactory extends DynamicTableFactory {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR marks all `ManagedTable` related APIs as `@Deprecated`, according to [FLIP-346](https://cwiki.apache.org/confluence/display/FLINK/FLIP-346%3A+Deprecate+ManagedTable+related+APIs).

## Brief change log
Mark all related methods/classes/interfaces as deprecated.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no) Mark as deprecated
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
