### PR TITLE
[FLINK-32709][network] Fix the bug of low memory utilization for Hybrid Shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/common/TieredStorageConfiguration.java
@@ -45,13 +45,15 @@ public class TieredStorageConfiguration {
 
     private static final int DEFAULT_REMOTE_TIER_EXCLUSIVE_BUFFERS = 1;
 
+    private static final int DEFAULT_MEMORY_TIER_SUBPARTITION_MAX_QUEUED_BUFFERS = 3;
+
     private static final int DEFAULT_NUM_BUFFERS_USE_SORT_ACCUMULATOR_THRESHOLD = 512;
 
-    private static final int DEFAULT_MEMORY_TIER_NUM_BYTES_PER_SEGMENT = 320 * 1024;
+    private static final int DEFAULT_MEMORY_TIER_NUM_BYTES_PER_SEGMENT = 2 * 32 * 1024;
 
-    private static final int DEFAULT_DISK_TIER_NUM_BYTES_PER_SEGMENT = 8 * 1024 * 1024;
+    private static final int DEFAULT_DISK_TIER_NUM_BYTES_PER_SEGMENT = 16 * 32 * 1024;
 
-    private static final int DEFAULT_REMOTE_TIER_NUM_BYTES_PER_SEGMENT = 8 * 1024 * 1024;
+    private static final int DEFAULT_REMOTE_TIER_NUM_BYTES_PER_SEGMENT = 16 * 32 * 1024;
 
     private static final float DEFAULT_NUM_BUFFERS_TRIGGER_FLUSH_RATIO = 0.6f;
 
@@ -304,6 +306,9 @@ public class TieredStorageConfiguration {
 
         private int remoteTierExclusiveBuffers = DEFAULT_REMOTE_TIER_EXCLUSIVE_BUFFERS;
 
+        private int memoryTierSubpartitionMaxQueuedBuffers =
+                DEFAULT_MEMORY_TIER_SUBPARTITION_MAX_QUEUED_BUFFERS;
+
         private int numBuffersUseSortAccumulatorThreshold =
                 DEFAULT_NUM_BUFFERS_USE_SORT_ACCUMULATOR_THRESHOLD;
 
@@ -375,6 +380,12 @@ public class TieredStorageConfiguration {
             return this;
         }
 
+        public Builder setMemoryTierSubpartitionMaxQueuedBuffers(
+                int memoryTierSubpartitionMaxQueuedBuffers) {
+            this.memoryTierSubpartitionMaxQueuedBuffers = memoryTierSubpartitionMaxQueuedBuffers;
+            return this;
+        }
+
         public Builder setNumBuffersTriggerFlushRatio(float numBuffersTriggerFlushRatio) {
             this.numBuffersTriggerFlushRatio = numBuffersTriggerFlushRatio;
             return this;
@@ -429,7 +440,10 @@ public class TieredStorageConfiguration {
             tierFactories = new ArrayList<>();
             tierExclusiveBuffers = new ArrayList<>();
             tierFactories.add(
-                    new MemoryTierFactory(memoryTierNumBytesPerSegment, tieredStorageBufferSize));
+                    new MemoryTierFactory(
+                            memoryTierNumBytesPerSegment,
+                            tieredStorageBufferSize,
+                            memoryTierSubpartitionMaxQueuedBuffers));
             tierExclusiveBuffers.add(memoryTierExclusiveBuffers);
             tierFactories.add(
                     new DiskTierFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionFactory.java
@@ -178,9 +178,11 @@ public class TieredResultPartitionFactory {
         tieredStorageMemorySpecs.add(
                 new TieredStorageMemorySpec(
                         bufferAccumulator,
-                        Math.min(
-                                numberOfSubpartitions + 1,
-                                tieredStorageConfiguration.getAccumulatorExclusiveBuffers())));
+                        2
+                                * Math.min(
+                                        numberOfSubpartitions + 1,
+                                        tieredStorageConfiguration
+                                                .getAccumulatorExclusiveBuffers())));
         List<Integer> tierExclusiveBuffers =
                 tieredStorageConfiguration.getEachTierExclusiveBufferNum();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/SortBufferAccumulator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/SortBufferAccumulator.java
@@ -221,7 +221,7 @@ public class SortBufferAccumulator implements BufferAccumulator {
         checkState(dataType != Buffer.DataType.EVENT_BUFFER);
         while (record.hasRemaining()) {
             int toCopy = Math.min(record.remaining(), bufferSizeBytes);
-            MemorySegment writeBuffer = checkNotNull(getFreeSegment());
+            MemorySegment writeBuffer = requestBuffer().getMemorySegment();
             writeBuffer.put(0, record, toCopy);
 
             flushBuffer(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
@@ -188,9 +188,7 @@ public class DiskIOScheduler implements Runnable, BufferRecycler, NettyServicePr
                 return;
             }
             isReleased = true;
-            failScheduledReaders(
-                    new ArrayList<>(allScheduledReaders.values()),
-                    new RuntimeException("Disk readers are released unexpectedly."));
+            allScheduledReaders.clear();
             partitionFileReader.release();
             bufferPool.unregisterRequester(this);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgent.java
@@ -218,6 +218,7 @@ public class DiskTierProducerAgent implements TierProducerAgent, NettyServicePro
         if (!isReleased) {
             firstBufferIndexInSegment.clear();
             diskCacheManager.release();
+            diskIOScheduler.release();
             isReleased = true;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
@@ -41,9 +41,13 @@ public class MemoryTierFactory implements TierFactory {
 
     private final int bufferSizeBytes;
 
-    public MemoryTierFactory(int segmentSizeBytes, int bufferSizeBytes) {
+    private final int subpartitionMaxQueuedBuffers;
+
+    public MemoryTierFactory(
+            int segmentSizeBytes, int bufferSizeBytes, int subpartitionMaxQueuedBuffers) {
         this.segmentSizeBytes = segmentSizeBytes;
         this.bufferSizeBytes = bufferSizeBytes;
+        this.subpartitionMaxQueuedBuffers = subpartitionMaxQueuedBuffers;
     }
 
     @Override
@@ -71,6 +75,7 @@ public class MemoryTierFactory implements TierFactory {
                 numSubpartitions,
                 bufferSizeBytes,
                 segmentSizeBytes,
+                subpartitionMaxQueuedBuffers,
                 isBroadcastOnly,
                 memoryManager,
                 nettyService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierSubpartitionProducerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierSubpartitionProducerAgent.java
@@ -63,6 +63,12 @@ class MemoryTierSubpartitionProducerAgent {
         addFinishedBuffer(segmentNettyPayload);
     }
 
+    int numQueuedBuffers() {
+        return nettyConnectionWriter == null
+                ? 0
+                : checkNotNull(nettyConnectionWriter).numQueuedBuffers();
+    }
+
     void release() {
         if (nettyConnectionWriter != null) {
             checkNotNull(nettyConnectionWriter).close(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageSortBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageSortBufferTest.java
@@ -139,7 +139,7 @@ class TieredStorageSortBufferTest {
                         numSubpartitions,
                         BUFFER_SIZE_BYTES,
                         numBuffersForSort);
-        MemorySegment memorySegment = bufferPool.requestMemorySegmentBlocking();
+        MemorySegment memorySegment = segments.poll();
         sortBuffer.finish();
         assertThat(sortBuffer.getNextBuffer(memorySegment)).isNull();
         assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(numBuffersForSort);


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Currently, each subpartition in Disk/Remote has a segment size of 8M. When writing segments to the Disk tier with a parallelism of 1000, only shuffle data exceeding 1000 * 8M can be written to the Memory tier again. However, for most shuffles, the data volume size falls below this limit, significantly impacting Memory tier utilization.
For better performance, it is necessary to address this issue to improve the memory tier utilization.*


## Brief change log

  - *Modify segment size to improve memory utilization for Hybrid Shuffle*


## Verifying this change

This change is an internal option default value hotfix change without tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
