### PR TITLE
[FLINK-31664][table]Add ARRAY_INTERSECT function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -673,6 +673,9 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
+  - sql: ARRAY_INTERSECT(array1, array2)
+    table: array1.arrayIntersect(array2)
+    description: Returns an array of the elements in the intersection of array1 and array2, without duplicates. If any of the array is null, the function will return null.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -240,6 +240,7 @@ advanced type helper functions
     Expression.map_entries
     Expression.map_keys
     Expression.map_values
+    Expression.array_intersect
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1575,6 +1575,13 @@ class Expression(Generic[T]):
         """
         return _unary_op("arrayMin")(self)
 
+    def array_intersect(self, array) -> 'Expression':
+        """
+        Returns an array of the elements in the intersection of array1 and array2, without
+        duplicates. If any of the array is null, the function will return null.
+        """
+        return _binary_op("arrayIntersect")(self, array)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -58,6 +58,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_INTERSECT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MAX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
@@ -226,6 +227,17 @@ public abstract class BaseExpressions<InType, OutType> {
                                         Stream.of(toExpr(), ApiExpressionUtils.valueLiteral(name)),
                                         Stream.of(extraNames).map(ApiExpressionUtils::valueLiteral))
                                 .toArray(Expression[]::new)));
+    }
+
+    /**
+     * Returns an array of the elements in the intersection of array1 and array2, without
+     * duplicates.
+     *
+     * <p>If any of the array is null, the function will return null.
+     */
+    public OutType arrayIntersect(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_INTERSECT, toExpr(), objectToExpression(array)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -388,7 +388,16 @@ public final class BuiltInFunctionDefinitions {
                     .inputTypeStrategy(sequence(ANY))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT().notNull())))
                     .runtimeProvided()
-                    .internal()
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_INTERSECT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_INTERSECT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayIntersectFunction")
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -388,6 +388,7 @@ public final class BuiltInFunctionDefinitions {
                     .inputTypeStrategy(sequence(ANY))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT().notNull())))
                     .runtimeProvided()
+                    .internal()
                     .build();
 
     public static final BuiltInFunctionDefinition ARRAY_INTERSECT =

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Expressions;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_INTERSECT}. */
+@Internal
+public class ArrayIntersectFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+    private final SpecializedFunction.ExpressionEvaluator hashcodeEvaluator;
+    private final SpecializedFunction.ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle hashcodeHandle;
+    private transient MethodHandle equalityHandle;
+
+    public ArrayIntersectFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_INTERSECT, context);
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType()
+                        .toInternal();
+        elementGetter = ArrayData.createElementGetter(dataType.toInternal().getLogicalType());
+        hashcodeEvaluator =
+                context.createEvaluator(
+                        Expressions.call("$HASHCODE$1", $("element1")),
+                        DataTypes.INT(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()));
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        hashcodeHandle = hashcodeEvaluator.open(context);
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData array1, ArrayData array2) {
+        try {
+            if (array1 == null || array2 == null) {
+                return null;
+            }
+            List<Object> list = new ArrayList<>();
+            Set<ObjectContainer> seen = new HashSet<>();
+
+            boolean isNullPresentInArrayTwo = false;
+            for (int pos = 0; pos < array2.size(); pos++) {
+                final Object element = elementGetter.getElementOrNull(array2, pos);
+                if (element == null) {
+                    isNullPresentInArrayTwo = true;
+                } else {
+                    ObjectContainer objectContainer = new ObjectContainer(element);
+                    seen.add(objectContainer);
+                }
+            }
+            boolean isNullPresentInArrayOne = false;
+            for (int pos = 0; pos < array1.size(); pos++) {
+                final Object element = elementGetter.getElementOrNull(array1, pos);
+                if (element == null) {
+                    isNullPresentInArrayOne = true;
+                } else {
+                    ObjectContainer objectContainer = new ObjectContainer(element);
+                    if (seen.contains(objectContainer)) {
+                        list.add(element);
+                    }
+                }
+            }
+            if (isNullPresentInArrayTwo && isNullPresentInArrayOne) {
+                list.add(null);
+            }
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    private class ObjectContainer {
+
+        Object o;
+
+        public ObjectContainer(Object o) {
+            this.o = o;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof ObjectContainer)) {
+                return false;
+            }
+            ObjectContainer that = (ObjectContainer) other;
+            try {
+                return (boolean) equalityHandle.invoke(this.o, that.o);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            try {
+                return (int) hashcodeHandle.invoke(o);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        hashcodeEvaluator.close();
+        equalityEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of ARRAY_INTERSECT function
Returns an array of the elements in the intersection of array1 and array2, without duplicates.

## Brief change log
ARRAY_INTERSECT for Table API and SQL

## Syntax:

`ARRAY_INTERSECT(array1, array2)`

## Arguments:
array: An ARRAY to be handled.

## Returns: 
Returns an array of the elements in the intersection of array1 and array2, without duplicates.

## Examples:

```
SELECT array_intersect(array(1, 2, 3), array(1, 3, 5));
[1,3]
```


## Verifying this change
CollectionFunctionsITCase

## see also:
spark https://spark.apache.org/docs/latest/api/sql/index.html#array_intersect
presto https://prestodb.io/docs/current/functions/array.html

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
