### PR TITLE
[FLINK-32859][scheduler] Introduce the StateWithoutExecutionGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -43,7 +42,6 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
@@ -56,10 +54,9 @@ import java.util.concurrent.ScheduledFuture;
  * If there are enough slots for the {@link ExecutionGraph} to run, the state transitions to {@link
  * Executing}.
  */
-public class CreatingExecutionGraph implements State {
+public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
 
     private final Context context;
-    private final Logger logger;
     private final OperatorCoordinatorHandlerFactory operatorCoordinatorHandlerFactory;
 
     private final @Nullable ExecutionGraph previousExecutionGraph;
@@ -71,8 +68,8 @@ public class CreatingExecutionGraph implements State {
             Logger logger,
             OperatorCoordinatorHandlerFactory operatorCoordinatorFactory,
             ExecutionGraph previousExecutionGraph1) {
+        super(context, logger);
         this.context = context;
-        this.logger = logger;
         this.operatorCoordinatorHandlerFactory = operatorCoordinatorFactory;
 
         FutureUtils.assertNoException(
@@ -93,11 +90,12 @@ public class CreatingExecutionGraph implements State {
             @Nullable ExecutionGraphWithVertexParallelism executionGraphWithVertexParallelism,
             @Nullable Throwable throwable) {
         if (throwable != null) {
-            logger.info(
-                    "Failed to go from {} to {} because the ExecutionGraph creation failed.",
-                    CreatingExecutionGraph.class.getSimpleName(),
-                    Executing.class.getSimpleName(),
-                    throwable);
+            getLogger()
+                    .info(
+                            "Failed to go from {} to {} because the ExecutionGraph creation failed.",
+                            CreatingExecutionGraph.class.getSimpleName(),
+                            Executing.class.getSimpleName(),
+                            throwable);
             context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, throwable));
         } else {
             for (ExecutionVertex vertex :
@@ -109,8 +107,9 @@ public class CreatingExecutionGraph implements State {
                     context.tryToAssignSlots(executionGraphWithVertexParallelism);
 
             if (result.isSuccess()) {
-                logger.debug(
-                        "Successfully reserved and assigned the required slots for the ExecutionGraph.");
+                getLogger()
+                        .debug(
+                                "Successfully reserved and assigned the required slots for the ExecutionGraph.");
                 final ExecutionGraph executionGraph = result.getExecutionGraph();
                 final ExecutionGraphHandler executionGraphHandler =
                         new ExecutionGraphHandler(
@@ -144,21 +143,12 @@ public class CreatingExecutionGraph implements State {
                         operatorCoordinatorHandler,
                         Collections.emptyList());
             } else {
-                logger.debug(
-                        "Failed to reserve and assign the required slots. Waiting for new resources.");
+                getLogger()
+                        .debug(
+                                "Failed to reserve and assign the required slots. Waiting for new resources.");
                 context.goToWaitingForResources(previousExecutionGraph);
             }
         }
-    }
-
-    @Override
-    public void cancel() {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.CANCELED, null));
-    }
-
-    @Override
-    public void suspend(Throwable cause) {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
     }
 
     @Override
@@ -166,39 +156,12 @@ public class CreatingExecutionGraph implements State {
         return JobStatus.CREATED;
     }
 
-    @Override
-    public ArchivedExecutionGraph getJob() {
-        return context.getArchivedExecutionGraph(getJobStatus(), null);
-    }
-
-    @Override
-    public void handleGlobalFailure(
-            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
-    }
-
-    @Override
-    public Logger getLogger() {
-        return logger;
-    }
-
     /** Context for the {@link CreatingExecutionGraph} state. */
     interface Context
-            extends GlobalFailureHandler,
+            extends StateWithoutExecutionGraph.Context,
+                    GlobalFailureHandler,
                     StateTransitions.ToExecuting,
-                    StateTransitions.ToFinished,
                     StateTransitions.ToWaitingForResources {
-
-        /**
-         * Creates the {@link ArchivedExecutionGraph} for the given job status and cause. Cause can
-         * be null if there is no failure.
-         *
-         * @param jobStatus jobStatus to initialize the {@link ArchivedExecutionGraph} with
-         * @param cause cause describing a failure cause; {@code null} if there is none
-         * @return the created {@link ArchivedExecutionGraph}
-         */
-        ArchivedExecutionGraph getArchivedExecutionGraph(
-                JobStatus jobStatus, @Nullable Throwable cause);
 
         /**
          * Runs the given action after a delay if the state at this time equals the expected state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraph.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Abstract state class which contains its {@link Context} and {@link #logger} to execute common
+ * operations.
+ */
+abstract class StateWithoutExecutionGraph implements State {
+
+    private final Context context;
+
+    private final Logger logger;
+
+    StateWithoutExecutionGraph(Context context, Logger logger) {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    @Override
+    public void cancel() {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.CANCELED, null));
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        return context.getArchivedExecutionGraph(getJobStatus(), null);
+    }
+
+    @Override
+    public void handleGlobalFailure(
+            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    /** Context of the {@link StateWithoutExecutionGraph} state. */
+    interface Context extends StateTransitions.ToFinished {
+
+        /**
+         * Creates the {@link ArchivedExecutionGraph} for the given job status and cause. Cause can
+         * be null if there is no failure.
+         *
+         * @param jobStatus jobStatus to initialize the {@link ArchivedExecutionGraph} with
+         * @param cause cause describing a failure cause; {@code null} if there is none
+         * @return the created {@link ArchivedExecutionGraph}
+         */
+        ArchivedExecutionGraph getArchivedExecutionGraph(
+                JobStatus jobStatus, @Nullable Throwable cause);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -237,7 +237,7 @@ class WaitingForResources implements State, ResourceListener {
                 Logger log,
                 Duration initialResourceAllocationTimeout,
                 Duration resourceStabilizationTimeout,
-                ExecutionGraph previousExecutionGraph) {
+                @Nullable ExecutionGraph previousExecutionGraph) {
             this.context = context;
             this.log = log;
             this.initialResourceAllocationTimeout = initialResourceAllocationTimeout;
@@ -258,10 +258,5 @@ class WaitingForResources implements State, ResourceListener {
                     SystemClock.getInstance(),
                     previousExecutionGraph);
         }
-    }
-
-    @Nullable
-    public ExecutionGraph getPreviousExecutionGraph() {
-        return previousExecutionGraph;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.clock.Clock;
@@ -32,18 +31,14 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 /**
  * State which describes that the scheduler is waiting for resources in order to execute the job.
  */
-class WaitingForResources implements State, ResourceListener {
+class WaitingForResources extends StateWithoutExecutionGraph implements ResourceListener {
 
     private final Context context;
-
-    private final Logger log;
 
     private final Clock clock;
 
@@ -78,8 +73,8 @@ class WaitingForResources implements State, ResourceListener {
             Duration resourceStabilizationTimeout,
             Clock clock,
             @Nullable ExecutionGraph previousExecutionGraph) {
+        super(context, log);
         this.context = Preconditions.checkNotNull(context);
-        this.log = Preconditions.checkNotNull(log);
         this.resourceStabilizationTimeout =
                 Preconditions.checkNotNull(resourceStabilizationTimeout);
         this.clock = clock;
@@ -107,34 +102,8 @@ class WaitingForResources implements State, ResourceListener {
     }
 
     @Override
-    public void cancel() {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.CANCELED, null));
-    }
-
-    @Override
-    public void suspend(Throwable cause) {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
-    }
-
-    @Override
     public JobStatus getJobStatus() {
         return JobStatus.CREATED;
-    }
-
-    @Override
-    public ArchivedExecutionGraph getJob() {
-        return context.getArchivedExecutionGraph(getJobStatus(), null);
-    }
-
-    @Override
-    public void handleGlobalFailure(
-            Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
-    }
-
-    @Override
-    public Logger getLogger() {
-        return log;
     }
 
     @Override
@@ -174,8 +143,9 @@ class WaitingForResources implements State, ResourceListener {
     }
 
     private void resourceTimeout() {
-        log.debug(
-                "Initial resource allocation timeout triggered: Creating ExecutionGraph with available resources.");
+        getLogger()
+                .debug(
+                        "Initial resource allocation timeout triggered: Creating ExecutionGraph with available resources.");
         createExecutionGraphWithAvailableResources();
     }
 
@@ -185,18 +155,7 @@ class WaitingForResources implements State, ResourceListener {
 
     /** Context of the {@link WaitingForResources} state. */
     interface Context
-            extends StateTransitions.ToCreatingExecutionGraph, StateTransitions.ToFinished {
-
-        /**
-         * Creates the {@link ArchivedExecutionGraph} for the given job status and cause. Cause can
-         * be null if there is no failure.
-         *
-         * @param jobStatus jobStatus to initialize the {@link ArchivedExecutionGraph} with
-         * @param cause cause describing a failure cause; {@code null} if there is none
-         * @return the created {@link ArchivedExecutionGraph}
-         */
-        ArchivedExecutionGraph getArchivedExecutionGraph(
-                JobStatus jobStatus, @Nullable Throwable cause);
+            extends StateWithoutExecutionGraph.Context, StateTransitions.ToCreatingExecutionGraph {
 
         /**
          * Checks whether we have the desired resources.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithoutExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithoutExecutionGraphContext.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.function.Consumer;
+
+/** Mock the {@link StateWithoutExecutionGraph.Context}. */
+class MockStateWithoutExecutionGraphContext
+        implements StateWithoutExecutionGraph.Context, AfterEachCallback {
+
+    private final StateValidator<ArchivedExecutionGraph> finishedStateValidator =
+            new StateValidator<>("Finished");
+
+    private boolean hasStateTransition = false;
+
+    public void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
+        finishedStateValidator.expectInput(asserter);
+    }
+
+    @Override
+    public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
+        finishedStateValidator.validateInput(archivedExecutionGraph);
+        registerStateTransition();
+    }
+
+    @Override
+    public ArchivedExecutionGraph getArchivedExecutionGraph(
+            JobStatus jobStatus, @Nullable Throwable cause) {
+        return new ArchivedExecutionGraphBuilder()
+                .setState(jobStatus)
+                .setFailureCause(cause == null ? null : new ErrorInfo(cause, 1337))
+                .build();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        finishedStateValidator.close();
+    }
+
+    public boolean hasStateTransition() {
+        return hasStateTransition;
+    }
+
+    public void registerStateTransition() {
+        hasStateTransition = true;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraphTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.failure.FailureEnricherUtils;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link StateWithoutExecutionGraph} state. */
+public class StateWithoutExecutionGraphTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreatedTest.class);
+
+    @RegisterExtension
+    MockStateWithoutExecutionGraphContext ctx = new MockStateWithoutExecutionGraphContext();
+
+    @Test
+    void testCancelTransitionsToFinished() {
+        TestingStateWithoutExecutionGraph state = new TestingStateWithoutExecutionGraph(ctx, LOG);
+
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.CANCELED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNull();
+                });
+        state.cancel();
+    }
+
+    @Test
+    void testSuspendTransitionsToFinished() {
+        FlinkException expectedException = new FlinkException("This is a test exception");
+        TestingStateWithoutExecutionGraph state = new TestingStateWithoutExecutionGraph(ctx, LOG);
+
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.SUSPENDED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNotNull();
+                    assertThat(
+                                    archivedExecutionGraph
+                                            .getFailureInfo()
+                                            .getException()
+                                            .deserializeError(this.getClass().getClassLoader()))
+                            .isEqualTo(expectedException);
+                });
+
+        state.suspend(expectedException);
+    }
+
+    @Test
+    void testTransitionToFinishedOnGlobalFailure() {
+        TestingStateWithoutExecutionGraph state = new TestingStateWithoutExecutionGraph(ctx, LOG);
+        RuntimeException expectedException = new RuntimeException("This is a test exception");
+
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.FAILED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNotNull();
+                    assertThat(
+                                    archivedExecutionGraph
+                                            .getFailureInfo()
+                                            .getException()
+                                            .deserializeError(this.getClass().getClassLoader()))
+                            .isEqualTo(expectedException);
+                });
+
+        state.handleGlobalFailure(expectedException, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
+    }
+
+    private static final class TestingStateWithoutExecutionGraph
+            extends StateWithoutExecutionGraph {
+
+        TestingStateWithoutExecutionGraph(Context context, Logger logger) {
+            super(context, logger);
+        }
+
+        @Override
+        public JobStatus getJobStatus() {
+            return null;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -25,11 +25,14 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.ManualClock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,256 +48,234 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for the WaitingForResources state. */
-public class WaitingForResourcesTest extends TestLogger {
+class WaitingForResourcesTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WaitingForResourcesTest.class);
+
     private static final Duration STABILIZATION_TIMEOUT = Duration.ofSeconds(1);
+
+    @RegisterExtension MockContext ctx = new MockContext();
 
     /** WaitingForResources is transitioning to Executing if there are enough resources. */
     @Test
-    public void testTransitionToCreatingExecutionGraph() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> true);
+    void testTransitionToCreatingExecutionGraph() {
+        ctx.setHasDesiredResources(() -> true);
 
-            ctx.setExpectCreatingExecutionGraph();
+        ctx.setExpectCreatingExecutionGraph();
 
-            new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+        new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
 
-            ctx.runScheduledTasks();
-        }
+        ctx.runScheduledTasks();
     }
 
     @Test
-    public void testNotEnoughResources() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+    void testNotEnoughResources() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
 
-            // we expect no state transition.
-            wfr.onNewResourcesAvailable();
-        }
+        // we expect no state transition.
+        wfr.onNewResourcesAvailable();
     }
 
     @Test
