### PR TITLE
[hotfix][javadocs] Fix some typo in java doc and comments

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -512,7 +512,7 @@ public class CheckpointCoordinator {
      * Triggers one new checkpoint with the given checkpointType. The returned future completes when
      * the triggered checkpoint finishes or an error occurred.
      *
-     * @param checkpointType specifies the back up type of the checkpoint to trigger.
+     * @param checkpointType specifies the backup type of the checkpoint to trigger.
      * @return a future to the completed checkpoint.
      */
     public CompletableFuture<CompletedCheckpoint> triggerCheckpoint(CheckpointType checkpointType) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -240,8 +240,8 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
     // ------------------------------------------------------------------------
 
     /**
-     * Register all shared states in the given registry. This is method is called before the
-     * checkpoint is added into the store.
+     * Register all shared states in the given registry. This method is called before the checkpoint
+     * is added into the store.
      *
      * @param sharedStateRegistry The registry where shared states are registered
      * @param restoreMode the mode in which this checkpoint was restored from

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -36,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Simple container class which contains the raw/managed operator state and key-group state handles
- * from all sub tasks of an operator and therefore represents the complete state of a logical
+ * from all subtasks of an operator and therefore represents the complete state of a logical
  * operator.
  */
 public class OperatorState implements CompositeStateHandle {
@@ -56,7 +56,7 @@ public class OperatorState implements CompositeStateHandle {
     private final int parallelism;
 
     /**
-     * The maximum parallelism (for number of keygroups) of the operator when the job was first
+     * The maximum parallelism (for number of KeyGroups) of the operator when the job was first
      * created.
      */
     private final int maxParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -40,7 +40,7 @@ import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKP
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * An input channel place holder to be replaced by either a {@link RemoteInputChannel} or {@link
+ * An input channel placeholder to be replaced by either a {@link RemoteInputChannel} or {@link
  * LocalInputChannel} at runtime.
  */
 class UnknownInputChannel extends InputChannel implements ChannelStateHolder {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
@@ -40,7 +40,7 @@ public interface StateObject extends Serializable {
     /**
      * Discards the state referred to and solemnly owned by this handle, to free up resources in the
      * persistent storage. This method is called when the state represented by this object will not
-     * be used any more.
+     * be used anymore.
      */
     void discardState() throws Exception;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -224,15 +224,12 @@ public class MetadataV3SerializerTest {
         out.close();
 
         // The relative pointer resolution in MetadataV2V3SerializerBase currently runs the same
-        // code as the file system checkpoint location resolution. Because of that, it needs the
-        // a "_metadata" file present. we could change the code to resolve the pointer without doing
+        // code as the file system checkpoint location resolution. Because of that, it needs a
+        // "_metadata" file present. we could change the code to resolve the pointer without doing
         // file I/O, but it is somewhat delicate to reproduce that logic without I/O and the same
-        // guarantees
-        // to differentiate between the supported options of directory addressing and metadata file
-        // addressing.
-        // So, better safe than sorry, we do actually do the file system operations in the
-        // serializer for now,
-        // even if it makes the tests a a tad bit more clumsy
+        // guarantees to differentiate between the supported options of directory addressing and
+        // metadata file addressing. So, better safe than sorry, we do actually do the file system
+        // operations in the serializer for now, even if it makes the tests a tad bit more clumsy.
         if (basePath != null) {
             final Path metaPath = new Path(basePath, "_metadata");
             // this is in the temp folder, so it will get automatically deleted

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -993,7 +993,7 @@ public class ChangelogKeyedStateBackend<K>
     }
 
     /**
-     * Snapshot State for ChangelogKeyedStatebackend, a wrapper over {@link SnapshotResult}.
+     * Snapshot State for ChangelogKeyedStateBackend, a wrapper over {@link SnapshotResult}.
      *
      * <p>It includes three parts: - materialized snapshot from the underlying delegated state
      * backend - non-materialized part in the current changelog - non-materialized changelog, from


### PR DESCRIPTION
## What is the purpose of the change

As the title, fix some typo in java doc and comments.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
