### PR TITLE
[BP-1.17][FLINK-32260][table] Add built-in ARRAY_SLICE function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,9 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ARRAY_SLICE(array, start_offset[, end_offset])
+    table: array.arraySlice(start_offset[, end_offset])
+    description: Returns a subarray of the input array between 'start_offset' and 'end_offset' inclusive. The offsets are 1-based however 0 is also treated as the beginning of the array. Positive values are counted from the beginning of the array while negative from the end. If 'end_offset' is omitted then this offset is treated as the length of the array. If 'start_offset' is after 'end_offset' or both are out of array bounds an empty array will be returned. Returns null if any input is null.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -225,6 +225,7 @@ advanced type helper functions
     Expression.cardinality
     Expression.element
     Expression.array_contains
+    Expression.array_slice
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,21 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    def array_slice(self, start_offset, end_offset=None) -> 'Expression':
+        """
+        Returns a subarray of the input array between 'start_offset' and 'end_offset' inclusive.
+        The offsets are 1-based however 0 is also treated as the beginning of the array.
+        Positive values are counted from the beginning of the array while negative from the end.
+        If 'end_offset' is omitted then this offset is treated as the length of the array.
+        If 'start_offset' is after 'end_offset' or both are out of array bounds an empty array will
+        be returned.
+        Returns null if any input is null.
+        """
+        if end_offset is None:
+            return _binary_op("array_slice")(self, start_offset)
+        else:
+            return _ternary_op("array_slice")(self, start_offset, end_offset)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -55,6 +55,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ACOS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_SLICE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASCII;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AT;
@@ -1347,6 +1348,29 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayContains(InType needle) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_CONTAINS, toExpr(), objectToExpression(needle)));
+    }
+
+    /**
+     * Returns a subarray of the input array between 'start_offset' and 'end_offset' inclusive. The
+     * offsets are 1-based however 0 is also treated as the beginning of the array. Positive values
+     * are counted from the beginning of the array while negative from the end. If 'end_offset' is
+     * omitted then this offset is treated as the length of the array. If 'start_offset' is after
+     * 'end_offset' or both are out of array bounds an empty array will be returned.
+     *
+     * <p>Returns null if any input is null.
+     */
+    public OutType arraySlice(InType startOffset, InType endOffset) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        ARRAY_SLICE,
+                        toExpr(),
+                        objectToExpression(startOffset),
+                        objectToExpression(endOffset)));
+    }
+
+    public OutType arraySlice(InType startOffset) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_SLICE, toExpr(), objectToExpression(startOffset)));
     }
 
     // Time definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -165,6 +165,24 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayContainsFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_SLICE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_SLICE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            logical(LogicalTypeRoot.ARRAY),
