### PR TITLE
[BP-1.17]historgram

### DIFF
--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -53,13 +53,14 @@ Example:
     >>>             col("b").stddev_samp.alias("k"),
     >>>             col("b").var_pop.alias("l"),
     >>>             col("b").var_samp.alias("m"),
-    >>>             col("b").collect.alias("n"))
+    >>>             col("b").collect.alias("n"),
+    >>>             col("b").histogram.alias("n"))
 
 .. seealso:: :py:attr:`~Expression.sum`, :py:attr:`~Expression.sum0`, :py:attr:`~Expression.min`,
              :py:attr:`~Expression.max`, :py:attr:`~Expression.count`, :py:attr:`~Expression.avg`,
              :py:attr:`~Expression.stddev_pop`, :py:attr:`~Expression.stddev_samp`,
              :py:attr:`~Expression.var_pop`, :py:attr:`~Expression.var_samp`,
-             :py:attr:`~Expression.collect`
+             :py:attr:`~Expression.collect`, :py:attr:`~Expression.histogram`
 """
 
 _math_log_doc = """
@@ -173,6 +174,7 @@ def _make_aggregation_doc():
         Expression.var_pop: "Returns the population standard variance of an expression.",
         Expression.var_samp: "Returns the sample variance of a given expression.",
         Expression.collect: "Returns multiset aggregate of a given expression.",
+        Expression.histogram: "Returns multiset aggregate of a given expression."
     }
 
     for func, op_desc in aggregation_funcs.items():
@@ -831,6 +833,10 @@ class Expression(Generic[T]):
     @property
     def collect(self) -> 'Expression':
         return _unary_op("collect")(self)
+
+    @property
+    def histogram(self) -> 'Expression':
+        return _unary_op("histogram")(self)
 
     def alias(self, name: str, *extra_names: str) -> 'Expression[T]':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -88,6 +88,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GET;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GREATER_THAN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.HEX;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.HISTOGRAM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IF;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IF_NULL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IN;
@@ -513,6 +514,11 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns multiset aggregate of a given expression. */
     public OutType collect() {
         return toApiSpecificExpression(unresolvedCall(COLLECT, toExpr()));
+    }
+
+    /** Returns multiset aggregate of a given expression. */
+    public OutType histogram() {
+        return toApiSpecificExpression(unresolvedCall(HISTOGRAM, toExpr()));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/MapView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/dataview/MapView.java
@@ -277,4 +277,8 @@ public class MapView<K, V> implements DataView {
         this.keyType = keyType;
         this.valueType = valueType;
     }
+
+    public int size() {
+        return map.size();
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -384,6 +384,15 @@ public final class BuiltInFunctionDefinitions {
                             TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
+    public static final BuiltInFunctionDefinition HISTOGRAM =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("histogram")
+                    .kind(AGGREGATE)
+                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.aggregate.HistogramAggFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition COUNT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("count")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/SqlAggFunctionVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/SqlAggFunctionVisitor.java
@@ -85,6 +85,8 @@ public class SqlAggFunctionVisitor extends ExpressionDefaultVisitor<SqlAggFuncti
         AGG_DEF_SQL_OPERATOR_MAPPING.put(
                 BuiltInFunctionDefinitions.COLLECT, FlinkSqlOperatorTable.COLLECT);
         AGG_DEF_SQL_OPERATOR_MAPPING.put(
+                BuiltInFunctionDefinitions.HISTOGRAM, FlinkSqlOperatorTable.HISTOGRAM);
+        AGG_DEF_SQL_OPERATOR_MAPPING.put(
                 BuiltInFunctionDefinitions.JSON_OBJECTAGG_NULL_ON_NULL,
                 FlinkSqlOperatorTable.JSON_OBJECTAGG_NULL_ON_NULL);
         AGG_DEF_SQL_OPERATOR_MAPPING.put(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -968,6 +968,8 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     /** <code>LISTAGG</code> aggregate function. */
     public static final SqlListAggFunction LISTAGG = new SqlListAggFunction();
 
+    public static final SqlAggFunction HISTOGRAM = new SqlFinkHistogramAggFunction();
+
     // -----------------------------------------------------------------------------
     // Window SQL functions
     // -----------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlFinkHistogramAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlFinkHistogramAggFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
+
+/**
+ * SQL version of {@link BuiltInFunctionDefinition} in cases where {@link BridgingSqlFunction} does
+ * not apply. This is the case when the operator has a special parsing syntax or uses other
+ * Calcite-specific features that are not exposed via {@link BuiltInFunctionDefinition} yet.
+ *
+ * <p>If {@link SqlOperator} were an interface, this interface would extend from it.
+ */
+public class SqlFinkHistogramAggFunction extends SqlAggFunction {
+    public SqlFinkHistogramAggFunction() {
+        super(
+                "histogram",
+                null,
+                SqlKind.OTHER_FUNCTION,
+                ReturnTypes.TO_MULTISET,
+                null,
+                OperandTypes.ANY,
+                SqlFunctionCategory.SYSTEM,
+                false,
+                false,
+                Optionality.OPTIONAL);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -147,6 +147,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 1)
             Collect(args.head)
 
+          case HISTOGRAM =>
+            assert(args.size == 1)
+            Histogram(args.head)
+
           case EXTRACT =>
             assert(args.size == 2)
             Extract(args.head, args.last)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
@@ -81,6 +81,15 @@ case class Collect(child: PlannerExpression) extends Aggregation {
   override def toString: String = s"collect($child)"
 }
 
+/** Returns a multiset aggregates. */
+case class Histogram(child: PlannerExpression) extends Aggregation {
+
+  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
+
+  override private[flink] def resultType: TypeInformation[_] =
+    MultisetTypeInfo.getInfoFor(child.resultType)
+}
+
 /** Expression for calling a user-defined (table)aggregate function. */
 case class AggFunctionCall(
     aggregateFunction: ImperativeAggregateFunction[_, _],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -23,9 +23,9 @@ import org.apache.flink.table.planner.functions.aggfunctions._
 import org.apache.flink.table.planner.functions.aggfunctions.SingleValueAggFunction._
 import org.apache.flink.table.planner.functions.aggfunctions.SumWithRetractAggFunction._
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
-import org.apache.flink.table.planner.functions.sql.{SqlFirstLastValueAggFunction, SqlListAggFunction}
+import org.apache.flink.table.planner.functions.sql.{SqlFinkHistogramAggFunction, SqlFirstLastValueAggFunction, SqlListAggFunction}
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
-import org.apache.flink.table.runtime.functions.aggregate.{BuiltInAggregateFunction, CollectAggFunction, FirstValueAggFunction, FirstValueWithRetractAggFunction, JsonArrayAggFunction, JsonObjectAggFunction, LagAggFunction, LastValueAggFunction, LastValueWithRetractAggFunction, ListAggWithRetractAggFunction, ListAggWsWithRetractAggFunction, MaxWithRetractAggFunction, MinWithRetractAggFunction}
+import org.apache.flink.table.runtime.functions.aggregate.{BuiltInAggregateFunction, CollectAggFunction, FirstValueAggFunction, FirstValueWithRetractAggFunction, HistogramAggFunction, JsonArrayAggFunction, JsonObjectAggFunction, LagAggFunction, LastValueAggFunction, LastValueWithRetractAggFunction, ListAggWithRetractAggFunction, ListAggWsWithRetractAggFunction, MaxWithRetractAggFunction, MinWithRetractAggFunction}
 import org.apache.flink.table.runtime.functions.aggregate.BatchApproxCountDistinctAggFunctions._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
@@ -145,6 +145,8 @@ class AggFunctionFactory(
 
       case a: SqlAggFunction if a.getKind == SqlKind.COLLECT =>
         createCollectAggFunction(argTypes)
+
+      case a: SqlFinkHistogramAggFunction => createHistogramAggFunction(argTypes)
 
       case fn: SqlAggFunction if fn.getKind == SqlKind.JSON_OBJECTAGG =>
         val onNull = fn.asInstanceOf[SqlJsonObjectAggAggFunction].getNullClause
@@ -619,5 +621,9 @@ class AggFunctionFactory(
 
   private def createCollectAggFunction(argTypes: Array[LogicalType]): UserDefinedFunction = {
     new CollectAggFunction(argTypes(0))
+  }
+
+  private def createHistogramAggFunction(argTypes: Array[LogicalType]): UserDefinedFunction = {
+    new HistogramAggFunction(argTypes(0))
   }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/HistogramAggregationFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/HistogramAggregationFunctionITCase.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.MULTISET;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.types.RowKind.INSERT;
+import static org.apache.flink.util.CollectionUtil.entry;
+
+/** Tests for built-in Histogram aggregation functions. */
+class HistogramAggregationFunctionITCase extends BuiltInAggregateFunctionTestBase {
+
+    @Override
+    public Stream<TestSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSpec.forFunction(BuiltInFunctionDefinitions.HISTOGRAM)
+                        .withDescription("Basic Aggregation")
+                        .withSource(
+                                ROW(STRING(), INT()),
+                                Arrays.asList(
+                                        Row.ofKind(INSERT, "A", 1),
+                                        Row.ofKind(INSERT, "B", null),
+                                        Row.ofKind(INSERT, "C", 3)))
+                        .testResult(
+                                source -> "SELECT HISTOGRAM(f1) FROM " + source,
+                                source -> source.select(($("f1").histogram())),
+                                ROW(MULTISET(INT()).notNull()),
+                                ROW(MULTISET(INT())),
+                                Collections.singletonList(
+                                        Row.of(CollectionUtil.map(entry(1, 1), entry(3, 1)))))
+                        .testResult(
+                                source -> "SELECT HISTOGRAM(f0) FROM " + source,
+                                source -> source.select(($("f0").histogram())),
+                                ROW(MULTISET(STRING()).notNull()),
+                                ROW(MULTISET(STRING())),
+                                Collections.singletonList(
+                                        Row.of(
+                                                CollectionUtil.map(
+                                                        entry("A", 1),
+                                                        entry("B", 1),
+                                                        entry("C", 1))))));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/HistogramAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/HistogramAggFunction.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggregate;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.dataview.MapView;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
+
+/** @param <T> */
+public class HistogramAggFunction<T>
+        extends BuiltInAggregateFunction<MapData, HistogramAggFunction.HistogramAccumulator<T>> {
+
+    private final transient DataType elementDataType;
+
+    private static final int LIMIT = 1000;
+
+    public HistogramAggFunction(LogicalType elementType) {
+        this.elementDataType = toInternalDataType(elementType);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Planning
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public List<DataType> getArgumentDataTypes() {
+        return Collections.singletonList(elementDataType);
+    }
+
+    @Override
+    public DataType getAccumulatorDataType() {
+        return DataTypes.STRUCTURED(
+                HistogramAccumulator.class,
+                DataTypes.FIELD(
+                        "map",
+                        MapView.newMapViewDataType(elementDataType.notNull(), DataTypes.INT())));
+    }
+
+    @Override
+    public DataType getOutputDataType() {
+        return DataTypes.MULTISET(elementDataType).bridgedTo(MapData.class);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Runtime
+    // --------------------------------------------------------------------------------------------
+    /** Accumulator for COLLECT. */
+    public static class HistogramAccumulator<T> {
+        public MapView<T, Integer> map;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            HistogramAccumulator<?> that = (HistogramAccumulator<?>) o;
+            return Objects.equals(map, that.map);
+        }
+    }
+
+    @Override
+    public HistogramAccumulator<T> createAccumulator() {
+        final HistogramAccumulator<T> acc = new HistogramAccumulator<>();
+        acc.map = new MapView<>();
+        return acc;
+    }
+
+    public void resetAccumulator(HistogramAccumulator<T> accumulator) {
+        accumulator.map.clear();
+    }
+
+    public void accumulate(HistogramAccumulator<T> accumulator, T value) throws Exception {
+        if (accumulator.map.size() < LIMIT && value != null) {
+            Integer count = accumulator.map.get(value);
+            if (count != null) {
+                accumulator.map.put(value, count + 1);
+            } else {
+                accumulator.map.put(value, 1);
+            }
+        }
+    }
+
+    public void merge(HistogramAccumulator<T> accumulator, Iterable<HistogramAccumulator<T>> others)
+            throws Exception {
+        for (HistogramAccumulator<T> other : others) {
+            for (Map.Entry<T, Integer> entry : other.map.entries()) {
+                T key = entry.getKey();
+                Integer newCount = entry.getValue();
+                Integer oldCount = accumulator.map.get(key);
+                if (accumulator.map.size() < LIMIT) {
+                    if (oldCount == null) {
+                        accumulator.map.put(key, newCount);
+                    } else {
+                        accumulator.map.put(key, oldCount + newCount);
+                    }
+                }
+            }
+        }
+    }
+
+    public void retract(HistogramAccumulator<T> accumulator, T value) throws Exception {
+        if (value != null) {
+            Integer count = accumulator.map.get(value);
+            if (count != null) {
+                if (count == 1) {
+                    accumulator.map.remove(value);
+                } else {
+                    accumulator.map.put(value, count - 1);
+                }
+            } else {
+                accumulator.map.put(value, -1);
+            }
+        }
+    }
+
+    @Override
+    public MapData getValue(HistogramAccumulator<T> accumulator) {
+        return new GenericMapData(accumulator.map.getMap());
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
This is an implementation of HISTOGRAM

Returns a map containing the distinct values of col1 mapped to the number of times each one occurs for the given window. This version limits the number of distinct values which can be counted to 1000, beyond which any additional entries are ignored.

### Brief change log
HISTOGRAM for Table API and SQL

Syntax:
`HISTOGRAM(col1)
`
Arguments:
col1: the data in col1

Examples:
```
Flink SQL> create temporary table orders (
> orderId INT,
> price DECIMAL(10,3)
> )with(
> 'connector' = 'datagen',
> 'rows-per-second' = '5',
> 'fields.orderId.min' = '1',
> 'fields.orderId.max' = '20',
> 'fields.price.min' = '1',
> 'fields.price.max' = '200'
> );
```
`Flink SQL> select histogram(price) as map from orders;`

`res: {147.451 = 1， 65.765 = 1， 41.662 = 1 …}`

see also:
KsqlDB: https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-reference/aggregate-functions/#histogram


### Verifying this change

- This change added tests in CollectionFunctionsITCase.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

### Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)
