### PR TITLE
[FLINK-32664][table] Fix TableSourceJsonPlanTest.testReuseSourceWithoutProjectionPushDown

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReuseSourceWithoutProjectionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReuseSourceWithoutProjectionPushDown.out
@@ -40,10 +40,11 @@
     "description" : "Calc(select=[x, ts])"
   }, {
     "id" : 3,
-    "type" : "stream-exec-sink_2",
+    "type" : "stream-exec-sink_1",
     "configuration" : {
       "table.exec.sink.keyed-shuffle" : "AUTO",
       "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
       "table.exec.sink.type-length-enforcer" : "IGNORE",
       "table.exec.sink.upsert-materialize" : "AUTO"
     },
@@ -92,10 +93,11 @@
     "description" : "Calc(select=[y, CAST(tags AS VARCHAR(2147483647)) AS tags])"
   }, {
     "id" : 5,
-    "type" : "stream-exec-sink_2",
+    "type" : "stream-exec-sink_1",
     "configuration" : {
       "table.exec.sink.keyed-shuffle" : "AUTO",
       "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
       "table.exec.sink.type-length-enforcer" : "IGNORE",
       "table.exec.sink.upsert-materialize" : "AUTO"
     },


### PR DESCRIPTION
## What is the purpose of the change

The PR is aiming to fix  failing ci tests especially `TableSourceJsonPlanTest.testReuseSourceWithoutProjectionPushDown` which became broken after https://issues.apache.org/jira/browse/FLINK-32657
https://github.com/apache/flink/commit/6a3808213d334de614e162362d1583f3e5322358 


## Verifying this change

The change is change of tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