-    public void testNotifyNewResourcesAvailable() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false); // initially, not enough resources
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
-            ctx.setHasDesiredResources(() -> true); // make resources available
-            ctx.setExpectCreatingExecutionGraph();
-            wfr.onNewResourcesAvailable(); // .. and notify
-        }
+    void testNotifyNewResourcesAvailable() {
+        ctx.setHasDesiredResources(() -> false); // initially, not enough resources
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
+        ctx.setHasDesiredResources(() -> true); // make resources available
+        ctx.setExpectCreatingExecutionGraph();
+        wfr.onNewResourcesAvailable(); // .. and notify
     }
 
     @Test
-    public void testSchedulingWithSufficientResourcesAndNoStabilizationTimeout() throws Exception {
-        try (MockContext ctx = new MockContext()) {
+    void testSchedulingWithSufficientResourcesAndNoStabilizationTimeout() {
+        Duration noStabilizationTimeout = Duration.ofMillis(0);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ofSeconds(1000), noStabilizationTimeout);
 
-            Duration noStabilizationTimeout = Duration.ofMillis(0);
-            WaitingForResources wfr =
-                    new WaitingForResources(
-                            ctx, log, Duration.ofSeconds(1000), noStabilizationTimeout);
-
-            ctx.setHasDesiredResources(() -> false);
-            ctx.setHasSufficientResources(() -> true);
-            ctx.setExpectCreatingExecutionGraph();
-            wfr.onNewResourcesAvailable();
-        }
+        ctx.setHasDesiredResources(() -> false);
+        ctx.setHasSufficientResources(() -> true);
+        ctx.setExpectCreatingExecutionGraph();
+        wfr.onNewResourcesAvailable();
     }
 
     @Test
-    public void testNoSchedulingIfStabilizationTimeoutIsConfigured() throws Exception {
-        try (MockContext ctx = new MockContext()) {
+    void testNoSchedulingIfStabilizationTimeoutIsConfigured() {
+        Duration stabilizationTimeout = Duration.ofMillis(50000);
 
-            Duration stabilizationTimeout = Duration.ofMillis(50000);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ofSeconds(1000), stabilizationTimeout);
 
-            WaitingForResources wfr =
-                    new WaitingForResources(
-                            ctx, log, Duration.ofSeconds(1000), stabilizationTimeout);
+        ctx.setHasDesiredResources(() -> false);
+        ctx.setHasSufficientResources(() -> true);
+        wfr.onNewResourcesAvailable();
+        // we are not triggering the scheduled tasks, to simulate a long stabilization timeout
 
-            ctx.setHasDesiredResources(() -> false);
-            ctx.setHasSufficientResources(() -> true);
-            wfr.onNewResourcesAvailable();
-            // we are not triggering the scheduled tasks, to simulate a long stabilization timeout
-
-            assertThat(ctx.hasStateTransition(), is(false));
-        }
+        assertThat(ctx.hasStateTransition()).isFalse();
     }
 
     @Test
-    public void testSchedulingWithSufficientResourcesAfterStabilizationTimeout() throws Exception {
-        try (MockContext ctx = new MockContext()) {
+    void testSchedulingWithSufficientResourcesAfterStabilizationTimeout() {
+        Duration initialResourceTimeout = Duration.ofMillis(-1);
+        Duration stabilizationTimeout = Duration.ofMillis(50_000L);
 
-            Duration initialResourceTimeout = Duration.ofMillis(-1);
-            Duration stabilizationTimeout = Duration.ofMillis(50_000L);
+        WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        initialResourceTimeout,
+                        stabilizationTimeout,
+                        ctx.getClock(),
+                        null);
+        // sufficient resources available
+        ctx.setHasDesiredResources(() -> false);
+        ctx.setHasSufficientResources(() -> true);
 
-            WaitingForResources wfr =
-                    new WaitingForResources(
-                            ctx,
-                            log,
-                            initialResourceTimeout,
-                            stabilizationTimeout,
-                            ctx.getClock(),
-                            null);
-            // sufficient resources available
-            ctx.setHasDesiredResources(() -> false);
-            ctx.setHasSufficientResources(() -> true);
+        // notify about sufficient resources
+        wfr.onNewResourcesAvailable();
 
-            // notify about sufficient resources
-            wfr.onNewResourcesAvailable();
+        ctx.setExpectCreatingExecutionGraph();
 
-            ctx.setExpectCreatingExecutionGraph();
+        // execute all runnables and trigger expected state transition
+        final Duration afterStabilizationTimeout = stabilizationTimeout.plusMillis(1);
+        ctx.advanceTimeByMillis(afterStabilizationTimeout.toMillis());
 
-            // execute all runnables and trigger expected state transition
-            final Duration afterStabilizationTimeout = stabilizationTimeout.plusMillis(1);
-            ctx.advanceTimeByMillis(afterStabilizationTimeout.toMillis());
+        ctx.runScheduledTasks(afterStabilizationTimeout.toMillis());
 
-            ctx.runScheduledTasks(afterStabilizationTimeout.toMillis());
-
-            assertThat(ctx.hasStateTransition(), is(true));
-        }
+        assertThat(ctx.hasStateTransition()).isTrue();
     }
 
     @Test
