### PR TITLE
[FLINK-32655][runtime]  Fix checkpoint aborted message being swallowed by RecreateOnResetOperatorCoordinator.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -116,6 +116,11 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        coordinator.applyCall("checkpointAborted", c -> c.notifyCheckpointAborted(checkpointId));
+    }
+
+    @Override
     public void resetToCheckpoint(final long checkpointId, @Nullable final byte[] checkpointData) {
         // First bump up the coordinator epoch to fence out the active coordinator.
         LOG.info("Resetting coordinator to checkpoint.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -264,6 +264,21 @@ public class RecreateOnResetOperatorCoordinatorTest {
                 "Timed out when waiting for the coordinator to close.");
     }
 
+    @Test
+    public void testNotifyCheckpointAbortedSuccess() throws Exception {
+        TestingCoordinatorProvider provider = new TestingCoordinatorProvider(null);
+        MockOperatorCoordinatorContext context =
+                new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SUBTASKS);
+        RecreateOnResetOperatorCoordinator coordinator = createCoordinator(provider, context);
+        TestingOperatorCoordinator internalCoordinatorAfterReset =
+                getInternalCoordinator(coordinator);
+
+        long checkpointId = 10L;
+        coordinator.notifyCheckpointAborted(checkpointId);
+        assertThat(internalCoordinatorAfterReset.getLastCheckpointAborted())
+                .isEqualTo(checkpointId);
+    }
+
     // ---------------
 
     private RecreateOnResetOperatorCoordinator createCoordinator(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -54,6 +54,8 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
 
     private final BlockingQueue<Long> lastCheckpointComplete;
 
+    private final BlockingQueue<Long> lastCheckpointAborted;
+
     private final BlockingQueue<OperatorEvent> receivedOperatorEvents;
 
     private final Map<Integer, SubtaskGateway> subtaskGateways;
@@ -72,6 +74,7 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
         this.context = context;
         this.triggeredCheckpoints = new LinkedBlockingQueue<>();
         this.lastCheckpointComplete = new LinkedBlockingQueue<>();
+        this.lastCheckpointAborted = new LinkedBlockingQueue<>();
         this.receivedOperatorEvents = new LinkedBlockingQueue<>();
         this.blockOnCloseLatch = blockOnCloseLatch;
         this.subtaskGateways = new HashMap<>();
@@ -123,6 +126,11 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
         lastCheckpointComplete.offer(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        lastCheckpointAborted.offer(checkpointId);
     }
 
     @Override
@@ -183,6 +191,10 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
 
     public long getLastCheckpointComplete() throws InterruptedException {
         return lastCheckpointComplete.take();
+    }
+
+    public long getLastCheckpointAborted() throws InterruptedException {
+        return lastCheckpointAborted.take();
     }
 
     @Nullable


### PR DESCRIPTION
Backporting #23059  to release-1.16