### PR TITLE
[BP-1.17] [FLINK-26948][table] Add-ARRAY_SORT-function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,9 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ARRAY_SORT(array, [ascendingOrder])
+    table: array.arraySort([ascendingOrder])
+    description: Returns the array in sorted order. Sorts the input array in ascending or descending order according to the natural ordering of the array elements. NULL elements are placed at the beginning of the returned array in ascending order or at the end of the returned array in descending order. If the array itself is null, the function will return null. The optional ascendingOrder argument defaults to true if not specified.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -225,7 +225,7 @@ advanced type helper functions
     Expression.cardinality
     Expression.element
     Expression.array_contains
-
+    Expression.array_sort
 
 time definition functions
 -------------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,20 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    def array_sort(self, ascending_order=None) -> 'Expression':
+        """
+        Returns the array in sorted order.
+        Sorts the input array in ascending or descending order according to the natural ordering of
+        the array elements. NULL elements are placed at the beginning of the returned array in
+        ascending order or at the end of the returned array in descending order. If the array
+        itself is null, the function will return null. The optional ascendingOrder argument
+        defaults to true if not specified.
+        """
+        if ascending_order is None:
+            return _unary_op("arraySort")(self)
+        else:
+            return _binary_op("arraySort")(self, ascending_order)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.strategies.ArrayComparableElementArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
 import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -163,6 +164,24 @@ public final class BuiltInFunctionDefinitions {
                                     ConstantArgumentCount.of(0), explicit(DataTypes.BOOLEAN())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayContainsFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_SORT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_SORT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            new ArrayComparableElementArgumentTypeStrategy(
+                                                    StructuredComparison.FULL)),
+                                    sequence(
+                                            new ArrayComparableElementArgumentTypeStrategy(
+                                                    StructuredComparison.FULL),
+                                            logical(LogicalTypeRoot.BOOLEAN))))
+                    .outputTypeStrategy(nullableIfArgs(argument(0)))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArraySortFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayComparableElementArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayComparableElementArgumentTypeStrategy.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentTypeStrategy} that checks if the input argument is an ARRAY type and check
+ * whether its' elements are comparable.
+ *
+ * <p>It requires one argument.
+ *
+ * <p>For the rules which types are comparable with which types see {@link
+ * #areComparable(LogicalType, LogicalType)}.
+ */
+public final class ArrayComparableElementArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+    private final StructuredType.StructuredComparison requiredComparison;
+
+    public ArrayComparableElementArgumentTypeStrategy(
+            StructuredType.StructuredComparison requiredComparison) {
+        Preconditions.checkArgument(requiredComparison != StructuredType.StructuredComparison.NONE);
+        this.requiredComparison = requiredComparison;
+    }
+
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+        final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        final DataType argumentType = argumentDataTypes.get(argumentPos);
+        if (!argumentType.getLogicalType().is(LogicalTypeRoot.ARRAY)) {
+            return callContext.fail(throwOnFailure, "All arguments requires to be an ARRAY type");
+        }
+        final DataType elementDataType = ((CollectionDataType) argumentType).getElementDataType();
+        final LogicalType elementLogicalDataType = elementDataType.getLogicalType();
+        if (!areComparable(elementLogicalDataType, elementLogicalDataType)) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Type '%s' should support %s comparison with itself.",
+                    elementLogicalDataType,
+                    comparisonToString());
+        }
+        return Optional.of(argumentType);
+    }
+
+    private String comparisonToString() {
+        return requiredComparison == StructuredType.StructuredComparison.EQUALS
+                ? "'EQUALS'"
+                : "both 'EQUALS' and 'ORDER'";
+    }
+
+    private boolean areComparable(LogicalType firstType, LogicalType secondType) {
+        return areComparableWithNormalizedNullability(firstType.copy(true), secondType.copy(true));
+    }
+
+    private boolean areComparableWithNormalizedNullability(
+            LogicalType firstType, LogicalType secondType) {
+        // A hack to support legacy types. To be removed when we drop the legacy types.
+        if (firstType instanceof LegacyTypeInformationType
+                || secondType instanceof LegacyTypeInformationType) {
+            return true;
+        }
+
+        // everything is comparable with null, it should return null in that case
+        if (firstType.is(LogicalTypeRoot.NULL) || secondType.is(LogicalTypeRoot.NULL)) {
+            return true;
+        }
+
+        if (firstType.is(LogicalTypeFamily.NUMERIC) && secondType.is(LogicalTypeFamily.NUMERIC)) {
+            return true;
+        }
+
+        // DATE + ALL TIMESTAMPS
+        if (firstType.is(LogicalTypeFamily.DATETIME) && secondType.is(LogicalTypeFamily.DATETIME)) {
+            return true;
+        }
+
+        // VARCHAR + CHAR (we do not compare collations here)
+        if (firstType.is(LogicalTypeFamily.CHARACTER_STRING)
+                && secondType.is(LogicalTypeFamily.CHARACTER_STRING)) {
+            return true;
+        }
+
+        // VARBINARY + BINARY
+        if (firstType.is(LogicalTypeFamily.BINARY_STRING)
+                && secondType.is(LogicalTypeFamily.BINARY_STRING)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public Signature.Argument getExpectedArgument(
+            FunctionDefinition functionDefinition, int argumentPos) {
+        return Signature.Argument.ofGroup("ARRAY<COMPARABLE>");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.api.DataTypes;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySortFunction.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of ARRAY_SORT function. */
+@Internal
+public class ArraySortFunction extends BuiltInScalarFunction {
+
+    private final ArrayData.ElementGetter elementGetter;
+    private final SpecializedFunction.ExpressionEvaluator greaterEvaluator;
+
+    private transient MethodHandle greaterHandle;
+
+    public ArraySortFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_SORT, context);
+        final DataType elementDataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(elementDataType.getLogicalType());
+        greaterEvaluator =
+                context.createEvaluator(
+                        $("element1").isGreater($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", elementDataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", elementDataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        greaterHandle = greaterEvaluator.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData array, Boolean... ascendingOrder) {
+        try {
+            if (array == null || ascendingOrder.length > 0 && ascendingOrder[0] == null) {
+                return null;
+            }
+            if (array.size() == 0) {
+                return array;
+            }
+
+            Object[] elements = new Object[array.size()];
+            for (int i = 0; i < array.size(); i++) {
+                elements[i] = elementGetter.getElementOrNull(array, i);
+            }
+
+            boolean isAscending = ascendingOrder.length > 0 ? ascendingOrder[0] : true;
+            Object[] temp = new Object[elements.length];
+            mergeSort(elements, temp, 0, elements.length - 1, isAscending);
+
+            return new GenericArrayData(elements);
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    private void mergeSort(Object[] array, Object[] temp, int left, int right, boolean isAscending)
+            throws Throwable {
+        if (left >= right) {
+            return;
+        }
+        int mid = left + (right - left) / 2;
+        mergeSort(array, temp, left, mid, isAscending);
+        mergeSort(array, temp, mid + 1, right, isAscending);
+        merge(array, temp, left, mid, right, isAscending);
+    }
+
+    private void merge(
+            Object[] array, Object[] temp, int left, int mid, int right, boolean isAscending)
+            throws Throwable {
+        int i = left, j = mid + 1, k = 0;
+
+        while (i <= mid && j <= right) {
+            if (array[i] == null) {
+                if (isAscending) {
+                    temp[k++] = array[i++];
+                } else {
+                    temp[k++] = array[j++];
+                }
+            } else if (array[j] == null) {
+                if (isAscending) {
+                    temp[k++] = array[j++];
+                } else {
+                    temp[k++] = array[i++];
+                }
+            } else {
+                try {
+                    boolean result = (boolean) (greaterHandle.invoke(array[i], array[j]));
+                    if (isAscending) {
+                        if (result) {
+                            temp[k++] = array[j++];
+                        } else {
+                            temp[k++] = array[i++];
+                        }
+                    } else {
+                        if (result) {
+                            temp[k++] = array[i++];
+                        } else {
+                            temp[k++] = array[j++];
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        while (i <= mid) {
+            if (array[i] == null && !isAscending) {
+                break;
+            }
+            temp[k++] = array[i++];
+        }
+
+        while (j <= right) {
+            if (array[j] == null && !isAscending) {
+                break;
+            }
+            temp[k++] = array[j++];
+        }
+        while (i <= mid) {
+            temp[k++] = array[i++];
+        }
+
+        while (j <= right) {
+            temp[k++] = array[j++];
+        }
+
+        for (int index = 0; index < k; index++) {
+            array[left + index] = temp[index];
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        greaterEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Implement the array_sort function to extract a subset of elements from an array.

Returns the array in sorted order. Sorts the input array in ascending or descending order according to the natural ordering of the array elements. NULL elements are placed at the beginning of the returned array in ascending order or at the end of the returned array in descending order. If the array itself is null, the function will return null. The optional ascendingOrder argument defaults to true if not specified.

 
## Brief change log

ARRAY_SORT for Table API and SQL

Syntax:

`ARRAY_SORT(array, [ascendingOrder])`

Arguments:
array: The array we want to sort.
ascendingOrder: this is an option, default and true stand for ascending order, false stand for descending order.


Returns:  
if the array is null or ascendingOrder is null return null. if array is empty return empty.

Examples:

```
SELECT ARRAY_SORT([5, 3, 2, 1, 0, null])
Output: [null, 0, 1, 2, 3, 5]
```

```
SELECT ARRAY_SORT([5, 3, 2, 1, 0, null], true)
Output: [null, 0, 1, 2, 3, 5]
```

```
SELECT ARRAY_SORT([null, 1, 2, 3, 5], false)
Output: [5, 3, 2, 1, null]
```

```
SELECT ARRAY_SORT(null)
null
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], null)
null

```

see also:
spark: https://spark.apache.org/docs/latest/api/sql/index.html#array_sort
databrick:https://docs.databricks.com/sql/language-manual/functions/array_sort.html

## Verifying this change

- This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
