### PR TITLE
[FLINK-32691] SELECT fcn does not work with an unset catalog or database

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -579,6 +580,19 @@ public final class FunctionCatalog {
     }
 
     // --------------------------------------------------------------------------------------------
+    private Optional<ContextResolvedFunction> resolvePreciseFunctionReference(String funcName) {
+        if (StringUtils.isNullOrWhitespaceOnly(catalogManager.getCurrentCatalog())
+                || StringUtils.isNullOrWhitespaceOnly(catalogManager.getCurrentDatabase())) {
+            return Optional.empty();
+        } else {
+            ObjectIdentifier oi =
+                    ObjectIdentifier.of(
+                            catalogManager.getCurrentCatalog(),
+                            catalogManager.getCurrentDatabase(),
+                            funcName);
+            return resolvePreciseFunctionReference(oi);
+        }
+    }
 
     private Optional<ContextResolvedFunction> resolvePreciseFunctionReference(ObjectIdentifier oi) {
         // resolve order:
@@ -647,11 +661,6 @@ public final class FunctionCatalog {
 
         Optional<FunctionDefinition> candidate =
                 moduleManager.getFunctionDefinition(normalizedName);
-        ObjectIdentifier oi =
-                ObjectIdentifier.of(
-                        catalogManager.getCurrentCatalog(),
-                        catalogManager.getCurrentDatabase(),
-                        funcName);
 
         return candidate
                 .map(
@@ -659,7 +668,7 @@ public final class FunctionCatalog {
                                 Optional.of(
                                         ContextResolvedFunction.permanent(
                                                 FunctionIdentifier.of(funcName), fd)))
-                .orElseGet(() -> resolvePreciseFunctionReference(oi));
+                .orElseGet(() -> resolvePreciseFunctionReference(funcName));
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
@@ -60,23 +60,11 @@ public class UnknownCatalogTest {
             ResolvedSchema.of(Column.physical("CURRENT_TIMESTAMP", TIMESTAMP_LTZ(3).notNull()));
 
     @Test
-    public void testUnsetCatalogWithSelect1() throws Exception {
-        ResolvedSchema EXPECTED_SCHEMA =
-                ResolvedSchema.of(Column.physical("EXPR$0", INT().notNull()));
-        TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
-
-        tEnv.useCatalog(null);
-        Table table = tEnv.sqlQuery(String.format("SELECT 1;"));
-
-        assertThat(table.getResolvedSchema()).isEqualTo(EXPECTED_SCHEMA);
-    }
-
-    @Test
     public void testUnsetCatalogWithSelectCurrentTimestamp() throws Exception {
         TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
 
         tEnv.useCatalog(null);
-        Table table = tEnv.sqlQuery(String.format("SELECT CURRENT_TIMESTAMP;"));
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }
@@ -87,7 +75,7 @@ public class UnknownCatalogTest {
 
         tEnv.useCatalog(BUILTIN_CATALOG);
         tEnv.useDatabase(null);
-        Table table = tEnv.sqlQuery(String.format("SELECT CURRENT_TIMESTAMP;"));
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }
@@ -97,7 +85,7 @@ public class UnknownCatalogTest {
         TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
 
         tEnv.useCatalog(BUILTIN_CATALOG);
-        Table table = tEnv.sqlQuery(String.format("SELECT CURRENT_TIMESTAMP;"));
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/UnknownCatalogTest.java
@@ -64,7 +64,7 @@ public class UnknownCatalogTest {
         TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
 
         tEnv.useCatalog(null);
-        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }
@@ -75,7 +75,7 @@ public class UnknownCatalogTest {
 
         tEnv.useCatalog(BUILTIN_CATALOG);
         tEnv.useDatabase(null);
-        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }
@@ -85,7 +85,7 @@ public class UnknownCatalogTest {
         TableEnvironment tEnv = TableEnvironment.create(ENVIRONMENT_SETTINGS);
 
         tEnv.useCatalog(BUILTIN_CATALOG);
-        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP;");
+        Table table = tEnv.sqlQuery("SELECT CURRENT_TIMESTAMP");
 
         assertThat(table.getResolvedSchema()).isEqualTo(CURRENT_TIMESTAMP_EXPECTED_SCHEMA);
     }


### PR DESCRIPTION
## What is the purpose of the change

This commit addresses FLINK-32691 by having function lookup skip looking for functions in catalog / database specific locations when the catalog and/or database is unset.

## Verifying this change

This change added tests and can be verified as follows:
 - Added test cases to UnknownCatalogTest.java.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
