### PR TITLE
[FLINK-32750] fix resouces not fix in testcase

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatStatisticsReportTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatStatisticsReportTest.java
@@ -128,11 +128,11 @@ public class CsvFormatStatisticsReportTest extends StatisticsReportTestBase {
     private static Path createTempFile(String content) throws IOException {
         File tempFile = File.createTempFile("test_contents", "tmp");
         tempFile.deleteOnExit();
-        OutputStreamWriter wrt =
+        try (OutputStreamWriter wrt =
                 new OutputStreamWriter(
-                        Files.newOutputStream(tempFile.toPath()), StandardCharsets.UTF_8);
-        wrt.write(content);
-        wrt.close();
+                        Files.newOutputStream(tempFile.toPath()), StandardCharsets.UTF_8)) {
+            wrt.write(content);
+        }
         return new Path(tempFile.toURI().toString());
     }
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/RowCsvInputFormatTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/RowCsvInputFormatTest.java
@@ -581,9 +581,9 @@ public class RowCsvInputFormatTest {
         tempFile.deleteOnExit();
         tempFile.setWritable(true);
 
-        OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
-        writer.write(fileContent);
-        writer.close();
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile))) {
+            writer.write(fileContent);
+        }
 
         TypeInformation[] fieldTypes =
                 new TypeInformation[] {
@@ -619,9 +619,9 @@ public class RowCsvInputFormatTest {
         tempFile.deleteOnExit();
         tempFile.setWritable(true);
 
-        OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
-        writer.write(fileContent);
-        writer.close();
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile))) {
+            writer.write(fileContent);
+        }
 
         TypeInformation[] fieldTypes =
                 new TypeInformation[] {
@@ -748,10 +748,10 @@ public class RowCsvInputFormatTest {
             throws IOException {
         File tempFile = File.createTempFile("test_contents", "tmp");
         tempFile.deleteOnExit();
-        OutputStreamWriter wrt =
-                new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8);
-        wrt.write(content);
-        wrt.close();
+        try (OutputStreamWriter wrt =
+                new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8)) {
+            wrt.write(content);
+        }
         return new FileInputSplit(
                 0,
                 new Path(tempFile.toURI().toString()),

--- a/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/orc/nohive/OrcColumnarRowSplitReaderNoHiveTest.java
+++ b/flink-formats/flink-orc-nohive/src/test/java/org/apache/flink/orc/nohive/OrcColumnarRowSplitReaderNoHiveTest.java
@@ -57,43 +57,43 @@ class OrcColumnarRowSplitReaderNoHiveTest extends OrcColumnarRowSplitReaderTest 
         org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(file);
         Configuration conf = new Configuration();
 
-        Writer writer =
-                OrcFile.createWriter(filePath, OrcFile.writerOptions(conf).setSchema(schema));
+        try (Writer writer =
+                OrcFile.createWriter(filePath, OrcFile.writerOptions(conf).setSchema(schema))) {
 
-        VectorizedRowBatch batch = schema.createRowBatch(rowSize);
-        DoubleColumnVector col0 = (DoubleColumnVector) batch.cols[0];
-        DoubleColumnVector col1 = (DoubleColumnVector) batch.cols[1];
-        TimestampColumnVector col2 = (TimestampColumnVector) batch.cols[2];
-        LongColumnVector col3 = (LongColumnVector) batch.cols[3];
-        LongColumnVector col4 = (LongColumnVector) batch.cols[4];
+            VectorizedRowBatch batch = schema.createRowBatch(rowSize);
+            DoubleColumnVector col0 = (DoubleColumnVector) batch.cols[0];
+            DoubleColumnVector col1 = (DoubleColumnVector) batch.cols[1];
+            TimestampColumnVector col2 = (TimestampColumnVector) batch.cols[2];
+            LongColumnVector col3 = (LongColumnVector) batch.cols[3];
+            LongColumnVector col4 = (LongColumnVector) batch.cols[4];
 
-        col0.noNulls = false;
-        col1.noNulls = false;
-        col2.noNulls = false;
-        col3.noNulls = false;
-        col4.noNulls = false;
-        for (int i = 0; i < rowSize - 1; i++) {
-            col0.vector[i] = i;
-            col1.vector[i] = i;
+            col0.noNulls = false;
+            col1.noNulls = false;
+            col2.noNulls = false;
+            col3.noNulls = false;
+            col4.noNulls = false;
+            for (int i = 0; i < rowSize - 1; i++) {
+                col0.vector[i] = i;
+                col1.vector[i] = i;
 
-            Timestamp timestamp = toTimestamp(i);
-            col2.time[i] = timestamp.getTime();
-            col2.nanos[i] = timestamp.getNanos();
+                Timestamp timestamp = toTimestamp(i);
+                col2.time[i] = timestamp.getTime();
+                col2.nanos[i] = timestamp.getNanos();
 
-            col3.vector[i] = i;
-            col4.vector[i] = i;
+                col3.vector[i] = i;
+                col4.vector[i] = i;
+            }
+
+            col0.isNull[rowSize - 1] = true;
+            col1.isNull[rowSize - 1] = true;
+            col2.isNull[rowSize - 1] = true;
+            col3.isNull[rowSize - 1] = true;
+            col4.isNull[rowSize - 1] = true;
+
+            batch.size = rowSize;
+            writer.addRowBatch(batch);
+            batch.reset();
         }
-
-        col0.isNull[rowSize - 1] = true;
-        col1.isNull[rowSize - 1] = true;
-        col2.isNull[rowSize - 1] = true;
-        col3.isNull[rowSize - 1] = true;
-        col4.isNull[rowSize - 1] = true;
-
-        batch.size = rowSize;
-        writer.addRowBatch(batch);
-        batch.reset();
-        writer.close();
     }
 
     @Override

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcColumnarRowSplitReaderTest.java
@@ -256,43 +256,43 @@ public class OrcColumnarRowSplitReaderTest {
         org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(file);
         Configuration conf = new Configuration();
 
-        Writer writer =
-                OrcFile.createWriter(filePath, OrcFile.writerOptions(conf).setSchema(schema));
+        try (Writer writer =
+                OrcFile.createWriter(filePath, OrcFile.writerOptions(conf).setSchema(schema))) {
 
-        VectorizedRowBatch batch = schema.createRowBatch(rowSize);
-        DoubleColumnVector col0 = (DoubleColumnVector) batch.cols[0];
-        DoubleColumnVector col1 = (DoubleColumnVector) batch.cols[1];
-        TimestampColumnVector col2 = (TimestampColumnVector) batch.cols[2];
-        LongColumnVector col3 = (LongColumnVector) batch.cols[3];
-        LongColumnVector col4 = (LongColumnVector) batch.cols[4];
+            VectorizedRowBatch batch = schema.createRowBatch(rowSize);
+            DoubleColumnVector col0 = (DoubleColumnVector) batch.cols[0];
+            DoubleColumnVector col1 = (DoubleColumnVector) batch.cols[1];
+            TimestampColumnVector col2 = (TimestampColumnVector) batch.cols[2];
+            LongColumnVector col3 = (LongColumnVector) batch.cols[3];
+            LongColumnVector col4 = (LongColumnVector) batch.cols[4];
 
-        col0.noNulls = false;
-        col1.noNulls = false;
-        col2.noNulls = false;
-        col3.noNulls = false;
-        col4.noNulls = false;
-        for (int i = 0; i < rowSize - 1; i++) {
-            col0.vector[i] = i;
-            col1.vector[i] = i;
+            col0.noNulls = false;
+            col1.noNulls = false;
+            col2.noNulls = false;
+            col3.noNulls = false;
+            col4.noNulls = false;
+            for (int i = 0; i < rowSize - 1; i++) {
+                col0.vector[i] = i;
+                col1.vector[i] = i;
 
-            Timestamp timestamp = toTimestamp(i);
-            col2.time[i] = timestamp.getTime();
-            col2.nanos[i] = timestamp.getNanos();
+                Timestamp timestamp = toTimestamp(i);
+                col2.time[i] = timestamp.getTime();
+                col2.nanos[i] = timestamp.getNanos();
 
-            col3.vector[i] = i;
-            col4.vector[i] = i;
+                col3.vector[i] = i;
+                col4.vector[i] = i;
+            }
+
+            col0.isNull[rowSize - 1] = true;
+            col1.isNull[rowSize - 1] = true;
+            col2.isNull[rowSize - 1] = true;
+            col3.isNull[rowSize - 1] = true;
+            col4.isNull[rowSize - 1] = true;
+
+            batch.size = rowSize;
+            writer.addRowBatch(batch);
+            batch.reset();
         }
-
-        col0.isNull[rowSize - 1] = true;
-        col1.isNull[rowSize - 1] = true;
-        col2.isNull[rowSize - 1] = true;
-        col3.isNull[rowSize - 1] = true;
-        col4.isNull[rowSize - 1] = true;
-
-        batch.size = rowSize;
-        writer.addRowBatch(batch);
-        batch.reset();
-        writer.close();
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

fix resouces not fix in testcase， in some test case did not close resource in right way，this can cause connection leak in extreme scenarios. so need make a pr to fix it

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

fix resouces not fix in testcase， in some test case did not close resource in right way，this can cause connection leak in extreme scenarios. so need make a pr to fix it


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
