### PR TITLE
[FLINK-32771][SlotManager] Remove the invalid config option slotmanager.request-timeout

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -167,23 +167,12 @@ public class ResourceManagerOptions {
                     .withDescription("The delay of the declare needed resources.");
 
     /**
-     * The timeout for a slot request to be discarded, in milliseconds.
-     *
-     * @deprecated Use {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.
-     */
-    @Deprecated
-    public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT =
-            ConfigOptions.key("slotmanager.request-timeout")
-                    .longType()
-                    .defaultValue(-1L)
-                    .withDescription("The timeout for a slot request to be discarded.");
-
-    /**
      * Time in milliseconds of the start-up period of a standalone cluster. During this time,
      * resource manager of the standalone cluster expects new task executors to be registered, and
      * will not fail slot requests that can not be satisfied by any current registered slots. After
      * this time, it will fail pending and new coming requests immediately that can not be satisfied
-     * by registered slots. If not set, {@link #SLOT_REQUEST_TIMEOUT} will be used by default.
+     * by registered slots. If not set, {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT} will be used
+     * by default.
      */
     public static final ConfigOption<Long> STANDALONE_CLUSTER_STARTUP_PERIOD_TIME =
             ConfigOptions.key("resourcemanager.standalone.start-up-time")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -42,7 +41,6 @@ public class SlotManagerConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(SlotManagerConfiguration.class);
 
     private final Time taskManagerRequestTimeout;
-    private final Time slotRequestTimeout;
     private final Time taskManagerTimeout;
     private final Duration requirementCheckDelay;
     private final Duration declareNeededResourceDelay;
@@ -58,7 +56,6 @@ public class SlotManagerConfiguration {
 
     public SlotManagerConfiguration(
             Time taskManagerRequestTimeout,
-            Time slotRequestTimeout,
             Time taskManagerTimeout,
             Duration requirementCheckDelay,
             Duration declareNeededResourceDelay,
@@ -73,7 +70,6 @@ public class SlotManagerConfiguration {
             int redundantTaskManagerNum) {
 
         this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
-        this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
         this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
         this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
         this.declareNeededResourceDelay = Preconditions.checkNotNull(declareNeededResourceDelay);
@@ -93,10 +89,6 @@ public class SlotManagerConfiguration {
 
     public Time getTaskManagerRequestTimeout() {
         return taskManagerRequestTimeout;
-    }
-
-    public Time getSlotRequestTimeout() {
-        return slotRequestTimeout;
     }
 
     public Time getTaskManagerTimeout() {
@@ -154,7 +146,6 @@ public class SlotManagerConfiguration {
         final Time rpcTimeout =
                 Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
 
-        final Time slotRequestTimeout = getSlotRequestTimeout(configuration);
         final Time taskManagerTimeout =
                 Time.milliseconds(
                         configuration.getLong(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
@@ -185,7 +176,6 @@ public class SlotManagerConfiguration {
 
         return new SlotManagerConfiguration(
                 rpcTimeout,
-                slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
                 declareNeededResourceDelay,
@@ -198,21 +188,6 @@ public class SlotManagerConfiguration {
                 getMaxTotalCpu(configuration, defaultWorkerResourceSpec, maxSlotNum),
                 getMaxTotalMem(configuration, defaultWorkerResourceSpec, maxSlotNum),
                 redundantTaskManagerNum);
-    }
-
-    private static Time getSlotRequestTimeout(final Configuration configuration) {
-        final long slotRequestTimeoutMs;
-        if (configuration.contains(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT)) {
-            LOGGER.warn(
-                    "Config key {} is deprecated; use {} instead.",
-                    ResourceManagerOptions.SLOT_REQUEST_TIMEOUT,
-                    JobManagerOptions.SLOT_REQUEST_TIMEOUT);
-            slotRequestTimeoutMs =
-                    configuration.getLong(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT);
-        } else {
-            slotRequestTimeoutMs = configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT);
-        }
-        return Time.milliseconds(slotRequestTimeoutMs);
     }
 
     private static CPUResource getMaxTotalCpu(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -39,7 +39,6 @@ public class DeclarativeSlotManagerBuilder {
     private boolean evenlySpreadOutSlots;
     private final ScheduledExecutor scheduledExecutor;
     private Time taskManagerRequestTimeout;
-    private Time slotRequestTimeout;
     private Time taskManagerTimeout;
     private boolean waitResultConsumedBeforeRelease;
     private WorkerResourceSpec defaultWorkerResourceSpec;
@@ -56,7 +55,6 @@ public class DeclarativeSlotManagerBuilder {
         this.evenlySpreadOutSlots = false;
         this.scheduledExecutor = scheduledExecutor;
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
-        this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
         this.waitResultConsumedBeforeRelease = true;
         this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
@@ -79,11 +77,6 @@ public class DeclarativeSlotManagerBuilder {
     public DeclarativeSlotManagerBuilder setTaskManagerRequestTimeout(
             Time taskManagerRequestTimeout) {
         this.taskManagerRequestTimeout = taskManagerRequestTimeout;
-        return this;
-    }
-
-    public DeclarativeSlotManagerBuilder setSlotRequestTimeout(Time slotRequestTimeout) {
-        this.slotRequestTimeout = slotRequestTimeout;
         return this;
     }
 
@@ -155,7 +148,6 @@ public class DeclarativeSlotManagerBuilder {
         final SlotManagerConfiguration slotManagerConfiguration =
                 new SlotManagerConfiguration(
                         taskManagerRequestTimeout,
-                        slotRequestTimeout,
                         taskManagerTimeout,
                         requirementCheckDelay,
                         declareNeededResourceDelay,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 /** Builder for {@link SlotManagerConfiguration}. */
 public class SlotManagerConfigurationBuilder {
     private Time taskManagerRequestTimeout;
-    private Time slotRequestTimeout;
     private Time taskManagerTimeout;
     private Duration requirementCheckDelay;
     private Duration declareNeededResourceDelay;
@@ -45,7 +44,6 @@ public class SlotManagerConfigurationBuilder {
 
     private SlotManagerConfigurationBuilder() {
         this.taskManagerRequestTimeout = TestingUtils.infiniteTime();
-        this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
         this.requirementCheckDelay = ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY.defaultValue();
         this.declareNeededResourceDelay =
@@ -68,11 +66,6 @@ public class SlotManagerConfigurationBuilder {
     public SlotManagerConfigurationBuilder setTaskManagerRequestTimeout(
             Time taskManagerRequestTimeout) {
         this.taskManagerRequestTimeout = taskManagerRequestTimeout;
-        return this;
-    }
-
-    public SlotManagerConfigurationBuilder setSlotRequestTimeout(Time slotRequestTimeout) {
-        this.slotRequestTimeout = slotRequestTimeout;
         return this;
     }
 
@@ -138,7 +131,6 @@ public class SlotManagerConfigurationBuilder {
     public SlotManagerConfiguration build() {
         return new SlotManagerConfiguration(
                 taskManagerRequestTimeout,
-                slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
                 declareNeededResourceDelay,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
@@ -32,42 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SlotManagerConfiguration}. */
 class SlotManagerConfigurationTest {
-
-    /**
-     * Tests that {@link SlotManagerConfiguration#getSlotRequestTimeout()} returns the value
-     * configured under key {@link JobManagerOptions#SLOT_REQUEST_TIMEOUT}.
-     */
-    @Test
-    void testSetSlotRequestTimeout() throws Exception {
-        final long slotIdleTimeout = 42;
-
-        final Configuration configuration = new Configuration();
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotIdleTimeout);
-        final SlotManagerConfiguration slotManagerConfiguration =
-                SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
-
-        assertThat(slotIdleTimeout)
-                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
-    }
-
-    /**
-     * Tests that {@link ResourceManagerOptions#SLOT_REQUEST_TIMEOUT} is preferred over {@link
-     * JobManagerOptions#SLOT_REQUEST_TIMEOUT} if set.
-     */
-    @Test
-    void testPreferLegacySlotRequestTimeout() throws Exception {
-        final long legacySlotIdleTimeout = 42;
-
-        final Configuration configuration = new Configuration();
-        configuration.setLong(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT, legacySlotIdleTimeout);
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 300000L);
-        final SlotManagerConfiguration slotManagerConfiguration =
-                SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
-
-        assertThat(legacySlotIdleTimeout)
-                .isEqualTo(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds());
-    }
-
     @Test
     void testComputeMaxTotalCpu() throws Exception {
         final Configuration configuration = new Configuration();


### PR DESCRIPTION

## What is the purpose of the change

slotmanager.request-timeout has been deprecated since 1.6 and is not used after the removal of SlotManagerImpl. We can simply remove it now.

## Brief change log
  - Remove the invalid config option slotmanager.request-timeout


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):(no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
