### PR TITLE
[FLINK-32769][hotfix][state-changelog] Fix the invalid placeholder {}…

### DIFF
--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/PeriodicMaterializationManager.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/PeriodicMaterializationManager.java
@@ -267,7 +267,7 @@ public class PeriodicMaterializationManager implements Closeable {
                                                 metrics.reportFailedMaterialization();
                                             }
                                         },
-                                        "Task {} update materializedSnapshot up to changelog sequence number: {}",
+                                        "Task %s update materializedSnapshot up to changelog sequence number: %s.",
                                         subtaskName,
                                         upTo);
 
@@ -310,7 +310,7 @@ public class PeriodicMaterializationManager implements Closeable {
                 () ->
                         target.handleMaterializationFailureOrCancellation(
                                 materializationId, upTo, cause),
-                "Task {} materialization:{},upTo:{} failed or canceled.",
+                "Task %s materialization: %d, upTo: %s, failed or canceled.",
                 subtaskName,
                 materializationId,
                 upTo);


### PR DESCRIPTION
… passed to MailboxExecutor#execute() in PeriodicMaterializationManager

## What is the purpose of the change

As title said, fix the invalid placeholder '{}' passed to MailboxExecutor#execute() in PeriodicMaterializationManager. Detail description in [FLINK-32769](https://issues.apache.org/jira/browse/FLINK-32769).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
