### PR TITLE
[BP-1.17][FLINK-31665] [table] Add ARRAY_CONCAT function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,9 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ARRAY_CONCAT(array1, ...)
+    table: array1.arrayConcat(...)
+    description: Returns an array that is the result of concatenating at least one array. This array contains all the elements in the first array, followed by all the elements in the second array, and so forth, up to the Nth array. If any input array is NULL, the function returns NULL.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -741,6 +741,9 @@ collection:
   - sql: CARDINALITY(map)
     table: MAP.cardinality()
     description: 返回 map 中的 entries 数量。
+  - sql: ARRAY_CONCAT(array1, ...)
+    table: array1.arrayConcat(...)
+    description: 返回一个数组，该数组是连接至少一个数组的结果。该数组包含第一个数组中的所有元素，然后是第二个数组中的所有元素，依此类推，直到第 N 个数组。如果任何输入数组为 NULL，则函数返回 NULL。
   - sql: map ‘[’ value ‘]’
     table: MAP.at(ANY)
     description: 返回 map 中指定 key 对应的值。

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -224,6 +224,7 @@ advanced type helper functions
     Expression.at
     Expression.cardinality
     Expression.element
+    Expression.array_concat
     Expression.array_contains
 
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,15 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    def array_concat(self, *arrays) -> 'Expression':
+        """
+        Returns an array that is the result of concatenating at least one array.
+        This array contains all the elements in the first array, followed by all
+        the elements in the second array, and so forth, up to the Nth array.
+        If any input array is NULL, the function returns NULL.
+        """
+        return _binary_op("arrayConcat")(self, *arrays)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -68,6 +68,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.NO_ARGS
 import static org.apache.flink.table.types.inference.InputTypeStrategies.OUTPUT_IF_NULL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.TYPE_LITERAL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.commonMultipleArrayType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.comparable;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.compositeSequence;
@@ -163,6 +164,16 @@ public final class BuiltInFunctionDefinitions {
                                     ConstantArgumentCount.of(0), explicit(DataTypes.BOOLEAN())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayContainsFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_CONCAT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_CONCAT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonMultipleArrayType(1))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayConcatFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.strategies.AndArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.AnyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.CommonArrayInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ComparableTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CompositeArgumentTypeStrategy;