-    public void testStabilizationTimeoutReset() throws Exception {
-        try (MockContext ctx = new MockContext()) {
+    void testStabilizationTimeoutReset() {
+        Duration initialResourceTimeout = Duration.ofMillis(-1);
+        Duration stabilizationTimeout = Duration.ofMillis(50L);
 
-            Duration initialResourceTimeout = Duration.ofMillis(-1);
-            Duration stabilizationTimeout = Duration.ofMillis(50L);
+        WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        initialResourceTimeout,
+                        stabilizationTimeout,
+                        ctx.getClock(),
+                        null);
 
-            WaitingForResources wfr =
-                    new WaitingForResources(
-                            ctx,
-                            log,
-                            initialResourceTimeout,
-                            stabilizationTimeout,
-                            ctx.getClock(),
-                            null);
+        ctx.setHasDesiredResources(() -> false);
 
-            ctx.setHasDesiredResources(() -> false);
+        // notify about resources, trigger stabilization timeout
+        ctx.setHasSufficientResources(() -> true);
+        ctx.advanceTimeByMillis(40); // advance time, but don't trigger stabilizationTimeout
+        wfr.onNewResourcesAvailable();
 
-            // notify about resources, trigger stabilization timeout
-            ctx.setHasSufficientResources(() -> true);
-            ctx.advanceTimeByMillis(40); // advance time, but don't trigger stabilizationTimeout
-            wfr.onNewResourcesAvailable();
+        // notify again, but insufficient (reset stabilization timeout)
+        ctx.setHasSufficientResources(() -> false);
+        ctx.advanceTimeByMillis(40);
+        wfr.onNewResourcesAvailable();
 
-            // notify again, but insufficient (reset stabilization timeout)
-            ctx.setHasSufficientResources(() -> false);
-            ctx.advanceTimeByMillis(40);
-            wfr.onNewResourcesAvailable();
+        // notify again, but sufficient, trigger timeout
+        ctx.setHasSufficientResources(() -> true);
+        ctx.advanceTimeByMillis(40);
+        wfr.onNewResourcesAvailable();
 
-            // notify again, but sufficient, trigger timeout
-            ctx.setHasSufficientResources(() -> true);
-            ctx.advanceTimeByMillis(40);
-            wfr.onNewResourcesAvailable();
+        // sanity check: no state transition has been triggered so far
+        assertThat(ctx.hasStateTransition()).isFalse();
+        assertThat(ctx.getTestDuration()).isGreaterThan(stabilizationTimeout);
 
-            // sanity check: no state transition has been triggered so far
-            assertThat(ctx.hasStateTransition(), is(false));
-            assertThat(ctx.getTestDuration(), greaterThan(stabilizationTimeout));
+        ctx.setExpectCreatingExecutionGraph();
 
-            ctx.setExpectCreatingExecutionGraph();
+        ctx.advanceTimeByMillis(1);
+        assertThat(ctx.hasStateTransition()).isFalse();
 
-            ctx.advanceTimeByMillis(1);
-            assertThat(ctx.hasStateTransition(), is(false));
-
-            ctx.advanceTimeByMillis(stabilizationTimeout.toMillis());
-            assertThat(ctx.hasStateTransition(), is(true));
-        }
+        ctx.advanceTimeByMillis(stabilizationTimeout.toMillis());
+        assertThat(ctx.hasStateTransition()).isTrue();
     }
 
     @Test
-    public void testNoStateTransitionOnNoResourceTimeout() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ofMillis(-1), STABILIZATION_TIMEOUT);
+    void testNoStateTransitionOnNoResourceTimeout() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ofMillis(-1), STABILIZATION_TIMEOUT);
 
-            ctx.runScheduledTasks();
-            assertThat(ctx.hasStateTransition(), is(false));
-        }
+        ctx.runScheduledTasks();
+        assertThat(ctx.hasStateTransition()).isFalse();
     }
 
     @Test
-    public void testStateTransitionOnResourceTimeout() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+    void testStateTransitionOnResourceTimeout() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
 
-            ctx.setExpectCreatingExecutionGraph();
+        ctx.setExpectCreatingExecutionGraph();
 
-            ctx.runScheduledTasks();
-        }
+        ctx.runScheduledTasks();
     }
 
     @Test
-    public void testTransitionToFinishedOnGlobalFailure() throws Exception {
-        final String testExceptionString = "This is a test exception";
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+    void testTransitionToFinishedOnGlobalFailure() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
+        RuntimeException expectedException = new RuntimeException("This is a test exception");
 
-            ctx.setExpectFinished(
-                    archivedExecutionGraph -> {
-                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
-                        assertThat(archivedExecutionGraph.getFailureInfo(), notNullValue());
-                        assertTrue(
-                                archivedExecutionGraph
-                                        .getFailureInfo()
-                                        .getExceptionAsString()
-                                        .contains(testExceptionString));
-                    });
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.FAILED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNotNull();
+                    assertThat(
+                                    archivedExecutionGraph
+                                            .getFailureInfo()
+                                            .getException()
+                                            .deserializeError(this.getClass().getClassLoader()))
+                            .isEqualTo(expectedException);
+                });
 
