### PR TITLE
[FLINK-15959][flink-runtime] Add min number of slots configuration to limit total number of slots

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -129,10 +129,28 @@
             <td>Maximum memory size the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.max'.</td>
         </tr>
         <tr>
+            <td><h5>slotmanager.min-total-resource.cpu</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Double</td>
+            <td>Minimum cpu cores the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.min'.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.min-total-resource.memory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Minimum memory size the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.min'.</td>
+        </tr>
+        <tr>
             <td><h5>slotmanager.number-of-slots.max</h5></td>
             <td style="word-wrap: break-word;">infinite</td>
             <td>Integer</td>
             <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.number-of-slots.min</h5></td>
+            <td style="word-wrap: break-word;">infinite</td>
+            <td>Integer</td>
+            <td>Defines the minimum number of slots that the Flink cluster allocates. This configuration option is meant for cluster to initialize certain workers in best efforts when starting. This can be used to speed up a job startup process. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>
         <tr>
             <td><h5>slow-task-detector.check-interval</h5></td>

--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -69,10 +69,28 @@
             <td>Maximum memory size the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.max'.</td>
         </tr>
         <tr>
+            <td><h5>slotmanager.min-total-resource.cpu</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Double</td>
+            <td>Minimum cpu cores the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.min'.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.min-total-resource.memory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Minimum memory size the Flink cluster allocates for slots. Resources for JobManager and TaskManager framework are excluded. If not configured, it will be derived from 'slotmanager.number-of-slots.min'.</td>
+        </tr>
+        <tr>
             <td><h5>slotmanager.number-of-slots.max</h5></td>
             <td style="word-wrap: break-word;">infinite</td>
             <td>Integer</td>
             <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.number-of-slots.min</h5></td>
+            <td style="word-wrap: break-word;">infinite</td>
+            <td>Integer</td>
+            <td>Defines the minimum number of slots that the Flink cluster allocates. This configuration option is meant for cluster to initialize certain workers in best efforts when starting. This can be used to speed up a job startup process. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>
         <tr>
             <td><h5>slotmanager.redundant-taskmanager-num</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -64,6 +64,18 @@ public class ResourceManagerOptions {
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> MIN_SLOT_NUM =
+            ConfigOptions.key("slotmanager.number-of-slots.min")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "Defines the minimum number of slots that the Flink cluster allocates. This configuration option "
+                                    + "is meant for cluster to initialize certain workers in best efforts when starting. This can "
+                                    + "be used to speed up a job startup process. Note that this configuration option does not take "
+                                    + "effect for standalone clusters, where how many slots are allocated is not controlled by Flink.");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    @Documentation.OverrideDefault("infinite")
     public static final ConfigOption<Integer> MAX_SLOT_NUM =
             ConfigOptions.key("slotmanager.number-of-slots.max")
                     .intType()
@@ -75,6 +87,18 @@ public class ResourceManagerOptions {
                                     + "effect for standalone clusters, where how many slots are allocated is not controlled by Flink.");
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    public static final ConfigOption<Double> MIN_TOTAL_CPU =
+            ConfigOptions.key("slotmanager.min-total-resource.cpu")
+                    .doubleType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Minimum cpu cores the Flink cluster allocates for slots. Resources "
+                                    + "for JobManager and TaskManager framework are excluded. If "
+                                    + "not configured, it will be derived from '"
+                                    + MIN_SLOT_NUM.key()
+                                    + "'.");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     public static final ConfigOption<Double> MAX_TOTAL_CPU =
             ConfigOptions.key("slotmanager.max-total-resource.cpu")
                     .doubleType()
