### PR TITLE
[FLINK-32706][table] Add built-in SPLIT_STRING function

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -453,9 +453,9 @@ Please refer to the [Debugging Classloading Docs]({{< ref "docs/ops/debugging/de
 
 {{< generated/expert_state_backends_section >}}
 
-### State Backends Latency Tracking Options
+### State Latency Tracking Options
 
-{{< generated/state_backend_latency_tracking_section >}}
+{{< generated/state_latency_tracking_section >}}
 
 ### Advanced RocksDB State Backends Options
 

--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -2241,12 +2241,12 @@ purposes.
 ## State access latency tracking
 
 Flink also allows to track the keyed state access latency for standard Flink state-backends or customized state backends which extending from `AbstractStateBackend`. This feature is disabled by default.
-To enable this feature you must set the `state.backend.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
+To enable this feature you must set the `state.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
 
-Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.backend.latency-track.sample-interval`.
+Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.latency-track.sample-interval`.
 This configuration has a default value of 100. A smaller value will get more accurate results but have a higher performance impact since it is sampled more frequently.
 
-As the type of this latency metrics is histogram, `state.backend.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
+As the type of this latency metrics is histogram, `state.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
 A larger value of this configuration will require more memory, but will provide a more accurate result.
 
 <span class="label label-danger">Warning</span> Enabling state-access-latency metrics may impact the performance.

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -455,9 +455,9 @@ Please refer to the [Debugging Classloading Docs]({{< ref "docs/ops/debugging/de
 
 {{< generated/expert_state_backends_section >}}
 
-### State Backends Latency Tracking Options
+### State Latency Tracking Options
 
-{{< generated/state_backend_latency_tracking_section >}}
+{{< generated/state_latency_tracking_section >}}
 
 ### Advanced RocksDB State Backends Options
 

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -2191,12 +2191,12 @@ purposes.
 ## State access latency tracking
 
 Flink also allows to track the keyed state access latency for standard Flink state-backends or customized state backends which extending from `AbstractStateBackend`. This feature is disabled by default.
-To enable this feature you must set the `state.backend.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
+To enable this feature you must set the `state.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
 
-Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.backend.latency-track.sample-interval`.
+Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.latency-track.sample-interval`.
 This configuration has a default value of 100. A smaller value will get more accurate results but have a higher performance impact since it is sampled more frequently.
 
-As the type of this latency metrics is histogram, `state.backend.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
+As the type of this latency metrics is histogram, `state.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
 A larger value of this configuration will require more memory, but will provide a more accurate result.
 
 <span class="label label-danger">Warning</span> Enabling state-access-latency metrics may impact the performance.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -682,6 +682,9 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
+  - sql: SPLIT(string, delimiter)
+    table: string.split(delimiter)
+    description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, every character in the string is split. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -285,10 +285,22 @@
             <td>The user-specified tolerations to be set to the TaskManager pod. The value should be in the form of key:key1,operator:Equal,value:value1,effect:NoSchedule;key:key2,operator:Exists,effect:NoExecute,tolerationSeconds:6000</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.transactional-operation.initial-retry-delay</h5></td>
+            <td style="word-wrap: break-word;">50 ms</td>
+            <td>Duration</td>
+            <td>Defines the initial duration of Kubernetes transactional operation retries after fail</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.transactional-operation.max-retries</h5></td>
-            <td style="word-wrap: break-word;">5</td>
+            <td style="word-wrap: break-word;">15</td>
             <td>Integer</td>
             <td>Defines the number of Kubernetes transactional operation retries before the client gives up. For example, <code class="highlighter-rouge">FlinkKubeClient#checkAndUpdateConfigMap</code>.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.transactional-operation.max-retry-delay</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Defines the max duration of Kubernetes transactional operation retries after fail</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/state_backend_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_backend_configuration.html
@@ -9,30 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>state.backend.latency-track.history-size</h5></td>
-            <td style="word-wrap: break-word;">128</td>
-            <td>Integer</td>
-            <td>Defines the number of measured latencies to maintain at each state access operation.</td>
-        </tr>
-        <tr>
-            <td><h5>state.backend.latency-track.keyed-state-enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to track latency of keyed state operations, e.g value state put/get/clear.</td>
-        </tr>
-        <tr>
-            <td><h5>state.backend.latency-track.sample-interval</h5></td>
-            <td style="word-wrap: break-word;">100</td>
-            <td>Integer</td>
-            <td>The sample interval of latency track once 'state.backend.latency-track.keyed-state-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
-        </tr>
-        <tr>
-            <td><h5>state.backend.latency-track.state-name-as-variable</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to expose state name as a variable if tracking latency.</td>
-        </tr>
-        <tr>
             <td><h5>state.backend.type</h5></td>
             <td style="word-wrap: break-word;">"hashmap"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/state_latency_track_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_latency_track_configuration.html
@@ -9,25 +9,25 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>state.backend.latency-track.history-size</h5></td>
+            <td><h5>state.latency-track.history-size</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
             <td>Defines the number of measured latencies to maintain at each state access operation.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.latency-track.keyed-state-enabled</h5></td>
+            <td><h5>state.latency-track.keyed-state-enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to track latency of keyed state operations, e.g value state put/get/clear.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.latency-track.sample-interval</h5></td>
+            <td><h5>state.latency-track.sample-interval</h5></td>
             <td style="word-wrap: break-word;">100</td>
             <td>Integer</td>
-            <td>The sample interval of latency track once 'state.backend.latency-track.keyed-state-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
+            <td>The sample interval of latency track once 'state.latency-track.keyed-state-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.latency-track.state-name-as-variable</h5></td>
+            <td><h5>state.latency-track.state-name-as-variable</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to expose state name as a variable if tracking latency.</td>

--- a/docs/layouts/shortcodes/generated/state_latency_tracking_section.html
+++ b/docs/layouts/shortcodes/generated/state_latency_tracking_section.html
@@ -1,0 +1,36 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>state.latency-track.history-size</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>Defines the number of measured latencies to maintain at each state access operation.</td>
+        </tr>
+        <tr>
+            <td><h5>state.latency-track.keyed-state-enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to track latency of keyed state operations, e.g value state put/get/clear.</td>
+        </tr>
+        <tr>
+            <td><h5>state.latency-track.sample-interval</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
+            <td>The sample interval of latency track once 'state.latency-track.keyed-state-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
+        </tr>
+        <tr>
+            <td><h5>state.latency-track.state-name-as-variable</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to expose state name as a variable if tracking latency.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
@@ -77,8 +77,7 @@ public final class Documentation {
 
         public static final String STATE_BACKEND_ROCKSDB = "state_backend_rocksdb";
 
-        public static final String STATE_BACKEND_LATENCY_TRACKING =
-                "state_backend_latency_tracking";
+        public static final String STATE_LATENCY_TRACKING = "state_latency_tracking";
 
         public static final String STATE_BACKEND_CHANGELOG = "state_backend_changelog";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
 /** A collection of all configuration options that relate to state backend. */
+@PublicEvolving
 public class StateBackendOptions {
 
     // ------------------------------------------------------------------------
@@ -63,7 +65,9 @@ public class StateBackendOptions {
                                     .text("Recognized shortcut names are 'hashmap' and 'rocksdb'.")
                                     .build());
 
-    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    /** @deprecated Use {@link StateLatencyTrackOptions#LATENCY_TRACK_ENABLED} instead. */
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
     public static final ConfigOption<Boolean> LATENCY_TRACK_ENABLED =
             ConfigOptions.key("state.backend.latency-track.keyed-state-enabled")
                     .booleanType()
@@ -71,7 +75,9 @@ public class StateBackendOptions {
                     .withDescription(
                             "Whether to track latency of keyed state operations, e.g value state put/get/clear.");
 
-    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    /** @deprecated Use {@link StateLatencyTrackOptions#LATENCY_TRACK_SAMPLE_INTERVAL} instead. */
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
     public static final ConfigOption<Integer> LATENCY_TRACK_SAMPLE_INTERVAL =
             ConfigOptions.key("state.backend.latency-track.sample-interval")
                     .intType()
@@ -82,7 +88,9 @@ public class StateBackendOptions {
                                             + "The default value is 100, which means we would track the latency every 100 access requests.",
                                     LATENCY_TRACK_ENABLED.key()));
 
-    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    /** @deprecated Use {@link StateLatencyTrackOptions#LATENCY_TRACK_HISTORY_SIZE} instead. */
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
     public static final ConfigOption<Integer> LATENCY_TRACK_HISTORY_SIZE =
             ConfigOptions.key("state.backend.latency-track.history-size")
                     .intType()
@@ -90,7 +98,12 @@ public class StateBackendOptions {
                     .withDescription(
                             "Defines the number of measured latencies to maintain at each state access operation.");
 
-    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    /**
+     * @deprecated Use {@link StateLatencyTrackOptions#LATENCY_TRACK_STATE_NAME_AS_VARIABLE}
+     *     instead.
+     */
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
     public static final ConfigOption<Boolean> LATENCY_TRACK_STATE_NAME_AS_VARIABLE =
             ConfigOptions.key("state.backend.latency-track.state-name-as-variable")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateLatencyTrackOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateLatencyTrackOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
+
+/**
+ * A collection of all configuration options that relate to the latency tracking for state access.
+ */
+@PublicEvolving
+public class StateLatencyTrackOptions {
+
+    @Documentation.Section(Documentation.Sections.STATE_LATENCY_TRACKING)
+    public static final ConfigOption<Boolean> LATENCY_TRACK_ENABLED =
+            ConfigOptions.key("state.latency-track.keyed-state-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDeprecatedKeys(StateBackendOptions.LATENCY_TRACK_ENABLED.key())
+                    .withDescription(
+                            "Whether to track latency of keyed state operations, e.g value state put/get/clear.");
+
+    @Documentation.Section(Documentation.Sections.STATE_LATENCY_TRACKING)
+    public static final ConfigOption<Integer> LATENCY_TRACK_SAMPLE_INTERVAL =
+            ConfigOptions.key("state.latency-track.sample-interval")
+                    .intType()
+                    .defaultValue(100)
+                    .withDeprecatedKeys(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL.key())
+                    .withDescription(
+                            String.format(
+                                    "The sample interval of latency track once '%s' is enabled. "
+                                            + "The default value is 100, which means we would track the latency every 100 access requests.",
+                                    LATENCY_TRACK_ENABLED.key()));
+
+    @Documentation.Section(Documentation.Sections.STATE_LATENCY_TRACKING)
+    public static final ConfigOption<Integer> LATENCY_TRACK_HISTORY_SIZE =
+            ConfigOptions.key("state.latency-track.history-size")
+                    .intType()
+                    .defaultValue(128)
+                    .withDeprecatedKeys(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.key())
+                    .withDescription(
+                            "Defines the number of measured latencies to maintain at each state access operation.");
+
+    @Documentation.Section(Documentation.Sections.STATE_LATENCY_TRACKING)
+    public static final ConfigOption<Boolean> LATENCY_TRACK_STATE_NAME_AS_VARIABLE =
+            ConfigOptions.key("state.latency-track.state-name-as-variable")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDeprecatedKeys(
+                            StateBackendOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE.key())
+                    .withDescription(
+                            "Whether to expose state name as a variable if tracking latency.");
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -62,11 +62,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 /** Implementation of {@link ResourceManagerDriver} for Kubernetes deployment. */
 public class KubernetesResourceManagerDriver
@@ -74,6 +74,8 @@ public class KubernetesResourceManagerDriver
 
     /** The taskmanager pod name pattern is {clusterId}-{taskmanager}-{attemptId}-{podIndex}. */
     private static final String TASK_MANAGER_POD_FORMAT = "%s-taskmanager-%d-%d";
+
+    private static final Long TERMINATION_WAIT_SECOND = 5L;
 
     private final String clusterId;
 
@@ -90,7 +92,10 @@ public class KubernetesResourceManagerDriver
     /** Current max pod index. When creating a new pod, it should increase one. */
     private long currentMaxPodId = 0;
 
-    private Optional<KubernetesWatch> podsWatchOpt;
+    private CompletableFuture<KubernetesWatch> podsWatchOptFuture =
+            FutureUtils.completedExceptionally(
+                    new ResourceManagerException(
+                            "KubernetesResourceManagerDriver is not initialized."));
 
     private volatile boolean running;
 
@@ -114,7 +119,7 @@ public class KubernetesResourceManagerDriver
 
     @Override
     protected void initializeInternal() throws Exception {
-        podsWatchOpt = watchTaskManagerPods();
+        podsWatchOptFuture = watchTaskManagerPods();
         final File podTemplateFile = KubernetesUtils.getTaskManagerPodTemplateFileInPod();
         if (podTemplateFile.exists()) {
             taskManagerPodTemplate =
@@ -139,7 +144,7 @@ public class KubernetesResourceManagerDriver
         Exception exception = null;
 
         try {
-            podsWatchOpt.ifPresent(KubernetesWatch::close);
+            podsWatchOptFuture.get(TERMINATION_WAIT_SECOND, TimeUnit.SECONDS).close();
         } catch (Exception e) {
             exception = e;
         }
@@ -412,11 +417,21 @@ public class KubernetesResourceManagerDriver
                         });
     }
 
-    private Optional<KubernetesWatch> watchTaskManagerPods() throws Exception {
-        return Optional.of(
+    private CompletableFuture<KubernetesWatch> watchTaskManagerPods() throws Exception {
+        CompletableFuture<KubernetesWatch> kubernetesWatchCompletableFuture =
                 flinkKubeClient.watchPodsAndDoCallback(
                         KubernetesUtils.getTaskManagerSelectors(clusterId),
-                        new PodCallbackHandlerImpl()));
+                        new PodCallbackHandlerImpl());
+        kubernetesWatchCompletableFuture.whenCompleteAsync(
+                (KubernetesWatch watch, Throwable throwable) -> {
+                    if (throwable != null) {
+                        getResourceEventHandler().onError(throwable);
+                    } else {
+                        log.info("Create watch on TaskManager pods successfully.");
+                    }
+                },
+                getMainThreadExecutor());
+        return kubernetesWatchCompletableFuture;
     }
 
     // ------------------------------------------------------------------------
@@ -448,19 +463,27 @@ public class KubernetesResourceManagerDriver
         @Override
         public void handleError(Throwable throwable) {
             if (throwable instanceof KubernetesTooOldResourceVersionException) {
-                getMainThreadExecutor()
-                        .execute(
-                                () -> {
-                                    if (running) {
-                                        podsWatchOpt.ifPresent(KubernetesWatch::close);
-                                        log.info("Creating a new watch on TaskManager pods.");
-                                        try {
-                                            podsWatchOpt = watchTaskManagerPods();
-                                        } catch (Exception e) {
-                                            getResourceEventHandler().onError(e);
-                                        }
+                podsWatchOptFuture.whenCompleteAsync(
+                        (KubernetesWatch watch, Throwable throwable1) -> {
+                            if (running) {
+                                try {
+                                    if (watch != null) {
+                                        watch.close();
                                     }
-                                });
+                                } catch (Exception e) {
+                                    log.warn(
+                                            "Error when get old watch to close, which is not supposed to happen",
+                                            e);
+                                }
+                                log.info("Creating a new watch on TaskManager pods.");
+                                try {
+                                    podsWatchOptFuture = watchTaskManagerPods();
+                                } catch (Exception e) {
+                                    getResourceEventHandler().onError(e);
+                                }
+                            }
+                        },
+                        getMainThreadExecutor());
             } else {
                 getResourceEventHandler().onError(throwable);
             }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -431,13 +432,36 @@ public class KubernetesConfigOptions {
     public static final ConfigOption<Integer> KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES =
             key("kubernetes.transactional-operation.max-retries")
                     .intType()
-                    .defaultValue(5)
+                    .defaultValue(15)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "Defines the number of Kubernetes transactional operation retries before the "
                                                     + "client gives up. For example, %s.",
                                             code("FlinkKubeClient#checkAndUpdateConfigMap"))
+                                    .build());
+
+    public static final ConfigOption<Duration>
+            KUBERNETES_TRANSACTIONAL_OPERATION_INITIAL_RETRY_DEALY =
+                    key("kubernetes.transactional-operation.initial-retry-delay")
+                            .durationType()
+                            .defaultValue(Duration.ofMillis(50))
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "Defines the initial duration of Kubernetes transactional operation retries "
+                                                            + "after fail")
+                                            .build());
+
+    public static final ConfigOption<Duration> KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRY_DEALY =
+            key("kubernetes.transactional-operation.max-retry-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the max duration of Kubernetes transactional operation retries "
+                                                    + "after fail")
                                     .build());
 
     public static final ConfigOption<String> JOB_MANAGER_POD_TEMPLATE;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -105,7 +105,7 @@ public interface FlinkKubeClient extends AutoCloseable {
      * @param podCallbackHandler podCallbackHandler which reacts to pod events
      * @return Return a watch for pods. It needs to be closed after use.
      */
-    KubernetesWatch watchPodsAndDoCallback(
+    CompletableFuture<KubernetesWatch> watchPodsAndDoCallback(
             Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler)
             throws Exception;
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** A {@link FlinkKubeClientFactory} for creating the {@link FlinkKubeClient}. */
 public class FlinkKubeClientFactory {
@@ -107,11 +107,12 @@ public class FlinkKubeClientFactory {
         final int poolSize =
                 flinkConfig.get(KubernetesConfigOptions.KUBERNETES_CLIENT_IO_EXECUTOR_POOL_SIZE);
         return new Fabric8FlinkKubeClient(
-                flinkConfig, client, createThreadPoolForAsyncIO(poolSize, useCase));
+                flinkConfig, client, createScheduledThreadPoolForAsyncIO(poolSize, useCase));
     }
 
-    private static ExecutorService createThreadPoolForAsyncIO(int poolSize, String useCase) {
-        return Executors.newFixedThreadPool(
+    private static ScheduledExecutorService createScheduledThreadPoolForAsyncIO(
+            int poolSize, String useCase) {
+        return Executors.newScheduledThreadPool(
                 poolSize, new ExecutorThreadFactory("flink-kubeclient-io-for-" + useCase));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.Executors;
 
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,7 +84,7 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                                 return new Fabric8FlinkKubeClient(
                                         flinkConfig,
                                         server.createClient().inNamespace(NAMESPACE),
-                                        Executors.newDirectExecutorService());
+                                        Executors.newSingleThreadScheduledExecutor());
                             }
                         });
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -334,7 +334,8 @@ class KubernetesResourceManagerDriverTest
                             } else {
                                 initWatchFuture.complete(null);
                                 getSetWatchPodsAndDoCallbackFuture().complete(handler);
-                                return new TestingFlinkKubeClient.MockKubernetesWatch();
+                                return CompletableFuture.supplyAsync(
+                                        TestingFlinkKubeClient.MockKubernetesWatch::new);
                             }
                         });
                 runTest(
@@ -383,7 +384,7 @@ class KubernetesResourceManagerDriverTest
                                                 }
                                             };
                                     podsWatches.add(watch);
-                                    return watch;
+                                    return CompletableFuture.supplyAsync(() -> watch);
                                 })
                         .setStopAndCleanupClusterConsumer(stopAndCleanupClusterFuture::complete)
                         .setCreateTaskManagerPodFunction(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -52,7 +52,9 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     private final Consumer<String> stopAndCleanupClusterConsumer;
     private final Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction;
     private final BiFunction<
-                    Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
+                    Map<String, String>,
+                    WatchCallbackHandler<KubernetesPod>,
+                    CompletableFuture<KubernetesWatch>>
             watchPodsAndDoCallbackFunction;
     private final Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction;
     private final Function<String, Optional<KubernetesConfigMap>> getConfigMapFunction;
@@ -77,7 +79,10 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
             Function<String, CompletableFuture<Void>> stopPodFunction,
             Consumer<String> stopAndCleanupClusterConsumer,
             Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction,
-            BiFunction<Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
+            BiFunction<
+                            Map<String, String>,
+                            WatchCallbackHandler<KubernetesPod>,
+                            CompletableFuture<KubernetesWatch>>
                     watchPodsAndDoCallbackFunction,
             Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction,
             Function<String, Optional<KubernetesConfigMap>> getConfigMapFunction,
@@ -149,7 +154,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public KubernetesWatch watchPodsAndDoCallback(
+    public CompletableFuture<KubernetesWatch> watchPodsAndDoCallback(
             Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler) {
         return watchPodsAndDoCallbackFunction.apply(labels, podCallbackHandler);
     }
@@ -218,8 +223,12 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         private Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction =
                 (ignore) -> Collections.emptyList();
         private BiFunction<
-                        Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
-                watchPodsAndDoCallbackFunction = (ignore1, ignore2) -> new MockKubernetesWatch();
+                        Map<String, String>,
+                        WatchCallbackHandler<KubernetesPod>,
+                        CompletableFuture<KubernetesWatch>>
+                watchPodsAndDoCallbackFunction =
+                        (ignore1, ignore2) ->
+                                CompletableFuture.supplyAsync(MockKubernetesWatch::new);
 
         private Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction =
                 (ignore) -> FutureUtils.completedVoidFuture();
@@ -277,7 +286,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                 BiFunction<
                                 Map<String, String>,
                                 WatchCallbackHandler<KubernetesPod>,
-                                KubernetesWatch>
+                                CompletableFuture<KubernetesWatch>>
                         watchPodsAndDoCallbackFunction) {
             this.watchPodsAndDoCallbackFunction =
                     Preconditions.checkNotNull(watchPodsAndDoCallbackFunction);

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -241,6 +241,7 @@ advanced type helper functions
     Expression.map_entries
     Expression.map_keys
     Expression.map_values
+    Expression.split
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1636,6 +1636,21 @@ class Expression(Generic[T]):
         """
         return _unary_op("mapEntries")(self)
 
+    def split(self, delimiter) -> 'Expression':
+        """
+        Splits a string into an array of substrings based on a delimiter. If the delimiter is not
+        found, then the original string is returned as the only element in the array.
+        Splits a string into an array of substrings based on a delimiter.
+        If the delimiter is not found, then the original string is returned as the only element in the array.
+        If the delimiter is empty, then all characters in the string are split.
+        If either, string or delimiter, are NULL, then a NULL value is returned.
+        If the delimiter is empty, then all characters in the string are split.
+        If either, string or delimiter, are NULL, then a NULL value is returned.
+        If the delimiter is found at the beginning or end of the string,
+        or there are contiguous delimiters, then an empty space is added to the array.
+        """
+        return _binary_op("split")(self, delimiter)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfig.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state.metrics;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.Preconditions;
 
@@ -86,12 +86,13 @@ public class LatencyTrackingStateConfig {
     public static class Builder implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        private boolean enabled = StateBackendOptions.LATENCY_TRACK_ENABLED.defaultValue();
+        private boolean enabled = StateLatencyTrackOptions.LATENCY_TRACK_ENABLED.defaultValue();
         private int sampleInterval =
-                StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue();
-        private int historySize = StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue();
+                StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue();
+        private int historySize =
+                StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue();
         private boolean stateNameAsVariable =
-                StateBackendOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE.defaultValue();
+                StateLatencyTrackOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE.defaultValue();
         private MetricGroup metricGroup;
 
         public Builder setEnabled(boolean enabled) {
@@ -120,12 +121,13 @@ public class LatencyTrackingStateConfig {
         }
 
         public Builder configure(ReadableConfig config) {
-            this.setEnabled(config.get(StateBackendOptions.LATENCY_TRACK_ENABLED))
+            this.setEnabled(config.get(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED))
                     .setSampleInterval(
-                            config.get(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL))
-                    .setHistorySize(config.get(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE))
+                            config.get(StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL))
+                    .setHistorySize(config.get(StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE))
                     .setStateNameAsVariable(
-                            config.get(StateBackendOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE));
+                            config.get(
+                                    StateLatencyTrackOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE));
             return this;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -48,7 +48,7 @@ import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.JavaSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.core.testutils.CheckedThread;
@@ -277,7 +277,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
     void testEnableStateLatencyTracking() throws Exception {
         ConfigurableStateBackend stateBackend = getStateBackend();
         Configuration config = new Configuration();
-        config.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        config.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend configuredBackend =
                 stateBackend.configure(config, Thread.currentThread().getContextClassLoader());
         KeyGroupRange groupRange = new KeyGroupRange(0, 1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state.metrics;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import org.junit.jupiter.api.Test;
@@ -46,11 +46,17 @@ class LatencyTrackingStateConfigTest {
                         .build();
         assertThat(latencyTrackingStateConfig.isEnabled()).isTrue();
         assertThat(latencyTrackingStateConfig.getSampleInterval())
-                .isEqualTo((int) StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue());
+                .isEqualTo(
+                        (int)
+                                StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL
+                                        .defaultValue());
         assertThat(latencyTrackingStateConfig.getHistorySize())
-                .isEqualTo((long) StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue());
+                .isEqualTo(
+                        (long) StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue());
         assertThat(latencyTrackingStateConfig.isStateNameAsVariable())
-                .isEqualTo(StateBackendOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE.defaultValue());
+                .isEqualTo(
+                        StateLatencyTrackOptions.LATENCY_TRACK_STATE_NAME_AS_VARIABLE
+                                .defaultValue());
     }
 
     @Test
@@ -72,9 +78,9 @@ class LatencyTrackingStateConfigTest {
     void testConfigureFromReadableConfig() {
         LatencyTrackingStateConfig.Builder builder = LatencyTrackingStateConfig.newBuilder();
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
-        configuration.set(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 10);
-        configuration.set(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, 500);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 10);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE, 500);
         LatencyTrackingStateConfig latencyTrackingStateConfig =
                 builder.configure(configuration)
                         .setMetricGroup(new UnregisteredMetricsGroup())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -58,11 +58,11 @@ abstract class LatencyTrackingStateTestBase<K> {
         KeyGroupRange keyGroupRange = new KeyGroupRange(0, 127);
         int numberOfKeyGroups = keyGroupRange.getNumberOfKeyGroups();
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
-        configuration.set(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
         // use a very large value to not let metrics data overridden.
         int historySize = 1000_000;
-        configuration.set(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
         HashMapStateBackend stateBackend =
                 new HashMapStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendTest;
 import org.apache.flink.runtime.execution.Environment;
@@ -105,7 +105,7 @@ public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend stateBackend =
                 getStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -101,7 +101,7 @@ public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest 
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend stateBackend =
                 getStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
@@ -92,7 +92,7 @@ public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend stateBackend =
                 getStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateLatencyTrackOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -101,7 +101,7 @@ public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendT
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         Configuration configuration = new Configuration();
-        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateLatencyTrackOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend stateBackend =
                 getStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -172,6 +172,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIGN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIMILAR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SINH;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT_INDEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SQRT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_POP;
@@ -1532,6 +1533,20 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns an array of all entries in the given map. */
     public OutType mapEntries() {
         return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
+    }
+
+    /**
+     * Returns an array of substrings by splitting the input string based on a given delimiter.
+     *
+     * <p>If the delimiter is not found in the string, the original string is returned as the only
+     * element in the array. If the delimiter is empty, every character in the string is split. If
+     * the string or delimiter is null, a null value is returned. If the delimiter is found at the
+     * beginning or end of the string, or there are contiguous delimiters, then an empty string is
+     * added to the array.
+     */
+    public OutType split(InType delimiter) {
+        return toApiSpecificExpression(
+                unresolvedCall(SPLIT, toExpr(), objectToExpression(delimiter)));
     }
 
     // Time definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -409,6 +409,18 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition SPLIT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("SPLIT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                    logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(forceNullable(explicit(DataTypes.ARRAY(STRING()))))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.SplitFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -54,7 +54,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayJoinTestCases(),
                         arraySliceTestCases(),
                         arrayMinTestCases(),
-                        arraySortTestCases())
+                        arraySortTestCases(),
+                        splitTestCases())
                 .flatMap(s -> s);
     }
 
@@ -1595,5 +1596,84 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     LocalDate.of(2012, 5, 16)
                                 },
                                 DataTypes.ARRAY(DataTypes.DATE())));
+    }
+
+    private Stream<TestSetSpec> splitTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.SPLIT)
+                        .onFieldsWithData(
+                                "123,123,23",
+                                null,
+                                ",123,123",
+                                ",123,123,",
+                                123,
+                                "12345",
+                                ",123,,,123,")
+                        .andDataTypes(
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                $("f0").split(","),
+                                "SPLIT(f0, ',')",
+                                new String[] {"123", "123", "23"},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f0").split(null),
+                                "SPLIT(f0, NULL)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f0").split(""),
+                                "SPLIT(f0, '')",
+                                new String[] {"1", "2", "3", ",", "1", "2", "3", ",", "2", "3"},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f1").split(","),
+                                "SPLIT(f1, ',')",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f1").split(null),
+                                "SPLIT(f1, null)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f2").split(","),
+                                "SPLIT(f2, ',')",
+                                new String[] {"", "123", "123"},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f3").split(","),
+                                "SPLIT(f3, ',')",
+                                new String[] {"", "123", "123", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f5").split(","),
+                                "SPLIT(f5, ',')",
+                                new String[] {"12345"},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f6").split(","),
+                                "SPLIT(f6, ',')",
+                                new String[] {"", "123", "", "", "123", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testTableApiValidationError(
+                                $("f4").split(","),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "SPLIT(f4, ',')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "SPLIT()", "No match found for function signature SPLIT()")
+                        .testSqlValidationError(
+                                "SPLIT(f1, '1', '2')",
+                                "No match found for function signature SPLIT(<CHARACTER>, <CHARACTER>, <CHARACTER>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#SPLIT}. */
+@Internal
+public class SplitFunction extends BuiltInScalarFunction {
+    public SplitFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.SPLIT, context);
+    }
+
+    public @Nullable ArrayData eval(@Nullable StringData string, @Nullable StringData delimiter) {
+        try {
+            if (string == null || delimiter == null) {
+                return null;
+            }
+            String string1 = string.toString();
+            String delimiter1 = delimiter.toString();
+            List<StringData> resultList = new ArrayList<>();
+
+            if (delimiter1.equals("")) {
+                for (char c : string1.toCharArray()) {
+                    resultList.add(BinaryStringData.fromString(String.valueOf(c)));
+                }
+            } else {
+                int start = 0;
+                int end = string1.indexOf(delimiter1);
+                while (end != -1) {
+                    String substring = string1.substring(start, end);
+                    resultList.add(
+                            BinaryStringData.fromString(
+                                    substring.isEmpty()
+                                            ? ""
+                                            : substring)); // Added this check to handle consecutive
+                    // delimiters
+                    start = end + delimiter1.length();
+                    end = string1.indexOf(delimiter1, start);
+                }
+                String remaining = string1.substring(start);
+                resultList.add(
+                        BinaryStringData.fromString(
+                                remaining.isEmpty()
+                                        ? ""
+                                        : remaining)); // Added this check to handle delimiter at
+                // the end
+            }
+            return new GenericArrayData(resultList.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of SPLIT


## Brief change log
Splits a string into an array of substrings based on a delimiter. If the delimiter is not found, then the original string is returned as the only element in the array. If the delimiter is empty, then all characters in the string are split. If either, string or delimiter, are NULL, then a NULL value is returned.
If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty space is added to the array.

- Syntax
`SPLIT(string, delimiter)`

- Arguments
string: The string need to be split
delimiter: Splits a string into an array of substrings based on a delimiter

- Returns
If the delimiter is not found, then the original string is returned as the only element in the array. If the delimiter is empty, then all characters in the string are split. If either, string or delimiter, are NULL, then a NULL value is returned.

- Examples
```
SELECT SPLIT('abcdefg', 'c');
Result: ['ab', 'defg']
```

- See also
1. ksqlDB Split function
ksqlDB provides a scalar function named SPLIT which splits a string into an array of substrings based on a delimiter.
Syntax: SPLIT(string, delimiter)
For example: SPLIT('a,b,c', ',') will return ['a', 'b', 'c'].
https://docs.ksqldb.io/en/0.8.1-ksqldb/developer-guide/ksqldb-reference/scalar-functions/#split

2. Apache Hive Split function
Hive offers a function named split which splits a string around a specified delimiter and returns an array of strings.
Syntax: array<string> split(string str, string pat)
For example: split('a,b,c', ',') will return ["a", "b", "c"].
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF

3. Spark SQL Split function
Spark SQL also offers a function named split, similar to the one in Hive.
Syntax: split(str, pattern[, limit])
Here, limit is an optional parameter to specify the maximum length of the returned array.
For example: split('oneAtwoBthreeC', '[ABC]', 2) will return ["one", "twoBthreeC"].
https://spark.apache.org/docs/latest/api/sql/index.html#split

4. Presto Split function
Presto offers a function named split which splits a string around a regular expression and returns an array of strings.
Syntax: array<varchar> split(string str, string regex)
For example: split('a.b.c', '\.') will return ["a", "b", "c"].
https://prestodb.io/docs/current/functions/string.html

## Verifying this change
This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:  
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
