### PR TITLE
[FLINK-32715][test] Make test wait for application to stop before shutting down the other services

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -238,8 +238,9 @@ class ProcessFailureCancelingITCase {
                 taskManagerProcess.destroy();
             }
             if (dispatcherResourceManagerComponent != null) {
-                dispatcherResourceManagerComponent.stopApplication(
-                        ApplicationStatus.SUCCEEDED, null);
+                dispatcherResourceManagerComponent
+                        .stopApplication(ApplicationStatus.SUCCEEDED, null)
+                        .get();
             }
 
             fatalErrorHandler.rethrowError();


### PR DESCRIPTION
## What is the purpose of the change

We introduced a Precondition checking whether the contenders deregistered themselves before closing the HA backend of the service. `ProcessFailureCancelingITCase` doesn't do that properly because it's not waiting for the `dispatcherResourceManagerComponent` application to stop. That might lead to test instabilities if stopping the application takes longer.

## Brief change log

* Made the `stopApplication` call to block

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable