### PR TITLE
[FLINK-32689] Improve validation of local time zone

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.table.factories.BulkReaderFormatFactory;
 import org.apache.flink.connector.file.table.factories.BulkWriterFormatFactory;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -38,6 +39,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.factories.TableFactory;
 
+import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,8 +47,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.time.ZoneId.SHORT_IDS;
 
 /**
  * File system {@link TableFactory}.
@@ -155,18 +155,9 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         helper.validateExcept(helper.getOptions().get(FactoryUtil.FORMAT) + ".");
 
         // validate time zone of watermark
-        String watermarkTimeZone =
+        validateTimeZone(
                 helper.getOptions()
-                        .get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE);
-        if (watermarkTimeZone.startsWith("UTC+")
-                || watermarkTimeZone.startsWith("UTC-")
-                || SHORT_IDS.containsKey(watermarkTimeZone)) {
-            throw new ValidationException(
-                    String.format(
-                            "The supported watermark time zone is either a full name such as 'America/Los_Angeles',"
-                                    + " or a custom time zone id such as 'GMT-08:00', but configured time zone is '%s'.",
-                            watermarkTimeZone));
-        }
+                        .get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));
     }
 
     private <I, F extends DecodingFormatFactory<I>> DecodingFormat<I> discoverDecodingFormat(
@@ -219,5 +210,29 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
                         .collect(Collectors.toList());
 
         return !matchingFactories.isEmpty();
+    }
+
+    /** Similar logic as for {@link TableConfig}. */
+    private void validateTimeZone(String zone) {
+        boolean isValid;
+        try {
+            // We enforce a zone string that is compatible with both java.util.TimeZone and
+            // java.time.ZoneId to avoid bugs.
+            // In general, advertising either TZDB ID, GMT+xx:xx, or UTC is the best we can do.
+            isValid = java.util.TimeZone.getTimeZone(zone).toZoneId().equals(ZoneId.of(zone));
+        } catch (Exception e) {
+            isValid = false;
+        }
+
+        if (!isValid) {
+            throw new ValidationException(
+                    String.format(
+                            "Invalid time zone for '%s'. The value should be a Time Zone Database (TZDB) ID "
+                                    + "such as 'America/Los_Angeles' to include daylight saving time. Fixed "
+                                    + "offsets are supported using 'GMT-03:00' or 'GMT+03:00'. Or use 'UTC' "
+                                    + "without time zone and daylight saving time.",
+                            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE
+                                    .key()));
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableConfigValidation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableConfigValidation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.ValidationException;
+
+import java.time.ZoneId;
+
+/** Utilities around validation to keep {@link TableConfig} clean. */
+@Internal
+public class TableConfigValidation {
+
+    /** Validates user configured time zone. */
+    public static void validateTimeZone(String zone) {
+        boolean isValid;
+        try {
+            // We enforce a zone string that is compatible with both java.util.TimeZone and
+            // java.time.ZoneId to avoid bugs.
+            // In general, advertising either TZDB ID, GMT+xx:xx, or UTC is the best we can do.
+            isValid = java.util.TimeZone.getTimeZone(zone).toZoneId().equals(ZoneId.of(zone));
+        } catch (Exception e) {
+            isValid = false;
+        }
+
+        if (!isValid) {
+            throw new ValidationException(
+                    "Invalid time zone. The value should be a Time Zone Database (TZDB) ID "
+                            + "such as 'America/Los_Angeles' to include daylight saving time. Fixed "
+                            + "offsets are supported using 'GMT-03:00' or 'GMT+03:00'. Or use 'UTC' "
+                            + "without time zone and daylight saving time.");
+        }
+    }
+
+    private TableConfigValidation() {
+        // No instantiation
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemTableFactoryTest.java
@@ -132,9 +132,7 @@ public class FileSystemTableFactoryTest {
                 .satisfies(
                         anyCauseMatches(
                                 ValidationException.class,
-                                "The supported watermark time zone is either a full name such "
-                                        + "as 'America/Los_Angeles', or a custom time zone id such "
-                                        + "as 'GMT-08:00', but configured time zone is 'UTC+8'."));
+                                "Invalid time zone for 'sink.partition-commit.watermark-time-zone'."));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This fixes the insufficient validation of ZoneId for setting local time zones.

## Brief change log

- It ensures that no information is lost when converting between TimeZone and ZoneId
- Now time zones such as `UT-1` fail with an error.
- ZoneOffset is converted to GMT zone in order to avoid issues where the offset is lost when converting between TimeZone and ZoneId

## Verifying this change

This change added tests and can be verified as follows:
- `TableConfigTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