+                                            logical(LogicalTypeRoot.INTEGER),
+                                            logical(LogicalTypeRoot.INTEGER)),
+                                    sequence(
+                                            logical(LogicalTypeRoot.ARRAY),
+                                            logical(LogicalTypeRoot.INTEGER))))
+                    .outputTypeStrategy(nullableIfArgs(argument(0)))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArraySliceFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -33,6 +33,10 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(arrayContainsTestCases(), arraySliceTestCases()).flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> arrayContainsTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS)
                         .onFieldsWithData(
@@ -111,5 +115,147 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayContains(true),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_CONTAINS(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arraySliceTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_SLICE)
+                        .onFieldsWithData(
+                                new Integer[] {null, 1, 2, 3, 4, 5, 6, null},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new String[] {"a", "b", "c", "d", "e"},
+                                new Integer[] {1, 2, 3, 4, 5})
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.STRING()),
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-123),
+                                "ARRAY_SLICE(f4, -123)",
+                                new Integer[] {1, 2, 3, 4, 5},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(0),
+                                "ARRAY_SLICE(f4, 0)",
+                                new Integer[] {1, 2, 3, 4, 5},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-3),
+                                "ARRAY_SLICE(f4, -3)",
+                                new Integer[] {3, 4, 5},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(9),
+                                "ARRAY_SLICE(f4, 9)",
+                                new Integer[] {},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-123, -231),
+                                "ARRAY_SLICE(f4, -123, -231)",
+                                new Integer[] {},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-5, -5),
+                                "ARRAY_SLICE(f4, -5, -5)",
+                                new Integer[] {1},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-6, -5),
+                                "ARRAY_SLICE(f4, -6, -5)",
+                                new Integer[] {1},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(5, 6),
+                                "ARRAY_SLICE(f4, 5, 6)",
+                                new Integer[] {5},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(20, 30),
+                                "ARRAY_SLICE(f4, 20, 30)",
+                                new Integer[] {},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f4").arraySlice(-123, 123),
+                                "ARRAY_SLICE(f4, -123, 123)",
+                                new Integer[] {1, 2, 3, 4, 5},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(0, 8),
+                                "ARRAY_SLICE(f0, 0, 8)",
+                                new Integer[] {null, 1, 2, 3, 4, 5, 6, null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(0, 9),
+                                "ARRAY_SLICE(f0, 0, 9)",
+                                new Integer[] {null, 1, 2, 3, 4, 5, 6, null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(0, -1),
+                                "ARRAY_SLICE(f0, 0, -1)",
+                                new Integer[] {null, 1, 2, 3, 4, 5, 6, null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(1, 0),
+                                "ARRAY_SLICE(f0, 1, 0)",
+                                new Integer[] {null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(-1, 15),
+                                "ARRAY_SLICE(f0, -1, 15)",
+                                new Integer[] {null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(8, 15),
+                                "ARRAY_SLICE(f0, 8, 15)",
+                                new Integer[] {null},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(null, 15),
+                                "ARRAY_SLICE(f0, null, 15)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(1, null),
+                                "ARRAY_SLICE(f0, 1, null)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arraySlice(null, null),
+                                "ARRAY_SLICE(f0, null, null)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f1").arraySlice(1, 3),
+                                "ARRAY_SLICE(f1, 1, 3)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f2").arraySlice(1, 1),
+                                "ARRAY_SLICE(f2, 1, 1)",
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                },
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())))
+                        .testSqlValidationError(
+                                "ARRAY_SLICE(f3, TRUE, 2.5)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>, <INTEGER>)")
+                        .testTableApiValidationError(
+                                $("f3").arraySlice(true, 2.5),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>, <INTEGER>)")
+                        .testSqlValidationError(
+                                "ARRAY_SLICE()",
+                                " No match found for function signature ARRAY_SLICE()")
+                        .testSqlValidationError("ARRAY_SLICE(null)", "Illegal use of 'NULL'"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySliceFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArraySliceFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_SLICE}. */
+@Internal
+public class ArraySliceFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    public ArraySliceFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_SLICE, context);
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+    }
+
+    public @Nullable ArrayData eval(
+            @Nullable ArrayData array, @Nullable Integer start, @Nullable Integer end) {
+        try {
+            if (array == null || start == null || end == null) {
+                return null;
+            }
+            if (array.size() == 0) {
+                return array;
+            }
+            int startIndex = start;
+            int endIndex = end;
+            startIndex += startIndex < 0 ? array.size() + 1 : 0;
+            endIndex += endIndex < 0 ? array.size() + 1 : 0;
+            startIndex = Math.max(1, startIndex);
+            endIndex = endIndex == 0 ? 1 : Math.min(endIndex, array.size());
+            if (endIndex < startIndex) {
+                return new GenericArrayData(new Object[0]);
+            }
+            if (startIndex == 1 && endIndex == array.size()) {
+                return array;
+            }
+            List<Object> slicedArray = new ArrayList<>();
+            for (int i = startIndex - 1; i <= endIndex - 1; i++) {
+                slicedArray.add(elementGetter.getElementOrNull(array, i));
+            }
+            return new GenericArrayData(slicedArray.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    public @Nullable ArrayData eval(@Nullable ArrayData array, @Nullable Integer start) {
+        return array == null ? null : eval(array, start, array.size());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Implement the array_slice function to extract a subset of elements from an array.

Returns a subarray of the input array between 'start_offset' and 'end_offset' inclusive. 
The offsets are 1-based however 0 is also treated as the beginning of the array. 
Positive values are counted from the beginning of the array while negative from the end. 
If 'end_offset' is omitted then this offset is treated as the length of the array. 
If 'start_offset' is after 'end_offset' or both are out of array bounds an empty array will be returned. 
Returns null if any input is null.
 
## Brief change log

ARRAY_SLICE for Table API and SQL

Syntax:

`ARRAY_SLICE(array, start_offset[, end_offset])`

Arguments:
array: The array that contains the elements you want to slice.
start_offset: The inclusive starting offset.
end_offset: The inclusive ending offset, this is an optional argument.


Returns:  
If 'start_offset' is after 'end_offset' or both are out of array bounds an empty array will be returned. 
Returns null if any input is null.

Examples:

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], 1, 3)
Output: [a, b, c]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], -1, -3)
Output: []
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], -3, -1)
Output[c, d, e]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], 3, 3)
Output[c]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], 1, 30)
Output[a, b,c,d,e]

```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], 1, -30)
Output[]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], -30, 30)
Output[a, b, c, d, e]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], -30, -5)
Output[a]
```

```
SELECT ARRAY_SLICE(['a', 'b', 'c', 'd', 'e'], 5, 30)
Output[e]

```

```
SELECT ARRAY_SLICE(['a', 'b', NULL, 'd', 'e'], 1, 3) 
Output[a, b, null]
```

```
SELECT ARRAY_SLICE(['a', 'b', NULL, 'd', 'e'], 1) 
Output[a, b, null, 'd', 'e']
```

```
SELECT ARRAY_SLICE(['a', 'b', NULL, 'd', 'e'], -1) 
Output['e']
```

```
SELECT ARRAY_SLICE(['a', 'b', NULL, 'd', 'e'], 0, 0) 
Output[a]
```
see also:
spark: https://spark.apache.org/docs/latest/api/sql/index.html#slice
google cloud: https://cloud.google.com/spanner/docs/reference/standard-sql/array_functions#array_slice
ClickHouse: https://clickhouse.com/docs/en/sql-reference/functions/array-functions#arrayslice
DockDb:  https://duckdb.org/docs/sql/functions/nested#list-functions

## Verifying this change

- This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
