### PR TITLE
[FLINK-32663][checkpoint] Fix the bug that checkpoint should not be triggered after all tasks have received end-of-data when checkpoint is disabled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -379,9 +379,7 @@ public class JobGraph implements Serializable {
             return false;
         }
 
-        long checkpointInterval =
-                snapshotSettings.getCheckpointCoordinatorConfiguration().getCheckpointInterval();
-        return checkpointInterval > 0 && checkpointInterval < Long.MAX_VALUE;
+        return snapshotSettings.getCheckpointCoordinatorConfiguration().isCheckpointingEnabled();
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -35,6 +35,9 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     public static final long MINIMAL_CHECKPOINT_TIME = 10;
 
+    // interval of max value means disable periodic checkpoint
+    public static final long DISABLED_CHECKPOINT_INTERVAL = Long.MAX_VALUE;
+
     private static final long serialVersionUID = 2L;
 
     private final long checkpointInterval;
@@ -133,6 +136,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     public long getCheckpointInterval() {
         return checkpointInterval;
+    }
+
+    public boolean isCheckpointingEnabled() {
+        return checkpointInterval > 0 && checkpointInterval < DISABLED_CHECKPOINT_INTERVAL;
     }
 
     public long getCheckpointTimeout() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -204,6 +204,7 @@ abstract class StateWithExecutionGraph implements State {
         CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
                 executionGraph.getCheckpointCoordinatorConfiguration();
         if (checkpointCoordinatorConfiguration != null
+                && checkpointCoordinatorConfiguration.isCheckpointingEnabled()
                 && checkpointCoordinatorConfiguration.isEnableCheckpointsAfterTasksFinish()) {
             vertexEndOfDataListener.recordTaskEndOfData(executionAttemptID);
             if (vertexEndOfDataListener.areAllTasksEndOfData()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -1923,8 +1923,7 @@ public class StreamingJobGraphGenerator {
 
         long interval = cfg.getCheckpointInterval();
         if (interval < MINIMAL_CHECKPOINT_TIME) {
-            // interval of max value means disable periodic checkpoint
-            interval = Long.MAX_VALUE;
+            interval = CheckpointCoordinatorConfiguration.DISABLED_CHECKPOINT_INTERVAL;
         }
 
         //  --- configure options ---


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug that checkpoint should not be triggered after all tasks have received end-of-data when checkpoint is disabled.


## Brief change log

- [FLINK-32663][checkpoint][refactor] Refactor the checkpoint interval value when checkpoint is disabled
- [FLINK-32663][checkpoint] Fix the bug that checkpoint should not be triggered after all tasks have received end-of-data when checkpoint is disabled


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no

