### PR TITLE
[FLINK-32681] Wait for RocksDBStateDownloader threads on failure to ensure proper cleanup.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.AbstractAutoCloseableRegistry;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.IOUtils;
 
 import javax.annotation.Nonnull;
@@ -72,5 +73,30 @@ public class CloseableRegistry
     @Override
     public void doClose(List<Closeable> toClose) throws IOException {
         IOUtils.closeAllQuietly(reverse(toClose));
+    }
+
+    /**
+     * Unregisters all given {@link Closeable} objects from this registry and closes all objects
+     * that are were actually registered. Suppressed (and collects) all exceptions that happen
+     * during closing and throws only when the all {@link Closeable} objects have been processed.
+     *
+     * @param toUnregisterAndClose closables to unregister and close.
+     * @throws IOException collects all exceptions encountered during closing of the given objects.
+     */
+    public void unregisterAndCloseAll(Closeable... toUnregisterAndClose) throws IOException {
+        IOException suppressed = null;
+        for (Closeable closeable : toUnregisterAndClose) {
+            if (unregisterCloseable(closeable)) {
+                try {
+                    closeable.close();
+                } catch (IOException ex) {
+                    suppressed = ExceptionUtils.firstOrSuppressed(ex, suppressed);
+                }
+            }
+        }
+
+        if (suppressed != null) {
+            throw suppressed;
+        }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -57,9 +57,9 @@ public class RocksDBStateDownloaderTest extends TestLogger {
     /** Test that the exception arose in the thread pool will rethrow to the main thread. */
     @Test
     public void testMultiThreadRestoreThreadPoolExceptionRethrow() {
-        SpecifiedException expectedException =
+        SpecifiedException expectedCause =
                 new SpecifiedException("throw exception while multi thread restore.");
-        StreamStateHandle stateHandle = new ThrowingStateHandle(expectedException);
+        StreamStateHandle stateHandle = new ThrowingStateHandle(expectedCause);
 
         Map<StateHandleID, StreamStateHandle> stateHandles = new HashMap<>(1);
         stateHandles.put(new StateHandleID("state1"), stateHandle);
@@ -82,7 +82,7 @@ public class RocksDBStateDownloaderTest extends TestLogger {
                     new CloseableRegistry());
             fail();
         } catch (Exception e) {
-            assertEquals(expectedException, e);
+            assertEquals(expectedCause, e.getCause());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes a test failure in `RocksDBStateDownloaderTest` by ensuring that on failure we first wait for all parallel download threads to complete and close their streams before cleaning up the download directories.

Downloader threads now also close and check against the `ClosableRegistry` more eagerly to fail fast.


## Brief change log
- Wait for all parallel download threads to terminate before cleanup.
- Eagerly close the `CloseableRegistry` that is shared across all download threads to fail faster.
- Early exit in download threads if registry is already close to terminate faster.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *(please describe tests)*.
- `RocksDBStateDownloaderTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature?  (no)
  - If yes, how is the feature documented? (not applicable)
