### PR TITLE
[BP-1.17][FLINK-32263][table]Add-ELT-function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,9 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ELT(n, row)
+    table: row.elt(n)
+    description: Returns the element at the n-th position from a list of input values. If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is null, the function will return null.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -225,6 +225,7 @@ advanced type helper functions
     Expression.cardinality
     Expression.element
     Expression.array_contains
+    Expression.elt
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,14 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    def elt(self, n) -> 'Expression':
+        """
+        Returns the element at the n-th position from a list of input values.
+        If 'n' is less than 1 or greater than the number of inputs,
+        or if any of the inputs is null, the function will return null.
+        """
+        return _binary_op("elt")(self, n)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -76,6 +76,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ELT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
@@ -1347,6 +1348,16 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayContains(InType needle) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_CONTAINS, toExpr(), objectToExpression(needle)));
+    }
+
+    /**
+     * Returns the element at the n-th position from a list of input values.
+     *
+     * <p>If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is
+     * null, the function will return null.
+     */
+    public OutType elt(InType input) {
+        return toApiSpecificExpression(unresolvedCall(ELT, toExpr(), objectToExpression(input)));
     }
 
     // Time definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.strategies.MixedTypeOutputForRowStrategy;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
 import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -163,6 +164,17 @@ public final class BuiltInFunctionDefinitions {
                                     ConstantArgumentCount.of(0), explicit(DataTypes.BOOLEAN())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.ArrayContainsFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition ELT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ELT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeRoot.ROW), logical(LogicalTypeRoot.INTEGER)))
+                    .outputTypeStrategy(new MixedTypeOutputForRowStrategy())
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputForRowStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
+ */
+public class MixedTypeOutputForRowStrategy implements TypeStrategy {
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        // Obtain the index value from the first argument.
+        Optional<Integer> fieldIndex = callContext.getArgumentValue(1, Integer.class);
+        Optional<DataType> result = Optional.empty();
+        if (fieldIndex.isPresent()) {
+            // The index starts from 1 in the subsequence, so we adjust the index value by adding 1.
+            int adjustedIndex = fieldIndex.get();
+            List<DataType> children = argumentDataTypes.get(0).getChildren();
+            if (adjustedIndex > 0 && adjustedIndex <= children.size()) {
+                result = Optional.of(children.get(adjustedIndex - 1));
+            } else {
+                throw new ValidationException(
+                        "the input should not smaller than 1 and larger than " + children.size());
+            }
+        } else {
+            return Optional.of(DataTypes.INT());
+        }
+        return result.map(
+                (type) -> {
+                    return argumentDataTypes.get(1).getLogicalType().isNullable()
+                            ? (DataType) type.nullable()
+                            : type;
+                });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MixedTypeOutputStrategy.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MixedTypeOutputStrategy strategy that returns a common, least restrictive type of all arguments.
+ */
+public class MixedTypeOutputStrategy implements TypeStrategy {
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        // Obtain the index value from the first argument.
+        Optional<Integer> fieldIndex = callContext.getArgumentValue(0, Integer.class);
+        Optional<DataType> result = Optional.empty();
+        if (fieldIndex.isPresent()) {
+            // The index starts from 1 in the subsequence, so we adjust the index value by adding 1.
+            int adjustedIndex = fieldIndex.get();
+            // Ensure the index is within the valid range.
+            if (adjustedIndex >= 0 && adjustedIndex < argumentDataTypes.size()) {
+                result = Optional.of(argumentDataTypes.get(adjustedIndex));
+            }
+        }
+        return result.map(
+                (type) -> {
+                    return argumentDataTypes.get(0).getLogicalType().isNullable()
+                            ? (DataType) type.nullable()
+                            : type;
+                });
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ELT}. */
+@Internal
+public class EltFunction extends BuiltInScalarFunction {
+
+    private final List<DataType> copyOfDataType;
+
+    public EltFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ELT, context);
+        List<DataType> dataType = context.getCallContext().getArgumentDataTypes();
+        copyOfDataType = new ArrayList<>();
+        for (int i = 0; i < dataType.size(); ++i) {
+            copyOfDataType.add(dataType.get(i));
+        }
+    }
+
+    public @Nullable Object eval(RowData inputs, Integer n) {
+        try {
+            if (n == null || inputs == null) {
+                return null;
+            }
+            if (n < 1 || n > inputs.getArity()) {
+                return null;
+            }
+            RowData.FieldGetter fieldGetter =
+                    RowData.createFieldGetter(
+                            copyOfDataType.get(0).getChildren().get(n - 1).getLogicalType(), n - 1);
+            Object res = fieldGetter.getFieldOrNull(inputs);
+            return res;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Implement the elt function to extract the n-th input value from a row of inputs.
The elt function in the ETL pipeline extracts the value at the n-th position from a input row. It is similar to array indexing, where the first element is at position 1. This function provides a convenient way to retrieve specific elements from a row of inputs.

## Brief change log
ELT for Table API and SQL

## Verifying this change

Syntax:
`ELT(row, n)`

Arguments:
row: input row, it can contain mixed type data.
n: The index of the input value to extract. It should be a positive integer.

Returns: Returns the element at the n-th position from a row of input values. If 'n' is less than 1 or greater than the number of inputs, or if any of the inputs is null, the function will return null.

Examples:

```

SELECT ELT(('scala', 'java'), 2)
Output: 'java'

SELECT ELT((2, 'a'), 1)
Output: 2  
```

See also: 
spark:https://spark.apache.org/docs/latest/api/sql/index.html#elt

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