@@ -84,6 +108,18 @@ public class ResourceManagerOptions {
                                     + "for JobManager and TaskManager framework are excluded. If "
                                     + "not configured, it will be derived from '"
                                     + MAX_SLOT_NUM.key()
+                                    + "'.");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    public static final ConfigOption<MemorySize> MIN_TOTAL_MEM =
+            ConfigOptions.key("slotmanager.min-total-resource.memory")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Minimum memory size the Flink cluster allocates for slots. Resources "
+                                    + "for JobManager and TaskManager framework are excluded. If "
+                                    + "not configured, it will be derived from '"
+                                    + MIN_SLOT_NUM.key()
                                     + "'.");
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -92,7 +92,9 @@ public class ResourceManagerRuntimeServices {
                             slotManagerConfiguration.getNumSlotsPerWorker(),
                             slotManagerConfiguration.isEvenlySpreadOutSlots(),
                             slotManagerConfiguration.getTaskManagerTimeout(),
-                            slotManagerConfiguration.getRedundantTaskManagerNum()));
+                            slotManagerConfiguration.getRedundantTaskManagerNum(),
+                            slotManagerConfiguration.getMinTotalCpu(),
+                            slotManagerConfiguration.getMinTotalMem()));
         } else {
             return new DeclarativeSlotManager(
                     scheduledExecutor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -98,7 +98,7 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
             createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
                     throws ConfigurationException {
         return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
-                getConfigurationWithoutMaxResourceIfSet(configuration),
+                getConfigurationWithoutResourceLimitationIfSet(configuration),
                 ArbitraryWorkerResourceSpecFactory.INSTANCE);
     }
 
@@ -109,19 +109,35 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
      * @return the configuration for standalone ResourceManager
      */
     @VisibleForTesting
-    public static Configuration getConfigurationWithoutMaxResourceIfSet(
+    public static Configuration getConfigurationWithoutResourceLimitationIfSet(
             Configuration configuration) {
         final Configuration copiedConfig = new Configuration(configuration);
-        removeMaxResourceConfig(copiedConfig);
+        removeResourceLimitationConfig(copiedConfig);
 
         return copiedConfig;
     }
 
-    private static void removeMaxResourceConfig(Configuration configuration) {
-        // The max slot/cpu/memory limit should not take effect for standalone cluster, we
-        // overwrite the
-        // configure in case user
-        // sets this value by mistake.
+    private static void removeResourceLimitationConfig(Configuration configuration) {
+        // The slot/cpu/memory limit should not take effect for standalone cluster, we overwrite the
+        // configure in case user sets this value by mistake.
+        if (configuration.removeConfig(ResourceManagerOptions.MIN_SLOT_NUM)) {
+            LOG.warn(
+                    "Config option {} will be ignored in standalone mode.",
+                    ResourceManagerOptions.MIN_SLOT_NUM.key());
+        }
+
+        if (configuration.removeConfig(ResourceManagerOptions.MIN_TOTAL_CPU)) {
+            LOG.warn(
+                    "Config option {} will be ignored in standalone mode.",
+                    ResourceManagerOptions.MIN_TOTAL_CPU.key());
+        }
+
+        if (configuration.removeConfig(ResourceManagerOptions.MIN_TOTAL_MEM)) {
+            LOG.warn(
+                    "Config option {} will be ignored in standalone mode.",
+                    ResourceManagerOptions.MIN_TOTAL_MEM.key());
+        }
+
         if (configuration.removeConfig(ResourceManagerOptions.MAX_SLOT_NUM)) {
             LOG.warn(
                     "Config option {} will be ignored in standalone mode.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -30,16 +30,10 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Duration;
 
 /** Configuration for the {@link SlotManager}. */
 public class SlotManagerConfiguration {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SlotManagerConfiguration.class);
-
     private final Time taskManagerRequestTimeout;
     private final Time taskManagerTimeout;
     private final Duration requirementCheckDelay;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -44,6 +44,7 @@ public class DeclarativeSlotManagerBuilder {
     private WorkerResourceSpec defaultWorkerResourceSpec;
     private int numSlotsPerWorker;
     private SlotManagerMetricGroup slotManagerMetricGroup;
+    private int minSlotNum;
     private int maxSlotNum;
     private int redundantTaskManagerNum;
     private ResourceTracker resourceTracker;
@@ -61,6 +62,7 @@ public class DeclarativeSlotManagerBuilder {
         this.numSlotsPerWorker = 1;
         this.slotManagerMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+        this.minSlotNum = ResourceManagerOptions.MIN_SLOT_NUM.defaultValue();
         this.maxSlotNum = ResourceManagerOptions.MAX_SLOT_NUM.defaultValue();
         this.redundantTaskManagerNum =
                 ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
@@ -113,6 +115,11 @@ public class DeclarativeSlotManagerBuilder {
         return this;
     }
 
+    public DeclarativeSlotManagerBuilder setMinSlotNum(int minSlotNum) {
+        this.minSlotNum = minSlotNum;
+        return this;
+    }
+
     public DeclarativeSlotManagerBuilder setMaxSlotNum(int maxSlotNum) {
         this.maxSlotNum = maxSlotNum;
         return this;
@@ -158,8 +165,11 @@ public class DeclarativeSlotManagerBuilder {
                         evenlySpreadOutSlots,
                         defaultWorkerResourceSpec,
                         numSlotsPerWorker,
+                        minSlotNum,
                         maxSlotNum,
+                        new CPUResource(Double.MIN_VALUE),
                         new CPUResource(Double.MAX_VALUE),
+                        MemorySize.ZERO,
                         MemorySize.MAX_VALUE,
                         redundantTaskManagerNum);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -19,14 +19,17 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.resources.ExternalResource;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.util.ResourceCounter;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -523,6 +526,137 @@ class DefaultResourceAllocationStrategyTest {
         assertThat(result.getTaskManagersToRelease()).isEmpty();
     }
 
+    @Test
+    void testMinRequiredCPULimitInTryReconcile() {
+        CPUResource minRequiredCPU =
+                DEFAULT_SLOT_RESOURCE
+                        .getCpuCores()
+                        .multiply(NUM_OF_SLOTS)
+                        .multiply(BigDecimal.valueOf(4.5));
+
+        testMinResourceLimitInReconcile(minRequiredCPU, MemorySize.ZERO, 2);
+        testMinResourceLimitInReconcileWithNoResource(minRequiredCPU, MemorySize.ZERO, 5);
+    }
+
+    @Test
+    void testMinRequiredMemoryLimitInTryReconcile() {
+        MemorySize minRequiredMemory =
+                DEFAULT_SLOT_RESOURCE.getTotalMemory().multiply(NUM_OF_SLOTS).multiply(3.5);
+        testMinResourceLimitInReconcile(new CPUResource(0.0), minRequiredMemory, 1);
+        testMinResourceLimitInReconcileWithNoResource(new CPUResource(0.0), minRequiredMemory, 4);
+    }
+
+    @Test
+    void testMinRequiredCPULimitInTryFulfill() {
+        CPUResource minRequiredCPU =
+                DEFAULT_SLOT_RESOURCE
+                        .getCpuCores()
+                        .multiply(NUM_OF_SLOTS)
+                        .multiply(BigDecimal.valueOf(4.5));
+
+        testMinRequiredResourceLimitInFulfillRequirements(minRequiredCPU, MemorySize.ZERO, 4);
+    }
+
+    @Test
+    void testMinRequiredMemoryLimitInTryFulfill() {
+        MemorySize minRequiredMemory =
+                DEFAULT_SLOT_RESOURCE.getTotalMemory().multiply(NUM_OF_SLOTS).multiply(3.5);
+        testMinRequiredResourceLimitInFulfillRequirements(
+                new CPUResource(0.0), minRequiredMemory, 3);
+    }
+
+    void testMinResourceLimitInReconcile(
+            CPUResource minRequiredCPU,
+            MemorySize minRequiredMemory,
+            int pendingTaskManagersToAllocate) {
+
+        final TaskManagerInfo taskManagerInUse =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                        DEFAULT_SLOT_RESOURCE);
+
+        final TestingTaskManagerInfo taskManagerIdle =
+                new TestingTaskManagerInfo(
+                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                        DEFAULT_SLOT_RESOURCE);
+        taskManagerIdle.setIdleSince(System.currentTimeMillis() - 10);
+
+        final PendingTaskManager pendingTaskManager =
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), NUM_OF_SLOTS);
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(
+                                () -> Arrays.asList(taskManagerInUse, taskManagerIdle))
+                        .setPendingTaskManagersSupplier(
+                                () -> Collections.singletonList(pendingTaskManager))
+                        .build();
+
+        DefaultResourceAllocationStrategy strategy =
+                createStrategy(minRequiredCPU, minRequiredMemory);
+        ResourceReconcileResult result =
+                strategy.tryReconcileClusterResources(taskManagerResourceInfoProvider);
+
+        assertThat(result.getPendingTaskManagersToRelease()).isEmpty();
+        assertThat(result.getTaskManagersToRelease()).isEmpty();
+        assertThat(result.getPendingTaskManagersToAllocate())
+                .hasSize(pendingTaskManagersToAllocate);
+    }
+
+    void testMinResourceLimitInReconcileWithNoResource(
+            CPUResource minRequiredCPU,
+            MemorySize minRequiredMemory,
+            int pendingTaskManagersToAllocate) {
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(Arrays::asList)
+                        .setPendingTaskManagersSupplier(Arrays::asList)
+                        .build();
+
+        DefaultResourceAllocationStrategy strategy =
+                createStrategy(minRequiredCPU, minRequiredMemory);
+        ResourceReconcileResult result =
+                strategy.tryReconcileClusterResources(taskManagerResourceInfoProvider);
+
+        assertThat(result.getPendingTaskManagersToRelease()).isEmpty();
+        assertThat(result.getTaskManagersToRelease()).isEmpty();
+        assertThat(result.getPendingTaskManagersToAllocate())
+                .hasSize(pendingTaskManagersToAllocate);
+    }
+
+    void testMinRequiredResourceLimitInFulfillRequirements(
+            CPUResource minRequiredCPU,
+            MemorySize minRequiredMemory,
+            int pendingTaskManagersToAllocate) {
+
+        final JobID jobId = new JobID();
+        final List<ResourceRequirement> requirements = Collections.emptyList();
+
+        final PendingTaskManager pendingTaskManager =
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), NUM_OF_SLOTS);
+
+        final TaskManagerResourceInfoProvider taskManagerResourceInfoProvider =
+                TestingTaskManagerResourceInfoProvider.newBuilder()
+                        .setRegisteredTaskManagersSupplier(Arrays::asList)
+                        .setPendingTaskManagersSupplier(
+                                () -> Collections.singletonList(pendingTaskManager))
+                        .build();
+
+        DefaultResourceAllocationStrategy strategy =
+                createStrategy(minRequiredCPU, minRequiredMemory);
+        ResourceAllocationResult result =
+                strategy.tryFulfillRequirements(
+                        Collections.singletonMap(jobId, requirements),
+                        taskManagerResourceInfoProvider,
+                        resourceID -> false);
+
+        assertThat(result.getPendingTaskManagersToAllocate())
+                .hasSize(pendingTaskManagersToAllocate);
+    }
+
     private static DefaultResourceAllocationStrategy createStrategy(boolean evenlySpreadOutSlots) {
         return createStrategy(evenlySpreadOutSlots, 0);
     }
@@ -538,6 +672,20 @@ class DefaultResourceAllocationStrategyTest {
                 NUM_OF_SLOTS,
                 evenlySpreadOutSlots,
                 Time.milliseconds(0),
-                redundantTaskManagerNum);
+                redundantTaskManagerNum,
+                new CPUResource(0.0),
+                MemorySize.ZERO);
+    }
+
+    private static DefaultResourceAllocationStrategy createStrategy(
+            CPUResource minRequiredCPU, MemorySize minRequiredMemory) {
+        return new DefaultResourceAllocationStrategy(
+                DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
+                NUM_OF_SLOTS,
+                false,
+                Time.milliseconds(0),
+                0,
+                minRequiredCPU,
+                minRequiredMemory);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -57,7 +57,9 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
                         DEFAULT_NUM_SLOTS_PER_WORKER,
                         slotManagerConfiguration.isEvenlySpreadOutSlots(),
                         slotManagerConfiguration.getTaskManagerTimeout(),
-                        slotManagerConfiguration.getRedundantTaskManagerNum()));
+                        slotManagerConfiguration.getRedundantTaskManagerNum(),
+                        slotManagerConfiguration.getMinTotalCpu(),
+                        slotManagerConfiguration.getMinTotalMem()));
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -36,8 +36,11 @@ public class SlotManagerConfigurationBuilder {
     private boolean waitResultConsumedBeforeRelease;
     private WorkerResourceSpec defaultWorkerResourceSpec;
     private int numSlotsPerWorker;
+    private int minSlotNum;
     private int maxSlotNum;
+    private CPUResource minTotalCpu;
     private CPUResource maxTotalCpu;
+    private MemorySize minTotalMem;
     private MemorySize maxTotalMem;
     private int redundantTaskManagerNum;
     private boolean evenlySpreadOutSlots;
@@ -51,8 +54,11 @@ public class SlotManagerConfigurationBuilder {
         this.waitResultConsumedBeforeRelease = true;
         this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
         this.numSlotsPerWorker = 1;
+        this.minSlotNum = ResourceManagerOptions.MIN_SLOT_NUM.defaultValue();
         this.maxSlotNum = ResourceManagerOptions.MAX_SLOT_NUM.defaultValue();
+        this.minTotalCpu = new CPUResource(Double.MIN_VALUE);
         this.maxTotalCpu = new CPUResource(Double.MAX_VALUE);
+        this.minTotalMem = MemorySize.ZERO;
         this.maxTotalMem = MemorySize.MAX_VALUE;
         this.redundantTaskManagerNum =
                 ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM.defaultValue();
@@ -103,14 +109,26 @@ public class SlotManagerConfigurationBuilder {
         return this;
     }
 
+    public void setMinSlotNum(int minSlotNum) {
+        this.minSlotNum = minSlotNum;
+    }
+
     public SlotManagerConfigurationBuilder setMaxSlotNum(int maxSlotNum) {
         this.maxSlotNum = maxSlotNum;
         return this;
     }
 
+    public void setMinTotalCpu(CPUResource minTotalCpu) {
+        this.minTotalCpu = minTotalCpu;
+    }
+
     public SlotManagerConfigurationBuilder setMaxTotalCpu(CPUResource maxTotalCpu) {
         this.maxTotalCpu = maxTotalCpu;
         return this;
+    }
+
+    public void setMinTotalMem(MemorySize minTotalMem) {
+        this.minTotalMem = minTotalMem;
     }
 
     public SlotManagerConfigurationBuilder setMaxTotalMem(MemorySize maxTotalMem) {
@@ -141,8 +159,11 @@ public class SlotManagerConfigurationBuilder {
                 evenlySpreadOutSlots,
                 defaultWorkerResourceSpec,
                 numSlotsPerWorker,
+                minSlotNum,
                 maxSlotNum,
+                minTotalCpu,
                 maxTotalCpu,
+                minTotalMem,
                 maxTotalMem,
                 redundantTaskManagerNum);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -28,9 +28,28 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /** Tests for {@link SlotManagerConfiguration}. */
 class SlotManagerConfigurationTest {
+    @Test
+    void testComputeMinTotalCpu() throws Exception {
+        final Configuration configuration = new Configuration();
+        final int minSlotNum = 9;
+        final int numSlots = 3;
+        final double cpuCores = 10;
+        configuration.set(ResourceManagerOptions.MIN_SLOT_NUM, minSlotNum);
+        final SlotManagerConfiguration slotManagerConfiguration =
+                SlotManagerConfiguration.fromConfiguration(
+                        configuration,
+                        new WorkerResourceSpec.Builder()
+                                .setNumSlots(numSlots)
+                                .setCpuCores(cpuCores)
+                                .build());
+        assertThat(slotManagerConfiguration.getMinTotalCpu().getValue().doubleValue())
+                .isEqualTo(cpuCores * minSlotNum / numSlots);
+    }
+
     @Test
     void testComputeMaxTotalCpu() throws Exception {
         final Configuration configuration = new Configuration();
@@ -47,6 +66,29 @@ class SlotManagerConfigurationTest {
                                 .build());
         assertThat(slotManagerConfiguration.getMaxTotalCpu().getValue().doubleValue())
                 .isEqualTo(cpuCores * maxSlotNum / numSlots);
+    }
+
+    @Test
+    void testComputeMinTotalMemory() throws Exception {
+        final Configuration configuration = new Configuration();
+        final int minSlotNum = 1000;
+        final int numSlots = 10;
+        final int totalTaskManagerMB =
+                MemorySize.parse("1", MemorySize.MemoryUnit.TERA_BYTES).getMebiBytes();
+        configuration.set(ResourceManagerOptions.MIN_SLOT_NUM, minSlotNum);
+        final SlotManagerConfiguration slotManagerConfiguration =
+                SlotManagerConfiguration.fromConfiguration(
+                        configuration,
+                        new WorkerResourceSpec.Builder()
+                                .setNumSlots(numSlots)
+                                .setTaskHeapMemoryMB(totalTaskManagerMB)
+                                .build());
+        assertThat(slotManagerConfiguration.getMinTotalMem().getBytes())
+                .isEqualTo(
+                        BigDecimal.valueOf(MemorySize.ofMebiBytes(totalTaskManagerMB).getBytes())
+                                .multiply(BigDecimal.valueOf(minSlotNum))
+                                .divide(BigDecimal.valueOf(numSlots))
+                                .longValue());
     }
 
     @Test
@@ -70,5 +112,91 @@ class SlotManagerConfigurationTest {
                                 .multiply(BigDecimal.valueOf(maxSlotNum))
                                 .divide(BigDecimal.valueOf(numSlots))
                                 .longValue());
+    }
+
+    @Test
+    void testComputeMinMaxSlotNumIsValid() throws Exception {
+        final Configuration configuration = new Configuration();
+        final int minSlotNum = 9;
+        final int maxSlotNum = 12;
+        final int numSlots = 3;
+        final double cpuCores = 10;
+        configuration.set(ResourceManagerOptions.MIN_SLOT_NUM, minSlotNum);
+        configuration.set(ResourceManagerOptions.MAX_SLOT_NUM, maxSlotNum);
+
+        final SlotManagerConfiguration slotManagerConfiguration =
+                SlotManagerConfiguration.fromConfiguration(
+                        configuration,
+                        new WorkerResourceSpec.Builder()
+                                .setNumSlots(numSlots)
+                                .setCpuCores(cpuCores)
+                                .build());
+        assertThat(slotManagerConfiguration.getMinTotalCpu().getValue().doubleValue())
+                .isEqualTo(cpuCores * minSlotNum / numSlots);
+        assertThat(slotManagerConfiguration.getMaxTotalCpu().getValue().doubleValue())
+                .isEqualTo(cpuCores * maxSlotNum / numSlots);
+    }
+
+    @Test
+    void testComputeMinMaxSlotNumIsInvalid() {
+        final Configuration configuration = new Configuration();
+        final int minSlotNum = 10;
+        final int maxSlotNum = 11;
+        final int numSlots = 3;
+        configuration.set(ResourceManagerOptions.MIN_SLOT_NUM, minSlotNum);
+        configuration.set(ResourceManagerOptions.MAX_SLOT_NUM, maxSlotNum);
+
+        assertThatIllegalStateException()
+                .isThrownBy(
+                        () ->
+                                SlotManagerConfiguration.fromConfiguration(
+                                        configuration,
+                                        new WorkerResourceSpec.Builder()
+                                                .setNumSlots(numSlots)
+                                                .build()));
+    }
+
+    @Test
+    void testComputeMinMaxCpuIsInvalid() {
+        final Configuration configuration = new Configuration();
+        final double minTotalCpu = 10.0;
+        final double maxTotalCpu = 11.0;
+        final int numSlots = 3;
+        final double cpuCores = 3;
+        configuration.set(ResourceManagerOptions.MIN_TOTAL_CPU, minTotalCpu);
+        configuration.set(ResourceManagerOptions.MAX_TOTAL_CPU, maxTotalCpu);
+
+        assertThatIllegalStateException()
+                .isThrownBy(
+                        () ->
+                                SlotManagerConfiguration.fromConfiguration(
+                                        configuration,
+                                        new WorkerResourceSpec.Builder()
+                                                .setNumSlots(numSlots)
+                                                .setCpuCores(cpuCores)
+                                                .build()));
+    }
+
+    @Test
+    void testComputeMinMaxMemoryIsInvalid() {
+        final Configuration configuration = new Configuration();
+        final MemorySize minMemorySize = MemorySize.ofMebiBytes(500);
+        final MemorySize maxMemorySize = MemorySize.ofMebiBytes(700);
+        final int numSlots = 3;
+        configuration.set(ResourceManagerOptions.MIN_TOTAL_MEM, minMemorySize);
+        configuration.set(ResourceManagerOptions.MAX_TOTAL_MEM, maxMemorySize);
+
+        assertThatIllegalStateException()
+                .isThrownBy(
+                        () ->
+                                SlotManagerConfiguration.fromConfiguration(
+                                        configuration,
+                                        new WorkerResourceSpec.Builder()
+                                                .setNumSlots(numSlots)
+                                                .setTaskHeapMemoryMB(100)
+                                                .setManagedMemoryMB(100)
+                                                .setNetworkMemoryMB(100)
+                                                .setTaskOffHeapMemoryMB(100)
+                                                .build()));
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -239,7 +239,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
                 createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
                         throws ConfigurationException {
             return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
-                    StandaloneResourceManagerFactory.getConfigurationWithoutMaxResourceIfSet(
+                    StandaloneResourceManagerFactory.getConfigurationWithoutResourceLimitationIfSet(
                             configuration),
                     ArbitraryWorkerResourceSpecFactory.INSTANCE);
         }


### PR DESCRIPTION
## What is the purpose of the change

Add min number of slots configuration to limit total number of slots


## Brief change log

- Introduce "slotmanager.number-of-slots.min" configuration option with default value 0
- Introduce "slotmanager.min-total-resource.cpu" and "slotmanager.min-total-resource.memory" configuration option with default value derived from "slotmanager.number-of-slots.min"
- Make DefaultResourceAllocationStrategy respect the min number of cpu and memory. DefaultResourceAllocationStrategy will alway check the min resource requirement when reconciling cluster resources or fulfilling resource requirement.


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests **SlotManagerConfigurationTest#testComputeMinTotalCpu**,  **SlotManagerConfigurationTest#testComputeMinTotalMemory**, **SlotManagerConfigurationTest#testComputeMinMaxSlotNumIsValid**, **SlotManagerConfigurationTest#testComputeMinMaxSlotNumIsInValid**, **SlotManagerConfigurationTest#testComputeMinMaxMemoryIsInValid**, **SlotManagerConfigurationTest#testComputeMinMaxCpuIsInValid** to test new added options
  - Added unit tests **DefaultResourceAllocationStrategyTest#testMinRequiredCPULimitInTryReconcile**, **DefaultResourceAllocationStrategyTest#testMinRequiredMemoryLimitInTryReconcile**, **DefaultResourceAllocationStrategyTest#testMinRequiredCPULimitInTryFulfill** and **DefaultResourceAllocationStrategyTest#testMinRequiredMemoryLimitInTryFulfill**  to test the function in DefaultResourceAllocationStrategy

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) yes, it will affect the behavior of SlotManager in  JobManager
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? [FLIP-362](https://cwiki.apache.org/confluence/display/FLINK/FLIP-362%3A+Support+minimum+resource+limitation)
