### PR TITLE
[FLINK-32763] [SocketSource] Catch exceptions for retry code to work

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -122,6 +122,9 @@ public class SocketTextStreamFunction implements SourceFunction<String> {
                         }
                     }
                 }
+            } catch (Exception e) {
+                LOG.error("Lost connection to server socket");
+                LOG.error(e.getMessage());
             }
 
             // if we dropped out of this loop due to an EOF, sleep and retry


### PR DESCRIPTION
[FLINK-32763](https://issues.apache.org/jira/browse/FLINK-32763) [SocketSource] Catch exceptions for retry code to work

## What is the purpose of the change

Catch the exception to make the retry code take effect


## Brief change log

  - Handle uncaught exceptions


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

- [x] This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
