### PR TITLE
[hotfix][docs] Add missing style options for `sql-client.display.color-schema` in docs

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -916,7 +916,7 @@ For more details about stopping jobs, please refer to [Job Statements]({{< ref "
 
 SQL Client can highlight SQL syntax with several color schemes.
 With `sql-client.display.color-schema` it could be set a color scheme.
-Available color schemes: `chester`, `dracula`, `solarized`, `vs2010`, `obsidian`, `geshi`, `default` (no highlighting).
+Available color schemes: `chester`, `dracula`, `solarized`, `vs2010`, `obsidian`, `geshi`, `dark`, `light`, `default` (no highlighting).
 In case of wrong name the fallback is to `default`.
 
 | Color schema \ Style | Keyword      | Default | Comment        | Hint         | Quoted  | SQL Identifier |
@@ -929,5 +929,6 @@ In case of wrong name the fallback is to `default`.
 | `Light`              | Bold red     | Black   | Italic bright  | Bold bright  | Green   | Cyan           |
 | `Obsidian`           | Bold green   | White   | Italic bright  | Bold bright  | Red     | Magenta        |
 | `VS2010`             | Bold blue    | White   | Italic green   | Bold green   | Red     | Magenta        |
+| `Solarized`          | Bold yellow  | Blue    | Italic bright  | Bold bright  | Green   | Red            |
 
 {{< top >}}

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -855,7 +855,7 @@ For more details about stopping jobs, please refer to [Job Statements]({{< ref "
 
 SQL Client can highlight SQL syntax with several color schemes.
 With `sql-client.display.color-schema` it could be set a color scheme.
-Available color schemes: `chester`, `dracula`, `solarized`, `vs2010`, `obsidian`, `geshi`, `default` (no highlighting).
+Available color schemes: `chester`, `dracula`, `solarized`, `vs2010`, `obsidian`, `geshi`, `dark`, `light`, `default` (no highlighting).
 In case of wrong name the fallback is to `default`.
 
 | Color schema \ Style | Keyword      | Default | Comment        | Hint         | Quoted  | SQL Identifier |
@@ -868,5 +868,6 @@ In case of wrong name the fallback is to `default`.
 | `Light`              | Bold red     | Black   | Italic bright  | Bold bright  | Green   | Cyan           |
 | `Obsidian`           | Bold green   | White   | Italic bright  | Bold bright  | Red     | Magenta        |
 | `VS2010`             | Bold blue    | White   | Italic green   | Bold green   | Red     | Magenta        |
+| `Solarized`          | Bold yellow  | Blue    | Italic bright  | Bold bright  | Green   | Red            |
 
 {{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

Add missing style options for `sql-client.display.color-schema` in docs

## Brief change log

Add missing style options for `sql-client.display.color-schema` in docs

## Verifying this change

This change is a docs change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
