### PR TITLE
[FLINK-32708][network] Fix the write logic in remote tier of hybrid shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileWriter.java
@@ -178,13 +178,13 @@ public class SegmentPartitionFileWriter implements PartitionFileWriter {
     private void writeSegmentFinishFile(
             TieredStoragePartitionId partitionId, int subpartitionId, int segmentId) {
         try {
-            SegmentPartitionFile.writeSegmentFinishFile(
-                    basePath, partitionId, subpartitionId, segmentId);
             WritableByteChannel channel = subpartitionChannels[subpartitionId];
             if (channel != null) {
                 channel.close();
                 subpartitionChannels[subpartitionId] = null;
             }
+            SegmentPartitionFile.writeSegmentFinishFile(
+                    basePath, partitionId, subpartitionId, segmentId);
         } catch (IOException exception) {
             ExceptionUtils.rethrow(exception);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteStorageScannerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteStorageScannerTest.java
@@ -34,12 +34,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.RejectedExecutionException;
 
 import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.SegmentPartitionFile.getSegmentPath;
 import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.SegmentPartitionFile.writeSegmentFinishFile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /** Tests for {@link RemoteStorageScanner}. */
 class RemoteStorageScannerTest {
@@ -123,9 +121,6 @@ class RemoteStorageScannerTest {
         remoteStorageScanner.watchSegment(DEFAULT_PARTITION_ID, DEFAULT_SUBPARTITION_ID, 0);
         remoteStorageScanner.start();
         future.get();
-        remoteStorageScanner.close();
-        assertThatThrownBy(remoteStorageScanner::start)
-                .isInstanceOf(RejectedExecutionException.class);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Fix the write logic in remote tier of hybrid shuffle.*


## Brief change log

  - *Fix the write logic in remote tier of hybrid shuffle.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
