### PR TITLE
[FLINK-32759][doc] Remove the `cluster.declarative-resource-management.enabled` in doc

### DIFF
--- a/docs/content.zh/docs/deployment/elastic_scaling.md
+++ b/docs/content.zh/docs/deployment/elastic_scaling.md
@@ -134,7 +134,6 @@ Adaptive 调度器可以基于现有的 Slot 调整 Job 的并行度。它会在
 需要设置如下的配置参数：
 
 - `jobmanager.scheduler: adaptive`：将默认的调度器换成 Adaptive。
-- `cluster.declarative-resource-management.enabled`：声明式资源管理必须开启（默认开启）。
 
 Adaptive 调度器可以通过[所有在名字包含 `adaptive-scheduler` 的配置]({{< ref "docs/deployment/config">}}#advanced-scheduling-options)修改其行为。
 

--- a/docs/content/docs/deployment/elastic_scaling.md
+++ b/docs/content/docs/deployment/elastic_scaling.md
@@ -135,10 +135,9 @@ One benefit of the Adaptive Scheduler over the default scheduler is that it can 
 
 ### Usage
 
-The following configuration parameters need to be set:
+The following configuration parameter need to be set:
 
 - `jobmanager.scheduler: adaptive`: Change from the default scheduler to adaptive scheduler
-- `cluster.declarative-resource-management.enabled` Declarative resource management must be enabled (enabled by default).
 
 The behavior of Adaptive Scheduler is configured by [all configuration options containing `adaptive-scheduler`]({{< ref "docs/deployment/config">}}#advanced-scheduling-options) in their name.
 


### PR DESCRIPTION
## What is the purpose of the change

The cluster.declarative-resource-management.enabled was removed at [FLINK-21095](https://issues.apache.org/jira/browse/FLINK-21095)(https://github.com/apache/flink/pull/15838/files), so it doesn't work now.

However, the flink doc still have it.

![](https://github.com/apache/flink/assets/38427477/1912dc7a-414f-44e1-906b-762ee1b5432b)


## Brief change log

[FLINK-32759][doc] Remove the `cluster.declarative-resource-management.enabled` in doc