### PR TITLE
[BP-1.17][FLINK-32565][table] Support Cast From NUMBER to BYTES

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.logical.LogicalTypeFamily.APPROXIMATE_NUMERIC;
 import static org.apache.flink.table.types.logical.LogicalTypeFamily.BINARY_STRING;
 import static org.apache.flink.table.types.logical.LogicalTypeFamily.CHARACTER_STRING;
 import static org.apache.flink.table.types.logical.LogicalTypeFamily.CONSTRUCTED;
@@ -136,14 +137,14 @@ public final class LogicalTypeCasts {
 
         castTo(BINARY)
                 .implicitFrom(BINARY)
-                .explicitFromFamily(CHARACTER_STRING)
+                .explicitFromFamily(CHARACTER_STRING, INTEGER_NUMERIC, APPROXIMATE_NUMERIC)
                 .explicitFrom(VARBINARY)
                 .explicitFrom(RAW)
                 .build();
 
         castTo(VARBINARY)
                 .implicitFromFamily(BINARY_STRING)
-                .explicitFromFamily(CHARACTER_STRING)
+                .explicitFromFamily(CHARACTER_STRING, INTEGER_NUMERIC, APPROXIMATE_NUMERIC)
                 .explicitFrom(BINARY)
                 .explicitFrom(RAW)
                 .build();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -167,6 +167,14 @@ public class SqlCastFunction extends SqlFunction {
             case MULTISET:
             case STRUCTURED:
             case ROW:
+            case BINARY:
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case VARBINARY:
+            case FLOAT:
+            case DOUBLE:
             case OTHER:
                 // We use our casting checker logic only for these types,
                 //  as the differences with calcite casting checker logic generates issues

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -88,6 +88,7 @@ public class CastRuleProvider {
                 // To binary rules
                 .addRule(BinaryToBinaryCastRule.INSTANCE)
                 .addRule(RawToBinaryCastRule.INSTANCE)
+                .addRule(NumericToBinaryCastRule.INSTANCE)
                 // Collection rules
                 .addRule(ArrayToArrayCastRule.INSTANCE)
                 .addRule(MapToMapAndMultisetToMultisetCastRule.INSTANCE)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NumericToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/NumericToBinaryCastRule.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.planner.codegen.CodeGenUtils;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+
+import static org.apache.flink.table.planner.codegen.CodeGenUtils.newName;
+import static org.apache.flink.table.planner.functions.casting.BinaryToBinaryCastRule.couldPad;
+import static org.apache.flink.table.planner.functions.casting.BinaryToBinaryCastRule.trimOrPadByteArray;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.EMPTY_STR_LITERAL;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.arrayLength;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.constructorCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.stringConcat;
+
+/** {@link LogicalTypeFamily#NUMERIC} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule. */
+class NumericToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Number, byte[]> {
+
+    static final NumericToBinaryCastRule INSTANCE = new NumericToBinaryCastRule();
+
+    protected NumericToBinaryCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeFamily.INTEGER_NUMERIC)
+                        .input(LogicalTypeFamily.APPROXIMATE_NUMERIC)
+                        .target(LogicalTypeFamily.BINARY_STRING)
+                        .build());
+    }
+
+    @Override
+    protected String generateCodeBlockInternal(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            String returnVariable,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        final CastRuleUtils.CodeWriter writer = new CastRuleUtils.CodeWriter();
+        final String resultStringTerm = newName("resultString");
+        final String inputstr = stringConcat(EMPTY_STR_LITERAL, inputTerm);
+        writer.declStmt(BinaryStringData.class, resultStringTerm);
+        writer.assignStmt(resultStringTerm, constructorCall(BinaryStringData.class, inputstr));
+
+        if (context.legacyBehaviour()) {
+            return writer.assignStmt(returnVariable, methodCall(resultStringTerm, "toBytes"))
+                    .toString();
+        } else {
+            final int targetLength = LogicalTypeChecks.getLength(targetLogicalType);
+            final String byteArrayTerm = CodeGenUtils.newName("byteArrayTerm");
+
+            return writer.declStmt(
+                            byte[].class, byteArrayTerm, methodCall(resultStringTerm, "toBytes"))
+                    .ifStmt(
+                            arrayLength(byteArrayTerm) + " <= " + targetLength,
+                            thenWriter -> {
+                                if (couldPad(targetLogicalType, targetLength)) {
+                                    trimOrPadByteArray(
+                                            returnVariable,
+                                            targetLength,
+                                            byteArrayTerm,
+                                            thenWriter);
+                                } else {
+                                    thenWriter.assignStmt(returnVariable, byteArrayTerm);
+                                }
+                            },
+                            elseWriter ->
+                                    trimOrPadByteArray(
+                                            returnVariable,
+                                            targetLength,
+                                            byteArrayTerm,
+                                            elseWriter))
+                    .toString();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -186,6 +186,12 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "a", new byte[] {97, 0})
                         .fromCase(VARCHAR(4), "FC", new byte[] {70, 67})
                         .fromCase(STRING(), "foobar", new byte[] {102, 111})
+                        .fromCase(TINYINT(), (byte) 102, new byte[] {49, 48})
+                        .fromCase(SMALLINT(), (short) 5, new byte[] {53, 0})
+                        .fromCase(INT(), 55, new byte[] {53, 53})
+                        .fromCase(BIGINT(), 102L, new byte[] {49, 48})
+                        .fromCase(FLOAT(), 102.0f, new byte[] {49, 48})
+                        .fromCase(DOUBLE(), 102.0d, new byte[] {49, 48})
                         // Not supported - no fix
                         .failValidation(BOOLEAN(), true)
                         //
@@ -197,12 +203,15 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(BYTES(), new byte[] {11}, new byte[] {11, 0})
                         // Not supported - no fix
                         .failValidation(DECIMAL(5, 3), 12.345)
-                        .failValidation(TINYINT(), DEFAULT_NEGATIVE_TINY_INT)
-                        .failValidation(SMALLINT(), DEFAULT_POSITIVE_SMALL_INT)
-                        .failValidation(INT(), DEFAULT_POSITIVE_INT)
-                        .failValidation(BIGINT(), DEFAULT_POSITIVE_BIGINT)
-                        .failValidation(FLOAT(), DEFAULT_POSITIVE_FLOAT)
-                        .failValidation(DOUBLE(), DEFAULT_POSITIVE_DOUBLE)
+                        //
+                        .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, new byte[] {45, 53})
+                        .fromCase(SMALLINT(), DEFAULT_POSITIVE_SMALL_INT, new byte[] {49, 50})
+                        .fromCase(INT(), DEFAULT_POSITIVE_INT, new byte[] {49, 50})
+                        .fromCase(BIGINT(), DEFAULT_POSITIVE_BIGINT, new byte[] {49, 50})
+                        .fromCase(FLOAT(), DEFAULT_POSITIVE_FLOAT, new byte[] {49, 50})
+                        .fromCase(DOUBLE(), DEFAULT_POSITIVE_DOUBLE, new byte[] {49, 50})
+                        // Not supported - no fix
+                        .failValidation(DECIMAL(5, 3), 12.345)
                         .failValidation(DATE(), DEFAULT_DATE)
                         .failValidation(TIME(), DEFAULT_TIME)
                         .failValidation(TIMESTAMP(), DEFAULT_TIMESTAMP)
@@ -231,12 +240,6 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(BYTES(), DEFAULT_BYTES, new byte[] {0, 1, 2, 3})
                         // Not supported - no fix
                         .failValidation(DECIMAL(5, 3), 12.345)
-                        .failValidation(TINYINT(), DEFAULT_NEGATIVE_TINY_INT)
-                        .failValidation(SMALLINT(), DEFAULT_POSITIVE_SMALL_INT)
-                        .failValidation(INT(), DEFAULT_POSITIVE_INT)
-                        .failValidation(BIGINT(), DEFAULT_POSITIVE_BIGINT)
-                        .failValidation(FLOAT(), DEFAULT_POSITIVE_FLOAT)
-                        .failValidation(DOUBLE(), DEFAULT_POSITIVE_DOUBLE)
                         .failValidation(DATE(), DEFAULT_DATE)
                         .failValidation(TIME(), DEFAULT_TIME)
                         .failValidation(TIMESTAMP(), DEFAULT_TIMESTAMP)
@@ -251,6 +254,32 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         //
                         // RAW supported - check CastFunctionMiscITCase
                         .build(),
+                CastTestSpecBuilder.testCastTo(VARBINARY(6))
+                        .fromCase(TINYINT(), (byte) 102, new byte[] {49, 48, 50})
+                        .fromCase(SMALLINT(), (short) 5, new byte[] {53})
+                        .fromCase(INT(), 2345, new byte[] {50, 51, 52, 53})
+                        .fromCase(BIGINT(), 102L, new byte[] {49, 48, 50})
+                        .fromCase(FLOAT(), 102.0f, new byte[] {49, 48, 50, 46, 48})
+                        .fromCase(DOUBLE(), 102.0d, new byte[] {49, 48, 50, 46, 48})
+                        .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, new byte[] {45, 53})
+                        .fromCase(
+                                SMALLINT(),
+                                DEFAULT_POSITIVE_SMALL_INT,
+                                new byte[] {49, 50, 51, 52, 53})
+                        .fromCase(INT(), DEFAULT_POSITIVE_INT, new byte[] {49, 50, 51, 52, 53, 54})
+                        .fromCase(
+                                BIGINT(),
+                                DEFAULT_POSITIVE_BIGINT,
+                                new byte[] {49, 50, 51, 52, 53, 54})
+                        .fromCase(
+                                FLOAT(),
+                                DEFAULT_POSITIVE_FLOAT,
+                                new byte[] {49, 50, 51, 46, 52, 53})
+                        .fromCase(
+                                DOUBLE(),
+                                DEFAULT_POSITIVE_DOUBLE,
+                                new byte[] {49, 50, 51, 46, 52, 53})
+                        .build(),
                 CastTestSpecBuilder.testCastTo(BYTES())
                         .fromCase(BYTES(), null, null)
                         .fromCase(CHAR(4), "foo", new byte[] {102, 111, 111, 32})
@@ -261,21 +290,35 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 new byte[] {65, 112, 97, 99, 104, 101, 32, 70, 108, 105, 110, 107})
                         // Not supported - no fix
                         .failValidation(BOOLEAN(), true)
+                        .failValidation(DECIMAL(5, 3), 12.345)
+                        .failValidation(DATE(), DEFAULT_DATE)
+                        .failValidation(TIME(), DEFAULT_TIME)
+                        .failValidation(TIMESTAMP(), DEFAULT_TIMESTAMP)
                         //
                         .fromCase(BINARY(2), DEFAULT_BINARY, DEFAULT_BINARY)
                         .fromCase(VARBINARY(3), DEFAULT_VARBINARY, DEFAULT_VARBINARY)
                         .fromCase(BYTES(), DEFAULT_BYTES, DEFAULT_BYTES)
-                        // Not supported - no fix
-                        .failValidation(DECIMAL(5, 3), 12.345)
-                        .failValidation(TINYINT(), DEFAULT_NEGATIVE_TINY_INT)
-                        .failValidation(SMALLINT(), DEFAULT_POSITIVE_SMALL_INT)
-                        .failValidation(INT(), DEFAULT_POSITIVE_INT)
-                        .failValidation(BIGINT(), DEFAULT_POSITIVE_BIGINT)
-                        .failValidation(FLOAT(), DEFAULT_POSITIVE_FLOAT)
-                        .failValidation(DOUBLE(), DEFAULT_POSITIVE_DOUBLE)
-                        .failValidation(DATE(), DEFAULT_DATE)
-                        .failValidation(TIME(), DEFAULT_TIME)
-                        .failValidation(TIMESTAMP(), DEFAULT_TIMESTAMP)
+                        .fromCase(TINYINT(), DEFAULT_NEGATIVE_TINY_INT, new byte[] {45, 53})
+                        .fromCase(
+                                SMALLINT(),
+                                DEFAULT_POSITIVE_SMALL_INT,
+                                new byte[] {49, 50, 51, 52, 53})
+                        .fromCase(
+                                INT(),
+                                DEFAULT_POSITIVE_INT,
+                                new byte[] {49, 50, 51, 52, 53, 54, 55})
+                        .fromCase(
+                                BIGINT(),
+                                DEFAULT_POSITIVE_BIGINT,
+                                new byte[] {49, 50, 51, 52, 53, 54, 55, 56, 57, 48, 49})
+                        .fromCase(
+                                FLOAT(),
+                                DEFAULT_POSITIVE_FLOAT,
+                                new byte[] {49, 50, 51, 46, 52, 53, 54})
+                        .fromCase(
+                                DOUBLE(),
+                                DEFAULT_POSITIVE_DOUBLE,
+                                new byte[] {49, 50, 51, 46, 52, 53, 54, 55, 56, 57})
                         // TIMESTAMP_WITH_TIME_ZONE
                         .failValidation(TIMESTAMP_LTZ(), DEFAULT_TIMESTAMP_LTZ)
                         .failValidation(INTERVAL(YEAR(), MONTH()), DEFAULT_INTERVAL_YEAR)
@@ -338,7 +381,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(BYTES(), DEFAULT_BYTES)
                         //
                         .fromCase(DECIMAL(4, 3), 9.87, (byte) 9)
-                        // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
+                        // https://issues.apache.org/jira/browse/FLINK-24420 -Check out of range
                         // instead of overflow
                         .fromCase(DECIMAL(10, 3), 9123.87, (byte) -93)
                         .fromCase(TINYINT(), DEFAULT_POSITIVE_TINY_INT, DEFAULT_POSITIVE_TINY_INT)
@@ -385,7 +428,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(BYTES(), DEFAULT_BYTES)
                         //
                         .fromCase(DECIMAL(4, 3), 9.87, (short) 9)
-                        // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
+                        // https://issues.apache.org/jira/browse/FLINK-24420 -Check out of range
                         // instead of overflow
                         .fromCase(DECIMAL(10, 3), 91235.87, (short) 25699)
                         .fromCase(
@@ -443,7 +486,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(BYTES(), DEFAULT_BYTES)
                         //
                         .fromCase(DECIMAL(4, 3), 9.87, 9)
-                        // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
+                        // https://issues.apache.org/jira/browse/FLINK-24420 -Check out of range
                         // instead of overflow
                         .fromCase(DECIMAL(20, 3), 3276913443134.87, -146603714)
                         .fromCase(
@@ -560,7 +603,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .failValidation(BYTES(), DEFAULT_BYTES)
                         //
                         .fromCase(DECIMAL(4, 3), 9.87, 9.87f)
-                        // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
+                        // https://issues.apache.org/jira/browse/FLINK-24420 -Check out of range
                         // instead of overflow
                         .fromCase(DECIMAL(4, 3), 9.87, 9.87f)
                         .fromCase(DECIMAL(20, 3), 3276913443134.87, 3.27691351E12f)
@@ -988,6 +1031,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(STRING(), "Apache Flink", "Apache Flink")
                         .fromCase(STRING(), null, null)
                         .fromCase(BOOLEAN(), true, "TRUE")
+                        .fromCase(BINARY(1), new byte[] {5}, "\u0005")
                         .fromCase(BINARY(2), DEFAULT_BINARY, "\u0000\u0001")
                         .fromCase(BINARY(3), DEFAULT_BINARY, "\u0000\u0001\u0000")
                         .fromCase(VARBINARY(3), DEFAULT_VARBINARY, "\u0000\u0001\u0002")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -393,6 +393,7 @@ public class BinaryStringDataUtil {
      * <p>This code is mostly copied from LazyLong.parseLong in Hive.
      */
     public static long toLong(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         int sizeInBytes = str.getSizeInBytes();
         byte[] tmpBytes = getTmpBytes(str, sizeInBytes);
         if (sizeInBytes == 0) {
@@ -481,6 +482,8 @@ public class BinaryStringDataUtil {
      * performance reasons, like Hive does.
      */
     public static int toInt(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
+
         int sizeInBytes = str.getSizeInBytes();
         byte[] tmpBytes = getTmpBytes(str, sizeInBytes);
         if (sizeInBytes == 0) {
@@ -574,10 +577,12 @@ public class BinaryStringDataUtil {
     }
 
     public static double toDouble(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         return Double.parseDouble(str.toString());
     }
 
     public static float toFloat(BinaryStringData str) throws NumberFormatException {
+        str = transformer(str);
         return Float.parseFloat(str.toString());
     }
 
@@ -1191,5 +1196,17 @@ public class BinaryStringDataUtil {
         } else {
             return str.toString();
         }
+    }
+
+    public static BinaryStringData transformer(BinaryStringData str) {
+        StringBuilder std = new StringBuilder();
+        for (int i = 0; i < (str.toString()).length(); i++) {
+            if (Character.isIdentifierIgnorable((str.toString()).charAt(i))) {
+                std.append((int) ((str.toString()).charAt(i)) + "");
+            } else {
+                std.append(str.toString().charAt(i) + "");
+            }
+        }
+        return new BinaryStringData(std.toString());
     }
 }


### PR DESCRIPTION
### What is the purpose of the change
Implement` CAST` from `NUMBER` to `BINARY`/`VARBINART`/`BYTES `

### Brief change log
` CAST` from `NUMBER` to `BINARY`/`VARBINART`/`BYTES ` for Table API and SQL

Syntax:
`
CAST(BYTES AS NUMBER)
`

Examples:
```
Flink SQL> select cast(1 as BYTES);
res: x'31'

Flink SQL> select cast(cast(1 as DOUBLE) as BYTES);
res: x'312e30'

Flink SQL> select cast(cast(1 as BIGINT) as BYTES);
res: x'31'

```

### Verifying this change

- This change added tests in CastFunctionITCase.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)

