### PR TITLE
[FLINK-32776][flink-metrics]Add HTTP basic authentication support to PrometheusPushGatewayReporter

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -225,6 +225,9 @@ metrics.reporter.promgateway.randomJobNameSuffix: true
 metrics.reporter.promgateway.deleteOnShutdown: false
 metrics.reporter.promgateway.groupingKey: k1=v1;k2=v2
 metrics.reporter.promgateway.interval: 60 SECONDS
+metrics.reporter.promgateway.basicAuth: true
+metrics.reporter.promgateway.username: username
+metrics.reporter.promgateway.password: password
 ```
 
 PrometheusPushGatewayReporter 发送器将运行指标发送给 [Pushgateway](https://github.com/prometheus/pushgateway)，Prometheus 再从 Pushgateway 拉取、解析运行指标。

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -213,6 +213,9 @@ metrics.reporter.promgateway.randomJobNameSuffix: true
 metrics.reporter.promgateway.deleteOnShutdown: false
 metrics.reporter.promgateway.groupingKey: k1=v1;k2=v2
 metrics.reporter.promgateway.interval: 60 SECONDS
+metrics.reporter.promgateway.basicAuth: true
+metrics.reporter.promgateway.username: username
+metrics.reporter.promgateway.password: password
 ```
 
 The PrometheusPushGatewayReporter pushes metrics to a [Pushgateway](https://github.com/prometheus/pushgateway), which can be scraped by Prometheus.

--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
@@ -44,5 +44,23 @@
             <td>Boolean</td>
             <td>Specifies whether a random suffix should be appended to the job name.</td>
         </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Specify whether the PushGateway requires HTTP basic authentication.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.username</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The username if the PushGateway requires HTTP basic authentication.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The password if the PushGateway requires HTTP basic authentication.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Specify whether the PushGateway requires HTTP basic authentication</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.prometheus.deleteOnShutdown</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
@@ -39,28 +45,22 @@
             <td>The job name under which metrics will be pushed</td>
         </tr>
         <tr>
+            <td><h5>metrics.reporter.prometheus.password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The password if the PushGateway requires HTTP basic authentication</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.prometheus.randomJobNameSuffix</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Specifies whether a random suffix should be appended to the job name.</td>
         </tr>
         <tr>
-            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Specify whether the PushGateway requires HTTP basic authentication.</td>
-        </tr>
-        <tr>
             <td><h5>metrics.reporter.prometheus.username</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The username if the PushGateway requires HTTP basic authentication.</td>
-        </tr>
-        <tr>
-            <td><h5>metrics.reporter.prometheus.password</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The password if the PushGateway requires HTTP basic authentication.</td>
+            <td>The username if the PushGateway requires HTTP basic authentication</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration_zh.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration_zh.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>指定PushGateway是否启用HTTP基础认证.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.prometheus.deleteOnShutdown</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
@@ -39,28 +45,22 @@
             <td>推送运行指标数据时的作业名。</td>
         </tr>
         <tr>
+            <td><h5>metrics.reporter.prometheus.password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>启用HTTP基础认证的PushGateway的密码.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.reporter.prometheus.randomJobNameSuffix</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>是否在作业名后添加一个随机后缀。</td>
         </tr>
         <tr>
-            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>指定PushGateway是否启用HTTP基础认证.</td>
-        </tr>
-        <tr>
             <td><h5>metrics.reporter.prometheus.username</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>启用HTTP基础认证的PushGateway的用户名.</td>
-        </tr>
-        <tr>
-            <td><h5>metrics.reporter.prometheus.password</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>启用HTTP基础认证的PushGateway的密码.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration_zh.html
+++ b/docs/layouts/shortcodes/generated/prometheus_push_gateway_reporter_configuration_zh.html
@@ -44,5 +44,23 @@
             <td>Boolean</td>
             <td>是否在作业名后添加一个随机后缀。</td>
         </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.basicAuth</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>指定PushGateway是否启用HTTP基础认证.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.username</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>启用HTTP基础认证的PushGateway的用户名.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.reporter.prometheus.password</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>启用HTTP基础认证的PushGateway的密码.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 import org.apache.flink.util.Preconditions;
 
+import io.prometheus.client.exporter.BasicAuthHttpConnectionFactory;
 import io.prometheus.client.exporter.PushGateway;
 
 import java.io.IOException;
@@ -50,6 +51,24 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
             final boolean deleteOnShutdown) {
         this.hostUrl = hostUrl;
         this.pushGateway = new PushGateway(hostUrl);
+        this.jobName = Preconditions.checkNotNull(jobName);
+        this.groupingKey = Preconditions.checkNotNull(groupingKey);
+        this.deleteOnShutdown = deleteOnShutdown;
+    }
+
+    PrometheusPushGatewayReporter(
+            URL hostUrl,
+            String jobName,
+            Map<String, String> groupingKey,
+            final boolean deleteOnShutdown,
+            String username,
+            String password) {
+        this.hostUrl = hostUrl;
+        this.pushGateway = new PushGateway(hostUrl);
+        this.pushGateway.setConnectionFactory(
+                new BasicAuthHttpConnectionFactory(
+                        Preconditions.checkNotNull(username),
+                        Preconditions.checkNotNull(password)));
         this.jobName = Preconditions.checkNotNull(jobName);
         this.groupingKey = Preconditions.checkNotNull(groupingKey);
         this.deleteOnShutdown = deleteOnShutdown;

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -57,6 +57,27 @@ public class PrometheusPushGatewayReporterOptions {
                     .defaultValue("")
                     .withDescription("The job name under which metrics will be pushed");
 
+    public static final ConfigOption<Boolean> BASIC_AUTH =
+            ConfigOptions.key("basicAuth")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specify whether the PushGateway requires HTTP basic authentication");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "The username if the PushGateway requires HTTP basic authentication");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "The password if the PushGateway requires HTTP basic authentication");
+
     public static final ConfigOption<Boolean> RANDOM_JOB_NAME_SUFFIX =
             ConfigOptions.key("randomJobNameSuffix")
                     .booleanType()

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterOptions.java
@@ -67,14 +67,14 @@ public class PrometheusPushGatewayReporterOptions {
     public static final ConfigOption<String> USERNAME =
             ConfigOptions.key("username")
                     .stringType()
-                    .defaultValue("")
+                    .noDefaultValue()
                     .withDescription(
                             "The username if the PushGateway requires HTTP basic authentication");
 
     public static final ConfigOption<String> PASSWORD =
             ConfigOptions.key("password")
                     .stringType()
-                    .defaultValue("")
+                    .noDefaultValue()
                     .withDescription(
                             "The password if the PushGateway requires HTTP basic authentication");
 


### PR DESCRIPTION
## What is the purpose of the change

* For security reasons, PushGateways generally enable HTTP basic authentication, but currently Flink does not support pushing metrics to a PushGateway that has HTTP basic authentication enabled, and this pull request add HTTP basic authentication support to PrometheusPushGatewayReporter


## Brief change log

- Add HTTP basic authentication support to PrometheusPushGatewayReporter

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