-            wfr.handleGlobalFailure(
-                    new RuntimeException(testExceptionString),
-                    FailureEnricherUtils.EMPTY_FAILURE_LABELS);
-        }
+        wfr.handleGlobalFailure(expectedException, FailureEnricherUtils.EMPTY_FAILURE_LABELS);
     }
 
     @Test
-    public void testCancel() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+    void testCancel() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
 
-            ctx.setExpectFinished(
-                    (archivedExecutionGraph -> {
-                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.CANCELED));
-                    }));
-            wfr.cancel();
-        }
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.CANCELED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNull();
+                });
+        wfr.cancel();
     }
 
     @Test
-    public void testSuspend() throws Exception {
-        try (MockContext ctx = new MockContext()) {
-            ctx.setHasDesiredResources(() -> false);
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, Duration.ZERO, STABILIZATION_TIMEOUT);
+    void testSuspend() {
+        ctx.setHasDesiredResources(() -> false);
+        WaitingForResources wfr =
+                new WaitingForResources(ctx, LOG, Duration.ZERO, STABILIZATION_TIMEOUT);
 
-            ctx.setExpectFinished(
-                    (archivedExecutionGraph -> {
-                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
-                        assertThat(archivedExecutionGraph.getFailureInfo(), notNullValue());
-                    }));
+        FlinkException expectedException = new FlinkException("This is a test exception");
 
-            wfr.suspend(new RuntimeException("suspend"));
-        }
+        ctx.setExpectFinished(
+                archivedExecutionGraph -> {
+                    assertThat(archivedExecutionGraph.getState()).isEqualTo(JobStatus.SUSPENDED);
+                    assertThat(archivedExecutionGraph.getFailureInfo()).isNotNull();
+                    assertThat(
+                                    archivedExecutionGraph
+                                            .getFailureInfo()
+                                            .getException()
+                                            .deserializeError(this.getClass().getClassLoader()))
+                            .isEqualTo(expectedException);
+                });
+
+        wfr.suspend(expectedException);
     }
 
     @Test