@@ -345,6 +346,22 @@ public final class InputTypeStrategies {
      */
     public static InputTypeStrategy commonType(int count) {
         return new CommonInputTypeStrategy(ConstantArgumentCount.of(count));
+    }
+
+    /**
+     * An {@link InputTypeStrategy} that expects {@code count} arguments that have a common array
+     * type.
+     */
+    public static InputTypeStrategy commonArrayType(int count) {
+        return new CommonArrayInputTypeStrategy(ConstantArgumentCount.of(count));
+    }
+
+    /**
+     * An {@link InputTypeStrategy} that expects {@code minCount} arguments that have a common array
+     * type.
+     */
+    public static InputTypeStrategy commonMultipleArrayType(int minCount) {
+        return new CommonArrayInputTypeStrategy(ConstantArgumentCount.from(minCount));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** An {@link InputTypeStrategy} that expects that all arguments have a common array type. */
+@Internal
+public final class CommonArrayInputTypeStrategy implements InputTypeStrategy {
+
+    private static final Argument COMMON_ARGUMENT = Argument.ofGroup("COMMON");
+
+    private final ArgumentCount argumentCount;
+
+    public CommonArrayInputTypeStrategy(ArgumentCount argumentCount) {
+        this.argumentCount = argumentCount;
+    }
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return argumentCount;
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        List<LogicalType> argumentTypes =
+                argumentDataTypes.stream()
+                        .map(DataType::getLogicalType)
+                        .collect(Collectors.toList());
+
+        if (!argumentTypes.stream()
+                .allMatch(logicalType -> logicalType.is(LogicalTypeRoot.ARRAY))) {
+            return callContext.fail(throwOnFailure, "All arguments requires to be a ARRAY type");
+        }
+
+        if (argumentTypes.stream().anyMatch(CommonArrayInputTypeStrategy::isLegacyType)) {
+            return Optional.of(argumentDataTypes);
+        }
+
+        Optional<LogicalType> commonType = LogicalTypeMerging.findCommonType(argumentTypes);
+
+        if (!commonType.isPresent()) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Could not find a common type for arguments: %s",
+                    argumentDataTypes);
+        }
+
+        return commonType.map(
+                type ->
+                        Collections.nCopies(
+                                argumentTypes.size(), TypeConversions.fromLogicalToDataType(type)));
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        Optional<Integer> minCount = argumentCount.getMinCount();
+        Optional<Integer> maxCount = argumentCount.getMaxCount();
+
+        int numberOfMandatoryArguments = minCount.orElse(0);
+
+        if (maxCount.isPresent()) {
+            return IntStream.range(numberOfMandatoryArguments, maxCount.get() + 1)
+                    .mapToObj(count -> Signature.of(Collections.nCopies(count, COMMON_ARGUMENT)))
+                    .collect(Collectors.toList());
+        }
+
+        List<Argument> arguments =
+                new ArrayList<>(Collections.nCopies(numberOfMandatoryArguments, COMMON_ARGUMENT));
+        arguments.add(Argument.ofGroupVarying("COMMON"));
+        return Collections.singletonList(Signature.of(arguments));
+    }
+
+    private static boolean isLegacyType(LogicalType type) {
+        return type instanceof LegacyTypeInformationType;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link CommonArrayInputTypeStrategy}. */
+class CommonArrayInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(InputTypeStrategies.commonArrayType(2))
+                        .expectSignature("f(<COMMON>, <COMMON>)")
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull())
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.DOUBLE()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE())),
+                TestSpec.forStrategy(
+                                "Strategy fails if not all of the argument types are ARRAY",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(DataTypes.INT(), DataTypes.ARRAY(DataTypes.INT()))
+                        .expectErrorMessage("All arguments requires to be a ARRAY type"),
+                TestSpec.forStrategy(
+                                "Strategy fails if can not find a common type",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .expectErrorMessage(
+                                "Could not find a common type for arguments: [ARRAY<INT>, ARRAY<STRING>]"));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -33,6 +33,10 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(arrayContainsTestCases(), arrayConcatTestCases()).flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> arrayContainsTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS)
                         .onFieldsWithData(
@@ -111,5 +115,96 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayContains(true),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_CONTAINS(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arrayConcatTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONCAT)
+                        .onFieldsWithData(
+                                new Integer[] {1, 2, null},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Integer[] {1},
+                                1,
+                                new Integer[][] {{1}},
+                                new String[] {"123"})
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.INT().notNull()),
+                                DataTypes.INT().notNull(),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())).notNull(),
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f0").arrayConcat(new Integer[] {1, null, 4}),
+                                "ARRAY_CONCAT(f0, ARRAY[1, NULL, 4])",
+                                new Integer[] {1, 2, null, 1, null, 4},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arrayConcat(),
+                                "ARRAY_CONCAT(f0)",
+                                new Integer[] {1, 2, null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testTableApiValidationError(
+                                $("f0").arrayConcat(
+                                                new Integer[] {null, null, null},
+                                                new Integer[] {1, 2, 3},
+                                                new Integer[] {3, 4, 5}),
+                                "Invalid function call:\n" + "array(NULL, NULL, NULL)")
+                        .testResult(
+                                $("f1").arrayConcat(
+                                                new Integer[] {1, null, 4},
+                                                new Integer[] {2, 3, 4},
+                                                new Integer[] {2, 3, 4}),
+                                "ARRAY_CONCAT(f1, ARRAY[1, NULL, 4], ARRAY[2, 3, 4], ARRAY[2, 3, 4])",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f2").arrayConcat(
+                                                new Row[] {
+                                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                                },
+                                                new Row[] {
+                                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                                }),
+                                "ARRAY_CONCAT(f2, ARRAY[(TRUE, DATE '1990-10-14')], ARRAY[(TRUE, DATE '1990-10-14')])",
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null,
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14))
+                                },
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())))
+                        .testResult(
+                                $("f3").arrayConcat(new Integer[] {2, null}),
+                                "ARRAY_CONCAT(f3, ARRAY[2, NULL])",
+                                new Integer[] {1, 2, null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testTableApiValidationError(
+                                $("f0").arrayConcat(
+                                                new Integer[] {null, null, null},
+                                                new Integer[] {1, 2, 3},
+                                                new Integer[] {3, 4, 5}),
+                                "Invalid function call:\n" + "array(NULL, NULL, NULL)")
+                        .testTableApiValidationError(
+                                $("f4").arrayConcat(true),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_CONCAT(<COMMON>, <COMMON>...)")
+                        .testTableApiValidationError(
+                                $("f5").arrayConcat(new Integer[] {1}),
+                                "Invalid function call:\n"
+                                        + "ARRAY_CONCAT(ARRAY<ARRAY<INT>> NOT NULL, ARRAY<INT NOT NULL> NOT NULL)")
+                        .testTableApiValidationError(
+                                $("f6").arrayConcat(new Integer[] {123}),
+                                "Invalid function call:\n"
+                                        + "ARRAY_CONCAT(ARRAY<STRING> NOT NULL, ARRAY<INT NOT NULL> NOT NULL)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayConcatFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayConcatFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_CONCAT}. */
+@Internal
+public class ArrayConcatFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    public ArrayConcatFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_CONCAT, context);
+        final DataType dataType =
+                // Since input arrays could be with different nullability we can not rely just on
+                // the first element.
+                ((CollectionDataType) context.getCallContext().getOutputDataType().get())
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+    }
+
+    public @Nullable ArrayData eval(ArrayData... arrays) {
+        if (arrays == null || arrays.length == 0) {
+            return null;
+        }
+        if (arrays.length == 1) {
+            return arrays[0];
+        }
+        try {
+            List<Object> list = new ArrayList<>();
+            for (ArrayData array : arrays) {
+                if (array != null) {
+                    appendElements(array, elementGetter, list);
+                } else {
+                    return null;
+                }
+            }
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    void appendElements(ArrayData array, ArrayData.ElementGetter elementGetter, List<Object> list)
+            throws Throwable {
+        for (int i = 0; i < array.size(); ++i) {
+            final Object element = elementGetter.getElementOrNull(array, i);
+            list.add(element);
+        }
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
This is an implementation of ARRAY_CONCAT

The array_concat() function concatenates at least one array, creating an array that contains all the elements in the first array followed by all the elements in the second array ... followed by all the elements in the n array.

### Brief change log
ARRAY_CONCAT for Table API and SQL

Syntax:
`ARRAY_CONCAT(arr1, tail...)
`
Arguments:
array: at least one ARRAY to be handled.

Returns:
The function returns NULL if any input argument is NULL.


Examples:
`Flink SQL> SELECT array_concat(array[1, 2, 3, null, 3], array[3], array[5]);
[1, 2, 3, null, 3, 3, 5]`

see also:
Google Cloud BigQuery: https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_concat


### Verifying this change

- This change added tests in CollectionFunctionsITCase.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)
