### PR TITLE
[FLINK-32761][state/backends] Use UUID based on PhysicalStateHandleID…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandle.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -332,7 +331,8 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
         for (HandleAndLocalPath handleAndLocalPath : sharedState) {
             StreamStateHandle reference =
                     stateRegistry.registerReference(
-                            createSharedStateRegistryKey(handleAndLocalPath.getHandle()),
+                            SharedStateRegistryKey.forStreamStateHandle(
+                                    handleAndLocalPath.getHandle()),
                             handleAndLocalPath.getHandle(),
                             checkpointID);
 
@@ -355,15 +355,6 @@ public class IncrementalRemoteKeyedStateHandle implements IncrementalKeyedStateH
                 metaStateHandle,
                 persistedSizeOfThisCheckpoint,
                 stateHandleId);
-    }
-
-    /** Create a unique key based on physical id to register one of our shared state handles. */
-    @VisibleForTesting
-    public SharedStateRegistryKey createSharedStateRegistryKey(StreamStateHandle handle) {
-        String keyString = handle.getStreamStateHandleID().getKeyString();
-        // key strings tend to be longer, so we use the MD5 of the key string to save memory
-        return new SharedStateRegistryKey(
-                UUID.nameUUIDFromBytes(keyString.getBytes(StandardCharsets.UTF_8)).toString());
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryKey.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.StringBasedID;
 
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
 /**
  * This class represents a key that uniquely identifies (on a logical level) state handles for
  * registration in the {@link SharedStateRegistry}. Two files which should logically be the same
@@ -38,5 +41,13 @@ public class SharedStateRegistryKey extends StringBasedID {
     @VisibleForTesting
     public SharedStateRegistryKey(String keyString) {
         super(keyString);
+    }
+
+    /** Create a unique key based on physical id. */
+    public static SharedStateRegistryKey forStreamStateHandle(StreamStateHandle handle) {
+        String keyString = handle.getStreamStateHandleID().getKeyString();
+        // key strings tend to be longer, so we use the MD5 of the key string to save memory
+        return new SharedStateRegistryKey(
+                UUID.nameUUIDFromBytes(keyString.getBytes(StandardCharsets.UTF_8)).toString());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -95,7 +95,8 @@ public class IncrementalRemoteKeyedStateHandleTest {
         for (HandleAndLocalPath handleAndLocalPath : stateHandle1.getSharedState()) {
             StreamStateHandle handle = handleAndLocalPath.getHandle();
 
-            SharedStateRegistryKey registryKey = stateHandle1.createSharedStateRegistryKey(handle);
+            SharedStateRegistryKey registryKey =
+                    SharedStateRegistryKey.forStreamStateHandle(handle);
 
             // stateHandle1 and stateHandle2 has same shared states, so same key register 2 times
             verify(registry, times(2)).registerReference(registryKey, handle, 0L);
@@ -104,7 +105,8 @@ public class IncrementalRemoteKeyedStateHandleTest {
         for (HandleAndLocalPath handleAndLocalPath : stateHandle2.getSharedState()) {
             StreamStateHandle handle = handleAndLocalPath.getHandle();
 
-            SharedStateRegistryKey registryKey = stateHandle2.createSharedStateRegistryKey(handle);
+            SharedStateRegistryKey registryKey =
+                    SharedStateRegistryKey.forStreamStateHandle(handle);
 
             // stateHandle1 and stateHandle2 has same shared states, so same key register 2 times
             verify(registry, times(2)).registerReference(registryKey, handle, 0L);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryImpl;
+import org.apache.flink.runtime.state.SharedStateRegistryKey;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendTestBase;
 import org.apache.flink.runtime.state.VoidNamespace;
@@ -594,7 +595,7 @@ public class EmbeddedRocksDBStateBackendTest
                     for (HandleAndLocalPath handleAndLocalPath : sharedState) {
                         verify(sharedStateRegistry)
                                 .registerReference(
-                                        stateHandle.createSharedStateRegistryKey(
+                                        SharedStateRegistryKey.forStreamStateHandle(
                                                 handleAndLocalPath.getHandle()),
                                         handleAndLocalPath.getHandle(),
                                         checkpointId);


### PR DESCRIPTION
… as SharedStateRegistryKey ChangelogStateHandleStreamImpl

## What is the purpose of the change

As title, details in [FLINK-32761](https://issues.apache.org/jira/browse/FLINK-32761).

## Brief change log

  - move *IncrementalRemoteKeyedStateHandle#createSharedStateRegistryKey()* to *SharedStateRegistry*
  - replace *ChangelogStateHandleStreamImpl#getKey()* with *SharedStateRegistry#createSharedStateRegistryKey()*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