-    public void testInternalRunScheduledTasks_correctExecutionOrder() {
-        MockContext ctx = new MockContext();
+    void testInternalRunScheduledTasks_correctExecutionOrder() {
         AtomicBoolean firstRun = new AtomicBoolean(false);
         AtomicBoolean secondRun = new AtomicBoolean(false);
         AtomicBoolean thirdRun = new AtomicBoolean(false);
@@ -302,16 +283,12 @@ public class WaitingForResourcesTest extends TestLogger {
         Runnable runFirstBecauseOfLowDelay = () -> firstRun.set(true);
         Runnable runSecondBecauseOfScheduleOrder =
                 () -> {
-                    if (!firstRun.get()) {
-                        fail("order violated");
-                    }
+                    assertThat(firstRun).as("order violated").isTrue();
                     secondRun.set(true);
                 };
         Runnable runLastBecauseOfHighDelay =
                 () -> {
-                    if (!secondRun.get()) {
-                        fail("order violated");
-                    }
+                    assertThat(secondRun).as("order violated").isTrue();
                     thirdRun.set(true);
                 };
 
@@ -328,19 +305,15 @@ public class WaitingForResourcesTest extends TestLogger {
 
         ctx.runScheduledTasks();
 
-        assertThat(thirdRun.get(), is(true));
+        assertThat(thirdRun).isTrue();
     }
 
     @Test
-    public void testInternalRunScheduledTasks_tasksAreRemovedAfterExecution() {
-        MockContext ctx = new MockContext();
-
+    void testInternalRunScheduledTasks_tasksAreRemovedAfterExecution() {
         AtomicBoolean executed = new AtomicBoolean(false);
         Runnable executeOnce =
                 () -> {
-                    if (executed.get()) {
-                        fail("Multiple executions");
-                    }
+                    assertThat(executed).as("Multiple executions").isFalse();
                     executed.set(true);
                 };
 
@@ -349,12 +322,11 @@ public class WaitingForResourcesTest extends TestLogger {
         // execute at least twice
         ctx.runScheduledTasks();
         ctx.runScheduledTasks();
+        assertThat(executed).isTrue();
     }
 
     @Test
-    public void testInternalRunScheduledTasks_upperBoundRespected() {
-        MockContext ctx = new MockContext();
-
+    void testInternalRunScheduledTasks_upperBoundRespected() {
         Runnable executeNever = () -> fail("Not expected");
 
         ctx.runIfState(new AdaptiveSchedulerTest.DummyState(), executeNever, Duration.ofMillis(10));
@@ -363,8 +335,7 @@ public class WaitingForResourcesTest extends TestLogger {
     }
 
     @Test
-    public void testInternalRunScheduledTasks_scheduleTaskFromRunnable() {
-        MockContext ctx = new MockContext();
+    void testInternalRunScheduledTasks_scheduleTaskFromRunnable() {
         final State state = new AdaptiveSchedulerTest.DummyState();
 
         AtomicBoolean executed = new AtomicBoolean(false);
@@ -378,10 +349,11 @@ public class WaitingForResourcesTest extends TestLogger {
 
         // choose time that includes inner execution as well
         ctx.runScheduledTasks(10);
-        assertThat(executed.get(), is(true));
+        assertThat(executed).isTrue();
     }
 
-    private static class MockContext implements WaitingForResources.Context, AutoCloseable {
+    private static class MockContext implements WaitingForResources.Context, AfterEachCallback {
+
         private static final Logger LOG = LoggerFactory.getLogger(MockContext.class);
 
         private final StateValidator<Void> creatingExecutionGraphStateValidator =
@@ -441,7 +413,7 @@ public class WaitingForResourcesTest extends TestLogger {
         }
 
         @Override
-        public void close() throws Exception {
+        public void afterEach(ExtensionContext extensionContext) throws Exception {
             creatingExecutionGraphStateValidator.close();
             finishedStateValidator.close();
         }
@@ -474,7 +446,7 @@ public class WaitingForResourcesTest extends TestLogger {
             final ScheduledTask<Void> scheduledTask =
                     new ScheduledTask<>(
                             () -> {
-                                if (!hasStateTransition) {
+                                if (!hasStateTransition()) {
                                     action.run();
                                 }
 
@@ -490,17 +462,21 @@ public class WaitingForResourcesTest extends TestLogger {
         @Override
         public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
             finishedStateValidator.validateInput(archivedExecutionGraph);
-            hasStateTransition = true;
+            registerStateTransition();
         }
 
         @Override
         public void goToCreatingExecutionGraph(@Nullable ExecutionGraph previousExecutionGraph) {
             creatingExecutionGraphStateValidator.validateInput(null);
-            hasStateTransition = true;
+            registerStateTransition();
         }
 
         public boolean hasStateTransition() {
             return hasStateTransition;
+        }
+
+        public void registerStateTransition() {
+            hasStateTransition = true;
         }
 
         public Clock getClock() {
@@ -550,6 +526,6 @@ public class WaitingForResourcesTest extends TestLogger {
     }
 
     static <T> Consumer<T> assertNonNull() {
-        return (item) -> assertThat(item, notNullValue());
+        return (item) -> assertThat(item).isNotNull();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, most of states of adaptive scheduler extends StateWithExecutionGraph, and it can reduce a lots of repeated code.

We can define the StateWithoutExecutionGraph and the corresponding Context as well, then the rest of states can extend the StateWithoutExecutionGraph, such as: Created, WaitingForResources, CreatingExecutionGraph.

This improvement can reduce a lot of code for these states, such as: cancel(), suspend(), getJob(), handleGlobalFailure() and getLogger().

These methods of Created, WaitingForResources and CreatingExecutionGraph are same.



## Brief change log

[FLINK-32859][scheduler] Introduce the StateWithoutExecutionGraph.


## Verifying this change

Add the test later.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

