### PR TITLE
[FLINK-32674][doc] Add documentation for the new getTargetColumns in DynamicTableSink

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/insert.md
+++ b/docs/content.zh/docs/dev/table/sql/insert.md
@@ -206,6 +206,12 @@ part_spec:
 
 `PARTITION` 语句应该包含需要插入的静态分区列与值。
 
+**COLUMN LIST**
+
+给定一个表 T(a INT, b INT, c INT)，Flink 支持 INSERT INTO T(c, b) SELECT x, y FROM S。
+预期行为是 “x” 被写入 “c” 列，“y” 被写入 “b” 列，而 “a” 被设置为空值（假设 “a” 列可为空）。
+对于连接器开发人员，在处理部分列更新时如果希望避免用空值覆盖非目标列，用户 insert 语句所指定的目标列信息可以从 {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}} 中获取。
+
 ### 示例
 
 ```sql

--- a/docs/content.zh/docs/dev/table/sql/insert.md
+++ b/docs/content.zh/docs/dev/table/sql/insert.md
@@ -209,8 +209,9 @@ part_spec:
 **COLUMN LIST**
 
 给定一个表 T(a INT, b INT, c INT)，Flink 支持 INSERT INTO T(c, b) SELECT x, y FROM S。
-预期行为是 “x” 被写入 “c” 列，“y” 被写入 “b” 列，而 “a” 被设置为空值（假设 “a” 列可为空）。
-对于连接器开发人员，在处理部分列更新时如果希望避免用空值覆盖非目标列，用户 insert 语句所指定的目标列信息可以从 {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}} 中获取。
+预期行为是 “x” 被写入 “c” 列，“y” 被写入 “b” 列，而 “a” 被设置为空值（假设 “a” 列可为空）。<br />
+连接器开发人员在处理部分列更新时，如果希望避免用空值覆盖非目标列，可以从 {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}}
+中获取用户插入语句指定的目标列信息，然后决定如何处理部分更新。
 
 ### 示例
 

--- a/docs/content/docs/dev/table/sql/insert.md
+++ b/docs/content/docs/dev/table/sql/insert.md
@@ -208,9 +208,10 @@ column_list:
 **COLUMN LIST**
 
 Given a table T(a INT, b INT, c INT), Flink supports INSERT INTO T(c, b) SELECT x, y FROM S. The expectation is
-that 'x' is written to column 'c' and 'y' is written to column 'b' and 'a' is set to NULL (assuming column 'a' is nullable).
-For the connector developers who want to avoid overwriting non-target columns with null values when processing partial column updates,
-this user specified target column list can be found from the {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}}.
+that 'x' is written to column 'c' and 'y' is written to column 'b' and 'a' is set to NULL (assuming column 'a' is nullable).<br />
+For connector developers who want to avoid overwriting non-target columns with null values when processing partial column updates,
+you can get the information about the target columns specified by the user's insert statement from {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}}
+and decide how to process the partial updates.
 
 ### Examples
 

--- a/docs/content/docs/dev/table/sql/insert.md
+++ b/docs/content/docs/dev/table/sql/insert.md
@@ -208,7 +208,9 @@ column_list:
 **COLUMN LIST**
 
 Given a table T(a INT, b INT, c INT), Flink supports INSERT INTO T(c, b) SELECT x, y FROM S. The expectation is
-that 'x' is written to column 'c' and 'y' is written to column 'b' and 'a' is set to NULL (assuming column 'a' is nullable). 
+that 'x' is written to column 'c' and 'y' is written to column 'b' and 'a' is set to NULL (assuming column 'a' is nullable).
+For the connector developers who want to avoid overwriting non-target columns with null values when processing partial column updates,
+this user specified target column list can be found from the {{< gh_link file="flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java" name="DynamicTableSink$Context.getTargetColumns()" >}}.
 
 ### Examples
 


### PR DESCRIPTION
## What is the purpose of the change
This is an addition to the documentation for the newly added interface in FLINK-31487. It may be beneficial for connector developers who want to avoid overwriting non-target columns with null values when processing partial column updates. 

## Brief change log
Update the current sql doc dev/table/sql/insert.md