### PR TITLE
[FLINK-32686][network] Avoid creating tiered internal shuffle master before enabling the tiered storage

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageIdMappingUtils.java
@@ -34,11 +34,11 @@ public class TieredStorageIdMappingUtils {
     }
 
     public static TieredStoragePartitionId convertId(ResultPartitionID resultPartitionId) {
-        return new TieredStoragePartitionId(resultPartitionId.getBytes());
+        return new TieredStoragePartitionId(resultPartitionId);
     }
 
     public static ResultPartitionID convertId(TieredStoragePartitionId partitionId) {
-        return new ResultPartitionID(partitionId.getBytes());
+        return partitionId.getPartitionID();
     }
 
     public static TieredStorageSubpartitionId convertId(int subpartitionId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStoragePartitionId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStoragePartitionId.java
@@ -18,23 +18,49 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.common;
 
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Identifier of a partition.
  *
  * <p>A partition is equivalent to a result partition in Flink.
  */
-public class TieredStoragePartitionId extends TieredStorageBytesBasedDataIdentifier {
+public class TieredStoragePartitionId implements TieredStorageDataIdentifier, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public TieredStoragePartitionId(byte[] bytes) {
-        super(bytes);
+    private final ResultPartitionID partitionID;
+
+    public TieredStoragePartitionId(ResultPartitionID partitionID) {
+        this.partitionID = partitionID;
+    }
+
+    public ResultPartitionID getPartitionID() {
+        return partitionID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TieredStoragePartitionId that = (TieredStoragePartitionId) o;
+        return Objects.equals(partitionID, that.partitionID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionID);
     }
 
     @Override
     public String toString() {
-        return "TieredStoragePartitionId{" + "ID=" + StringUtils.byteToHexString(bytes) + '}';
+        return "TieredStoragePartitionId{" + "ID=" + partitionID + '}';
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -34,6 +34,9 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.api.common.BatchShuffleMode.ALL_EXCHANGES_HYBRID_FULL;
+import static org.apache.flink.api.common.BatchShuffleMode.ALL_EXCHANGES_HYBRID_SELECTIVE;
+import static org.apache.flink.configuration.ExecutionOptions.BATCH_SHUFFLE_MODE;
 import static org.apache.flink.configuration.NettyShuffleEnvironmentOptions.NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -71,7 +74,7 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
                 conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
         networkBufferSize = ConfigurationParserUtils.getPageSize(conf);
 
-        if (conf.getBoolean(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE)) {
+        if (isHybridShuffleNewModeEnabled(conf)) {
             tieredInternalShuffleMaster = new TieredInternalShuffleMaster(conf);
         } else {
             tieredInternalShuffleMaster = null;
@@ -156,5 +159,11 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
                         desc.getPartitionTypes());
 
         return new MemorySize((long) networkBufferSize * numRequiredNetworkBuffers);
+    }
+
+    private boolean isHybridShuffleNewModeEnabled(Configuration conf) {
+        return (conf.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_FULL
+                        || conf.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_SELECTIVE)
+                && conf.getBoolean(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Avoid creating tiered internal shuffle master before enabling the tiered storage.*


## Brief change log

  - *Avoid creating tiered internal shuffle master before enabling the tiered storage.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
