### PR TITLE
[FLINK-32809][yarn] Fixes YarnClusterDescriptor#isArchiveOnlyIncluded…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -305,23 +305,25 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     private void addShipArchives(List<File> shipArchives) {
         checkArgument(
                 isArchiveOnlyIncludedInShipArchiveFiles(shipArchives),
-                "Non-archive files are included.");
+                "Not all files included in shipArchives are archive files.");
         this.shipArchives.addAll(shipArchives);
     }
 
     private static boolean isArchiveOnlyIncludedInShipArchiveFiles(List<File> shipFiles) {
-        return shipFiles.stream()
+        List<String> shipFileNames = shipFiles.stream()
                 .filter(File::isFile)
                 .map(File::getName)
                 .map(String::toLowerCase)
-                .allMatch(
+                .filter(
                         name ->
                                 name.endsWith(".tar.gz")
                                         || name.endsWith(".tar")
                                         || name.endsWith(".tgz")
                                         || name.endsWith(".dst")
                                         || name.endsWith(".jar")
-                                        || name.endsWith(".zip"));
+                                        || name.endsWith(".zip"))
+                .collect(Collectors.toList());
+        return shipFileNames.size() == shipFiles.size();
     }
 
     private void isReadyForDeployment(ClusterSpecification clusterSpecification) throws Exception {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -305,12 +305,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     private void addShipArchives(List<File> shipArchives) {
         checkArgument(
                 isArchiveOnlyIncludedInShipArchiveFiles(shipArchives),
-                "Not all files included in shipArchives are archive files.");
+                "Directories or non-archive files are included.");
         this.shipArchives.addAll(shipArchives);
     }
 
     private static boolean isArchiveOnlyIncludedInShipArchiveFiles(List<File> shipFiles) {
-        List<String> shipFileNames = shipFiles.stream()
+        long archivedFileCount = shipFiles.stream()
                 .filter(File::isFile)
                 .map(File::getName)
                 .map(String::toLowerCase)
@@ -322,8 +322,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                                         || name.endsWith(".dst")
                                         || name.endsWith(".jar")
                                         || name.endsWith(".zip"))
-                .collect(Collectors.toList());
-        return shipFileNames.size() == shipFiles.size();
+                .count();
+        return archivedFileCount == shipFiles.size();
     }
 
     private void isReadyForDeployment(ClusterSpecification clusterSpecification) throws Exception {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -310,19 +310,20 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     }
 
     private static boolean isArchiveOnlyIncludedInShipArchiveFiles(List<File> shipFiles) {
-        long archivedFileCount = shipFiles.stream()
-                .filter(File::isFile)
-                .map(File::getName)
-                .map(String::toLowerCase)
-                .filter(
-                        name ->
-                                name.endsWith(".tar.gz")
-                                        || name.endsWith(".tar")
-                                        || name.endsWith(".tgz")
-                                        || name.endsWith(".dst")
-                                        || name.endsWith(".jar")
-                                        || name.endsWith(".zip"))
-                .count();
+        long archivedFileCount =
+                shipFiles.stream()
+                        .filter(File::isFile)
+                        .map(File::getName)
+                        .map(String::toLowerCase)
+                        .filter(
+                                name ->
+                                        name.endsWith(".tar.gz")
+                                                || name.endsWith(".tar")
+                                                || name.endsWith(".tgz")
+                                                || name.endsWith(".dst")
+                                                || name.endsWith(".jar")
+                                                || name.endsWith(".zip"))
+                        .count();
         return archivedFileCount == shipFiles.size();
     }
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -672,6 +672,30 @@ class YarnClusterDescriptorTest {
         }
     }
 
