### PR TITLE
[FLINK-28046][connectors] Mark SourceFunction interface as @Deprecated

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -94,7 +94,11 @@ import java.io.Serializable;
  * SourceContext#emitWatermark(Watermark)}.
  *
  * @param <T> The type of the elements produced by this source.
+ * @deprecated This interface will be removed in future versions. Use the new {@link
+ *     org.apache.flink.api.connector.source.Source} interface instead. NOTE: All sub-tasks from
+ *     FLINK-28045 must be closed before this API can be completely removed.
  */
+@Deprecated
 @Public
 public interface SourceFunction<T> extends Function, Serializable {
 


### PR DESCRIPTION
This is a trivial change that marks SourceFunction API as `@Deprecated`.