### PR TITLE
[FLINK-32667][dispatcher] Do not save job without restart strategy to job writer and store

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph.failover.flip1;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestartStrategyOptions;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -57,6 +58,22 @@ public final class FailoverStrategyFactoryLoader {
             default:
                 throw new IllegalConfigurationException(
                         "Unknown failover strategy: " + strategyParam);
+        }
+    }
+
+    public static boolean isJobRestartDisable(final Configuration configuration) {
+        final String restartStrategyName =
+                configuration.getString(RestartStrategyOptions.RESTART_STRATEGY);
+        if (restartStrategyName == null) {
+            return true;
+        }
+        switch (restartStrategyName.toLowerCase()) {
+            case "none":
+            case "off":
+            case "disable":
+                return true;
+            default:
+                return false;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.jobmanager.DelegateJobGraphStore;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
 import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.LeaderElection;
@@ -138,7 +139,7 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
 
     @Override
     public JobGraphStore getJobGraphStore() throws Exception {
-        return createJobGraphStore();
+        return new DelegateJobGraphStore(createJobGraphStore());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DelegateJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DelegateJobGraphStore.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader.isJobRestartDisable;
+
+/** Delegate for job graph store with filter for job without restart strategy. */
+public class DelegateJobGraphStore implements JobGraphStore {
+    private final JobGraphStore delegate;
+    private final Set<JobID> filterJobs;
+
+    public DelegateJobGraphStore(JobGraphStore delegate) {
+        this.delegate = delegate;
+        this.filterJobs = new HashSet<>();
+    }
+
+    @Override
+    public void start(JobGraphListener jobGraphListener) throws Exception {
+        this.delegate.start(jobGraphListener);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        this.delegate.stop();
+    }
+
+    @Override
+    public void putJobGraph(JobGraph jobGraph) throws Exception {
+        if (isJobRestartDisable(jobGraph.getJobConfiguration())) {
+            this.filterJobs.add(jobGraph.getJobID());
+        } else {
+            this.delegate.putJobGraph(jobGraph);
+        }
+    }
+
+    @Nullable
+    @Override
+    public JobGraph recoverJobGraph(JobID jobId) throws Exception {
+        return filterJob(jobId) ? null : this.delegate.recoverJobGraph(jobId);
+    }
+
+    private boolean filterJob(JobID jobId) {
+        return filterJobs.contains(jobId);
+    }
+
+    @Override
+    public Collection<JobID> getJobIds() throws Exception {
+        return this.delegate.getJobIds();
+    }
+
+    @VisibleForTesting
+    Set<JobID> getFilterJobs() {
+        return this.filterJobs;
+    }
+
+    @Override
+    public void putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements) throws Exception {
+        if (filterJob(jobId)) {
+            throw new IllegalStateException(
+                    "Cannot update resource requirements for the job without restart strategy.");
+        }
+
+        this.delegate.putJobResourceRequirements(jobId, jobResourceRequirements);
+    }
+
+    @Override
+    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+        if (filterJob(jobId)) {
+            filterJobs.remove(jobId);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return this.delegate.localCleanupAsync(jobId, executor);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> globalCleanupAsync(JobID jobId, Executor executor) {
+        if (filterJob(jobId)) {
+            filterJobs.remove(jobId);
+            return CompletableFuture.completedFuture(null);
+        } else {
+            return this.delegate.globalCleanupAsync(jobId, executor);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DelegateJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DelegateJobGraphStoreTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
+import org.apache.flink.runtime.testutils.TestingJobGraphStore;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for delegate job graph store. */
+class DelegateJobGraphStoreTest {
+    @Test
+    void testJobGraphForDelegateStore() throws Exception {
+        JobGraph jobGraph1 = JobGraphTestUtils.emptyJobGraph();
+        jobGraph1.getJobConfiguration().set(RestartStrategyOptions.RESTART_STRATEGY, "fixeddelay");
+        JobGraph jobGraph2 = JobGraphTestUtils.emptyJobGraph();
+        JobGraph jobGraph3 = JobGraphTestUtils.emptyJobGraph();
+
+        CompletableFuture<JobID> jobResourceRequirementsFuture = new CompletableFuture<>();
+        CompletableFuture<JobID> localCleanupFuture = new CompletableFuture<>();
+        CompletableFuture<JobID> globalCleanupFuture = new CompletableFuture<>();
+        CompletableFuture<JobID> stopFuture = new CompletableFuture<>();
+
+        JobGraphStore store =
+                TestingJobGraphStore.newBuilder()
+                        .setPutJobResourceRequirementsConsumer(
+                                (job, requirements) ->
+                                        jobResourceRequirementsFuture.complete(job.getJobID()))
+                        .setLocalCleanupFunction(
+                                (jobId, executor) -> {
+                                    localCleanupFuture.complete(jobId);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                        .setGlobalCleanupFunction(
+                                (jobId, executor) -> {
+                                    globalCleanupFuture.complete(jobId);
+                                    return CompletableFuture.completedFuture(null);
+                                })
+                        .setStopRunnable(() -> stopFuture.complete(jobGraph1.getJobID()))
+                        .withAutomaticStart()
+                        .build();
+        DelegateJobGraphStore delegate = new DelegateJobGraphStore(store);
+
+        // Add job1 and job2 to store.
+        delegate.putJobGraph(jobGraph1);
+        delegate.putJobGraph(jobGraph2);
+        delegate.putJobGraph(jobGraph3);
+
+        // Only add jobs without restart strategy in filter jobs.
+        assertThat(delegate.getFilterJobs())
+                .isEqualTo(
+                        new HashSet<>(Arrays.asList(jobGraph2.getJobID(), jobGraph3.getJobID())));
+
+        // Only get stored job ids for recovery.
+        assertThat(delegate.getJobIds()).isEqualTo(Collections.singleton(jobGraph1.getJobID()));
+        assertThat(store.getJobIds()).isEqualTo(Collections.singleton(jobGraph1.getJobID()));
+        assertThat(
+                        Objects.requireNonNull(delegate.recoverJobGraph(jobGraph1.getJobID()))
+                                .getJobID())
+                .isEqualTo(jobGraph1.getJobID());
+        assertThat(delegate.recoverJobGraph(jobGraph2.getJobID())).isNull();
+
+        delegate.putJobResourceRequirements(
+                jobGraph1.getJobID(), new JobResourceRequirements(Collections.emptyMap()));
+        assertThat(jobResourceRequirementsFuture.get(10, TimeUnit.SECONDS))
+                .isEqualTo(jobGraph1.getJobID());
+        // Update resource requirements for the job without restart strategy will throw exception.
+        assertThatThrownBy(
+                        () ->
+                                delegate.putJobResourceRequirements(
+                                        jobGraph2.getJobID(),
+                                        new JobResourceRequirements(Collections.emptyMap())))
+                .hasMessage(
+                        "Cannot update resource requirements for the job without restart strategy.");
+
+        delegate.localCleanupAsync(jobGraph1.getJobID(), null);
+        assertThat(localCleanupFuture.get(10, TimeUnit.SECONDS)).isEqualTo(jobGraph1.getJobID());
+        delegate.globalCleanupAsync(jobGraph1.getJobID(), null);
+        assertThat(globalCleanupFuture.get(10, TimeUnit.SECONDS)).isEqualTo(jobGraph1.getJobID());
+
+        // Clean filter jobs for local and global cleanup
+        delegate.localCleanupAsync(jobGraph2.getJobID(), null);
+        delegate.globalCleanupAsync(jobGraph3.getJobID(), null);
+        assertThat(delegate.getFilterJobs().isEmpty()).isTrue();
+
+        delegate.stop();
+        assertThat(stopFuture.get(10, TimeUnit.SECONDS)).isEqualTo(jobGraph1.getJobID());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to not save job which without restart strategy to job writer and store.
In olap scenario, jobs always has no restart strategy. It will increase latency if the jobs are saved to zookeeper or configmap for k8s. It is not necessary for the jobs without restart strategy to save these information.

## Brief change log
  - Add DispatcherJobStorage for Dispatcher to manage job writer and store
  - Register job to DispatcherJobStorage if it has no restart strategy
  - Do not save job information if job has no restart strategy
  - Unregister job in DispatcherJobStorage when job reaches termination

## Verifying this change

This change added tests and can be verified as follows:
  - Added `testCleanupWhenJobFinishedWithNoRestart` and `testCleanupWhenJobCanceledWithNoRestart` to test register and unregister in Dispatcher

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
