### PR TITLE
[FLINK-32680][streaming] Fix the messed up JobVertex name when the source nodes chained with a MultipleInput node.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -896,12 +896,13 @@ public class StreamingJobGraphGenerator {
             Integer vertexID,
             List<StreamEdge> chainedOutputs,
             Optional<OperatorChainInfo> operatorChainInfo) {
+        List<ChainedSourceInfo> chainedSourceInfos =
+                operatorChainInfo
+                        .map(chainInfo -> getChainedSourcesByVertexId(vertexID, chainInfo))
+                        .orElse(Collections.emptyList());
         final String operatorName =
                 nameWithChainedSourcesInfo(
-                        streamGraph.getStreamNode(vertexID).getOperatorName(),
-                        operatorChainInfo
-                                .map(chain -> chain.getChainedSources().values())
-                                .orElse(Collections.emptyList()));
+                        streamGraph.getStreamNode(vertexID).getOperatorName(), chainedSourceInfos);
         if (chainedOutputs.size() > 1) {
             List<String> outputChainedNames = new ArrayList<>();
             for (StreamEdge chainable : chainedOutputs) {
@@ -913,6 +914,14 @@ public class StreamingJobGraphGenerator {
         } else {
             return operatorName;
         }
+    }
+
+    private List<ChainedSourceInfo> getChainedSourcesByVertexId(
+            Integer vertexId, OperatorChainInfo chainInfo) {
+        return streamGraph.getStreamNode(vertexId).getInEdges().stream()
+                .map(inEdge -> chainInfo.getChainedSources().get(inEdge.getSourceId()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     private ResourceSpec createChainedMinResources(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -108,7 +108,6 @@ import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.util.TestAnyModeReadingStreamOperator;
 import org.apache.flink.util.AbstractID;
@@ -135,6 +134,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1655,28 +1655,51 @@ class StreamingJobGraphGeneratorTest {
     @Test
     void testNamingOfChainedMultipleInputs() {
         String[] sources = new String[] {"source-1", "source-2", "source-3"};
-        JobGraph graph = createGraphWithMultipleInputs(true, sources);
-        JobVertex head = graph.getVerticesSortedTopologicallyFromSources().iterator().next();
-        assertThat(sources).allMatch(source -> head.getOperatorPrettyName().contains(source));
+        String sink = "sink";
+        JobGraph graph = createGraphWithMultipleInputs(true, sink, sources);
+        Iterator<JobVertex> iterator = graph.getVerticesSortedTopologicallyFromSources().iterator();
+
+        JobVertex multipleVertex = iterator.next();
+        assertThat(multipleVertex.getName())
+                .isEqualTo("mit [Source: source-1, Source: source-2, Source: source-3]");
+        assertThat(multipleVertex.getOperatorPrettyName())
+                .isEqualTo("mit [Source: source-1, Source: source-2, Source: source-3]\n");
+
+        JobVertex sinkVertex = iterator.next();
+        assertThat(sinkVertex.getName()).isEqualTo("Sink: sink");
+        assertThat(sinkVertex.getOperatorPrettyName()).isEqualTo("Sink: sink\n");
     }
 
     @Test
     void testNamingOfNonChainedMultipleInputs() {
         String[] sources = new String[] {"source-1", "source-2", "source-3"};
-        JobGraph graph = createGraphWithMultipleInputs(false, sources);
-        JobVertex head =
-                Iterables.find(
-                        graph.getVertices(),
-                        vertex ->
-                                vertex.getInvokableClassName()
-                                        .equals(MultipleInputStreamTask.class.getName()));
-        assertThat(head.getName()).withFailMessage(head.getName()).doesNotContain("source-1");
-        assertThat(head.getOperatorPrettyName())
-                .withFailMessage(head.getOperatorPrettyName())
-                .doesNotContain("source-1");
+        String sink = "sink";
+        JobGraph graph = createGraphWithMultipleInputs(false, sink, sources);
+        Iterator<JobVertex> iterator = graph.getVerticesSortedTopologicallyFromSources().iterator();
+
+        JobVertex source1 = iterator.next();
+        assertThat(source1.getName()).isEqualTo("Source: source-1");
+        assertThat(source1.getOperatorPrettyName()).isEqualTo("Source: source-1\n");
+
+        JobVertex source2 = iterator.next();
+        assertThat(source2.getName()).isEqualTo("Source: source-2");
+        assertThat(source2.getOperatorPrettyName()).isEqualTo("Source: source-2\n");
+
+        JobVertex source3 = iterator.next();
+        assertThat(source3.getName()).isEqualTo("Source: source-3");
+        assertThat(source3.getOperatorPrettyName()).isEqualTo("Source: source-3\n");
+
+        JobVertex multipleVertex = iterator.next();
+        assertThat(multipleVertex.getName()).isEqualTo("mit");
+        assertThat(multipleVertex.getOperatorPrettyName()).isEqualTo("mit\n");
+
+        JobVertex sinkVertex = iterator.next();
+        assertThat(sinkVertex.getName()).isEqualTo("Sink: sink");
+        assertThat(sinkVertex.getOperatorPrettyName()).isEqualTo("Sink: sink\n");
     }
 
-    public JobGraph createGraphWithMultipleInputs(boolean chain, String... inputNames) {
+    public JobGraph createGraphWithMultipleInputs(
+            boolean chain, String sinkName, String... inputNames) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         MultipleInputTransformation<Long> transform =
                 new MultipleInputTransformation<>(
@@ -1692,6 +1715,10 @@ class StreamingJobGraphGeneratorTest {
                 .forEach(transform::addInput);
         transform.setChainingStrategy(
                 chain ? ChainingStrategy.HEAD_WITH_SOURCES : ChainingStrategy.NEVER);
+
+        DataStream<Long> dataStream = new DataStream<>(env, transform);
+        // do not chain with sink operator.
+        dataStream.rebalance().addSink(new DiscardingSink<>()).name(sinkName);
 
         env.addOperator(transform);
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There is a bug in generating the JobVertex name when the source nodes are chained with a MultipleInput node, resulting in a messed up JobVertex name.


## Brief change log

When generating a JobVertex name, filter the chained source by the vertex ID.

## Verifying this change


This change can be verified by StreamingJobGraphGeneratorTest#testNamingOfChainedMultipleInputs


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