+    /** Tests that the {@code YarnConfigOptions.SHIP_ARCHIVES} only supports archive files. */
+    @Test
+    void testShipArchives() throws IOException {
+        final File homeFolder =
+                Files.createTempDirectory(temporaryFolder, UUID.randomUUID().toString()).toFile();
+        File dir1 = new File(homeFolder.getPath(), "dir1");
+        File archive1 = new File(homeFolder.getPath(), "archive1.zip");
+        File archive2 = new File(homeFolder.getPath(), "archive2.zip");
+        assertThat(dir1.createNewFile()).isTrue();
+        assertThat(archive1.createNewFile()).isTrue();
+        assertThat(archive2.createNewFile()).isTrue();
+        Configuration flinkConfiguration = new Configuration();
+        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+                Arrays.asList(dir1.getAbsolutePath(), archive1.getAbsolutePath()));
+
+        assertThrows("Not all files included in shipArchives are archive files.",
+                IllegalArgumentException.class,
+                () -> createYarnClusterDescriptor(flinkConfiguration));
+
+        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+                Arrays.asList(archive1.getAbsolutePath(), archive2.getAbsolutePath()));
+        createYarnClusterDescriptor(flinkConfiguration);
+    }
+
     /** Tests that the YarnClient is only shut down if it is not shared. */
     @Test
     void testYarnClientShutDown() {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -678,16 +678,24 @@ class YarnClusterDescriptorTest {
         final File homeFolder =
                 Files.createTempDirectory(temporaryFolder, UUID.randomUUID().toString()).toFile();
         File dir1 = new File(homeFolder.getPath(), "dir1");
+        File file1 = new File(homeFolder.getPath(), "file1");
         File archive1 = new File(homeFolder.getPath(), "archive1.zip");
         File archive2 = new File(homeFolder.getPath(), "archive2.zip");
-        assertThat(dir1.createNewFile()).isTrue();
+        assertThat(dir1.mkdirs()).isTrue();
+        assertThat(file1.createNewFile()).isTrue();
         assertThat(archive1.createNewFile()).isTrue();
         assertThat(archive2.createNewFile()).isTrue();
+
         Configuration flinkConfiguration = new Configuration();
         flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
                 Arrays.asList(dir1.getAbsolutePath(), archive1.getAbsolutePath()));
+        assertThrows("Directories or non-archive files are included.",
+                IllegalArgumentException.class,
+                () -> createYarnClusterDescriptor(flinkConfiguration));
 
-        assertThrows("Not all files included in shipArchives are archive files.",
+        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+                Arrays.asList(file1.getAbsolutePath(), archive1.getAbsolutePath()));
+        assertThrows("Directories or non-archive files are included.",
                 IllegalArgumentException.class,
                 () -> createYarnClusterDescriptor(flinkConfiguration));
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -687,19 +687,24 @@ class YarnClusterDescriptorTest {
         assertThat(archive2.createNewFile()).isTrue();
 
         Configuration flinkConfiguration = new Configuration();
-        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+        flinkConfiguration.set(
+                YarnConfigOptions.SHIP_ARCHIVES,
                 Arrays.asList(dir1.getAbsolutePath(), archive1.getAbsolutePath()));
-        assertThrows("Directories or non-archive files are included.",
+        assertThrows(
+                "Directories or non-archive files are included.",
                 IllegalArgumentException.class,
                 () -> createYarnClusterDescriptor(flinkConfiguration));
 
-        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+        flinkConfiguration.set(
+                YarnConfigOptions.SHIP_ARCHIVES,
                 Arrays.asList(file1.getAbsolutePath(), archive1.getAbsolutePath()));
-        assertThrows("Directories or non-archive files are included.",
+        assertThrows(
+                "Directories or non-archive files are included.",
                 IllegalArgumentException.class,
                 () -> createYarnClusterDescriptor(flinkConfiguration));
 
-        flinkConfiguration.set(YarnConfigOptions.SHIP_ARCHIVES,
+        flinkConfiguration.set(
+                YarnConfigOptions.SHIP_ARCHIVES,
                 Arrays.asList(archive1.getAbsolutePath(), archive2.getAbsolutePath()));
         createYarnClusterDescriptor(flinkConfiguration);
     }


### PR DESCRIPTION
…InShipArchiveFiles dose not work as expected

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

- *Fixed YarnClusterDescriptor#isArchiveonlyincludedinShipArchiveFiles dose not work as expected*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that `YarnConfigOptions.SHIP_ARCHIVES` only support archive files *


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
