### PR TITLE
[FLINK-32811][runtime] Add port range support for "taskmanager.data.bind-port"

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -27,6 +27,12 @@
             <td>Time we wait for the timers in milliseconds to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.data.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Also accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. If not configured, 'taskmanager.data.port' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/common_host_port_section.html
+++ b/docs/layouts/shortcodes/generated/common_host_port_section.html
@@ -51,6 +51,12 @@
             <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.data.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Also accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. If not configured, 'taskmanager.data.port' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -11,8 +11,8 @@
         <tr>
             <td><h5>taskmanager.data.bind-port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The task manager's bind port used for data exchange operations. If not configured, 'taskmanager.data.port' will be used.</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Also accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. If not configured, 'taskmanager.data.port' will be used.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.port</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -54,12 +54,18 @@ public class NettyShuffleEnvironmentOptions {
                             "The task manager’s external port used for data exchange operations.");
 
     /** The local network port that the task manager listen at for data exchange. */
-    public static final ConfigOption<Integer> DATA_BIND_PORT =
+    @Documentation.Section({
+        Documentation.Sections.COMMON_HOST_PORT,
+        Documentation.Sections.ALL_TASK_MANAGER
+    })
+    public static final ConfigOption<String> DATA_BIND_PORT =
             key("taskmanager.data.bind-port")
-                    .intType()
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The task manager's bind port used for data exchange operations. If not configured, '"
+                            "The task manager's bind port used for data exchange operations."
+                                    + " Also accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both."
+                                    + " If not configured, '"
                                     + DATA_PORT.key()
                                     + "' will be used.");
 

