### PR TITLE
[BP-1.17][FLINK-32262] Add MAP_ENTRIES support 

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,15 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: MAP_KEYS(map)
+    table: MAP.mapKeys()
+    description: Returns the keys of the map as array. No order guaranteed.
+  - sql: MAP_VALUES(map)
+    table: MAP.mapValues()
+    description: Returns the values of the map as array. No order guaranteed.
+  - sql: MAP_ENTRIES(map)
+    table: MAP.mapEntries()
+    description: Returns an array of all entries in the given map. No order guaranteed.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -225,7 +225,9 @@ advanced type helper functions
     Expression.cardinality
     Expression.element
     Expression.array_contains
-
+    Expression.map_entries
+    Expression.map_keys
+    Expression.map_values
 
 time definition functions
 -------------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,30 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    @property
+    def map_keys(self) -> 'Expression':
+        """
+        Returns the keys of the map as an array. No order guaranteed.
+        .. seealso:: :py:attr:`~Expression.map_keys`
+        """
+        return _unary_op("mapKeys")(self)
+
+    @property
+    def map_values(self) -> 'Expression':
+        """
+        Returns the values of the map as an array. No order guaranteed.
+        .. seealso:: :py:attr:`~Expression.map_values`
+        """
+        return _unary_op("mapValues")(self)
+
+    @property
+    def map_entries(self) -> 'Expression':
+        """
+        Returns an array of all entries in the given map. No order guaranteed.
+        .. seealso:: :py:attr:`~Expression.map_entries`
+        """
+        return _unary_op("mapEntries")(self)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -117,6 +117,9 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOG2;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOWER;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LPAD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LTRIM;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_ENTRIES;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_KEYS;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_VALUES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MD5;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MIN;
@@ -1347,6 +1350,21 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayContains(InType needle) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_CONTAINS, toExpr(), objectToExpression(needle)));
+    }
+
+    /** Returns the keys of the map as an array. */
+    public OutType mapKeys() {
+        return toApiSpecificExpression(unresolvedCall(MAP_KEYS, toExpr()));
+    }
+
+    /** Returns the values of the map as an array. */
+    public OutType mapValues() {
+        return toApiSpecificExpression(unresolvedCall(MAP_VALUES, toExpr()));
+    }
+
+    /** Returns an array of all entries in the given map. */
+    public OutType mapEntries() {
+        return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
     }
 
     // Time definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -165,6 +165,44 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayContainsFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition MAP_KEYS =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_KEYS")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    new String[] {"input"},
+                                    new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_KEYS))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.MapKeysFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition MAP_VALUES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_VALUES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    new String[] {"input"},
+                                    new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_VALUES))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapValuesFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition MAP_ENTRIES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_ENTRIES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    new String[] {"input"},
+                                    new ArgumentTypeStrategy[] {logical(LogicalTypeRoot.MAP)}))
+                    .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_ENTRIES))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapEntriesFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -53,7 +53,7 @@ public final class SpecificInputTypeStrategies {
     /** See {@link MapInputTypeStrategy}. */
     public static final InputTypeStrategy MAP = new MapInputTypeStrategy();
 
-    /** See {@link CurrentWatermarkTypeStrategy}. */
+    /** See {@link CurrentWatermarkInputTypeStrategy}. */
     public static final InputTypeStrategy CURRENT_WATERMARK =
             new CurrentWatermarkInputTypeStrategy();
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -19,8 +19,13 @@
 package org.apache.flink.table.types.inference.strategies;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.Optional;
 
 /**
  * Entry point for specific type strategies not covered in {@link TypeStrategies}.
@@ -51,6 +56,43 @@ public final class SpecificTypeStrategies {
 
     /** See {@link ArrayTypeStrategy}. */
     public static final TypeStrategy ARRAY = new ArrayTypeStrategy();
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_KEYS}. */
+    public static final TypeStrategy MAP_KEYS =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getKeyDataType()));
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_VALUES}. */
+    public static final TypeStrategy MAP_VALUES =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    ((KeyValueDataType) callContext.getArgumentDataTypes().get(0))
+                                            .getValueDataType()));
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_ENTRIES}. */
+    public static final TypeStrategy MAP_ENTRIES =
+            callContext ->
+                    Optional.of(
+                            DataTypes.ARRAY(
+                                    DataTypes.ROW(
+                                            DataTypes.FIELD(
+                                                    "key",
+                                                    ((KeyValueDataType)
+                                                                    callContext
+                                                                            .getArgumentDataTypes()
+                                                                            .get(0))
+                                                            .getKeyDataType()),
+                                            DataTypes.FIELD(
+                                                    "value",
+                                                    ((KeyValueDataType)
+                                                                    callContext
+                                                                            .getArgumentDataTypes()
+                                                                            .get(0))
+                                                            .getValueDataType()))));
 
     /** See {@link GetTypeStrategy}. */
     public static final TypeStrategy GET = new GetTypeStrategy();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
 import java.math.BigDecimal;
