### PR TITLE
[FLINK-32734][build] Adds .mvn/maven.config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ scalastyle-output.xml
 filter.properties
 logs.zip
 .mvn/wrapper/*.jar
+.mvn/maven.config
 target
 tmp
 *.class


### PR DESCRIPTION


## What is the purpose of the change

This allows the checkout-specific customization of the Maven build (e.g. setting a different local repository).

## Brief change log

* Added `.mvn/maven.config` to `.gitignore`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable