### PR TITLE
[FLINK-32740][core] added literal null value support for flink-conf

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -761,6 +761,19 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         }
     }
 
+    public Map<String, String> toMapWithNullLiterals() {
+        synchronized (this.confData) {
+            Map<String, String> ret =
+                    CollectionUtil.newHashMapWithExpectedSize(this.confData.size());
+            for (Map.Entry<String, Object> entry : confData.entrySet()) {
+                ret.put(
+                        entry.getKey(),
+                        ConfigurationUtils.convertToStringWithNullLiterals(entry.getValue()));
+            }
+            return ret;
+        }
+    }
+
     /**
      * Removes given config option from the configuration.
      *

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -407,6 +407,24 @@ public class ConfigurationUtils {
         return MemorySize.parse(o.toString());
     }
 
+    static String convertToStringWithNullLiterals(Object o) {
+        if (o.getClass() == String.class) {
+            return convertStringConsideringNullLiterals((String) o);
+        } else {
+            return convertToString(o);
+        }
+    }
+
+    private static String convertStringConsideringNullLiterals(String s) {
+        if (s.equals("null")) {
+            return "\"null\"";
+        }
+        if (s.equals("~")) {
+            return "\"~\"";
+        }
+        return s;
+    }
+
     static String convertToString(Object o) {
         if (o.getClass() == String.class) {
             return (String) o;

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -319,6 +319,18 @@ public final class DelegatingConfiguration extends Configuration {
         return prefixed;
     }
 
+    public Map<String, String> toMapWithNullLiterals() {
+        Map<String, String> map = backingConfig.toMapWithNullLiterals();
+        Map<String, String> prefixed = new HashMap<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                String keyWithoutPrefix = entry.getKey().substring(prefix.length());
+                prefixed.put(keyWithoutPrefix, entry.getValue());
+            }
+        }
+        return prefixed;
+    }
+
     @Override
     public <T> boolean removeConfig(ConfigOption<T> configOption) {
         return backingConfig.removeConfig(configOption);

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -218,6 +218,12 @@ public final class GlobalConfiguration {
                     String key = kv[0].trim();
                     String value = kv[1].trim();
 
+                    if (isNullLiterally(value)) {
+                        continue;
+                    }
+
+                    value = removeDoubleQuotes(value);
+
                     // sanity check
                     if (key.length() == 0 || value.length() == 0) {
                         LOG.warn(
@@ -237,6 +243,27 @@ public final class GlobalConfiguration {
         }
 
         return config;
+    }
+
+    /**
+     * Remove the leading and trailing double quotes.
+     *
+     * @param value the config value
+     */
+    private static String removeDoubleQuotes(String value) {
+        if (value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    /**
+     * Check whether the config value represents null literal.
+     *
+     * @param value the config value
+     */
+    private static boolean isNullLiterally(String value) {
+        return value.equals("null") || value.equals("~");
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -75,7 +75,7 @@ public class BootstrapTools {
     public static void writeConfiguration(Configuration cfg, File file) throws IOException {
         try (FileWriter fwrt = new FileWriter(file);
                 PrintWriter out = new PrintWriter(fwrt)) {
-            for (Map.Entry<String, String> entry : cfg.toMap().entrySet()) {
+            for (Map.Entry<String, String> entry : cfg.toMapWithNullLiterals().entrySet()) {
                 out.print(entry.getKey());
                 out.print(": ");
                 out.println(entry.getValue());


### PR DESCRIPTION
## What is the purpose of the change

Added literal null value support for flink-conf.yaml.

## Brief change log

- flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
- flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java

## Verifying this change

This change added tests and can be verified as follows:

flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java::testNullLiteralValue

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