@@ -28,6 +29,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -44,6 +46,7 @@ import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.map;
 import static org.apache.flink.util.CollectionUtil.entry;
 
@@ -62,6 +65,15 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(
+                        mapTestCases(),
+                        mapKeysTestCases(),
+                        mapValuesTestCases(),
+                        mapEntriesTestCases())
+                .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> mapTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MAP)
                         .onFieldsWithData(
@@ -206,5 +218,135 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                                         STRING().notNull(),
                                                         INTERVAL(MONTH()).nullable())
                                                 .notNull())));
+    }
+
+    private Stream<TestSetSpec> mapKeysTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MAP_KEYS)
+                        .onFieldsWithData(
+                                null,
+                                "item",
+                                Collections.singletonMap(1, "value"),
+                                Collections.singletonMap(new Integer[] {1, 2}, "value"))
+                        .andDataTypes(
+                                DataTypes.BOOLEAN().nullable(),
+                                DataTypes.STRING(),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
+                                DataTypes.MAP(DataTypes.ARRAY(DataTypes.INT()), DataTypes.STRING()))
+                        .testTableApiValidationError(
+                                call("MAP_KEYS", $("f0"), $("f1")),
+                                "Invalid function call:\nMAP_KEYS(BOOLEAN, STRING)")
+                        .testResult(
+                                map(
+                                                $("f0").cast(DataTypes.BOOLEAN()),
+                                                $("f1").cast(DataTypes.STRING()))
+                                        .mapKeys(),
+                                "MAP_KEYS(MAP[CAST(f0 AS BOOLEAN), CAST(f1 AS STRING)])",
+                                new Boolean[] {null},
+                                DataTypes.ARRAY(DataTypes.BOOLEAN()).notNull())
+                        .testResult(
+                                $("f2").mapKeys(),
+                                "MAP_KEYS(f2)",
+                                new Integer[] {1},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f3").mapKeys(),
+                                "MAP_KEYS(f3)",
+                                new Integer[][] {new Integer[] {1, 2}},
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT()))));
+    }
+
+    private Stream<TestSetSpec> mapValuesTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MAP_VALUES)
+                        .onFieldsWithData(
+                                null,
+                                "item",
+                                Collections.singletonMap(1, "value1"),
+                                Collections.singletonMap(
+                                        3, Collections.singletonMap(true, "value2")))
+                        .andDataTypes(
+                                DataTypes.BOOLEAN().nullable(),
+                                DataTypes.STRING(),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
+                                DataTypes.MAP(
+                                        DataTypes.INT(),
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.STRING())))
+                        .testTableApiValidationError(
+                                call("MAP_VALUES", $("f0"), $("f1")),
+                                "Invalid function call:\nMAP_VALUES(BOOLEAN, STRING)")
+                        .testResult(
+                                map(
+                                                $("f1").cast(DataTypes.STRING()),
+                                                $("f0").cast(DataTypes.BOOLEAN()))
+                                        .mapValues(),
+                                "MAP_VALUES(MAP[CAST(f1 AS STRING), CAST(f0 AS BOOLEAN)])",
+                                new Boolean[] {null},
+                                DataTypes.ARRAY(DataTypes.BOOLEAN()).notNull())
+                        .testResult(
+                                $("f2").mapValues(),
+                                "MAP_VALUES(f2)",
+                                new String[] {"value1"},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f3").mapValues(),
+                                "MAP_VALUES(f3)",
+                                new Map[] {Collections.singletonMap(true, "value2")},
+                                DataTypes.ARRAY(
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.STRING()))));
+    }
+
+    private Stream<TestSetSpec> mapEntriesTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MAP_ENTRIES)
+                        .onFieldsWithData(
+                                null,
+                                "item",
+                                Collections.singletonMap(1, "value1"),
+                                Collections.singletonMap(
+                                        3, Collections.singletonMap(true, "value2")))
+                        .andDataTypes(
+                                DataTypes.BOOLEAN().nullable(),
+                                DataTypes.STRING(),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()),
+                                DataTypes.MAP(
+                                        DataTypes.INT(),
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.STRING())))
+                        .testTableApiValidationError(
+                                call("MAP_ENTRIES", $("f0"), $("f1")),
+                                "Invalid function call:\nMAP_ENTRIES(BOOLEAN, STRING)")
+                        .testResult(
+                                map(
+                                                $("f0").cast(DataTypes.BOOLEAN()),
+                                                $("f1").cast(DataTypes.STRING()))
+                                        .mapEntries(),
+                                "MAP_ENTRIES(MAP[CAST(f0 AS BOOLEAN), CAST(f1 AS STRING)])",
+                                new Row[] {Row.of(null, "item")},
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("key", DataTypes.BOOLEAN()),
+                                                        DataTypes.FIELD(
+                                                                "value", DataTypes.STRING())))
+                                        .notNull())
+                        .testResult(
+                                $("f2").mapEntries(),
+                                "MAP_ENTRIES(f2)",
+                                new Row[] {Row.of(1, "value1")},
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD("value", DataTypes.STRING()))))
+                        .testResult(
+                                $("f3").mapEntries(),
+                                "MAP_ENTRIES(f3)",
+                                new Row[] {Row.of(3, Collections.singletonMap(true, "value2"))},
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD(
+                                                        "value",
+                                                        DataTypes.MAP(
+                                                                DataTypes.BOOLEAN(),
+                                                                DataTypes.STRING()))))));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapEntriesFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.KeyValueDataType;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_ENTRIES}. */
+@Internal
+public class MapEntriesFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter keyElementGetter;
+    private final ArrayData.ElementGetter valueElementGetter;
+
+    public MapEntriesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_ENTRIES, context);
+        KeyValueDataType inputType =
+                ((KeyValueDataType) context.getCallContext().getArgumentDataTypes().get(0));
+        keyElementGetter =
+                ArrayData.createElementGetter(inputType.getKeyDataType().getLogicalType());
+        valueElementGetter =
+                ArrayData.createElementGetter(inputType.getValueDataType().getLogicalType());
+    }
+
+    public @Nullable ArrayData eval(@Nullable MapData input) {
+        if (input == null) {
+            return null;
+        }
+
+        ArrayData keys = input.keyArray();
+        ArrayData values = input.valueArray();
+        int size = input.size();
+
+        Object[] resultData = new Object[size];
+        for (int pos = 0; pos < size; pos++) {
+            final Object key = keyElementGetter.getElementOrNull(keys, pos);
+            final Object value = valueElementGetter.getElementOrNull(values, pos);
+            resultData[pos] = GenericRowData.of(key, value);
+        }
+        return new GenericArrayData(resultData);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapKeysFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapKeysFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_KEYS}. */
+@Internal
+public class MapKeysFunction extends BuiltInScalarFunction {
+    public MapKeysFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_KEYS, context);
+    }
+
+    public @Nullable ArrayData eval(@Nullable MapData input) {
+        if (input == null) {
+            return null;
+        }
+
+        return input.keyArray();
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapValuesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapValuesFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_VALUES}. */
+@Internal
+public class MapValuesFunction extends BuiltInScalarFunction {
+    public MapValuesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_VALUES, context);
+    }
+
+    public @Nullable ArrayData eval(@Nullable MapData input) {
+        if (input == null) {
+            return null;
+        }
+
+        return input.valueArray();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is an implementation of MAP_ENTRIES in apache:release-1.17 

Implement the map_entries method to transform a map into an array of key-value structs.

Description: The current implementation of the map_entries method in the Flink library does not provide a way to transform a map into an array of key-value structs. This enhancement aims to add this functionality, allowing users to convert a map into a more structured format for further processing.

## Brief change log
MAP_ENTRIES for Table API and SQL

- Syntax:
` map_entries[map: Map[K, V]] -> Array[Struct<K, V>] `

- Arguments:
map: The input map to be transformed

- Returns: An array of key-value structs obtained from the input map. Each struct consists of two fields: key of type K and value of type V.

- Examples:
Transforming a map into key-value structs:
```

input_map = [1: 'apple', 2: 'banana', 3: 'cherry'] 
 map_entries[input_map] 
 Output: [{'key': 1, 'value': 'apple'}, {'key': 2, 'value': 'banana'}, {'key': 3, 'value': 'cherry'}]
Handling an empty map:
empty_map = {} 
map_entries[empty_map]
Output: []
```

See also: spark:https://spark.apache.org/docs/latest/api/sql/index.html#map_entries

## Verifying this change
- This change added tests in MapFunctionITCase.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
