### PR TITLE
[FLINK-32720][table] Add built-in GENERATE_SERIES function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -682,6 +682,9 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
+  - sql: GENERATE_SERIES(start, end[, step])
+    table: generateSeries(start, end[, step])
+    description: Returns an array of values between start and end, inclusive. Parameters start and end can be an INT or BIGINT. Step, if supplied, specifies the step size. The step can be positive or negative. If not supplied, step defaults to 1. Parameter step must be an INT.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -79,6 +79,7 @@ Expressions
     json_array_agg
     call
     call_sql
+    generate_series
 
 
 Expression
@@ -241,7 +242,6 @@ advanced type helper functions
     Expression.map_entries
     Expression.map_keys
     Expression.map_values
-
 
 time definition functions
 -------------------------

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -33,7 +33,7 @@ __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'not_', 'UNBOU
            'concat_ws', 'uuid', 'null_of', 'log', 'with_columns', 'without_columns', 'json_string',
            'json_object', 'json_object_agg', 'json_array', 'json_array_agg', 'call', 'call_sql',
            'source_watermark', 'to_timestamp_ltz', 'from_unixtime', 'to_date', 'to_timestamp',
-           'convert_tz', 'unix_timestamp']
+           'convert_tz', 'unix_timestamp', 'generate_series']
 
 
 def _leaf_op(op_name: str) -> Expression:
@@ -760,6 +760,19 @@ def json_string(value) -> Expression:
         >>> json_string([1, 2])          # '[1,2]'
     """
     return _unary_op("jsonString", value)
+
+
+def generate_series(start, end, step=None) -> Expression:
+    """
+    Returns an array of values between start and end, inclusive.
+    Parameters start and end can be an INT or BIGINT.
+    Step, if supplied, specifies the step size. The step can be positive or negative.
+    If not supplied, step defaults to 1. Parameter step must be an INT.
+    """
+    if step is None:
+        return _binary_op("generateSeries", start, end)
+    else:
+        return _ternary_op("generateSeries", start, end, step)
 
 
 def json_object(on_null: JsonOnNull = JsonOnNull.NULL, *args) -> Expression:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -554,6 +554,32 @@ public final class Expressions {
     }
 
     /**
+     * Returns an array of values between start and end, inclusive.
+     *
+     * <p>Parameters start and end can be an INT or BIGINT.
+     */
+    public static ApiExpression generateSeries(Object start, Object end) {
+        return apiCall(
+                BuiltInFunctionDefinitions.GENERATE_SERIES,
+                objectToExpression(start),
+                objectToExpression(end));
+    }
+
+    /**
+     * Returns an array of values between start and end, inclusive with a specific step size.
+     *
+     * <p>Parameters start and end can be an INT or BIGINT. Step specifies the step size which must
+     * be an INT.
+     */
+    public static ApiExpression generateSeries(Object start, Object end, Object step) {
+        return apiCall(
+                BuiltInFunctionDefinitions.GENERATE_SERIES,
+                objectToExpression(start),
+                objectToExpression(end),
+                objectToExpression(step));
+    }
+
+    /**
      * Creates an interval of rows.
      *
      * @see Table#window(GroupWindow)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -409,6 +409,25 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition GENERATE_SERIES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("GENERATE_SERIES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            logical(LogicalTypeRoot.BIGINT),
+                                            logical(LogicalTypeRoot.BIGINT)),
+                                    sequence(
+                                            logical(LogicalTypeRoot.BIGINT),
+                                            logical(LogicalTypeRoot.BIGINT),
+                                            logical(LogicalTypeRoot.INTEGER))))
+                    .outputTypeStrategy(
+                            nullableIfArgs(explicit(DataTypes.ARRAY(DataTypes.BIGINT()))))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.GenerateSeriesFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/GenerateSeriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/GenerateSeriesFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#GENERATE_SERIES}. */
+public class GenerateSeriesFunction extends BuiltInScalarFunction {
+    public GenerateSeriesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.GENERATE_SERIES, context);
+    }
+
+    public @Nullable ArrayData eval(Long start, Long end) {
+        try {
+            if (start == null || end == null) {
+                return null;
+            }
+            return generateSeries(start, end, (long) 1);
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    public @Nullable ArrayData eval(Long start, Long end, Integer step) {
+        try {
+            if (start == null || end == null || step == null) {
+                return null;
+            }
+            if (step == 0) {
+                throw new FlinkRuntimeException(
+                        "Step argument in GENERATE_SERIES function cannot be zero.");
+            }
+            return generateSeries(start, end, (long) step);
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    private ArrayData generateSeries(Long start, Long end, Long step) {
+        List<Long> result = new ArrayList<>();
+        if (step > 0) {
+            for (Long i = start; i <= end; i += step) {
+                result.add(i);
+            }
+        } else {
+            for (Long i = start; i >= end; i += step) {
+                result.add(i);
+            }
+        }
+        return new GenericArrayData(result.toArray());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of GENERATE_SERIES


## Brief change log
Constructs an array of values between start and end, inclusive.
Parameters start and end can be an INT or BIGINT.
step, if supplied, specifies the step size. The step can be positive or negative. If not supplied, step defaults to 1. Parameter step must be an INT.

- Syntax
```
GENERATE_SERIES(start, end)
GENERATE_SERIES(start, end, step)
```

- Arguments
start: the beginning element of return array
end: the ending element of return array
step: the size of step

- Returns
return an array of values between start and end, inclusive.
if any input arguments equal to null, return null.

- Examples
```
SELECT GENERATE_SERISE(1, 5);
Result: [1,2,3,4,5]

SELECT GENERATE_SERISE(0, 10, 2); 
Result: [0, 2, 4, 6, 8, 10] 
```

- See also

1.PostgreSQL: PostgreSQL offers a function called generate_series which generates a set of contiguous integers from a start to an end value. An optional 'step' parameter is available to specify the increment between each integer.

https://www.postgresql.org/docs/current/functions-srf.html

2.ksqlDB: As you mentioned, ksqlDB provides a function called GENERATE_SERIES that generates a series of numbers, starting from a given start value, incrementing each time by a step value, until it reaches or exceeds a given end value.

https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-reference/scalar-functions/#generate_series

3.BigQuery: BigQuery has a function called GENERATE_ARRAY that generates an array consisting of integers from the start value to the end value, with each integer incremented by the step value. You can find more details in the https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_array



## Verifying this change
This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:  
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
