### PR TITLE
[WIP] support flush

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_configuration.html
@@ -33,6 +33,12 @@
             <td>Tells if we should use compression for the state snapshot data or not</td>
         </tr>
         <tr>
+            <td><h5>execution.max-flush-interval</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>If this configuration is not null and every source has isProcessingBacklog=false, each operator can optionally delay emitting the results until flush() is invoked by Flink runtime. An operator should only delay emitting the results if doing so helps increase its throughput. It is guaranteed that setting this config to not-null will not increase the maximum per-record processing latency. But it might increase median per-record processing latency by at most half of the configured value plus the time needed to process the corresponding mini-batch of records.</td>
+        </tr>
+        <tr>
             <td><h5>execution.runtime-mode</h5></td>
             <td style="word-wrap: break-word;">STREAMING</td>
             <td><p>Enum</p></td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -936,6 +936,27 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         configuration.set(ExecutionOptions.SNAPSHOT_COMPRESSION, useSnapshotCompression);
     }
 
+    /** Sets the processing latency of a Flink job. */
+    public ExecutionConfig setMaxFlushInterval(long interval) {
+        Preconditions.checkArgument(interval >= 0, "Flush interval must not be negative.");
+        return setMaxFlushInterval(Duration.ofMillis(interval));
+    }
+
+    private ExecutionConfig setMaxFlushInterval(Duration interval) {
+        configuration.set(ExecutionOptions.MAX_FLUSH_INTERVAL, interval);
+        return this;
+    }
+
+    /**
+     * Returns the processing latency of a Flink job.
+     *
+     * @see #setMaxFlushInterval(long)
+     */
+    public long getMaxFlushInterval() {
+        Duration interval = configuration.get(ExecutionOptions.MAX_FLUSH_INTERVAL);
+        return interval == null ? 0 : interval.toMillis();
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof ExecutionConfig) {
@@ -1154,6 +1175,10 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         configuration
                 .getOptional(JobManagerOptions.SCHEDULER)
                 .ifPresent(t -> this.configuration.set(JobManagerOptions.SCHEDULER, t));
+
+        configuration
+                .getOptional(ExecutionOptions.MAX_FLUSH_INTERVAL)
+                .ifPresent(m -> this.configuration.set(ExecutionOptions.MAX_FLUSH_INTERVAL, m));
     }
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -128,6 +128,22 @@ public class ExecutionOptions {
                                                             + "throughput"))
                                     .build());
 
