### PR TITLE
[hotfix][javadocs] Fix the typo in java doc of WatermarkStrategy#forBoundedOutOfOrderness

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategy.java
@@ -214,7 +214,7 @@ public interface WatermarkStrategy<T>
     /**
      * Creates a watermark strategy for situations where records are out of order, but you can place
      * an upper bound on how far the events are out of order. An out-of-order bound B means that
-     * once the an event with timestamp T was encountered, no events older than {@code T - B} will
+     * once an event with timestamp T was encountered, no events older than {@code T - B} will
      * follow any more.
      *
      * <p>The watermarks are generated periodically. The delay introduced by this watermark strategy


### PR DESCRIPTION
## What is the purpose of the change

*Fix the typo in java doc of WatermarkStrategy#forBoundedOutOfOrderness.*


## Brief change log
  - *Remove duplicate article `the` in java doc.*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
