### PR TITLE
[FLINK-29913][hotfix][checkpointing] Fix outdated java doc in …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -54,19 +54,20 @@ public interface SharedStateRegistry extends AutoCloseable {
     }
 
     /**
-     * Register a reference to the given shared state in the registry. If there is already a state
-     * handle registered under the given key, the "new" state handle is disposed .
+     * Register a reference to the given shared state in the registry. The registry key should be
+     * based on the physical identifier of the state. If there is already a state handle registered
+     * under the same key and the 'new' state is not equal to the old one, an exception will be
+     * thrown.
      *
-     * <p>IMPORTANT: caller should check the state handle returned by the result, because the
-     * registry is performing de-duplication and could potentially return a handle that is supposed
-     * to replace the one from the registration request.
+     * <p>IMPORTANT: the caller must use the returned state handle instead of the passed one because
+     * the registry might replace or update it.
      *
      * @param state the shared state for which we register a reference.
      * @param checkpointID which uses the state
      * @param preventDiscardingCreatedCheckpoint as long as this state is still in use. The
      *     "checkpoint that created the state" is recorded on the first state registration.
-     * @return the result of this registration request, consisting of the state handle that is
-     *     registered under the key by the end of the operation and its current reference count.
+     * @return the state handle registered under the given key. It might differ from the passed
+     *     state handle, e.g. if it was a placeholder.
      */
     StreamStateHandle registerReference(
             SharedStateRegistryKey registrationKey,


### PR DESCRIPTION
…SharedStateRegistry after FLINK-29913

## What is the purpose of the change

As the title, fix outdated java doc in *SharedStateRegistry* after [FLINK-29913](https://issues.apache.org/jira/browse/FLINK-29913).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no