+    public static final ConfigOption<Duration> MAX_FLUSH_INTERVAL =
+            ConfigOptions.key("execution.max-flush-interval")
+                    .durationType()
+                    .defaultValue(null)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If this configuration is not null and every source has isProcessingBacklog=false, each"
+                                                    + " operator can optionally delay emitting the results until flush() is invoked by Flink"
+                                                    + " runtime. An operator should only delay emitting the results if doing so helps increase"
+                                                    + " its throughput. It is guaranteed that setting this config to not-null will not increase"
+                                                    + " the maximum per-record processing latency. But it might increase median per-record"
+                                                    + " processing latency by at most half of the configured value plus the time needed to"
+                                                    + " process the corresponding mini-batch of records.")
+                                    .build());
+
     @Documentation.ExcludeFromDocumentation(
             "This is an expert option, that we do not want to expose in the documentation")
     public static final ConfigOption<Boolean> SORT_INPUTS =

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -35,6 +36,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -72,6 +74,33 @@ final class StubStateBackend implements StateBackend {
             throws Exception {
 
         return backend.createKeyedStateBackend(
+                env,
+                jobID,
+                operatorIdentifier,
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                kvStateRegistry,
+                this.ttlTimeProvider,
+                metricGroup,
+                stateHandles,
+                cancelStreamRegistry);
+    }
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry) throws IOException {
+        return backend.createKeyedStateBuffer(
                 env,
                 jobID,
                 operatorIdentifier,

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -334,6 +334,29 @@ under the License.
 						</configuration>
 					</execution>
 
+					<execution>
+						<id>AllowLatency</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>AllowLatency</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.streaming.examples.allowlatency.AllowLatency</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/streaming/examples/allowlatency/*.class</include>
+								<include>META-INF/LICENSE</include>
+								<include>META-INF/NOTICE</include>
+							</includes>
+						</configuration>
+					</execution>
+
 				</executions>
 			</plugin>
 
@@ -389,6 +412,7 @@ under the License.
 								<copy file="${project.basedir}/target/flink-examples-streaming-${project.version}-WindowJoin.jar" tofile="${project.basedir}/target/WindowJoin.jar" />
 								<copy file="${project.basedir}/target/flink-examples-streaming-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
 								<copy file="${project.basedir}/target/flink-examples-streaming-${project.version}-SocketWindowWordCount.jar" tofile="${project.basedir}/target/SocketWindowWordCount.jar" />
+								<copy file="${project.basedir}/target/flink-examples-streaming-${project.version}-AllowLatency.jar" tofile="${project.basedir}/target/AllowLatency.jar" />
 							</target>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/AllowLatency.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/AllowLatency.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.allowlatency;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import java.util.Map;
+
+/**
+ * Example illustrating aggregations on data stream supporting user define max flush interval.
+ *
+ * <p>The example pipeline aggregates the data with configurable checkpoint interval and flush
+ * interval.
+ *
+ * <p>The example uses a built-in sample data generator that generates the streams of pairs at a
+ * configurable rate.
+ *
+ * <p>Usage:
+ *
+ * <p><code>
+ *     AllowLatency --execution.checkpointing.interval &lt;n&gt --execution.max-flush-interval &lt;n&gt;
+ *     --dataNum &lt;n&gt; --keySize &lt;n&gt;
+ * </code>
+ */
+public class AllowLatency {
+    //    private static Map<Integer, Long> testMap;
+
+    public static void main(String[] args) throws Exception {
+        //        testMap = new HashMap<>();
+
+        final Map<String, String> params = MultipleParameterTool.fromArgs(args).toMap();
+
+        Configuration config = new Configuration();
+        config.setBoolean(DeploymentOptions.ATTACHED, true);
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.getConfig().enableObjectReuse();
+        env.getConfig().disableGenericTypes();
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        env.setParallelism(1);
+        env.getConfig().setAutoWatermarkInterval(0);
+        env.getCheckpointConfig().disableCheckpointing();
+        env.setStateBackend(new EmbeddedRocksDBStateBackend());
+        //        env.setStateBackend(new HashMapStateBackend());
+        Configuration conf = Configuration.fromMap(params);
+        env.getCheckpointConfig().configure(conf);
+        env.getConfig().configure(conf, Thread.currentThread().getContextClassLoader());
+        long dataNum =
+                params.get("dataNum") == null ? 100000000 : Long.parseLong(params.get("dataNum"));
+        long pause =
+                params.get("pause") == null ? dataNum / 10 : Long.parseLong(params.get("pause"));
+
+        System.out.println("Number of records: " + dataNum);
+        System.out.println(
+                "Checkpoint interval: " + env.getCheckpointConfig().getCheckpointInterval());
+        System.out.println("Checkpoint storage: " + env.getCheckpointConfig().getCheckpointStorage());
+        System.out.println("Max flush interval: " + env.getConfig().getMaxFlushInterval());
+
+        DataStream<Integer> ds1 = env.addSource(new MyJoinSource(dataNum, pause));
+        ds1.keyBy(value -> value)
+                .transform(
+                        "MyAggregator",
+                        new TupleTypeInfo<>(
+                                IntegerTypeInfo.INT_TYPE_INFO, IntegerTypeInfo.LONG_TYPE_INFO),
+                        new MyAggregator(value -> value))
+                .addSink(new CountingAndDiscardingSink<>());
+        //                .addSink(
+        //                        new SinkFunction<Tuple2<Integer, Long>>() {
+        //                            @Override
+        //                            public void invoke(Tuple2<Integer, Long> value) throws
+        // Exception {
+        //                                Long v = testMap.get(value.f0);
+        //                                if (v == null || v < value.f1) {
+        //                                    testMap.put(value.f0, value.f1);
+        //                                }
+        //                            }
+        //                        });
+
+        long startTime = System.currentTimeMillis();
+        JobExecutionResult executionResult = env.execute("");
+        long endTime = System.currentTimeMillis();
+        System.out.println("Duration: " + (endTime - startTime));
+        System.out.println("Throughput: " + (dataNum / (endTime - startTime)));
+        //        testMap.forEach(
+        //                (k, v) -> {
+        //                    System.out.println(k + ": " + v);
+        //                });
+    }
+
+    private static class CountingAndDiscardingSink<T> extends RichSinkFunction<T> {
+        public static final String COUNTER_NAME = "numElements";
+
+        private static final long serialVersionUID = 1L;
+
+        private final LongCounter numElementsCounter = new LongCounter();
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+            getRuntimeContext().addAccumulator(COUNTER_NAME, numElementsCounter);
+        }
+
+        @Override
+        public void invoke(T value, Context context) {
+            numElementsCounter.add(1L);
+        }
+    }
+}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyAggregator.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyAggregator.java
@@ -46,6 +46,7 @@ public class MyAggregator extends AbstractStreamOperator<Tuple2<Integer, Long>>
     private final KeySelector<Integer, Integer> keySelector;
     private ValueState<Long> store;
     private PartitionableListState<Tuple2<Integer, Long>> bundleState;
+    private ValueState<Long> keyedBundleState;
     private long visits = 0;
 
     public MyAggregator(KeySelector<Integer, Integer> keySelector) {
@@ -63,6 +64,9 @@ public class MyAggregator extends AbstractStreamOperator<Tuple2<Integer, Long>>
         store =
                 context.getKeyedStateStore()
                         .getState(new ValueStateDescriptor<>("store", Long.class));
+        keyedBundleState =
+                context.getKeyedStateBufferStore()
+                        .getState(new ValueStateDescriptor<>("buffer", Long.class));
         this.bundle = new HashMap<>();
         bundleState =
                 (PartitionableListState<Tuple2<Integer, Long>>)

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyAggregator.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyAggregator.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.allowlatency;
+
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.PartitionableListState;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An aggregation operator with user-defined flush function.
+ *
+ * <p>The operator will buffer inputs in memory until a flush operation is triggered.
+ */
+public class MyAggregator extends AbstractStreamOperator<Tuple2<Integer, Long>>
+        implements OneInputStreamOperator<Integer, Tuple2<Integer, Long>> {
+    private transient Map<Integer, Long> bundle;
+    private final KeySelector<Integer, Integer> keySelector;
+    private ValueState<Long> store;
+    private PartitionableListState<Tuple2<Integer, Long>> bundleState;
+    private long visits = 0;
+
+    public MyAggregator(KeySelector<Integer, Integer> keySelector) {
+        super();
+        this.keySelector = keySelector;
+    }
+
+    private Integer getKey(Integer input) throws Exception {
+        return keySelector.getKey(input);
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        store =
+                context.getKeyedStateStore()
+                        .getState(new ValueStateDescriptor<>("store", Long.class));
+        this.bundle = new HashMap<>();
+        bundleState =
+                (PartitionableListState<Tuple2<Integer, Long>>)
+                        context.getOperatorStateStore()
+                                .getListState(
+                                        new ListStateDescriptor<>(
+                                                "bundle",
+                                                TypeInformation.of(
+                                                        new TypeHint<Tuple2<Integer, Long>>() {})));
+        if (context.isRestored()) {
+            for (Tuple2<Integer, Long> t : bundleState.get()) {
+                bundle.put(t.f0, t.f1);
+            }
+        }
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+    }
+
+    @Override
+    public void processElement(StreamRecord<Integer> element) throws Exception {
+        Integer input = element.getValue();
+        if (getExecutionConfig().getMaxFlushInterval() > 0) {
+            Long bundleValue = bundle.get(input);
+            // get a new value after adding this element to bundle
+            Long newBundleValue = bundleValue == null ? 1 : bundleValue + 1;
+            bundle.put(input, newBundleValue);
+        } else {
+            visits += 1;
+            Long storeValue = store.value();
+            Long newStoreValue = storeValue == null ? 1 : storeValue + 1;
+            store.update(newStoreValue);
+            output.collect(new StreamRecord<>(new Tuple2<>(input, newStoreValue)));
+        }
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        bundleState.clear();
+        bundle.forEach(
+                (k, v) -> {
+                    bundleState.add(new Tuple2<>(k, v));
+                });
+        LOG.info("Operator state size: {}", bundle.size());
+    }
+
+    @Override
+    public void finish() throws Exception {
+        finishBundle();
+        System.out.println("visits: " + visits);
+    }
+
+    public void finishBundle() {
+        if (bundle != null && !bundle.isEmpty()) {
+            finishBundle(bundle, output);
+            bundle.clear();
+        }
+    }
+
+    public void finishBundle(
+            Map<Integer, Long> bundle, Output<StreamRecord<Tuple2<Integer, Long>>> output) {
+        //        long keyCnt = 0L;
+        for (Map.Entry<Integer, Long> entry : bundle.entrySet()) {
+            int k = entry.getKey();
+            long v = entry.getValue();
+            try {
+                visits += 1;
+                setKeyContextElement1(new StreamRecord<>(k));
+                Long storeValue = store.value();
+                Long newStoreValue = storeValue == null ? v : storeValue + v;
+                store.update(newStoreValue);
+                output.collect(new StreamRecord<>(new Tuple2<>(k, newStoreValue)));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        //        keyCnt /= (double) bundle.size();
+        //        LOG.info("Average key count: " + keyCnt);
+    }
+
+    @Override
+    public void flush() {
+        finishBundle();
+    }
+}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyJoinSource.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyJoinSource.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.allowlatency;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+/** A parallel source to generate data stream for joining operation. */
+public class MyJoinSource extends RichParallelSourceFunction<Integer> {
+    private long numValues;
+    private long numValuesOnThisTask;
+    private int numPreGeneratedData;
+    private long pause;
+
+    public MyJoinSource(long numValues, long pause) {
+        this.numValues = numValues;
+        this.pause = pause;
+    }
+
+    @Override
+    public final void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        int taskIdx = getRuntimeContext().getIndexOfThisSubtask();
+        int numTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+        long div = numValues / numTasks;
+        long mod = numValues % numTasks;
+        numValuesOnThisTask = mod > taskIdx ? div + 1 : div;
+        numPreGeneratedData = (int) Math.min(Math.max(numValues / 50, 10), 100000000);
+    }
+
+    @Override
+    public void run(SourceContext ctx) throws Exception {
+        long cnt = 0;
+        while (cnt < this.numValuesOnThisTask) {
+            ctx.collect((int) (cnt % this.numPreGeneratedData));
+            cnt += 1;
+        }
+    }
+
+    @Override
+    public void cancel() {}
+}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyJoinSource.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/allowlatency/MyJoinSource.java
@@ -40,7 +40,7 @@ public class MyJoinSource extends RichParallelSourceFunction<Integer> {
         long div = numValues / numTasks;
         long mod = numValues % numTasks;
         numValuesOnThisTask = mod > taskIdx ? div + 1 : div;
-        numPreGeneratedData = (int) Math.min(Math.max(numValues / 50, 10), 100000000);
+        numPreGeneratedData = (int) Math.min(Math.max(1000000, 10), 100000000);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -228,4 +228,9 @@ public abstract class AbstractInvokable
     public boolean isUsingNonBlockingInput() {
         return false;
     }
+
+    @Override
+    public void triggerLocalFlushEvent(boolean isPeriodic) throws IOException {
+        throw new UnsupportedOperationException("should never be called");
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Future;
  * @see AbstractInvokable
  */
 @Internal
-public interface CheckpointableTask {
+public interface CheckpointableTask extends FlushingTask {
 
     /**
      * This method is called to trigger a checkpoint, asynchronously by the checkpoint coordinator.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/FlushingTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/FlushingTask.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.tasks;
+
+import java.io.IOException;
+
+public interface FlushingTask {
+    void triggerLocalFlushEvent(boolean isPeriodic) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -83,4 +83,21 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
             @Nonnull Collection<OperatorStateHandle> stateHandles,
             CloseableRegistry cancelStreamRegistry)
             throws Exception;
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws IOException {
+        return null;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ManagedInitializationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ManagedInitializationContext.java
@@ -51,4 +51,6 @@ public interface ManagedInitializationContext {
 
     /** Returns an interface that allows for registering keyed state with the backend. */
     KeyedStateStore getKeyedStateStore();
+
+    KeyedStateStore getKeyedStateBufferStore();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -158,6 +159,20 @@ public interface StateBackend extends java.io.Serializable {
                 stateHandles,
                 cancelStreamRegistry);
     }
+
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws IOException;
 
     /**
      * Creates a new {@link OperatorStateBackend} that can be used for storing operator state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateInitializationContextImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateInitializationContextImpl.java
@@ -35,6 +35,8 @@ public class StateInitializationContextImpl implements StateInitializationContex
 
     private final KeyedStateStore keyedStateStore;
 
+    private final KeyedStateStore keyedStateBufferStore;
+
     private final Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs;
     private final Iterable<StatePartitionStreamProvider> rawOperatorStateInputs;
 
@@ -42,12 +44,14 @@ public class StateInitializationContextImpl implements StateInitializationContex
             @Nullable Long restoredCheckpointId,
             OperatorStateStore operatorStateStore,
             KeyedStateStore keyedStateStore,
+            KeyedStateStore keyedStateBufferStore,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs,
             Iterable<StatePartitionStreamProvider> rawOperatorStateInputs) {
 
         this.restoredCheckpointId = restoredCheckpointId;
         this.operatorStateStore = operatorStateStore;
         this.keyedStateStore = keyedStateStore;
+        this.keyedStateBufferStore = keyedStateBufferStore;
         this.rawOperatorStateInputs = rawOperatorStateInputs;
         this.rawKeyedStateInputs = rawKeyedStateInputs;
     }
@@ -87,5 +91,10 @@ public class StateInitializationContextImpl implements StateInitializationContex
     @Override
     public KeyedStateStore getKeyedStateStore() {
         return keyedStateStore;
+    }
+
+    @Override
+    public KeyedStateStore getKeyedStateBufferStore() {
+        return keyedStateBufferStore;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -584,6 +584,33 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
     }
 
     @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry) throws IOException {
+        return createKeyedStateBackend(
+                env,
+                jobID,
+                operatorIdentifier,
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                kvStateRegistry,
+                ttlTimeProvider,
+                metricGroup,
+                stateHandles,
+                cancelStreamRegistry);
+    }
+
+    @Override
     public OperatorStateBackend createOperatorStateBackend(
             Environment env,
             String operatorIdentifier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/hashmap/HashMapStateBackend.java
@@ -144,6 +144,33 @@ public class HashMapStateBackend extends AbstractStateBackend implements Configu
     }
 
     @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry) throws IOException {
+        return createKeyedStateBackend(
+                env,
+                jobID,
+                operatorIdentifier,
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                kvStateRegistry,
+                ttlTimeProvider,
+                metricGroup,
+                stateHandles,
+                cancelStreamRegistry);
+    }
+
+    @Override
     public OperatorStateBackend createOperatorStateBackend(
             Environment env,
             String operatorIdentifier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -132,7 +132,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend
     private static final long serialVersionUID = 4109305377809414635L;
 
     /** The default maximal size that the snapshotted memory state may have (5 MiBytes). */
-    public static final int DEFAULT_MAX_STATE_SIZE = 5 * 1024 * 1024;
+    public static final int DEFAULT_MAX_STATE_SIZE = 20 * 1024 * 1024;
 
     /** The maximal size that the snapshotted memory state may have. */
     private final int maxStateSize;
@@ -382,6 +382,33 @@ public class MemoryStateBackend extends AbstractFileStateBackend
                         isUsingAsynchronousSnapshots(),
                         cancelStreamRegistry)
                 .build();
+    }
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry) throws IOException {
+        return createKeyedStateBackend(
+                env,
+                jobID,
+                operatorIdentifier,
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                kvStateRegistry,
+                ttlTimeProvider,
+                metricGroup,
+                stateHandles,
+                cancelStreamRegistry);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -48,6 +48,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -170,6 +171,22 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
                 @Nonnull Collection<KeyedStateHandle> stateHandles,
                 CloseableRegistry cancelStreamRegistry)
                 throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -73,6 +74,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -1045,6 +1047,22 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
                 @Nonnull Collection<KeyedStateHandle> stateHandles,
                 CloseableRegistry cancelStreamRegistry)
                 throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
@@ -42,6 +42,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -436,6 +437,22 @@ public class CheckpointStorageLoaderTest extends TestLogger {
         }
 
         @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
+            return null;
+        }
+
+        @Override
         public OperatorStateBackend createOperatorStateBackend(
                 Environment env,
                 String operatorIdentifier,
@@ -462,6 +479,22 @@ public class CheckpointStorageLoaderTest extends TestLogger {
                 Collection<KeyedStateHandle> stateHandles,
                 CloseableRegistry cancelStreamRegistry)
                 throws Exception {
+            return null;
+        }
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
             return null;
         }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -155,6 +156,23 @@ public abstract class AbstractChangelogStateBackend
                                         baseHandles,
                                         cancelStreamRegistry,
                                         managedMemoryFraction));
