### PR TITLE
[BP-1.17][FLINK-31663][table] Add-ARRAY_EXCEPT-function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -631,6 +631,9 @@ collection:
   - sql: ARRAY_CONTAINS(haystack, needle)
     table: haystack.arrayContains(needle)
     description: Returns whether the given element exists in an array. Checking for null elements in the array is supported. If the array itself is null, the function will return null. The given element is cast implicitly to the array's element type if necessary.
+  - sql: ARRAY_EXCEPT(array1, array2)
+    table: arrayOne.arrayExcept(arrayTwo)
+    description: Returns an array of the elements in array1 but not in array2, without duplicates. If array1 is null, the function will return null.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -225,6 +225,7 @@ advanced type helper functions
     Expression.cardinality
     Expression.element
     Expression.array_contains
+    Expression.array_except
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1480,6 +1480,13 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayContains")(self, needle)
 
+    def array_except(self, array) -> 'Expression':
+        """
+        Returns an array of the elements in array1 but not in array2, without duplicates.
+        If array1 is null, the function will return null.
+        """
+        return _binary_op("arrayExcept")(self, array)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -44,7 +44,6 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.objectToExpr
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.HASHCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAY;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAYAGG_ABSENT_ON_NULL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAYAGG_NULL_ON_NULL;
@@ -834,10 +833,6 @@ public final class Expressions {
      */
     public static ApiExpression jsonString(Object value) {
         return apiCallAtLeastOneArgument(JSON_STRING, value);
-    }
-
-    public static ApiExpression hashCodeGenerate(Object value) {
-        return apiCallAtLeastOneArgument(HASHCODE, value);
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -44,6 +44,7 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.objectToExpr
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.HASHCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAY;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAYAGG_ABSENT_ON_NULL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_ARRAYAGG_NULL_ON_NULL;
@@ -833,6 +834,10 @@ public final class Expressions {
      */
     public static ApiExpression jsonString(Object value) {
         return apiCallAtLeastOneArgument(JSON_STRING, value);
+    }
+
+    public static ApiExpression hashCodeGenerate(Object value) {
+        return apiCallAtLeastOneArgument(HASHCODE, value);
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -55,6 +55,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ACOS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_EXCEPT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASCII;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ASIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AT;
@@ -213,6 +214,16 @@ public abstract class BaseExpressions<InType, OutType> {
                                         Stream.of(toExpr(), ApiExpressionUtils.valueLiteral(name)),
                                         Stream.of(extraNames).map(ApiExpressionUtils::valueLiteral))
                                 .toArray(Expression[]::new)));
+    }
+
+    /**
+     * Return an array of the elements in array1 but not in array2, without duplicates
+     *
+     * <p>If array1 is null, the function will return null.
+     */
+    public OutType arrayExcept(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_EXCEPT, toExpr(), objectToExpression(array)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -68,6 +68,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.NO_ARGS
 import static org.apache.flink.table.types.inference.InputTypeStrategies.OUTPUT_IF_NULL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.TYPE_LITERAL;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.and;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.commonArrayType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.comparable;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.compositeSequence;
@@ -183,6 +184,16 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.table.UnnestRowsFunction")
                     .internal()
+                    .build();
+
+    public static final BuiltInFunctionDefinition ARRAY_EXCEPT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_EXCEPT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayExceptFunction")
                     .build();
 
     // --------------------------------------------------------------------------------------------
@@ -1982,6 +1993,16 @@ public final class BuiltInFunctionDefinitions {
                     .inputTypeStrategy(sequence(JSON_ARGUMENT))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
                     .runtimeProvided()
+                    .build();
+
+    public static final BuiltInFunctionDefinition HASHCODE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("$HASHCODE$1")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(ANY))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT().notNull())))
+                    .runtimeProvided()
+                    .internal()
                     .build();
 
     public static final BuiltInFunctionDefinition JSON_OBJECT =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.strategies.AndArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.AnyArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.CommonArrayInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CommonInputTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.ComparableTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.CompositeArgumentTypeStrategy;
