### PR TITLE
[FLINK-32665][format] Support reading null value for csv format

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -343,6 +343,27 @@ public class CsvFormatFactoryTest extends TestLogger {
         assertThat(deserialized).isEqualTo(expected);
     }
 
+    @Test
+    public void testDeserializeNullValue() throws IOException {
+        final Map<String, String> options = getAllOptions();
+        options.put("csv.ignore-parse-errors", "false");
+        // Use "|" here to avoid checkstyle failed
+        options.put("csv.field-delimiter", "|");
+
+        List<String> fields = Arrays.asList("a", "b", "c");
+        final Projection projection = Projection.fromFieldNames(PHYSICAL_DATA_TYPE, fields);
+
+        final int[][] projectionMatrix = projection.toNestedIndexes();
+        DeserializationSchema<RowData> actualDeser =
+                createDeserializationSchema(options, projectionMatrix);
+
+        String data = "a1||";
+        RowData deserialized = actualDeser.deserialize(data.getBytes());
+        GenericRowData expected = GenericRowData.of(fromString("a1"), null, null);
+
+        assertThat(deserialized).isEqualTo(expected);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Currently we can create table with nullable column for csv format table, but it will throw exception if there's null value in the record for these columns. This PR aims to support reading null value for csv format.

## Brief change log
  - Return null value for int/long/double/boolean when the text is empty

## Verifying this change

This change added tests and can be verified as follows:

  - Added CsvFormatFactoryTest.testDeserializeNullValue to read null value

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