+    }
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws IOException {
+        return null;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1957,7 +1957,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
      */
     public <OUT> DataStreamSource<OUT> addSource(
             SourceFunction<OUT> function, String sourceName, TypeInformation<OUT> typeInfo) {
-        return addSource(function, sourceName, typeInfo, Boundedness.CONTINUOUS_UNBOUNDED);
+        return addSource(function, sourceName, typeInfo, Boundedness.BOUNDED);
     }
 
     private <OUT> DataStreamSource<OUT> addSource(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFutures.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFutures.java
@@ -44,6 +44,8 @@ public class OperatorSnapshotFutures {
 
     @Nonnull private RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture;
 
+    @Nonnull private RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedBufferManagedFuture;
+
     @Nonnull private RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture;
 
     @Nonnull private RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateManagedFuture;
@@ -65,11 +67,13 @@ public class OperatorSnapshotFutures {
                 DoneFuture.of(SnapshotResult.empty()),
                 DoneFuture.of(SnapshotResult.empty()),
                 DoneFuture.of(SnapshotResult.empty()),
+                DoneFuture.of(SnapshotResult.empty()),
                 DoneFuture.of(SnapshotResult.empty()));
     }
 
     public OperatorSnapshotFutures(
             @Nonnull RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture,
+            @Nonnull RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedBufferManagedFuture,
             @Nonnull RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture,
             @Nonnull RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateManagedFuture,
             @Nonnull RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateRawFuture,
@@ -80,6 +84,7 @@ public class OperatorSnapshotFutures {
                     Future<SnapshotResult<StateObjectCollection<ResultSubpartitionStateHandle>>>
                             resultSubpartitionStateFuture) {
         this.keyedStateManagedFuture = keyedStateManagedFuture;
+        this.keyedBufferManagedFuture = keyedBufferManagedFuture;
         this.keyedStateRawFuture = keyedStateRawFuture;
         this.operatorStateManagedFuture = operatorStateManagedFuture;
         this.operatorStateRawFuture = operatorStateRawFuture;
@@ -95,6 +100,16 @@ public class OperatorSnapshotFutures {
     public void setKeyedStateManagedFuture(
             @Nonnull RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture) {
         this.keyedStateManagedFuture = keyedStateManagedFuture;
+    }
+
+    @Nonnull
+    public RunnableFuture<SnapshotResult<KeyedStateHandle>> getKeyedBufferManagedFuture() {
+        return keyedBufferManagedFuture;
+    }
+
+    public void setKeyedBufferManagedFuture(
+            @Nonnull RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedBufferManagedFuture) {
+        this.keyedBufferManagedFuture = keyedBufferManagedFuture;
     }
 
     @Nonnull
@@ -159,6 +174,7 @@ public class OperatorSnapshotFutures {
     public Tuple2<Long, Long> cancel() throws Exception {
         List<Tuple2<Future<? extends StateObject>, String>> pairs = new ArrayList<>();
         pairs.add(new Tuple2<>(getKeyedStateManagedFuture(), "managed keyed"));
+        pairs.add(new Tuple2<>(getKeyedBufferManagedFuture(), "managed buffered"));
         pairs.add(new Tuple2<>(getKeyedStateRawFuture(), "managed operator"));
         pairs.add(new Tuple2<>(getOperatorStateManagedFuture(), "raw keyed"));
         pairs.add(new Tuple2<>(getOperatorStateRawFuture(), "raw operator"));
@@ -189,6 +205,7 @@ public class OperatorSnapshotFutures {
     public Future<?>[] getAllFutures() {
         return new Future<?>[] {
             keyedStateManagedFuture,
+            keyedBufferManagedFuture,
             keyedStateRawFuture,
             operatorStateManagedFuture,
             operatorStateRawFuture,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -148,4 +148,6 @@ public interface StreamOperator<OUT> extends CheckpointListener, KeyContext, Ser
     OperatorMetricGroup getMetricGroup();
 
     OperatorID getOperatorID();
+
+    default void flush() throws Exception {}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -54,6 +54,8 @@ public interface StreamOperatorStateContext {
      */
     CheckpointableKeyedStateBackend<?> keyedStateBackend();
 
+    CheckpointableKeyedStateBackend<?> keyedStateBuffer();
+
     /**
      * Returns the internal timer service manager for the stream operator. This method returns null
      * for non-keyed operators.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -35,6 +36,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /** A simple {@link StateBackend} which is used in a BATCH style execution. */
@@ -55,6 +57,22 @@ public class BatchExecutionStateBackend implements StateBackend {
             CloseableRegistry cancelStreamRegistry) {
         return new BatchExecutionKeyedStateBackend<>(
                 keySerializer, keyGroupRange, env.getExecutionConfig());
+    }
+
+    @Override
+    public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry) throws IOException {
+        return null;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -969,4 +969,6 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                                         .sendEventToCoordinator(
                                                 new AcknowledgeCheckpointEvent(checkpointId)));
     }
+
+    void flush() throws Exception {}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -237,4 +237,13 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
             throw ex;
         }
     }
+
+    @Override
+    void flush() throws Exception {
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators()) {
+            if (!operatorWrapper.isClosed()) {
+                operatorWrapper.getStreamOperator().flush();
+            }
+        }
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -727,7 +727,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             checkpointStorage.clearCacheFor(checkpointId);
         }
 
-        LOG.debug(
+        checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
+        LOG.info(
                 "{} - finished synchronous part of checkpoint {}. Alignment duration: {} ms, snapshot duration {} ms, is unaligned checkpoint : {}",
                 taskName,
                 checkpointId,
@@ -735,7 +736,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 checkpointMetrics.getSyncDurationMillis(),
                 checkpointOptions.isUnalignedCheckpoint());
 
-        checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
         return true;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -96,6 +96,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
             "["
                     + "close[], "
                     + "finish[], "
+                    + "flush[], "
                     + "getCurrentKey[], "
                     + "getMetricGroup[], "
                     + "getOperatorID[], "

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
@@ -66,6 +66,8 @@ public class OperatorSnapshotFinalizerTest extends TestLogger {
 
         SnapshotResult<KeyedStateHandle> manKeyed =
                 withLocalState(deepDummyCopy(keyedTemplate), deepDummyCopy(keyedTemplate));
+        SnapshotResult<KeyedStateHandle> manBuffered =
+                withLocalState(deepDummyCopy(keyedTemplate), deepDummyCopy(keyedTemplate));
         SnapshotResult<KeyedStateHandle> rawKeyed =
                 withLocalState(deepDummyCopy(keyedTemplate), deepDummyCopy(keyedTemplate));
         SnapshotResult<OperatorStateHandle> manOper =
@@ -84,6 +86,7 @@ public class OperatorSnapshotFinalizerTest extends TestLogger {
         OperatorSnapshotFutures snapshotFutures =
                 new OperatorSnapshotFutures(
                         new PseudoNotDoneFuture<>(manKeyed),
+                        new PseudoNotDoneFuture<>(manBuffered),
                         new PseudoNotDoneFuture<>(rawKeyed),
                         new PseudoNotDoneFuture<>(manOper),
                         new PseudoNotDoneFuture<>(rawOper),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
@@ -59,6 +59,7 @@ public class OperatorSnapshotFuturesTest extends TestLogger {
         OperatorSnapshotFutures futures =
                 new OperatorSnapshotFutures(
                         DoneFuture.of(SnapshotResult.of(s1)),
+                        DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.of(s2)),
                         DoneFuture.of(SnapshotResult.empty()),
                         ExceptionallyDoneFuture.of(new RuntimeException()),
@@ -121,6 +122,7 @@ public class OperatorSnapshotFuturesTest extends TestLogger {
         operatorSnapshotResult =
                 new OperatorSnapshotFutures(
                         keyedStateManagedFuture,
+                        DoneFuture.of(SnapshotResult.empty()),
                         keyedStateRawFuture,
                         operatorStateManagedFuture,
                         operatorStateRawFuture,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
@@ -123,7 +123,7 @@ public class SourceOperatorTestContext implements AutoCloseable {
         // Crate the state context.
         OperatorStateStore operatorStateStore = createOperatorStateStore();
         StateInitializationContext stateContext =
-                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
+                new StateInitializationContextImpl(null, operatorStateStore, null, null, null, null);
 
         // Update the context.
         stateContext

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -229,6 +229,7 @@ public class StateInitializationContextImplTest {
                         restoredCheckpointId.isPresent() ? restoredCheckpointId.getAsLong() : null,
                         stateContext.operatorStateBackend(),
                         mock(KeyedStateStore.class),
+                        null,
                         stateContext.rawKeyedStateInputs(),
                         stateContext.rawOperatorStateInputs());
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -76,6 +76,8 @@ public class StreamOperatorStateHandlerTest {
         try (CloseableRegistry closeableRegistry = new CloseableRegistry()) {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture =
                     new CancelableFuture<>();
+            RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedBufferManagedFuture =
+                    new CancelableFuture<>();
             RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture =
                     new CancelableFuture<>();
             RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateManagedFuture =
@@ -90,6 +92,7 @@ public class StreamOperatorStateHandlerTest {
             OperatorSnapshotFutures operatorSnapshotResult =
                     new OperatorSnapshotFutures(
                             keyedStateManagedFuture,
+                            keyedBufferManagedFuture,
                             keyedStateRawFuture,
                             operatorStateManagedFuture,
                             operatorStateRawFuture,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -56,12 +56,14 @@ import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.CloseableIterable;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.OptionalLong;
@@ -156,6 +158,22 @@ public class StreamTaskStateInitializerImplTest {
                                     @Nonnull Collection<KeyedStateHandle> stateHandles,
                                     CloseableRegistry cancelStreamRegistry)
                                     throws Exception {
+                                return mock(AbstractKeyedStateBackend.class);
+                            }
+
+                            @Override
+                            public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                                    Environment env,
+                                    JobID jobID,
+                                    String operatorIdentifier,
+                                    TypeSerializer<K> keySerializer,
+                                    int numberOfKeyGroups,
+                                    KeyGroupRange keyGroupRange,
+                                    TaskKvStateRegistry kvStateRegistry,
+                                    TtlTimeProvider ttlTimeProvider,
+                                    MetricGroup metricGroup,
+                                    @NotNull Collection<KeyedStateHandle> stateHandles,
+                                    CloseableRegistry cancelStreamRegistry) throws IOException {
                                 return mock(AbstractKeyedStateBackend.class);
                             }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/MockFunctionInitializationContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/MockFunctionInitializationContext.java
@@ -50,4 +50,9 @@ public class MockFunctionInitializationContext implements FunctionInitialization
     public KeyedStateStore getKeyedStateStore() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public KeyedStateStore getKeyedStateBufferStore() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -133,7 +133,7 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
                                 new CloseableRegistry());
 
         final StateInitializationContext stateContext =
-                new StateInitializationContextImpl(null, operatorStateStore, null, null, null);
+                new StateInitializationContextImpl(null, operatorStateStore, null, null, null, null);
 
         TestProcessingTimeService timeService = new TestProcessingTimeService();
         timeService.setCurrentTime(Integer.MAX_VALUE); // start somewhere that is not zero

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -89,6 +89,7 @@ public class AsyncCheckpointRunnableTest {
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
+                        DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty())));
 
         final TestEnvironment environment = new TestEnvironment();
@@ -114,6 +115,7 @@ public class AsyncCheckpointRunnableTest {
         snapshotsInProgress.put(
                 new OperatorID(),
                 new OperatorSnapshotFutures(
+                        DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -84,6 +84,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -291,6 +292,22 @@ public class StreamTaskTerminationTest extends TestLogger {
                 MetricGroup metricGroup,
                 @Nonnull Collection<KeyedStateHandle> stateHandles,
                 CloseableRegistry cancelStreamRegistry) {
+            return null;
+        }
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
             return null;
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -645,6 +645,7 @@ public class StreamTaskTest {
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()),
+                        DoneFuture.of(SnapshotResult.empty()),
                         DoneFuture.of(SnapshotResult.empty()));
 
         final TestingUncaughtExceptionHandler uncaughtExceptionHandler =
@@ -826,6 +827,7 @@ public class StreamTaskTest {
                         checkpointResponder);
 
         KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
+        KeyedStateHandle managedKeyedBufferHandle = mock(KeyedStateHandle.class);
         KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
         OperatorStateHandle managedOperatorStateHandle = mock(OperatorStreamStateHandle.class);
         OperatorStateHandle rawOperatorStateHandle = mock(OperatorStreamStateHandle.class);
@@ -833,6 +835,7 @@ public class StreamTaskTest {
         OperatorSnapshotFutures operatorSnapshotResult =
                 new OperatorSnapshotFutures(
                         DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
+                        DoneFuture.of(SnapshotResult.of(managedKeyedBufferHandle)),
                         DoneFuture.of(SnapshotResult.of(rawKeyedStateHandle)),
                         DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
                         DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)),
@@ -922,6 +925,7 @@ public class StreamTaskTest {
     void testAsyncCheckpointingConcurrentCloseBeforeAcknowledge() throws Exception {
 
         final TestingKeyedStateHandle managedKeyedStateHandle = new TestingKeyedStateHandle();
+        final TestingKeyedStateHandle managedKeyedBufferHandle = new TestingKeyedStateHandle();
         final TestingKeyedStateHandle rawKeyedStateHandle = new TestingKeyedStateHandle();
         final TestingOperatorStateHandle managedOperatorStateHandle =
                 new TestingOperatorStateHandle();
@@ -932,6 +936,7 @@ public class StreamTaskTest {
         OperatorSnapshotFutures operatorSnapshotResult =
                 new OperatorSnapshotFutures(
                         DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
+                        DoneFuture.of(SnapshotResult.of(managedKeyedBufferHandle)),
                         rawKeyedStateHandleFuture,
                         DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
                         DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)),
@@ -2333,6 +2338,11 @@ public class StreamTaskTest {
                     @Override
                     public CheckpointableKeyedStateBackend<?> keyedStateBackend() {
                         return controller.keyedStateBackend();
+                    }
+
+                    @Override
+                    public CheckpointableKeyedStateBackend<?> keyedStateBuffer() {
+                        return controller.keyedStateBuffer();
                     }
 
                     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -459,6 +459,7 @@ public class SubtaskCheckpointCoordinatorTest {
             OperatorSnapshotFutures operatorSnapshotResult =
                     new OperatorSnapshotFutures(
                             DoneFuture.of(SnapshotResult.empty()),
+                            DoneFuture.of(SnapshotResult.empty()),
                             rawKeyedStateHandleFuture,
                             DoneFuture.of(SnapshotResult.empty()),
                             DoneFuture.of(SnapshotResult.empty()),

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -125,6 +126,22 @@ public class StateBackendITCase extends AbstractTestBase {
                 @Nonnull Collection<KeyedStateHandle> stateHandles,
                 CloseableRegistry cancelStreamRegistry)
                 throws IOException {
+            throw new SuccessException();
+        }
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBuffer(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @NotNull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) throws IOException {
             throw new SuccessException();
         }
 


### PR DESCRIPTION
| Parameter | Type | Description |
| ---- | ---- | ---- |
| execution.max-flush-interval | long | Maximum interval between two flush operations |
| dateNum | long | Number of input data |
### Example usage
```bash
$ ./bin/flink run examples/streaming/AllowedLatency.jar --execution.max-flush-interval 2000 --dataNum 10000000
```
## Benchmark
### With Heap State Backend
| Parameter | Value |
| :----: | :----: |
| Number of records | 100000000 |
| Number of distinct keys | 2000000 |
|Max flush interval | 5000ms |

| Throughput | Memory Visits |
| :----: | :----: |
| 4967 /ms | 121324416 |
| 2390 /ms | 100000000 |

When flush is enabled, the operator buffers the input records until a flush event is triggered. At that point, it emits a single record for each distinct key, effectively reducing the number of emitted records. On the other hand, without the flush operation, the operator would emit one output record for each input record, potentially leading to a larger number of records being processed.
Despite the higher memory access overhead, the aggregation with flush enabled proves more efficient due to its optimized handling of data emission by reducing the number of output records through key-based aggregation.

### Number of Distinct Keys

| Number of records | Number of distinct keys | Average key count | Max Flush Interval | RocksDB Visits | Throughput |
| :----: | :----: | :----: | :----: | :----: | :----: |
| 1e7 | 1e7 | / | / | 10000000 | 206 /ms |
| 1e7 | 1e7 | 1 | 1000 ms | 10000000 | 150 /ms |
| 1e8 | 2e6 | 3 | 1000 ms | 26000012 | 589 /ms |
| 1e8 | 1e6 | 8 | 1000 ms | 11000010 | 1701 /ms |
| 1e6 | 1e6 | / | / | 1000000 | 175 /ms |
| 1e6 | 1e6 | 1 | 1000 ms | 1000000 | 168 /ms |
| 5e7 | 1e6 | 8 | 500 ms | 6000005 | 1528 /ms |
| 1e8 | 5e5 | 16 | 500 ms | 6000011 | 2785 /ms |

Performance improvements are attained when working with a smaller number of distinct keys. This is primarily attributed to the decreased visits to the state backend.

### Checkpoint
| Number of distinct keys | Max Flush Interval | Checkpoint Interval | Average duration | Max duration |
| :----: | :----: | :----: | :----: | :----: |
| 1e6 | 1000ms | 10000ms | 67 ms | 100 ms |
| 1e6 | / | 10000ms | 86 ms | 161 ms |