### PR TITLE
[FLINK-32683][rpc] Update Pekko from 1.0.0 to 1.0.1

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -37,7 +37,7 @@ under the License.
 	</description>
 
 	<properties>
-		<pekko.version>1.0.0</pekko.version>
+		<pekko.version>1.0.1</pekko.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala.version>2.12.16</scala.version>
 	</properties>

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -11,12 +11,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.typesafe:ssl-config-core_2.12:0.6.1
 - io.netty:netty:3.10.6.Final
 - org.agrona:agrona:1.15.1
-- org.apache.pekko:pekko-actor_2.12:1.0.0
-- org.apache.pekko:pekko-remote_2.12:1.0.0
-- org.apache.pekko:pekko-pki_2.12:1.0.0
-- org.apache.pekko:pekko-protobuf-v3_2.12:1.0.0
-- org.apache.pekko:pekko-slf4j_2.12:1.0.0
-- org.apache.pekko:pekko-stream_2.12:1.0.0
+- org.apache.pekko:pekko-actor_2.12:1.0.1
+- org.apache.pekko:pekko-remote_2.12:1.0.1
+- org.apache.pekko:pekko-pki_2.12:1.0.1
+- org.apache.pekko:pekko-protobuf-v3_2.12:1.0.1
+- org.apache.pekko:pekko-slf4j_2.12:1.0.1
+- org.apache.pekko:pekko-stream_2.12:1.0.1
 - org.scala-lang:scala-library:2.12.16
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps Pekko from v1.0.0 to 1.0.1. The main and hence only significant change from Pekko 1.0.0 to Pekko 1.0.1 is https://github.com/apache/incubator-pekko/pull/492, see issue at https://github.com/apache/incubator-pekko/issues/491.

Just to provide some context, the core issue is that using `$` in any symbol name for user defined classes breaks the JVM spec (initially it was thought that it only broke the Scala spec but this was later clarified in https://github.com/lampepfl/dotty/issues/18234#issuecomment-1639861800 ).

While it is highly unlikely that using Pekko 1.0.0 will cause any problems, if there does happen to be an issue theoretically speaking it wouldn't be self contained to only Scala users. As such its recommend to update to Pekko 1.0.1 if its not a big deal to do so.

## Brief change log

* Update Pekko dependency to 1.0.1 in the `pom.xml` file as well as updating `NOTICE` file


## Verifying this change

This change is already covered by existing tests, such as all tests within Flink rpc.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
