### PR TITLE
[FLINK-32730][table-planner] Fix the bug of Scan reuse after projection pushdown without considering the dpp pattern

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
@@ -44,17 +44,15 @@ public class ReplaceScanWithCalcShuttle extends DefaultRelShuttle {
             // if there is already one Calc, we should merge it and new projection node.
             Calc calc = (Calc) rel;
             RelNode input = calc.getInput();
-            visitDppSource(input);
-
             RelNode newNode = replaceMap.get(input);
             if (newNode instanceof Calc && isMergeable(calc, (Calc) newNode)) {
+                visitScanInput(input);
                 return merge(calc, (Calc) newNode);
             }
         } else if (rel instanceof CommonPhysicalTableSourceScan) {
-            visitDppSource(rel);
-
             RelNode newNode = replaceMap.get(rel);
             if (newNode != null) {
+                visitScanInput(rel);
                 return newNode;
             }
         }
@@ -62,7 +60,7 @@ public class ReplaceScanWithCalcShuttle extends DefaultRelShuttle {
         return super.visit(rel);
     }
 
-    private void visitDppSource(RelNode scan) {
+    private void visitScanInput(RelNode scan) {
         // If scan has input such as dpp dynamic scan node, traverse its input first
         if (!scan.getInputs().isEmpty()) {
             super.visit(scan.getInput(0));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
@@ -46,24 +46,15 @@ public class ReplaceScanWithCalcShuttle extends DefaultRelShuttle {
             RelNode input = calc.getInput();
             RelNode newNode = replaceMap.get(input);
             if (newNode instanceof Calc && isMergeable(calc, (Calc) newNode)) {
-                visitScanInput(input);
                 return merge(calc, (Calc) newNode);
             }
         } else if (rel instanceof CommonPhysicalTableSourceScan) {
             RelNode newNode = replaceMap.get(rel);
             if (newNode != null) {
-                visitScanInput(rel);
                 return newNode;
             }
         }
 
         return super.visit(rel);
-    }
-
-    private void visitScanInput(RelNode scan) {
-        // If scan has input such as dpp dynamic scan node, traverse its input first
-        if (!scan.getInputs().isEmpty()) {
-            super.visit(scan.getInput(0));
-        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReplaceScanWithCalcShuttle.java
@@ -63,8 +63,7 @@ public class ReplaceScanWithCalcShuttle extends DefaultRelShuttle {
     }
 
     private void visitDppSource(RelNode scan) {
-        // If scan is BatchPhysicalDynamicFilteringTableSourceScan,the input should be recursive
-        // first
+        // If scan has input such as dpp dynamic scan node, traverse its input first
         if (!scan.getInputs().isEmpty()) {
             super.visit(scan.getInput(0));
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
@@ -42,7 +42,8 @@ public class ReusableScanVisitor extends RelVisitor {
             CommonPhysicalTableSourceScan scan = (CommonPhysicalTableSourceScan) node;
             String digest = getDigest(scan, true);
             digestToReusableScans.computeIfAbsent(digest, k -> new ArrayList<>()).add(scan);
-            // BatchPhysicalDynamicFilteringTableSourceScan has one input, so need to consider it
+            // If the scan has input such as dpp dynamic scan node, so also need to consider the
+            // input
             if (!scan.getInputs().isEmpty()) {
                 super.visit(scan.getInput(0), 0, scan);
             }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ReusableScanVisitor.java
@@ -42,6 +42,10 @@ public class ReusableScanVisitor extends RelVisitor {
             CommonPhysicalTableSourceScan scan = (CommonPhysicalTableSourceScan) node;
             String digest = getDigest(scan, true);
             digestToReusableScans.computeIfAbsent(digest, k -> new ArrayList<>()).add(scan);
+            // BatchPhysicalDynamicFilteringTableSourceScan has one input, so need to consider it
+            if (!scan.getInputs().isEmpty()) {
+                super.visit(scan.getInput(0), 0, scan);
+            }
         } else {
             super.visit(node, ordinal, parent);
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -332,7 +332,12 @@ public class ScanReuserUtils {
 
         // input should be the first item
         if (!scan.getInputs().isEmpty()) {
-            digest.add("input=[" + scan.getInputs() + "]");
+            digest.add(
+                    "input=["
+                            + scan.getInputs().stream()
+                                    .map(RelNode::getDigest)
+                                    .collect(Collectors.joining(","))
+                            + "]");
         }
 
         if (withoutEscape) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -329,6 +329,12 @@ public class ScanReuserUtils {
         TableSourceTable table = scan.tableSourceTable();
         List<String> digest = new ArrayList<>();
         digest.addAll(table.getNames());
+
+        // input should be the first item
+        if (!scan.getInputs().isEmpty()) {
+            digest.add("input=[" + scan.getInputs() + "]");
+        }
+
         if (withoutEscape) {
             digest.addAll(extraDigestsWithoutEscapedAndIgnored(table));
         } else {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.java
@@ -658,4 +658,47 @@ public class DynamicPartitionPruningProgramTest extends TableTestBase {
                         + " and dim.price < 500 and dim.price > 300";
         util.verifyRelPlan(query);
     }
+
+    @Test
+    public void testDppFactSideCannotReuseWithSameCommonSource() {
+        String query =
+                "SELECT * FROM(\n"
+                        + " Select fact_part.id, fact_part.price, fact_part.amount from fact_part join (Select * from dim) t1"
+                        + " on fact_part.fact_date_sk = dim_date_sk where t1.price < 500\n"
+                        + " UNION ALL Select fact_part.id, fact_part.price, fact_part.amount from fact_part)";
+        util.verifyExecPlan(query);
+    }
+
+    @Test
+    public void testDimSideReuseWithUnionAllTwoFactSide() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE fact_part2 (\n"
+                                + "  id BIGINT,\n"
+                                + "  name STRING,\n"
+                                + "  amount BIGINT,\n"
+                                + "  price BIGINT,\n"
+                                + "  fact_date_sk BIGINT\n"
+                                + ") PARTITIONED BY (fact_date_sk)\n"
+                                + "WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'runtime-source' = 'NewSource',\n"
+                                + " 'partition-list' = 'fact_date_sk:1990;fact_date_sk:1991;fact_date_sk:1992',\n"
+                                + " 'dynamic-filtering-fields' = 'fact_date_sk;amount',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")");
+
+        String query =
+                "SELECT * FROM\n"
+                        + "(SELECT /*+ BROADCAST(dim) */ fact.id, fact.price, fact.amount FROM (\n"
+                        + " SELECT id, price, amount, fact_date_sk FROM fact_part "
+                        + " UNION ALL SELECT id, price, amount, fact_date_sk FROM fact_part2) fact, dim\n"
+                        + " WHERE fact_date_sk = dim_date_sk"
+                        + " and dim.price < 500 and dim.price > 300)\n"
+                        + " UNION ALL (\n"
+                        + " SELECT fact_part.id, fact_part.price, fact_part.amount FROM fact_part, dim"
+                        + " WHERE fact_part.id = dim.id AND dim.amount < 10"
+                        + " )";
+        util.verifyExecPlan(query);
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFilteringTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFilteringTest.xml
@@ -145,10 +145,7 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
    :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
    +- Exchange(distribution=[hash[b10]])
       +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
-         +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
-            +- DynamicFilteringDataCollector(fields=[p])
-               +- Calc(select=[x, y, z, p], where=[>(x, 10)])
-                  +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
 
 == Optimized Execution Plan ==
 Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
@@ -156,7 +153,7 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
    :- Exchange(distribution=[hash[y]])
    :  +- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
    :     :- Exchange(distribution=[hash[p1]])
-   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])(reuse_id=[2])
+   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
    :     :     +- DynamicFilteringDataCollector(fields=[p])
    :     :        +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
    :     :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
@@ -164,7 +161,7 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
    :        +- Reused(reference_id=[1])
    +- Exchange(distribution=[hash[b10]])
       +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
-         +- Reused(reference_id=[2])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
 
 == Physical Execution Plan ==
 {
@@ -232,6 +229,12 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
       "ship_strategy" : "HASH[p1]",
       "side" : "second"
     } ]
+  }, {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
   }, {
     "id" : ,
     "type" : "Calc[]",
@@ -302,10 +305,7 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
    :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
    +- Exchange(distribution=[hash[b10]])
       +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
-         +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
-            +- DynamicFilteringDataCollector(fields=[p])
-               +- Calc(select=[x, y, z, p], where=[>(x, 10)])
-                  +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
 
 == Optimized Execution Plan ==
 Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
@@ -313,16 +313,16 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
    :- Exchange(distribution=[hash[y]])
    :  +- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
    :     :- Exchange(distribution=[hash[p1]])
-   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])(reuse_id=[2])
+   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
    :     :     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
    :     :        +- DynamicFilteringDataCollector(fields=[p])
    :     :           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
    :     :              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
    :     +- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])
    :        +- Reused(reference_id=[1])
-   +- Exchange(distribution=[hash[b10]], shuffle_mode=[BATCH])
+   +- Exchange(distribution=[hash[b10]])
       +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
-         +- Reused(reference_id=[2])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
 
 == Physical Execution Plan ==
 {
@@ -390,6 +390,12 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
       "ship_strategy" : "HASH[p1]",
       "side" : "second"
     } ]
+  }, {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
   }, {
     "id" : ,
     "type" : "Calc[]",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.xml
@@ -143,51 +143,45 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id,
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testDimSideReuseWithUnionAllTwoFactSide">
+  <TestCase name="testDimSideReuseAfterProjectionPushdown">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM
+      <![CDATA[SELECT /*+ BROADCAST(dim) */ fact3.* FROM
 (SELECT /*+ BROADCAST(dim) */ fact.id, fact.price, fact.amount FROM (
  SELECT id, price, amount, fact_date_sk FROM fact_part  UNION ALL SELECT id, price, amount, fact_date_sk FROM fact_part2) fact, dim
  WHERE fact_date_sk = dim_date_sk and dim.price < 500 and dim.price > 300)
- UNION ALL (
- SELECT fact_part.id, fact_part.price, fact_part.amount FROM fact_part, dim WHERE fact_part.id = dim.id AND dim.amount < 10 )]]>
+ fact3 JOIN dim ON fact3.amount = dim.id AND dim.amount < 10]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalUnion(all=[true])
-:- LogicalProject(id=[$0], price=[$1], amount=[$2])
-:  +- LogicalProject(id=[$0], price=[$1], amount=[$2])
-:     +- LogicalFilter(condition=[AND(=($3, $8), <($7, 500), >($7, 300))])
-:        +- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0, 0] options:[dim]]]])
-:           :- LogicalUnion(all=[true])
-:           :  :- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
-:           :  :  +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]], hints=[[[ALIAS inheritPath:[] options:[fact_part]]]])
-:           :  +- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
-:           :     +- LogicalTableScan(table=[[testCatalog, test_database, fact_part2]], hints=[[[ALIAS inheritPath:[] options:[fact_part2]]]])
-:           +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
-+- LogicalProject(id=[$0], price=[$3], amount=[$2])
-   +- LogicalFilter(condition=[AND(=($0, $5), <($7, 10))])
-      +- LogicalJoin(condition=[true], joinType=[inner])
-         :- LogicalTableScan(table=[[testCatalog, test_database, fact_part]], hints=[[[ALIAS inheritPath:[] options:[fact_part]]]])
-         +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
+LogicalProject(id=[$0], price=[$1], amount=[$2])
++- LogicalJoin(condition=[AND(=($2, $3), <($5, 10))], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[dim]]]])
+   :- LogicalProject(id=[$0], price=[$1], amount=[$2])
+   :  +- LogicalFilter(condition=[AND(=($3, $8), <($7, 500), >($7, 300))])
+   :     +- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0, 0] options:[dim]]]])
+   :        :- LogicalUnion(all=[true])
+   :        :  :- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
+   :        :  :  +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]], hints=[[[ALIAS inheritPath:[] options:[fact_part]]]])
+   :        :  +- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
+   :        :     +- LogicalTableScan(table=[[testCatalog, test_database, fact_part2]], hints=[[[ALIAS inheritPath:[] options:[fact_part2]]]])
+   :        +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
+   +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-MultipleInput(readOrder=[0,2,1,1,1], members=[\nUnion(all=[true], union=[id, price, amount])\n:- Calc(select=[id, price, amount])\n:  +- HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, price, amount, fact_date_sk, dim_date_sk], isBroadcast=[true], build=[right])\n:     :- Union(all=[true], union=[id, price, amount, fact_date_sk])\n:     :  :- [#4] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     :  +- [#5] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     +- [#1] Exchange(distribution=[broadcast])\n+- Calc(select=[id, price, amount])\n   +- HashJoin(joinType=[InnerJoin], where=[(id = id0)], select=[id, amount, price, id0], build=[right])\n      :- [#2] Exchange(distribution=[hash[id]])\n      +- [#3] Exchange(distribution=[hash[id]])\n])
-:- Exchange(distribution=[broadcast])
-:  +- Calc(select=[dim_date_sk], where=[SEARCH(price, Sarg[(300..500)])])(reuse_id=[2])
-:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[id, amount, price, dim_date_sk], metadata=[]]], fields=[id, amount, price, dim_date_sk])(reuse_id=[1])
-:- Exchange(distribution=[hash[id]])
-:  +- TableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, amount, price], metadata=[]]], fields=[id, amount, price])
-:- Exchange(distribution=[hash[id]])
-:  +- Calc(select=[id], where=[(amount < 10)])
-:     +- Reused(reference_id=[1])
-:- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
-:  +- DynamicFilteringDataCollector(fields=[dim_date_sk])(reuse_id=[3])
-:     +- Reused(reference_id=[2])
-+- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
-   +- Reused(reference_id=[3])
+Calc(select=[id, price, amount])
++- MultipleInput(readOrder=[0,0,1,1], members=[\nHashJoin(joinType=[InnerJoin], where=[(amount = id0)], select=[id, price, amount, id0], isBroadcast=[true], build=[right])\n:- Calc(select=[id, price, amount])\n:  +- HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, price, amount, fact_date_sk, dim_date_sk], isBroadcast=[true], build=[right])\n:     :- Union(all=[true], union=[id, price, amount, fact_date_sk])\n:     :  :- [#3] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     :  +- [#4] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     +- [#2] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[id], where=[(amount < 10)])(reuse_id=[2])
+   :     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[id, amount, price, dim_date_sk], metadata=[]]], fields=[id, amount, price, dim_date_sk])(reuse_id=[1])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[dim_date_sk], where=[SEARCH(price, Sarg[(300..500)])])
+   :     +- Reused(reference_id=[1])
+   :- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
+   :  +- DynamicFilteringDataCollector(fields=[id])(reuse_id=[3])
+   :     +- Reused(reference_id=[2])
+   +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
+      +- Reused(reference_id=[3])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/DynamicPartitionPruningProgramTest.xml
@@ -143,6 +143,54 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id,
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDimSideReuseWithUnionAllTwoFactSide">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM
+(SELECT /*+ BROADCAST(dim) */ fact.id, fact.price, fact.amount FROM (
+ SELECT id, price, amount, fact_date_sk FROM fact_part  UNION ALL SELECT id, price, amount, fact_date_sk FROM fact_part2) fact, dim
+ WHERE fact_date_sk = dim_date_sk and dim.price < 500 and dim.price > 300)
+ UNION ALL (
+ SELECT fact_part.id, fact_part.price, fact_part.amount FROM fact_part, dim WHERE fact_part.id = dim.id AND dim.amount < 10 )]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalUnion(all=[true])
+:- LogicalProject(id=[$0], price=[$1], amount=[$2])
+:  +- LogicalProject(id=[$0], price=[$1], amount=[$2])
+:     +- LogicalFilter(condition=[AND(=($3, $8), <($7, 500), >($7, 300))])
+:        +- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0, 0] options:[dim]]]])
+:           :- LogicalUnion(all=[true])
+:           :  :- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
+:           :  :  +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]], hints=[[[ALIAS inheritPath:[] options:[fact_part]]]])
+:           :  +- LogicalProject(id=[$0], price=[$3], amount=[$2], fact_date_sk=[$4])
+:           :     +- LogicalTableScan(table=[[testCatalog, test_database, fact_part2]], hints=[[[ALIAS inheritPath:[] options:[fact_part2]]]])
+:           +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
++- LogicalProject(id=[$0], price=[$3], amount=[$2])
+   +- LogicalFilter(condition=[AND(=($0, $5), <($7, 10))])
+      +- LogicalJoin(condition=[true], joinType=[inner])
+         :- LogicalTableScan(table=[[testCatalog, test_database, fact_part]], hints=[[[ALIAS inheritPath:[] options:[fact_part]]]])
+         +- LogicalTableScan(table=[[testCatalog, test_database, dim]], hints=[[[ALIAS inheritPath:[] options:[dim]]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+MultipleInput(readOrder=[0,2,1,1,1], members=[\nUnion(all=[true], union=[id, price, amount])\n:- Calc(select=[id, price, amount])\n:  +- HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, price, amount, fact_date_sk, dim_date_sk], isBroadcast=[true], build=[right])\n:     :- Union(all=[true], union=[id, price, amount, fact_date_sk])\n:     :  :- [#4] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     :  +- [#5] DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])\n:     +- [#1] Exchange(distribution=[broadcast])\n+- Calc(select=[id, price, amount])\n   +- HashJoin(joinType=[InnerJoin], where=[(id = id0)], select=[id, amount, price, id0], build=[right])\n      :- [#2] Exchange(distribution=[hash[id]])\n      +- [#3] Exchange(distribution=[hash[id]])\n])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[dim_date_sk], where=[SEARCH(price, Sarg[(300..500)])])(reuse_id=[2])
+:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[id, amount, price, dim_date_sk], metadata=[]]], fields=[id, amount, price, dim_date_sk])(reuse_id=[1])
+:- Exchange(distribution=[hash[id]])
+:  +- TableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, amount, price], metadata=[]]], fields=[id, amount, price])
+:- Exchange(distribution=[hash[id]])
+:  +- Calc(select=[id], where=[(amount < 10)])
+:     +- Reused(reference_id=[1])
+:- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
+:  +- DynamicFilteringDataCollector(fields=[dim_date_sk])(reuse_id=[3])
+:     +- Reused(reference_id=[2])
++- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part2, project=[id, price, amount, fact_date_sk], metadata=[]]], fields=[id, price, amount, fact_date_sk])
+   +- Reused(reference_id=[3])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDimTableFilteringFieldsNotInJoinKey">
     <Resource name="sql">
       <![CDATA[Select * from dim, fact_part where fact_part.id = dim.id and dim.price < 500]]>
@@ -240,6 +288,42 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id,
 :     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
 +- Exchange(distribution=[hash[fact_date_sk]])
    +- TableSourceScan(table=[[testCatalog, test_database, fact_part]], fields=[id, name, amount, price, fact_date_sk])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDppFactSideCannotReuseWithSameCommonSource">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM(
+ Select fact_part.id, fact_part.price, fact_part.amount from fact_part join (Select * from dim) t1 on fact_part.fact_date_sk = dim_date_sk where t1.price < 500
+ UNION ALL Select fact_part.id, fact_part.price, fact_part.amount from fact_part)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], price=[$1], amount=[$2])
++- LogicalUnion(all=[true])
+   :- LogicalProject(id=[$0], price=[$3], amount=[$2])
+   :  +- LogicalFilter(condition=[<($8, 500)])
+   :     +- LogicalJoin(condition=[=($4, $9)], joinType=[inner])
+   :        :- LogicalTableScan(table=[[testCatalog, test_database, fact_part]])
+   :        +- LogicalProject(id=[$0], male=[$1], amount=[$2], price=[$3], dim_date_sk=[$4])
+   :           +- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+   +- LogicalProject(id=[$0], price=[$3], amount=[$2])
+      +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Union(all=[true], union=[id, price, amount])
+:- Calc(select=[id, price, amount])
+:  +- HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, amount, price, fact_date_sk, dim_date_sk], build=[right])
+:     :- Exchange(distribution=[hash[fact_date_sk]])
+:     :  +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, amount, price, fact_date_sk], metadata=[]]], fields=[id, amount, price, fact_date_sk])
+:     :     +- DynamicFilteringDataCollector(fields=[dim_date_sk])
+:     :        +- Calc(select=[dim_date_sk], where=[(price < 500)])(reuse_id=[1])
+:     :           +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
+:     +- Exchange(distribution=[hash[dim_date_sk]])
+:        +- Reused(reference_id=[1])
++- TableSourceScan(table=[[testCatalog, test_database, fact_part, project=[id, price, amount], metadata=[]]], fields=[id, price, amount])
 ]]>
     </Resource>
   </TestCase>
@@ -541,17 +625,18 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id,
 :     :     +- DynamicFilteringDataCollector(fields=[dim_date_sk])
 :     :        +- HashJoin(joinType=[LeftSemiJoin], where=[=(price, price0)], select=[id, male, amount, price, dim_date_sk], build=[right])
 :     :           :- Exchange(distribution=[hash[price]])
-:     :           :  +- TableSourceScan(table=[[testCatalog, test_database, dim]], fields=[id, male, amount, price, dim_date_sk])
+:     :           :  +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[id, male, amount, price, dim_date_sk], metadata=[]]], fields=[id, male, amount, price, dim_date_sk])
 :     :           +- Exchange(distribution=[hash[price]])
 :     :              +- Calc(select=[price])
 :     :                 +- NestedLoopJoin(joinType=[InnerJoin], where=[=(amount, $f0)], select=[amount, price, $f0], build=[right], singleRowJoin=[true])
-:     :                    :- TableSourceScan(table=[[testCatalog, test_database, dim, project=[amount, price], metadata=[]]], fields=[amount, price])
+:     :                    :- Calc(select=[amount, price])
+:     :                    :  +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[id, male, amount, price, dim_date_sk], metadata=[]]], fields=[id, male, amount, price, dim_date_sk])
 :     :                    +- Exchange(distribution=[broadcast])
 :     :                       +- HashAggregate(isMerge=[true], select=[Final_SINGLE_VALUE(value$0, count$1) AS $f0])
 :     :                          +- Exchange(distribution=[single])
 :     :                             +- LocalHashAggregate(select=[Partial_SINGLE_VALUE(amount) AS (value$0, count$1)])
 :     :                                +- Calc(select=[CAST(2000 AS BIGINT) AS amount], where=[=(amount, 2000)])
-:     :                                   +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[amount], metadata=[]]], fields=[amount])
+:     :                                   +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[id, male, amount, price, dim_date_sk], metadata=[]]], fields=[id, male, amount, price, dim_date_sk])
 :     +- Exchange(distribution=[hash[id]])
 :        +- TableSourceScan(table=[[testCatalog, test_database, item]], fields=[id, amount, price])
 +- Exchange(distribution=[hash[dim_date_sk]])


### PR DESCRIPTION
## What is the purpose of the change

*Fix the bug of Scan reuse after projection pushdown without considering the dpp pattern, this will cause the fact side of dpp to reuse with non-dpp scan which has the same table, the plan and result is wrong, so we need to fix it.*


## Brief change log

  - *Fix the bug of Scan reuse after projection pushdown without considering the dpp pattern*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added plan tests in DynamicPartitionPruningProgramTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
