### PR TITLE
[FLINK-32682] Make it possible to use query time based time functions in streaming mode

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -179,6 +179,12 @@ By default no operator is disabled.</td>
             <td>Specifies a minimum time interval for how long idle state (i.e. state which was not updated), will be retained. State will never be cleared until it was idle for less than the minimum time, and will be cleared at some time after it was idle. Default is never clean-up the state. NOTE: Cleaning up state requires additional overhead for bookkeeping. Default value is 0, which means that it will never clean up state.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.time-function-evaluation</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">AUTO</td>
+            <td><p>Enum</p></td>
+            <td>Decides if time functions such as e.g. CURRENT_TIMESTAMP, CURRENT_DATE should use a stable time when the query has been planned or should they derive the time when processing a record.<br /><br />Possible values:<ul><li>"AUTO": Evaluates time functions based on the execution mode. Uses row based time in streaming mode and query time in batch mode.</li><li>"ROW": Evaluates time functions per every incoming record.</li><li>"QUERY_START": Evaluates time functions once, at the time of query start.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.uid.format</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"&lt;id&gt;_&lt;transformation&gt;"</td>
             <td>String</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -573,6 +573,16 @@ public class ExecutionConfigOptions {
                                     + "leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. "
                                     + "The default value is 0, which means it will clean up unmatched records immediately.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<TimeFunctionEvaluation> TIME_FUNCTION_EVALUATION =
+            key("table.exec.time-function-evaluation")
+                    .enumType(TimeFunctionEvaluation.class)
+                    .defaultValue(TimeFunctionEvaluation.AUTO)
+                    .withDescription(
+                            "Decides if time functions such as e.g. CURRENT_TIMESTAMP,"
+                                    + " CURRENT_DATE should use a stable time when the query has been"
+                                    + " planned or should they derive the time when processing a record.");
+
     // ------------------------------------------------------------------------------------------
     // Enum option types
     // ------------------------------------------------------------------------------------------
@@ -746,6 +756,28 @@ public class ExecutionConfigOptions {
         }
 
         @Internal
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /** Determines how to evaluate time for time functions. */
+    @PublicEvolving
+    public enum TimeFunctionEvaluation implements DescribedEnum {
+        AUTO(
+                text(
+                        "Evaluates time functions based on the execution mode. Uses row based time in"
+                                + " streaming mode and query time in batch mode.")),
+        ROW(text("Evaluates time functions per every incoming record.")),
+        QUERY_START(text("Evaluates time functions once, at the time of query start."));
+
+        private final InlineElement description;
+
+        TimeFunctionEvaluation(InlineElement description) {
+            this.description = description;
+        }
+
         @Override
         public InlineElement getDescription() {
             return description;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ClockPlannerConfig.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/ClockPlannerConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.delegation;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.PlannerConfig;
+import org.apache.flink.util.clock.Clock;
+
+/**
+ * A {@link PlannerConfig} extension that allows overwriting the {@link Clock} used for storing
+ * query time for time functions.
+ */
+@Internal
+public interface ClockPlannerConfig extends PlannerConfig {
+    Clock getClock();
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentDateDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentDateDynamicFunction.java
@@ -27,27 +27,27 @@ import java.util.Objects;
 
 /**
  * The Flink CURRENT_DATE function differs from the parent {@link SqlCurrentDateFunction} which is
- * aware of whether it is used in batch mode, if true it will act totally same as the parent {@link
- * SqlCurrentDateFunction}, but will be a non-deterministic function if not in batch mode.
+ * aware of whether it uses a stable time. If true it will act totally same as the parent {@link
+ * SqlCurrentDateFunction}, but will be a non-deterministic function if it uses record level time.
  */
 @Internal
 public class FlinkCurrentDateDynamicFunction extends SqlCurrentDateFunction {
 
-    private final boolean isBatchMode;
+    private final boolean useQueryTime;
 
-    public FlinkCurrentDateDynamicFunction(boolean isBatchMode) {
-        this.isBatchMode = isBatchMode;
+    public FlinkCurrentDateDynamicFunction(boolean useQueryTime) {
+        this.useQueryTime = useQueryTime;
     }
 
     @Override
     public boolean isDynamicFunction() {
-        return isBatchMode && super.isDynamicFunction();
+        return useQueryTime && super.isDynamicFunction();
     }
 
     @Override
     public boolean isDeterministic() {
         // be a non-deterministic function in streaming mode
-        return isBatchMode;
+        return useQueryTime;
     }
 
     @Override
@@ -61,11 +61,11 @@ public class FlinkCurrentDateDynamicFunction extends SqlCurrentDateFunction {
         FlinkCurrentDateDynamicFunction other = (FlinkCurrentDateDynamicFunction) obj;
         return this.getName().equals(other.getName())
                 && kind == other.kind
-                && this.isBatchMode == other.isBatchMode;
+                && this.useQueryTime == other.useQueryTime;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, this.getName(), isBatchMode);
+        return Objects.hash(kind, this.getName(), useQueryTime);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampDynamicFunction.java
@@ -30,30 +30,30 @@ import java.util.Objects;
 /**
  * Function that used to define SQL time functions like LOCALTIME, CURRENT_TIME(these are all
  * dynamic functions in Calcite's {@link SqlStdOperatorTable}) in Flink, the difference from the
- * parent {@link SqlAbstractTimeFunction} is this function class be aware of whether it is used in
- * batch mode, if true it will act totally same as the parent {@link SqlAbstractTimeFunction}, but
- * will be a non-deterministic function if not in batch mode.
+ * parent {@link SqlAbstractTimeFunction} is this function class be aware of whether it uses a
+ * stable time. If true it will act totally same as the parent {@link SqlAbstractTimeFunction}, but
+ * will be a non-deterministic function if it uses record level time.
  */
 @Internal
 public class FlinkTimestampDynamicFunction extends SqlAbstractTimeFunction {
 
-    protected final boolean isBatchMode;
+    protected final boolean useQueryTime;
 
     public FlinkTimestampDynamicFunction(
-            String functionName, SqlTypeName returnTypeName, boolean isBatchMode) {
+            String functionName, SqlTypeName returnTypeName, boolean useQueryTime) {
         super(functionName, returnTypeName);
-        this.isBatchMode = isBatchMode;
+        this.useQueryTime = useQueryTime;
     }
 
     @Override
     public boolean isDynamicFunction() {
-        return isBatchMode && super.isDynamicFunction();
+        return useQueryTime && super.isDynamicFunction();
     }
 
     @Override
     public boolean isDeterministic() {
-        // be a non-deterministic function in streaming mode
-        return isBatchMode;
+        // be a non-deterministic function if using record level timestamp
+        return useQueryTime;
     }
 
     @Override
@@ -67,11 +67,11 @@ public class FlinkTimestampDynamicFunction extends SqlAbstractTimeFunction {
         FlinkTimestampDynamicFunction other = (FlinkTimestampDynamicFunction) obj;
         return this.getName().equals(other.getName())
                 && kind == other.kind
-                && this.isBatchMode == other.isBatchMode;
+                && this.useQueryTime == other.useQueryTime;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, this.getName(), isBatchMode);
+        return Objects.hash(kind, this.getName(), useQueryTime);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampWithPrecisionDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampWithPrecisionDynamicFunction.java
@@ -41,8 +41,8 @@ public class FlinkTimestampWithPrecisionDynamicFunction extends FlinkTimestampDy
     private final int precision;
 
     public FlinkTimestampWithPrecisionDynamicFunction(
-            String name, SqlTypeName typeName, boolean isBatchMode, int precision) {
-        super(name, typeName, isBatchMode);
+            String name, SqlTypeName typeName, boolean useQueryTime, int precision) {
+        super(name, typeName, useQueryTime);
         this.returnTypeName = typeName;
         this.precision = precision;
     }
@@ -64,13 +64,13 @@ public class FlinkTimestampWithPrecisionDynamicFunction extends FlinkTimestampDy
                 (FlinkTimestampWithPrecisionDynamicFunction) obj;
         return this.getName().equals(other.getName())
                 && kind == other.kind
-                && this.isBatchMode == other.isBatchMode
+                && this.useQueryTime == other.useQueryTime
                 && this.precision == other.precision
                 && this.returnTypeName.equals(other.returnTypeName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(kind, this.getName(), isBatchMode, precision, returnTypeName);
+        return Objects.hash(kind, this.getName(), useQueryTime, precision, returnTypeName);
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/CurrentTimePointCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/CurrentTimePointCallGen.scala
@@ -26,59 +26,59 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot.{DATE, TIME_WITHOUT_
  * Generates function call to determine current time point (as date/time/timestamp) in local
  * timezone or not.
  */
-class CurrentTimePointCallGen(local: Boolean, isStreaming: Boolean) extends CallGenerator {
+class CurrentTimePointCallGen(local: Boolean, useRecordLevelTime: Boolean) extends CallGenerator {
 
   override def generate(
       ctx: CodeGeneratorContext,
       operands: Seq[GeneratedExpression],
       returnType: LogicalType): GeneratedExpression = returnType.getTypeRoot match {
     // LOCALTIME in Streaming mode
-    case TIME_WITHOUT_TIME_ZONE if local && isStreaming =>
+    case TIME_WITHOUT_TIME_ZONE if local && useRecordLevelTime =>
       val time = ctx.addReusableRecordLevelLocalTime()
       generateNonNullField(returnType, time)
 
     // LOCALTIME in Batch mode
-    case TIME_WITHOUT_TIME_ZONE if local && !isStreaming =>
+    case TIME_WITHOUT_TIME_ZONE if local && !useRecordLevelTime =>
       val time = ctx.addReusableQueryLevelLocalTime()
       generateNonNullField(returnType, time)
 
     // LOCALTIMESTAMP in Streaming mode
-    case TIMESTAMP_WITHOUT_TIME_ZONE if local && isStreaming =>
+    case TIMESTAMP_WITHOUT_TIME_ZONE if local && useRecordLevelTime =>
       val timestamp = ctx.addReusableRecordLevelLocalDateTime()
       generateNonNullField(returnType, timestamp)
 
     // LOCALTIMESTAMP in Batch mode
-    case TIMESTAMP_WITHOUT_TIME_ZONE if local && !isStreaming =>
+    case TIMESTAMP_WITHOUT_TIME_ZONE if local && !useRecordLevelTime =>
       val timestamp = ctx.addReusableQueryLevelLocalDateTime()
       generateNonNullField(returnType, timestamp)
 
     // CURRENT_DATE in Streaming mode
-    case DATE if isStreaming =>
+    case DATE if useRecordLevelTime =>
       val date = ctx.addReusableRecordLevelCurrentDate()
       generateNonNullField(returnType, date)
 
     // CURRENT_DATE in Batch mode
-    case DATE if !isStreaming =>
+    case DATE if !useRecordLevelTime =>
       val date = ctx.addReusableQueryLevelCurrentDate()
       generateNonNullField(returnType, date)
 
     // CURRENT_TIME in Streaming mode
-    case TIME_WITHOUT_TIME_ZONE if isStreaming =>
+    case TIME_WITHOUT_TIME_ZONE if useRecordLevelTime =>
       val time = ctx.addReusableRecordLevelLocalTime()
       generateNonNullField(returnType, time)
 
     // CURRENT_TIME in Batch mode
-    case TIME_WITHOUT_TIME_ZONE if !isStreaming =>
+    case TIME_WITHOUT_TIME_ZONE if !useRecordLevelTime =>
       val time = ctx.addReusableQueryLevelLocalTime()
       generateNonNullField(returnType, time)
 
     // CURRENT_TIMESTAMP in Streaming mode
-    case TIMESTAMP_WITH_LOCAL_TIME_ZONE if isStreaming =>
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE if useRecordLevelTime =>
       val timestamp = ctx.addReusableRecordLevelCurrentTimestamp()
       generateNonNullField(returnType, timestamp)
 
     // CURRENT_TIMESTAMP in Batch mode
-    case TIMESTAMP_WITH_LOCAL_TIME_ZONE if !isStreaming =>
+    case TIMESTAMP_WITH_LOCAL_TIME_ZONE if !useRecordLevelTime =>
       val timestamp = ctx.addReusableQueryLevelCurrentTimestamp()
       generateNonNullField(returnType, timestamp)
   }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/TimeFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/TimeFunctionsITCase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.delegation.ClockPlannerConfig;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for evaluating time functions. */
+public class TimeFunctionsITCase {
+
+    @Test
+    void testTemporalFunctionsInStreamModeQueryTime() throws Exception {
+        final TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        env.getConfig().setLocalTimeZone(ZoneId.of("Europe/Berlin"));
+        env.getConfig()
+                .set(
+                        ExecutionConfigOptions.TIME_FUNCTION_EVALUATION,
+                        ExecutionConfigOptions.TimeFunctionEvaluation.QUERY_START);
+        final ManualClockPlannerConfig clockPlannerConfig = new ManualClockPlannerConfig();
+        env.getConfig().setPlannerConfig(clockPlannerConfig);
+
+        try (CloseableIterator<Row> iterator =
+                env.executeSql(
+                                "SELECT CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP,NOW(),LOCALTIME,LOCALTIMESTAMP")
+                        .collect()) {
+            final Row row = iterator.next();
+
+            assertThat(row.toString())
+                    .isEqualTo(
+                            "+I[1970-01-01, 01:00:01.234, "
+                                    + "1970-01-01T00:00:01.234Z, 1970-01-01T00:00:01.234Z, 01:00:01.234, "
+                                    + "1970-01-01T01:00:01.234]");
+        }
+    }
+
+    private static class ManualClockPlannerConfig implements ClockPlannerConfig {
+
+        private final ManualClock clock = new ManualClock(1234L * 1_000_000);
+
+        @Override
+        public Clock getClock() {
+            return clock;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces the option as discussed in FLIP-162 future work section to choose how time based functions should be evaluated.


## Verifying this change

Added test in org.apache.flink.table.planner.runtime.stream.sql.TimeFunctionsITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
