### PR TITLE
[FLINK-32823][doc] Update the adaptive scheduler fall back strategy doc for batch jobs

### DIFF
--- a/docs/content.zh/docs/deployment/elastic_scaling.md
+++ b/docs/content.zh/docs/deployment/elastic_scaling.md
@@ -141,7 +141,7 @@ Adaptive 调度器可以通过[所有在名字包含 `adaptive-scheduler` 的配
 
 ### 局限性
 
-- **只支持流式 Job**：Adaptive 调度器的第一个版本仅支持流式 Job。当提交的是一个批处理 Job 时，我们会自动换回默认调度器。
+- **只支持流式 Job**：Adaptive 调度器仅支持流式 Job。当提交的是一个批处理 Job 时，Flink 会自动使用批处理 Job 的默认调度器，即 Adaptive Batch Scheduler。
 - **不支持部分故障恢复**: 部分故障恢复意味着调度器可以只重启失败 Job 其中某一部分（在 Flink 的内部结构中被称之为 Region）而不是重启整个 Job。这个限制只会影响那些独立并行（Embarrassingly Parallel）Job的恢复时长，默认的调度器可以重启失败的部分，然而 Adaptive 将需要重启整个 Job。
 - 扩缩容事件会触发 Job 和 Task 重启，Task 重试的次数也会增加。
 

--- a/docs/content/docs/deployment/elastic_scaling.md
+++ b/docs/content/docs/deployment/elastic_scaling.md
@@ -143,7 +143,7 @@ The behavior of Adaptive Scheduler is configured by [all configuration options c
 
 ### Limitations
 
-- **Streaming jobs only**: The first version of Adaptive Scheduler runs with streaming jobs only. When submitting a batch job, we will automatically fall back to the default scheduler.
+- **Streaming jobs only**: The Adaptive Scheduler runs with streaming jobs only. When submitting a batch job, Flink will use the default scheduler of batch jobs, i.e. Adaptive Batch Scheduler.
 - **No support for partial failover**: Partial failover means that the scheduler is able to restart parts ("regions" in Flink's internals) of a failed job, instead of the entire job. This limitation impacts only recovery time of embarrassingly parallel jobs: Flink's default scheduler can restart failed parts, while Adaptive Scheduler will restart the entire job.
 - Scaling events trigger job and task restarts, which will increase the number of Task attempts.
 


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-30846](https://issues.apache.org/jira/browse/FLINK-30846) [1] updated the fall back strategy from default Scheduler to AdaptiveBatch Scheduler when batch job enable `jobmanager.scheduler: adaptive`.

However, the doc[2] isn't updated.

## Brief change log
[FLINK-32823][doc] Update the adaptive scheduler fall back strategy doc for batch jobs

[1] https://github.com/apache/flink/pull/21814/files
[2] https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/elastic_scaling/#limitations-1