### PR TITLE
[FLINK-32670] Cascade deprecation to classes that implement SourceFunction

### DIFF
--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
@@ -26,7 +26,12 @@ import java.util.concurrent.TimeUnit;
 /**
  * This class is a SourceFunction that reads {@link WikipediaEditEvent} instances from the IRC
  * channel <code>#en.wikipedia</code>.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 public class WikipediaEditsSource extends RichSourceFunction<WikipediaEditEvent> {
 
     /** Hostname of the server to connect to. */

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -75,7 +75,14 @@ public class PeriodicStreamingJob {
         sEnv.execute();
     }
 
-    /** Data-generating source function. */
+    /**
+     * Data-generating source function.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     public static class PeriodicSourceGenerator
             implements SourceFunction<Tuple>, ResultTypeQueryable<Tuple>, CheckpointedFunction {
         private final int sleepMs;

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
@@ -33,7 +33,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-/** This source function generates a sequence of long values per key. */
+/**
+ * This source function generates a sequence of long values per key.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+ */
+@Deprecated
 public class SequenceGeneratorSource extends RichParallelSourceFunction<Event>
         implements CheckpointedFunction {
 

--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
@@ -123,7 +123,14 @@ public enum FileSinkProgram {
         }
     }
 
-    /** Data-generating source function. */
+    /**
+     * Data-generating source function.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     public static final class Generator
             implements SourceFunction<Tuple2<Integer, Integer>>, CheckpointedFunction {
 

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/src/main/java/org/apache/flink/deployment/HeavyDeploymentStressTestProgram.java
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/src/main/java/org/apache/flink/deployment/HeavyDeploymentStressTestProgram.java
@@ -77,7 +77,14 @@ public class HeavyDeploymentStressTestProgram {
         env.execute("HeavyDeploymentStressTestProgram");
     }
 
-    /** Source with dummy operator state that results in inflated meta data. */
+    /**
+     * Source with dummy operator state that results in inflated meta data.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     static class SimpleEndlessSourceWithBloatedState extends RichParallelSourceFunction<String>
             implements CheckpointedFunction, CheckpointListener {
 

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
@@ -131,7 +131,14 @@ public class StickyAllocationAndLocalRecoveryTestJob {
         env.execute("Sticky Allocation And Local Recovery Test");
     }
 
-    /** Source function that produces a long sequence. */
+    /**
+     * Source function that produces a long sequence.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     private static final class RandomLongSource extends RichParallelSourceFunction<Long>
             implements CheckpointedFunction {
 

--- a/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/src/main/java/org/apache/flink/streaming/tests/NettyShuffleMemoryControlTestProgram.java
+++ b/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/src/main/java/org/apache/flink/streaming/tests/NettyShuffleMemoryControlTestProgram.java
@@ -101,6 +101,12 @@ public class NettyShuffleMemoryControlTestProgram {
         env.execute("Netty Shuffle Memory Control Test");
     }
 
+    /**
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     private static class StringSourceFunction extends RichParallelSourceFunction<String> {
         private static final long serialVersionUID = 1L;
 

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateProducer.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateProducer.java
@@ -95,6 +95,12 @@ public class QsStateProducer {
         env.execute();
     }
 
+    /**
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     private static class EmailSource extends RichSourceFunction<Email> {
 
         private static final long serialVersionUID = -7286937645300388040L;

--- a/flink-end-to-end-tests/flink-state-evolution-test/src/main/java/org/apache/flink/test/StatefulStreamingJob.java
+++ b/flink-end-to-end-tests/flink-state-evolution-test/src/main/java/org/apache/flink/test/StatefulStreamingJob.java
@@ -45,7 +45,14 @@ public class StatefulStreamingJob {
 
     private static final String EXPECTED_DEFAULT_VALUE = "123";
 
-    /** Stub source that emits one record per second. */
+    /**
+     * Stub source that emits one record per second.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     public static class MySource extends RichParallelSourceFunction<Integer> {
 
         private static final long serialVersionUID = 1L;

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -247,7 +247,14 @@ public class StreamSQLTestProgram {
         }
     }
 
-    /** Data-generating source function. */
+    /**
+     * Data-generating source function.
+     *
+     * @deprecated This class is based on the {@link
+     *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+     *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+     */
+    @Deprecated
     public static class Generator
             implements SourceFunction<Row>, ResultTypeQueryable<Row>, CheckpointedFunction {
 

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlStateUpdateSource.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/TtlStateUpdateSource.java
@@ -31,7 +31,12 @@ import java.util.stream.Collectors;
  * <p>Internal loop generates {@code sleepAfterElements} state updates for each verifier from {@link
  * TtlStateVerifier#VERIFIERS} using {@link TtlStateVerifier#generateRandomUpdate} and waits for
  * {@code sleepTime} to continue generation.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 class TtlStateUpdateSource extends RichParallelSourceFunction<TtlStateUpdate> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -70,6 +70,8 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-datagen</artifactId>
 			<version>${project.version}</version>
+			<!-- required by the shade plugin -->
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
@@ -342,6 +344,19 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-connector-datagen</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
 					<execution>
 						<id>MatrixVectorMul</id>
 						<phase>package</phase>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -344,6 +344,7 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
+					<!-- DataGeneratorSource is used across the streaming examples and is bundled to make examples self-contained -->
 					<execution>
 						<phase>package</phase>
 						<goals>

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java
@@ -23,13 +23,12 @@ import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.datagen.source.DataGeneratorSource;
 import org.apache.flink.connector.datagen.source.GeneratorFunction;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.examples.utils.ParameterTool;
 import org.apache.flink.util.Preconditions;
@@ -108,13 +107,13 @@ public class MatrixVectorMul {
                     return randomRecord;
                 };
 
+        // Generates random vectors with specified dimension
         DataGeneratorSource<List<Float>> generatorSource =
                 new DataGeneratorSource<>(generatorFunction, dataSize, Types.LIST(Types.FLOAT));
 
-        DataStreamSource<List<Float>> result =
-                env.fromSource(generatorSource, WatermarkStrategy.noWatermarks(), "Vectors Source");
-
-        result.print();
+        DataStream<List<Float>> result =
+                env.fromSource(generatorSource, WatermarkStrategy.noWatermarks(), "Vectors Source")
+                        .map(new Multiplier(dimension, resourceName));
 
         // Emit result
         if (params.has("output")) {

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/gpu/MatrixVectorMul.java
@@ -18,15 +18,19 @@
 
 package org.apache.flink.streaming.examples.gpu;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.examples.utils.ParameterTool;
 import org.apache.flink.util.Preconditions;
 
@@ -44,10 +48,10 @@ import java.util.UUID;
 /**
  * Implements the matrix-vector multiplication program that shows how to use GPU resources in Flink.
  *
- * <p>The input is a vector stream from a {@link RandomVectorSource}, which will generate random
- * vectors with specified dimension. The data size of the vector stream could be specified by user.
- * Each vector will be multiplied with a random dimension * dimension matrix in {@link Multiplier}
- * and the result would be emitted to output.
+ * <p>The input is a vector stream, which will generate random vectors with specified dimension. The
+ * data size of the vector stream could be specified by user. Each vector will be multiplied with a
+ * random dimension * dimension matrix in {@link Multiplier} and the result would be emitted to
+ * output.
  *
  * <p>Usage: MatrixVectorMul [--output &lt;path&gt;] [--dimension &lt;dimension&gt; --data-size
  * &lt;data_size&gt;]
@@ -95,9 +99,22 @@ public class MatrixVectorMul {
         final int dataSize = params.getInt("data-size", DEFAULT_DATA_SIZE);
         final String resourceName = params.get("resource-name", DEFAULT_RESOURCE_NAME);
 
-        DataStream<List<Float>> result =
-                env.addSource(new RandomVectorSource(dimension, dataSize))
-                        .map(new Multiplier(dimension, resourceName));
+        GeneratorFunction<Long, List<Float>> generatorFunction =
+                index -> {
+                    List<Float> randomRecord = new ArrayList<>();
+                    for (int i = 0; i < dimension; ++i) {
+                        randomRecord.add((float) Math.random());
+                    }
+                    return randomRecord;
+                };
+
+        DataGeneratorSource<List<Float>> generatorSource =
+                new DataGeneratorSource<>(generatorFunction, dataSize, Types.LIST(Types.FLOAT));
+
+        DataStreamSource<List<Float>> result =
+                env.fromSource(generatorSource, WatermarkStrategy.noWatermarks(), "Vectors Source");
+
+        result.print();
 
         // Emit result
         if (params.has("output")) {
@@ -117,45 +134,6 @@ public class MatrixVectorMul {
     // *************************************************************************
     // USER FUNCTIONS
     // *************************************************************************
-
-    /**
-     * Random vector source which generates random vectors with specified dimension and total data
-     * size.
-     */
-    private static final class RandomVectorSource extends RichSourceFunction<List<Float>> {
-
-        private transient volatile boolean running;
-        private final int dimension;
-        private final int dataSize;
-
-        RandomVectorSource(int dimension, int dataSize) {
-            this.dimension = dimension;
-            this.dataSize = dataSize;
-        }
-
-        @Override
-        public void open(Configuration parameters) {
-            running = true;
-        }
-
-        @Override
-        public void run(SourceContext<List<Float>> ctx) {
-            int count = 0;
-            while (running && count < dataSize) {
-                List<Float> randomRecord = new ArrayList<>();
-                for (int i = 0; i < dimension; ++i) {
-                    randomRecord.add((float) Math.random());
-                }
-                ctx.collect(randomRecord);
-                count += 1;
-            }
-        }
-
-        @Override
-        public void cancel() {
-            running = false;
-        }
-    }
 
     /** Matrix-Vector multiplier using CUBLAS library. */
     private static final class Multiplier extends RichMapFunction<List<Float>, List<Float>> {

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
@@ -41,7 +41,6 @@ public class KafkaEventsGeneratorJob {
         final ParameterTool params = ParameterTool.fromArgs(args);
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
 
         final double errorRate = params.getDouble("error-rate", 0.0);
         final int sleep = params.getInt("sleep", 1);

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/generator/EventsGeneratorFunction.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/generator/EventsGeneratorFunction.java
@@ -18,50 +18,40 @@
 
 package org.apache.flink.streaming.examples.statemachine.generator;
 
-import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
 import org.apache.flink.streaming.examples.statemachine.event.Event;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-/** A event stream source that generates the events on the fly. Useful for self-contained demos. */
+/** A generator function that produces the events on the fly. Useful for self-contained demos. */
 @SuppressWarnings("serial")
-public class EventsGeneratorSource extends RichParallelSourceFunction<Event> {
+public class EventsGeneratorFunction implements GeneratorFunction<Long, Event> {
 
     private final double errorProbability;
 
-    private final int delayPerRecordMillis;
+    transient EventsGenerator generator;
+    private int min;
+    private int max;
 
-    private volatile boolean running = true;
-
-    public EventsGeneratorSource(double errorProbability, int delayPerRecordMillis) {
+    public EventsGeneratorFunction(double errorProbability) {
         checkArgument(
                 errorProbability >= 0.0 && errorProbability <= 1.0,
                 "error probability must be in [0.0, 1.0]");
-        checkArgument(delayPerRecordMillis >= 0, "delay must be >= 0");
 
         this.errorProbability = errorProbability;
-        this.delayPerRecordMillis = delayPerRecordMillis;
     }
 
     @Override
-    public void run(SourceContext<Event> sourceContext) throws Exception {
-        final EventsGenerator generator = new EventsGenerator(errorProbability);
-
-        final int range = Integer.MAX_VALUE / getRuntimeContext().getNumberOfParallelSubtasks();
-        final int min = range * getRuntimeContext().getIndexOfThisSubtask();
-        final int max = min + range;
-
-        while (running) {
-            sourceContext.collect(generator.next(min, max));
-
-            if (delayPerRecordMillis > 0) {
-                Thread.sleep(delayPerRecordMillis);
-            }
-        }
+    public void open(SourceReaderContext readerContext) throws Exception {
+        final int range = Integer.MAX_VALUE / readerContext.currentParallelism();
+        min = range * readerContext.getIndexOfSubtask();
+        max = min + range;
+        generator = new EventsGenerator(errorProbability);
     }
 
     @Override
-    public void cancel() {
-        running = false;
+    public Event map(Long value) throws Exception {
+        return generator.next(min, max);
     }
 }

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
@@ -18,31 +18,44 @@
 
 package org.apache.flink.streaming.examples.windowing;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.util.Collector;
 
-/**
- * An example of grouped stream windowing into sliding time windows. This example uses {@link
- * RichParallelSourceFunction} to generate a list of key-value pairs.
- */
+/** An example of grouped stream windowing into sliding time windows. */
 public class GroupedProcessingTimeWindowExample {
 
     public static void main(String[] args) throws Exception {
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        DataStream<Tuple2<Long, Long>> stream = env.addSource(new DataSource());
+        final long numElementsPerParallel = 20000000;
+        final long numKeys = 10000;
+
+        GeneratorFunction<Long, Tuple2<Long, Long>> generatorFunction =
+                new DataGeneratorFunction(numElementsPerParallel, numKeys);
+
+        DataGeneratorSource<Tuple2<Long, Long>> generatorSource =
+                new DataGeneratorSource<>(
+                        generatorFunction,
+                        numElementsPerParallel * env.getParallelism(),
+                        Types.TUPLE(Types.LONG, Types.LONG));
+
+        DataStream<Tuple2<Long, Long>> stream =
+                env.fromSource(generatorSource, WatermarkStrategy.noWatermarks(), "Data Generator");
 
         stream.keyBy(value -> value.f0)
                 .window(
@@ -97,38 +110,34 @@ public class GroupedProcessingTimeWindowExample {
         }
     }
 
-    /** Parallel data source that serves a list of key-value pairs. */
-    private static class DataSource extends RichParallelSourceFunction<Tuple2<Long, Long>> {
+    private static class DataGeneratorFunction
+            implements GeneratorFunction<Long, Tuple2<Long, Long>> {
 
-        private volatile boolean running = true;
+        private final long numElements;
+        private final long numKeys;
+        private long startTime;
 
-        @Override
-        public void run(SourceContext<Tuple2<Long, Long>> ctx) throws Exception {
-
-            final long startTime = System.currentTimeMillis();
-
-            final long numElements = 20000000;
-            final long numKeys = 10000;
-            long val = 1L;
-            long count = 0L;
-
-            while (running && count < numElements) {
-                count++;
-                ctx.collect(new Tuple2<>(val++, 1L));
-
-                if (val > numKeys) {
-                    val = 1L;
-                }
-            }
-
-            final long endTime = System.currentTimeMillis();
-            System.out.println(
-                    "Took " + (endTime - startTime) + " msecs for " + numElements + " values");
+        public DataGeneratorFunction(long numElements, long numKeys) {
+            this.numElements = numElements;
+            this.numKeys = numKeys;
         }
 
         @Override
-        public void cancel() {
-            running = false;
+        public Tuple2<Long, Long> map(Long value) throws Exception {
+            if ((value % numElements) == 0) {
+                startTime = System.currentTimeMillis();
+            }
+            if ((value % numElements + 1) == numElements) {
+                final long endTime = System.currentTimeMillis();
+                System.out.println(
+                        Thread.currentThread()
+                                + ": Took "
+                                + (endTime - startTime)
+                                + " msecs for "
+                                + numElements
+                                + " values");
+            }
+            return new Tuple2<>(value % numKeys, 1L);
         }
     }
 }

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/GroupedProcessingTimeWindowExample.java
@@ -110,6 +110,11 @@ public class GroupedProcessingTimeWindowExample {
         }
     }
 
+    /**
+     * This class represents a data generator function that generates a stream of tuples. Each tuple
+     * contains a key and a value. The function measures and prints the time it takes to generate
+     * numElements. The key space is limited to numKeys. The value is always 1.
+     */
     private static class DataGeneratorFunction
             implements GeneratorFunction<Long, Tuple2<Long, Long>> {
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
@@ -56,7 +56,14 @@ import java.nio.channels.Channels;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-/** An Arrow {@link SourceFunction} which takes the serialized arrow record batch data as input. */
+/**
+ * An Arrow {@link SourceFunction} which takes the serialized arrow record batch data as input.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+ */
+@Deprecated
 @Internal
 public class ArrowSourceFunction extends RichParallelSourceFunction<RowData>
         implements ResultTypeQueryable<RowData>, CheckpointedFunction {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ExternallyInducedSource.java
@@ -36,7 +36,11 @@ import org.apache.flink.util.FlinkException;
  *
  * @param <T> Type of the elements produced by the source function
  * @param <CD> The type of the data stored in the checkpoint by the master that triggers
+ * @deprecated This interface is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public interface ExternallyInducedSource<T, CD>
         extends SourceFunction<T>, WithMasterCheckpointHook<CD> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -63,7 +63,12 @@ import java.util.TreeMap;
  *
  * <p><b>IMPORTANT NOTE: </b> Splits are forwarded downstream for reading in ascending modification
  * time order, based on the modification time of the files they belong to.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @Internal
 public class ContinuousFileMonitoringFunction<OUT>
         extends RichSourceFunction<TimestampedFileInputSplit> implements CheckpointedFunction {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
@@ -38,6 +38,9 @@ import java.util.Map;
  * new files. Used together with {@link FileReadFunction}.
  *
  * @deprecated Internal class deprecated in favour of {@link ContinuousFileMonitoringFunction}.
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Internal
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -57,7 +57,11 @@ import java.util.Objects;
  * <p><b>NOTE:</b> This source has a parallelism of 1.
  *
  * @param <T> The type of elements returned by this function.
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public class FromElementsFunction<T>
         implements SourceFunction<T>, CheckpointedFunction, OutputTypeConfigurable<T> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
@@ -21,7 +21,14 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import java.util.Iterator;
 
-/** A {@link SourceFunction} that reads elements from an {@link Iterator} and emits them. */
+/**
+ * A {@link SourceFunction} that reads elements from an {@link Iterator} and emits them.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+ */
+@Deprecated
 @PublicEvolving
 public class FromIteratorFunction<T> implements SourceFunction<T> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
@@ -25,7 +25,12 @@ import java.util.Iterator;
 
 /**
  * A {@link SourceFunction} that reads elements from an {@link SplittableIterator} and emits them.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public class FromSplittableIteratorFunction<T> extends RichParallelSourceFunction<T> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
@@ -32,7 +32,14 @@ import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-/** A {@link SourceFunction} that reads data using an {@link InputFormat}. */
+/**
+ * A {@link SourceFunction} that reads data using an {@link InputFormat}.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+ */
+@Deprecated
 @Internal
 public class InputFormatSourceFunction<OUT> extends RichParallelSourceFunction<OUT> {
     private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
@@ -87,7 +87,11 @@ import java.util.Set;
  *
  * @param <Type> The type of the messages created by the source.
  * @param <UId> The type of unique IDs which may be used to acknowledge elements.
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public abstract class MessageAcknowledgingSourceBase<Type, UId> extends RichSourceFunction<Type>
         implements CheckpointedFunction, CheckpointListener {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MultipleIdsMessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MultipleIdsMessageAcknowledgingSourceBase.java
@@ -52,7 +52,11 @@ import java.util.Set;
  * @param <UId> The type of the unique IDs which are consistent across sessions.
  * @param <SessionId> The type of the IDs that are used for acknowledging elements (ids valid during
  *     session).
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public abstract class MultipleIdsMessageAcknowledgingSourceBase<Type, UId, SessionId>
         extends MessageAcknowledgingSourceBase<Type, UId> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ParallelSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ParallelSourceFunction.java
@@ -29,6 +29,10 @@ import org.apache.flink.annotation.Public;
  * information like the number of parallel tasks, and which parallel task the current instance is.
  *
  * @param <OUT> The type of the records produced by this source.
+ * @deprecated This interface is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @Public
 public interface ParallelSourceFunction<OUT> extends SourceFunction<OUT> {}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/RichParallelSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/RichParallelSourceFunction.java
@@ -30,7 +30,11 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
  * #open(org.apache.flink.configuration.Configuration)} and {@link #close()}.
  *
  * @param <OUT> The type of the records produced by this source.
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @Public
 public abstract class RichParallelSourceFunction<OUT> extends AbstractRichFunction
         implements ParallelSourceFunction<OUT> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/RichSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/RichSourceFunction.java
@@ -41,7 +41,11 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
  * </ul>
  *
  * @param <OUT> The type of the records produced by this source.
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @Public
 public abstract class RichSourceFunction<OUT> extends AbstractRichFunction
         implements SourceFunction<OUT> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -42,7 +42,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>The function can be set to reconnect to the server socket in case that the stream is closed on
  * the server side.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public class SocketTextStreamFunction implements SourceFunction<String> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
@@ -40,7 +40,12 @@ import java.util.Deque;
  *
  * <p>This strategy guarantees that each element will be emitted exactly-once, but elements will not
  * necessarily be emitted in ascending order, even for the same tasks.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
+@Deprecated
 @PublicEvolving
 public class StatefulSequenceSource extends RichParallelSourceFunction<Long>
         implements CheckpointedFunction {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/FiniteTestSource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/FiniteTestSource.java
@@ -35,8 +35,13 @@ import static org.apache.flink.util.Preconditions.checkState;
  * another two checkpoints and 5) exiting.
  *
  * <p>This class was written to test the Bulk Writers used by the StreamingFileSink.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+@Deprecated
 public class FiniteTestSource<T> implements SourceFunction<T>, CheckpointListener {
 
     private static final long serialVersionUID = 1L;

--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
@@ -25,7 +25,13 @@ import org.apache.flink.walkthrough.common.entity.Transaction;
 import java.io.Serializable;
 import java.util.Iterator;
 
-/** A stream of transactions. */
+/**
+ * A stream of transactions.
+ *
+ * @deprecated This class is based on the {@link
+ *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
+ *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
+ */
 @Public
 public class TransactionSource extends FromIteratorFunction<Transaction> {
 


### PR DESCRIPTION
This is a trivial change that marks sub-classes/interfaces of SourceFunction as `@Deprecated` and adjusts some examples to fix the strict deprecation complier check failure.