@@ -345,6 +346,14 @@ public final class InputTypeStrategies {
      */
     public static InputTypeStrategy commonType(int count) {
         return new CommonInputTypeStrategy(ConstantArgumentCount.of(count));
+    }
+
+    /**
+     * An {@link InputTypeStrategy} that expects {@code count} arguments that have a common array
+     * type.
+     */
+    public static InputTypeStrategy commonArrayType(int count) {
+        return new CommonArrayInputTypeStrategy(ConstantArgumentCount.of(count));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategy.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** An {@link InputTypeStrategy} that expects that all arguments have a common array type. */
+@Internal
+public final class CommonArrayInputTypeStrategy implements InputTypeStrategy {
+
+    private static final Argument COMMON_ARGUMENT = Argument.ofGroup("COMMON");
+
+    private final ArgumentCount argumentCount;
+
+    public CommonArrayInputTypeStrategy(ArgumentCount argumentCount) {
+        this.argumentCount = argumentCount;
+    }
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return argumentCount;
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+        List<LogicalType> argumentTypes =
+                argumentDataTypes.stream()
+                        .map(DataType::getLogicalType)
+                        .collect(Collectors.toList());
+
+        if (!argumentTypes.stream()
+                .allMatch(logicalType -> logicalType.is(LogicalTypeRoot.ARRAY))) {
+            return callContext.fail(throwOnFailure, "All arguments requires to be a ARRAY type");
+        }
+
+        if (argumentTypes.stream().anyMatch(CommonArrayInputTypeStrategy::isLegacyType)) {
+            return Optional.of(argumentDataTypes);
+        }
+
+        Optional<LogicalType> commonType = LogicalTypeMerging.findCommonType(argumentTypes);
+
+        if (!commonType.isPresent()) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "Could not find a common type for arguments: %s",
+                    argumentDataTypes);
+        }
+
+        return commonType.map(
+                type ->
+                        Collections.nCopies(
+                                argumentTypes.size(), TypeConversions.fromLogicalToDataType(type)));
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        Optional<Integer> minCount = argumentCount.getMinCount();
+        Optional<Integer> maxCount = argumentCount.getMaxCount();
+
+        int numberOfMandatoryArguments = minCount.orElse(0);
+
+        if (maxCount.isPresent()) {
+            return IntStream.range(numberOfMandatoryArguments, maxCount.get() + 1)
+                    .mapToObj(count -> Signature.of(Collections.nCopies(count, COMMON_ARGUMENT)))
+                    .collect(Collectors.toList());
+        }
+
+        List<Argument> arguments =
+                new ArrayList<>(Collections.nCopies(numberOfMandatoryArguments, COMMON_ARGUMENT));
+        arguments.add(Argument.ofGroupVarying("COMMON"));
+        return Collections.singletonList(Signature.of(arguments));
+    }
+
+    private static boolean isLegacyType(LogicalType type) {
+        return type instanceof LegacyTypeInformationType;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/CommonArrayInputTypeStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link CommonArrayInputTypeStrategy}. */
+class CommonArrayInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(InputTypeStrategies.commonArrayType(2))
+                        .expectSignature("f(<COMMON>, <COMMON>)")
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull())
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.DOUBLE()),
+                                DataTypes.ARRAY(DataTypes.DOUBLE())),
+                TestSpec.forStrategy(
+                                "Strategy fails if not all of the argument types are ARRAY",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(DataTypes.INT(), DataTypes.ARRAY(DataTypes.INT()))
+                        .expectErrorMessage("All arguments requires to be a ARRAY type"),
+                TestSpec.forStrategy(
+                                "Strategy fails if can not find a common type",
+                                InputTypeStrategies.commonArrayType(2))
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .expectErrorMessage(
+                                "Could not find a common type for arguments: [ARRAY<INT>, ARRAY<STRING>]"));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -815,6 +815,9 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
           case BuiltInFunctionDefinitions.JSON_STRING =>
             new JsonStringCallGen(call).generate(ctx, operands, resultType)
 
+          case BuiltInFunctionDefinitions.HASHCODE =>
+            new HashCodeCallGen().generate(ctx, operands, resultType)
+
           case BuiltInFunctionDefinitions.AGG_DECIMAL_PLUS |
               BuiltInFunctionDefinitions.HIVE_AGG_DECIMAL_PLUS =>
             val left = operands.head

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingFunctionGenUtil.scala
@@ -587,7 +587,7 @@ object BridgingFunctionGenUtil {
            |public class $evaluatorName extends ${className[AbstractRichFunction]} {
            |
            |  ${ctx.reuseMemberCode()}
-           |
+           |  ${ctx.reuseInnerClassDefinitionCode()}
            |  public $evaluatorName(Object[] references) throws Exception {
            |    ${ctx.reuseInitCode()}
            |  }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -21,18 +21,26 @@ package org.apache.flink.table.planner.functions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.row;
+import static org.apache.flink.util.CollectionUtil.entry;
 
 /** Tests for {@link BuiltInFunctionDefinitions} around arrays. */
 class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(arrayContainsTestCases(), arrayExceptTestCases()).flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> arrayContainsTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS)
                         .onFieldsWithData(
@@ -111,5 +119,146 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayContains(true),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_CONTAINS(haystack <ARRAY>, needle <ARRAY ELEMENT>)"));
+    }
+
+    private Stream<TestSetSpec> arrayExceptTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_EXCEPT)
+                        .onFieldsWithData(
+                                new Integer[] {1, 2, 2},
+                                null,
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null
+                                },
+                                new Integer[] {null, null, 1},
+                                new Integer[][] {
+                                    new Integer[] {1, null, 3}, new Integer[] {0}, new Integer[] {1}
+                                },
+                                new Map[] {
+                                    CollectionUtil.map(entry(1, "a"), entry(2, "b")),
+                                    CollectionUtil.map(entry(3, "c"), entry(4, "d")),
+                                    null
+                                })
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())),
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())))
+                        // ARRAY<INT>
+                        .testResult(
+                                $("f0").arrayExcept(new Integer[] {1, null, 4}),
+                                "ARRAY_EXCEPT(f0, ARRAY[1, NULL, 4])",
+                                new Integer[] {2},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        .testResult(
+                                $("f0").arrayExcept(new Integer[] {1}),
+                                "ARRAY_EXCEPT(f0, ARRAY[1])",
+                                new Integer[] {2},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        .testResult(
+                                $("f0").arrayExcept(new Integer[] {42}),
+                                "ARRAY_EXCEPT(f0, ARRAY[42])",
+                                new Integer[] {1, 2},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        // arrayTwo is NULL
+                        .testResult(
+                                $("f0").arrayExcept(
+                                                lit(null, DataTypes.ARRAY(DataTypes.INT()))
+                                                        .cast(DataTypes.ARRAY(DataTypes.INT()))),
+                                "ARRAY_EXCEPT(f0, CAST(NULL AS ARRAY<INT>))",
+                                new Integer[] {1, 2},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        // arrayTwo contains null elements
+                        .testResult(
+                                $("f0").arrayExcept(new Integer[] {null, 2}),
+                                "ARRAY_EXCEPT(f0, ARRAY[null, 2])",
+                                new Integer[] {1},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        // arrayOne is NULL
+                        .testResult(
+                                $("f1").arrayExcept(new Integer[] {1, 2, 3}),
+                                "ARRAY_EXCEPT(f1, ARRAY[1,2,3])",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        // arrayOne contains null elements
+                        .testResult(
+                                $("f3").arrayExcept(new Integer[] {null, 42}),
+                                "ARRAY_EXCEPT(f3, ARRAY[null, 42])",
+                                new Integer[] {1},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        // ARRAY<ROW<BOOLEAN, DATE>>
+                        .testResult(
+                                $("f2").arrayExcept(
+                                                new Row[] {
+                                                    Row.of(true, LocalDate.of(1990, 10, 14))
+                                                }),
+                                "ARRAY_EXCEPT(f2, ARRAY[(TRUE, DATE '1990-10-14')])",
+                                new Row[] {Row.of(true, LocalDate.of(2022, 4, 20)), null},
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                        DataTypes.BOOLEAN(), DataTypes.DATE()))
+                                        .nullable())
+                        .testResult(
+                                $("f2").arrayExcept(
+                                                lit(
+                                                                null,
+                                                                DataTypes.ARRAY(
+                                                                        DataTypes.ROW(
+                                                                                DataTypes.BOOLEAN(),
+                                                                                DataTypes.DATE())))
+                                                        .cast(
+                                                                DataTypes.ARRAY(
+                                                                        DataTypes.ROW(
+                                                                                DataTypes.BOOLEAN(),
+                                                                                DataTypes
+                                                                                        .DATE())))),
+                                "ARRAY_EXCEPT(f2, CAST(NULL AS ARRAY<ROW<col1 BOOLEAN, col2 DATE>>))",
+                                new Row[] {
+                                    Row.of(true, LocalDate.of(2022, 4, 20)),
+                                    Row.of(true, LocalDate.of(1990, 10, 14)),
+                                    null,
+                                },
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                        DataTypes.BOOLEAN(), DataTypes.DATE()))
+                                        .nullable())
+                        // ARRAY<ARRAY<INT>>
+                        .testResult(
+                                $("f4").arrayExcept(new Integer[][] {new Integer[] {0}}),
+                                "ARRAY_EXCEPT(f4, ARRAY[ARRAY[0]])",
+                                new Integer[][] {new Integer[] {1, null, 3}, new Integer[] {1}},
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT()).nullable()))
+                        // ARRAY<MAP<INT, STRING>> with NULL elements
+                        .testResult(
+                                $("f5").arrayExcept(
+                                                new Map[] {
+                                                    CollectionUtil.map(entry(3, "c"), entry(4, "d"))
+                                                }),
+                                "ARRAY_EXCEPT(f5, ARRAY[MAP[3, 'c', 4, 'd']])",
+                                new Map[] {CollectionUtil.map(entry(1, "a"), entry(2, "b")), null},
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                                        .nullable())
+                        // Invalid signatures
+                        .testSqlValidationError(
+                                "ARRAY_EXCEPT(f0, TRUE)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_EXCEPT(<COMMON>, <COMMON>)")
+                        .testTableApiValidationError(
+                                $("f0").arrayExcept(true),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_EXCEPT(<COMMON>, <COMMON>)")
+                        .testSqlValidationError(
+                                "ARRAY_EXCEPT(f0, ARRAY['hi', 'there'])",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_EXCEPT(<COMMON>, <COMMON>)")
+                        .testTableApiValidationError(
+                                $("f0").arrayExcept(new String[] {"hi", "there"}),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_EXCEPT(<COMMON>, <COMMON>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayExceptFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayExceptFunction.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Expressions;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_EXCEPT}. */
+@Internal
+public class ArrayExceptFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+    private final SpecializedFunction.ExpressionEvaluator containsEvaluator;
+    private transient MethodHandle containsHandle;
+
+    public ArrayExceptFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_EXCEPT, context);
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+        containsEvaluator =
+                context.createEvaluator(
+                        Expressions.call("$HASHCODE$1", $("element1")),
+                        DataTypes.INT(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        containsHandle = containsEvaluator.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData arrayOne, ArrayData arrayTwo) {
+        try {
+            if (arrayOne == null) {
+                return null;
+            }
+
+            List<Object> list = new ArrayList();
+            Set<Integer> seen = new HashSet<>();
+
+            boolean isNullPresentInArrayTwo = false;
+            if (arrayTwo != null) {
+                for (int pos = 0; pos < arrayTwo.size(); pos++) {
+                    final Object element = elementGetter.getElementOrNull(arrayTwo, pos);
+                    if (element == null) {
+                        isNullPresentInArrayTwo = true;
+                    } else {
+                        int hashCode = (int) containsHandle.invoke(element);
+                        if (!seen.contains(hashCode)) {
+                            seen.add(hashCode);
+                        }
+                    }
+                }
+            }
+            boolean isNullPresentInArrayOne = false;
+            if (arrayOne != null) {
+                for (int pos = 0; pos < arrayOne.size(); pos++) {
+                    final Object element = elementGetter.getElementOrNull(arrayOne, pos);
+                    if (element == null) {
+                        isNullPresentInArrayOne = true;
+                    } else {
+                        int hashCode = (int) containsHandle.invoke(element);
+                        if (!seen.contains(hashCode)) {
+                            seen.add(hashCode);
+                            list.add(element);
+                        }
+                    }
+                }
+            }
+            if (!isNullPresentInArrayTwo && isNullPresentInArrayOne) {
+                list.add(null);
+            }
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        containsEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of ARRAY_EXCEPT function
ARRAY_EXCEPT(array1, array2) - Returns an array of the elements in array1 but not in array2, without duplicates.

## Brief change log
ARRAY_EXCEPT for Table API and SQL

## Syntax:

`ARRAY_EXCEPT(array1, array2)`

## Arguments:
array: An ARRAY to be handled.

## Returns: 
Returns an array of the elements in array1 but not in array2, without duplicates.

## Examples:

```
Flink SQL> SELECT array_except(array[1,2,2], array[2,3,4]);
[1]

Flink SQL> SELECT array_except(array[1,2,2], array[1]);
[2]

Flink SQL> SELECT array_except(array[1,2,2], array[42]);
[1, 2]

Flink SQL> SELECT array_except(array[1,2,2], cast(null as array<int>));
[1, 2]

Flink SQL> SELECT array_except(array[1,2,2], array[null,2]);
[1]

Flink SQL> SELECT array_except(cast(null as array<int>), array[1,2,3]);
<NULL>

Flink SQL> SELECT array_except(array[null,null,1], array[42]);
[NULL, 1]

Flink SQL> SELECT array_except(array[null,null,1], array[null, 42]);
[1]

Flink SQL> SELECT array_except(array[(TRUE, DATE '2022-04-20'), (TRUE, DATE '1990-10-14'), null], array[(TRUE, DATE '1990-10-14')]);
[(TRUE, 2022-04-20), NULL]

Flink SQL> SELECT array_except(array[(TRUE, DATE '2022-04-20'), (TRUE, DATE '1990-10-14'), null], cast(null as array<row<col1 boolean, col2 date>>));
[(TRUE, 2022-04-20), (TRUE, 1990-10-14), NULL]

Flink SQL> SELECT array_except(array[array[1,null,3], array[0], array[1]], array[array[0]]);
[[1, NULL, 3], [1]]

Flink SQL> SELECT array_except(array[map[1, 'a', 2, 'b'], map[3, 'c', 4, 'd']], array[map[3, 'c', 4, 'd']]);
[{1=a, 2=b}]

// Error message with the CommonArrayInputStrategy. Without the CommonArrayInputStrategy the output is [1]
Flink SQL> SELECT array_except(array[1], array['this is a string']);
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.table.api.ValidationException: Could not find a common type for arguments: [ARRAY<INT NOT NULL> NOT NULL, ARRAY<CHAR(16) NOT NULL> NOT NULL]
```


## Verifying this change
CollectionFunctionsITCase

## see also:
spark:https://spark.apache.org/docs/latest/api/sql/index.html#array_except

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
