### PR TITLE
[FLINK-31168] Fix JobManagerHAProcessFailureRecoveryITCase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -195,7 +195,7 @@ public abstract class TestJvmProcess {
         System.out.println("-----------------------------------------");
     }
 
-    public void destroy() {
+    public void destroy() throws InterruptedException {
         synchronized (createDestroyLock) {
             checkState(process != null, "process not started");
 
@@ -207,27 +207,10 @@ public abstract class TestJvmProcess {
             LOG.info("Destroying " + getName() + " process.");
 
             try {
-                // try to call "destroyForcibly()" on Java 8
-                boolean destroyed = false;
-                try {
-                    Method m = process.getClass().getMethod("destroyForcibly");
-                    m.setAccessible(true);
-                    m.invoke(process);
-                    destroyed = true;
-                } catch (NoSuchMethodException ignored) {
-                    // happens on Java 7
-                } catch (Throwable t) {
-                    LOG.error("Failed to forcibly destroy process", t);
-                }
-
-                // if it was not destroyed, call the regular destroy method
-                if (!destroyed) {
-                    try {
-                        process.destroy();
-                    } catch (Throwable t) {
-                        LOG.error("Error while trying to destroy process.", t);
-                    }
-                }
+                process.destroyForcibly();
+                process.waitFor();
+            } catch (Throwable t) {
+                LOG.error("Error while trying to destroy process.", t);
             } finally {
                 destroyed = true;
                 ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -209,8 +209,6 @@ public abstract class TestJvmProcess {
             try {
                 process.destroyForcibly();
                 process.waitFor();
-            } catch (Throwable t) {
-                LOG.error("Error while trying to destroy process.", t);
             } finally {
                 destroyed = true;
                 ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);


### PR DESCRIPTION
## What is the purpose of the change

`JobManagerHAProcessFailureRecoveryITCase` fails with JDK17 occassionally. This PR is about investigating and fixing the issue.

The issue was that the destruction of the process took occassionally longer (the `destroyForcibly` failed under JDK17 due to the restrictive module encapsulation). The JM process that was subject to destruction might have had the chance to finish the job because `TestJvmProcess.destroy` didn't block until the process was actually gone. The new JM process wouldn't have any job to recover as the consequence which caused the `FlinkJobNotFoundException`. 

## Brief change log

* Replaced the `destroyForcibly` reflection logic that was introduced for JDK7 (which we don't support anymore) by the usual `destroy` call. `destroyForcibly` is also available through the `Process` interface. ~But it does only call `destroy` in the default implementation. Waiting for the process destruction is good enough here.~

I was wrong about the `destroyForcibly` just calling `destroy`. The `ProcessImpl` class is actually used (at least in my JDK version) which forcefully destroys the process. That's necessary because of `BlockingShutdownTest#testProcessExitsDespiteBlockingShutdownHook` which would block forever if we're not forcing the destruction of the blocking process.

I'm gonna run another test with the fix to update the test run table below.

## Verifying this change

Two test builds with the number of test runs per stage:

| run | misc-0 | misc-1 | misc-2 | misc-3 | misc-4 | misc-5 | misc-6 |
|------|-----------|----------|----------|-----------|----------|-----------|----------|
| [w/o fix](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=51842&view=results)* | :heavy_multiplication_x: 109 | :heavy_multiplication_x: 181 | :heavy_multiplication_x: 129 | :heavy_multiplication_x: 182 | :heavy_multiplication_x: 127 | :heavy_check_mark: 169 | :heavy_multiplication_x: 133 |
| [w/ fix](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=51885&view=results)* | :heavy_check_mark: 74 | :heavy_check_mark: 76 | :heavy_check_mark: 74 | :heavy_check_mark: 73 | :heavy_check_mark: 73 | :heavy_check_mark: 73 | :heavy_check_mark: 73 |

\* test run with https://github.com/apache/flink/pull/23103/commits/d609760a26e40eb63c34c8ed4273286b2040431e

:heavy_multiplication_x: - eventually failed
:heavy_check_mark: - ran into 4h CI timeout

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable