### PR TITLE
[FLINK-32753] Print JVM flags on AZP

### DIFF
--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -27,6 +27,9 @@ print_system_info() {
     echo "Disk information"
     df -h
 
+    echo "JVM information"
+    java -XX:+PrintFlagsFinal -version
+
     echo "Running build as"
     whoami
 }


### PR DESCRIPTION
## What is the purpose of the change

JVM flags could help investigate the test failures (especially memory or GC related issue). This PR prints the JVM flags before tests run.  An example of pipeline output [here](https://dev.azure.com/lzq82555906/flink-for-Zakelly/_build/results?buildId=122&view=logs&j=9dc1b5dc-bcfa-5f83-eaa7-0cb181ddc267&t=511d2595-ec54-5ab7-86ce-92f328796f20&l=165 ). You may search 'JVM information' in this log.

## Brief change log

add JVM information printing section in `print_system_info` of pipeline scripts.

## Verifying this change

This change is a pipeline script update without any test coverage. Check the AZP log and get the print.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