--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -404,7 +404,7 @@ public class NetUtils {
             int dashIdx = range.indexOf('-');
             if (dashIdx == -1) {
                 // only one port in range:
-                final int port = Integer.valueOf(range);
+                final int port = Integer.parseInt(range);
                 if (!isValidHostPort(port)) {
                     throw new IllegalConfigurationException(
                             "Invalid port configuration. Port must be between 0"
@@ -415,21 +415,29 @@ public class NetUtils {
                 rangeIterator = Collections.singleton(Integer.valueOf(range)).iterator();
             } else {
                 // evaluate range
-                final int start = Integer.valueOf(range.substring(0, dashIdx));
+                final int start = Integer.parseInt(range.substring(0, dashIdx));
                 if (!isValidHostPort(start)) {
                     throw new IllegalConfigurationException(
                             "Invalid port configuration. Port must be between 0"
-                                    + "and 65535, but was "
+                                    + "and 65535, but range start was "
                                     + start
                                     + ".");
                 }
-                final int end = Integer.valueOf(range.substring(dashIdx + 1, range.length()));
+                final int end = Integer.parseInt(range.substring(dashIdx + 1));
                 if (!isValidHostPort(end)) {
                     throw new IllegalConfigurationException(
                             "Invalid port configuration. Port must be between 0"
-                                    + "and 65535, but was "
+                                    + "and 65535, but range end was "
                                     + end
                                     + ".");
+                }
+                if (start >= end) {
+                    throw new IllegalConfigurationException(
+                            "Invalid port configuration."
+                                    + " Port range end must be bigger than port range start."
+                                    + " If you wish to use single port please provide the value directly, not as a range."
+                                    + " Given range: "
+                                    + range);
                 }
                 rangeIterator =
                         new Iterator<Integer>() {

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.configuration.IllegalConfigurationException;
+
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -258,6 +260,38 @@ public class NetUtilsTest extends TestLogger {
             error = t;
         }
         Assert.assertTrue(error instanceof NumberFormatException);
+
+        // invalid port
+        try {
+            NetUtils.getPortRangeFromString("70000");
+        } catch (Throwable t) {
+            error = t;
+        }
+        Assert.assertTrue(error instanceof IllegalConfigurationException);
+
+        // invalid start
+        try {
+            NetUtils.getPortRangeFromString("70000-70001");
+        } catch (Throwable t) {
+            error = t;
+        }
+        Assert.assertTrue(error instanceof IllegalConfigurationException);
+
+        // invalid end
+        try {
+            NetUtils.getPortRangeFromString("0-70000");
+        } catch (Throwable t) {
+            error = t;
+        }
+        Assert.assertTrue(error instanceof IllegalConfigurationException);
+
+        // same range
+        try {
+            NetUtils.getPortRangeFromString("5-5");
+        } catch (Throwable t) {
+            error = t;
+        }
+        Assert.assertTrue(error instanceof IllegalConfigurationException);
     }
 
     @Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -157,7 +157,8 @@ class NettyClient {
     private void initNioBootstrap() {
         // Add the server port number to the name in order to distinguish
         // multiple clients running on the same host.
-        String name = NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPort() + ")";
+        String name =
+                NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPortRange() + ")";
 
         NioEventLoopGroup nioGroup =
                 new NioEventLoopGroup(
@@ -189,7 +190,8 @@ class NettyClient {
     private void initEpollBootstrap() {
         // Add the server port number to the name in order to distinguish
         // multiple clients running on the same host.
-        String name = NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPort() + ")";
+        String name =
+                NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPortRange() + ")";
 
         EpollEventLoopGroup epollGroup =
                 new EpollEventLoopGroup(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
-import org.apache.flink.util.NetUtils;
+import org.apache.flink.runtime.util.PortRange;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class NettyConfig {
 
     private final InetAddress serverAddress;
 
-    private final int serverPort;
+    private final PortRange serverPortRange;
 
     private final int memorySegmentSize;
 
@@ -65,11 +65,18 @@ public class NettyConfig {
             int memorySegmentSize,
             int numberOfSlots,
             Configuration config) {
+        this(serverAddress, new PortRange(serverPort), memorySegmentSize, numberOfSlots, config);
+    }
+
+    public NettyConfig(
+            InetAddress serverAddress,
+            PortRange serverPortRange,
+            int memorySegmentSize,
+            int numberOfSlots,
+            Configuration config) {
 
         this.serverAddress = checkNotNull(serverAddress);
-
-        checkArgument(NetUtils.isValidHostPort(serverPort), "Invalid port number.");
-        this.serverPort = serverPort;
+        this.serverPortRange = serverPortRange;
 
         checkArgument(memorySegmentSize > 0, "Invalid memory segment size.");
         this.memorySegmentSize = memorySegmentSize;
@@ -86,8 +93,8 @@ public class NettyConfig {
         return serverAddress;
     }
 
-    int getServerPort() {
-        return serverPort;
+    PortRange getServerPortRange() {
+        return serverPortRange;
     }
 
     // ------------------------------------------------------------------------
@@ -179,7 +186,7 @@ public class NettyConfig {
         String format =
                 "NettyConfig ["
                         + "server address: %s, "
-                        + "server port: %d, "
+                        + "server port range: %s, "
                         + "ssl enabled: %s, "
                         + "memory segment size (bytes): %d, "
                         + "transport type: %s, "
@@ -195,7 +202,7 @@ public class NettyConfig {
         return String.format(
                 format,
                 serverAddress,
-                serverPort,
+                serverPortRange,
                 getSSLEnabled() ? "true" : "false",
                 memorySegmentSize,
                 getTransportType(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -315,6 +315,10 @@ public class TaskManagerServices {
                         ioExecutor);
         final int listeningDataPort = shuffleEnvironment.start();
 
+        LOG.info(
+                "TaskManager data connection initialized successfully; listening internally on port: {}",
+                listeningDataPort);
+
         final KvStateService kvStateService =
                 KvStateService.fromConfiguration(taskManagerServicesConfiguration);
         kvStateService.start();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartition
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
+import org.apache.flink.runtime.util.PortRange;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -296,7 +297,7 @@ public class NettyShuffleEnvironmentConfiguration {
             boolean localTaskManagerCommunication,
             InetAddress taskManagerAddress) {
 
-        final int dataBindPort = getDataBindPort(configuration);
+        final PortRange dataBindPortRange = getDataBindPortRange(configuration);
 
         final int pageSize = ConfigurationParserUtils.getPageSize(configuration);
 
@@ -305,7 +306,7 @@ public class NettyShuffleEnvironmentConfiguration {
                         configuration,
                         localTaskManagerCommunication,
                         taskManagerAddress,
-                        dataBindPort);
+                        dataBindPortRange);
 
         final int numberOfNetworkBuffers =
                 calculateNumberOfNetworkBuffers(configuration, networkMemorySize, pageSize);
@@ -447,26 +448,22 @@ public class NettyShuffleEnvironmentConfiguration {
      * @param configuration configuration object
      * @return the data port
      */
-    private static int getDataBindPort(Configuration configuration) {
-        final int dataBindPort;
+    private static PortRange getDataBindPortRange(Configuration configuration) {
         if (configuration.contains(NettyShuffleEnvironmentOptions.DATA_BIND_PORT)) {
-            dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_BIND_PORT);
-            ConfigurationParserUtils.checkConfigParameter(
-                    dataBindPort >= 0,
-                    dataBindPort,
-                    NettyShuffleEnvironmentOptions.DATA_BIND_PORT.key(),
-                    "Leave config parameter empty to fallback to '"
-                            + NettyShuffleEnvironmentOptions.DATA_PORT.key()
-                            + "' automatically.");
-        } else {
-            dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
-            ConfigurationParserUtils.checkConfigParameter(
-                    dataBindPort >= 0,
-                    dataBindPort,
-                    NettyShuffleEnvironmentOptions.DATA_PORT.key(),
-                    "Leave config parameter empty or use 0 to let the system choose a port automatically.");
+            String dataBindPort =
+                    configuration.getString(NettyShuffleEnvironmentOptions.DATA_BIND_PORT);
+
+            return new PortRange(dataBindPort);
         }
-        return dataBindPort;
+
+        int dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
+        ConfigurationParserUtils.checkConfigParameter(
+                dataBindPort >= 0,
+                dataBindPort,
+                NettyShuffleEnvironmentOptions.DATA_PORT.key(),
+                "Leave config parameter empty or use 0 to let the system choose a port automatically.");
+
+        return new PortRange(dataBindPort);
     }
 
     /**
@@ -511,7 +508,7 @@ public class NettyShuffleEnvironmentConfiguration {
      * @param localTaskManagerCommunication true, to skip initializing the network stack
      * @param taskManagerAddress identifying the IP address under which the TaskManager will be
      *     accessible
-     * @param dataport data port for communication and data exchange
+     * @param dataPortRange data port range for communication and data exchange
      * @return the netty configuration or {@code null} if communication is in the same task manager
      */
     @Nullable
@@ -519,17 +516,17 @@ public class NettyShuffleEnvironmentConfiguration {
             Configuration configuration,
             boolean localTaskManagerCommunication,
             InetAddress taskManagerAddress,
-            int dataport) {
+            PortRange dataPortRange) {
 
         final NettyConfig nettyConfig;
         if (!localTaskManagerCommunication) {
             final InetSocketAddress taskManagerInetSocketAddress =
-                    new InetSocketAddress(taskManagerAddress, dataport);
+                    new InetSocketAddress(taskManagerAddress, 0);
 
             nettyConfig =
                     new NettyConfig(
                             taskManagerInetSocketAddress.getAddress(),
-                            taskManagerInetSocketAddress.getPort(),
+                            dataPortRange,
                             ConfigurationParserUtils.getPageSize(configuration),
                             ConfigurationParserUtils.getSlot(configuration),
                             configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/PortRange.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/PortRange.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.util.NetUtils;
+
+import java.util.Iterator;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Represents a port range and provides access to an iterator of the given range. */
+public class PortRange {
+
+    private final String portRange;
+    private final Iterator<Integer> portsIterator;
+
+    public PortRange(int port) {
+        this(String.valueOf(port));
+    }
+
+    /**
+     * Creates a new port range instance.
+     *
+     * @param portRange given port range string
+     * @throws IllegalConfigurationException if given port range string is invalid
+     */
+    public PortRange(String portRange) {
+        this.portRange = checkNotNull(portRange);
+        try {
+            portsIterator = NetUtils.getPortRangeFromString(portRange);
+        } catch (NumberFormatException e) {
+            throw new IllegalConfigurationException("Invalid port range: \"" + portRange + "\"");
+        }
+    }
+
+    public Iterator<Integer> getPortsIterator() {
+        return portsIterator;
+    }
+
+    @Override
+    public String toString() {
+        return portRange;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.string.StringDecoder;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.string.StringEncoder;
@@ -91,7 +90,7 @@ public class NettyClientServerSslTest extends TestLogger {
         OneShotLatch serverChannelInitComplete = new OneShotLatch();
         final SslHandler[] serverSslHandler = new SslHandler[1];
 
-        NettyProtocol protocol = new NoOpProtocol();
+        NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
         NettyServerAndClient serverAndClient;
         try (NetUtils.Port port = NetUtils.getAvailablePort()) {
@@ -179,7 +178,7 @@ public class NettyClientServerSslTest extends TestLogger {
     /** Verify failure on invalid ssl configuration. */
     @Test
     public void testInvalidSslConfiguration() throws Exception {
-        NettyProtocol protocol = new NoOpProtocol();
+        NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
         Configuration config = createSslConfig();
         // Modify the keystore password to an incorrect one
@@ -201,7 +200,7 @@ public class NettyClientServerSslTest extends TestLogger {
     /** Verify SSL handshake error when untrusted server certificate is used. */
     @Test
     public void testSslHandshakeError() throws Exception {
-        NettyProtocol protocol = new NoOpProtocol();
+        NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
         Configuration config = createSslConfig();
 
@@ -242,7 +241,7 @@ public class NettyClientServerSslTest extends TestLogger {
             final NettyConfig nettyClientConfig = createNettyConfig(clientConfig, clientPort);
 
             final NettyBufferPool bufferPool = new NettyBufferPool(1);
-            final NettyProtocol protocol = new NoOpProtocol();
+            final NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
             final NettyServer server =
                     NettyTestUtil.initServer(nettyServerConfig, protocol, bufferPool);
@@ -264,7 +263,7 @@ public class NettyClientServerSslTest extends TestLogger {
 
     @Test
     public void testSslPinningForValidFingerprint() throws Exception {
-        NettyProtocol protocol = new NoOpProtocol();
+        NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
         Configuration config = createSslConfig();
 
@@ -291,7 +290,7 @@ public class NettyClientServerSslTest extends TestLogger {
 
     @Test
     public void testSslPinningForInvalidFingerprint() throws Exception {
-        NettyProtocol protocol = new NoOpProtocol();
+        NettyProtocol protocol = new NettyTestUtil.NoOpProtocol();
 
         Configuration config = createSslConfig();
 
@@ -329,23 +328,6 @@ public class NettyClientServerSslTest extends TestLogger {
                 NettyTestUtil.DEFAULT_SEGMENT_SIZE,
                 1,
                 config);
-    }
-
-    private static final class NoOpProtocol extends NettyProtocol {
-
-        NoOpProtocol() {
-            super(null, null);
-        }
-
-        @Override
-        public ChannelHandler[] getServerChannelHandlers() {
-            return new ChannelHandler[0];
-        }
-
-        @Override
-        public ChannelHandler[] getClientChannelHandlers() {
-            return new ChannelHandler[0];
-        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerFromPortRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerFromPortRangeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.util.PortRange;
+import org.apache.flink.util.NetUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for initializing Netty server from a port range. */
+class NettyServerFromPortRangeTest {
+
+    @Test
+    void testStartMultipleNettyServerSameConfig() throws Exception {
+        NetUtils.Port port1 = NetUtils.getAvailablePort();
+        NetUtils.Port port2;
+        do {
+            port2 = NetUtils.getAvailablePort();
+        } while (port1.getPort() == port2.getPort());
+
+        NettyConfig config = getConfig(port1, port2);
+        NettyServer nettyServer1 = new NettyServer(config);
+        int listeningPort1 =
+                nettyServer1.init(new NettyTestUtil.NoOpProtocol(), new NettyBufferPool(1));
+
+        NettyServer nettyServer2 = new NettyServer(config);
+        int listeningPort2 =
+                nettyServer2.init(new NettyTestUtil.NoOpProtocol(), new NettyBufferPool(1));
+
+        assertThat(listeningPort1).isEqualTo(port1.getPort());
+        assertThat(listeningPort2).isEqualTo(port2.getPort());
+    }
+
+    private NettyConfig getConfig(NetUtils.Port... ports) {
+        String portRangeStr =
+                Arrays.stream(ports)
+                        .map(NetUtils.Port::getPort)
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(","));
+
+        return new NettyConfig(
+                InetAddress.getLoopbackAddress(),
+                new PortRange(portRangeStr),
+                NettyTestUtil.DEFAULT_SEGMENT_SIZE,
+                1,
+                new Configuration());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import java.net.BindException;
@@ -136,7 +137,7 @@ public class NettyTestUtil {
         final NettyConfig config = server.getConfig();
 
         return client.connect(
-                        new InetSocketAddress(config.getServerAddress(), config.getServerPort()))
+                        new InetSocketAddress(config.getServerAddress(), server.getListeningPort()))
                 .sync()
                 .channel();
     }
@@ -247,9 +248,25 @@ public class NettyTestUtil {
             return new ConnectionID(
                     resourceID,
                     new InetSocketAddress(
-                            server.getConfig().getServerAddress(),
-                            server.getConfig().getServerPort()),
+                            server.getConfig().getServerAddress(), server.getListeningPort()),
                     connectionIndex);
+        }
+    }
+
+    static final class NoOpProtocol extends NettyProtocol {
+
+        NoOpProtocol() {
+            super(null, null);
+        }
+
+        @Override
+        public ChannelHandler[] getServerChannelHandlers() {
+            return new ChannelHandler[0];
+        }
+
+        @Override
+        public ChannelHandler[] getClientChannelHandlers() {
+            return new ChannelHandler[0];
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/PortRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/PortRangeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.IllegalConfigurationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PortRange}. */
+class PortRangeTest {
+
+    @Test
+    void testInvalidPortRange() {
+        assertThatThrownBy(() -> new PortRange(null)).isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new PortRange(""))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("Invalid port range: \"\"");
+
+        assertThatThrownBy(() -> new PortRange("asd"))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("Invalid port range: \"asd\"");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Adds port range support for `taskmanager.data.bind-port`, which can be helpful in a restrictive network setup.

## Brief change log

- Changed `taskmanager.data.bind-port` opion type from `Integer` to `String`.
- Introduced `PortRange` utility to be able to carry the port range string and its generated iterator together.
- Updated `NettyConfig` to handle a `PortRange` instead of a `port` as the port of the server.
- Updated `NettyServer` to be able to initialize itself from a `PortRange`.
- Adapted relevant code pieces and documentation.

## Verifying this change

This change added tests and can be verified as follows:
- Added `NettyServerFromPortRangeTest` to test Netty server init from a port range.
- Manually verified by setting `taskmanager.data.bind-port` to a port range (e.g. 55000-55100) while `taskmanager.data.port` is set to `0`, then TM should bind to the first available port from the given range both locally and externally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no