### PR TITLE
[FLINK-32835][runtime] Migrate unit tests in "accumulators" and "blob" packages to JUnit5

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -30,12 +30,9 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.examples.java.wordcount.WordCount;
-import org.apache.flink.runtime.blob.BlobCacheCorruptionTest;
-import org.apache.flink.runtime.blob.BlobCacheRecoveryTest;
-import org.apache.flink.runtime.blob.BlobServerCorruptionTest;
-import org.apache.flink.runtime.blob.BlobServerRecoveryTest;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.blob.TestingBlobHelpers;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.OperatingSystem;
@@ -215,7 +212,7 @@ public class HDFSTest {
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
         try {
-            BlobServerRecoveryTest.testBlobServerRecovery(
+            TestingBlobHelpers.testBlobServerRecovery(
                     config, blobStoreService, temporaryFolder.newFolder());
         } finally {
             blobStoreService.closeAndCleanupAllData();
@@ -238,7 +235,7 @@ public class HDFSTest {
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
         try {
-            BlobServerCorruptionTest.testGetFailsFromCorruptFile(
+            TestingBlobHelpers.testGetFailsFromCorruptFile(
                     config, blobStoreService, temporaryFolder.newFolder());
         } finally {
             blobStoreService.closeAndCleanupAllData();
@@ -261,7 +258,7 @@ public class HDFSTest {
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
         try {
-            BlobCacheRecoveryTest.testBlobCacheRecovery(
+            TestingBlobHelpers.testBlobCacheRecovery(
                     config, blobStoreService, temporaryFolder.newFolder());
         } finally {
             blobStoreService.closeAndCleanupAllData();
@@ -284,7 +281,7 @@ public class HDFSTest {
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
         try {
-            BlobCacheCorruptionTest.testGetFailsFromCorruptFile(
+            TestingBlobHelpers.testGetFailsFromCorruptFile(
                     new JobID(), config, blobStoreService, temporaryFolder.newFolder());
         } finally {
             blobStoreService.closeAndCleanupAllData();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResultTest.java
@@ -25,21 +25,20 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.OptionalFailure;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link StringifiedAccumulatorResult}. */
-public class StringifiedAccumulatorResultTest {
+class StringifiedAccumulatorResultTest {
 
     @Test
-    public void testSerialization() throws IOException {
+    void testSerialization() throws IOException {
         final String name = "a";
         final String type = "b";
         final String value = "c";
@@ -47,20 +46,20 @@ public class StringifiedAccumulatorResultTest {
                 new StringifiedAccumulatorResult(name, type, value);
 
         // Confirm no funny business in the constructor to getter pathway
-        assertEquals(name, original.getName());
-        assertEquals(type, original.getType());
-        assertEquals(value, original.getValue());
+        assertThat(original.getName()).isEqualTo(name);
+        assertThat(original.getType()).isEqualTo(type);
+        assertThat(original.getValue()).isEqualTo(value);
 
         final StringifiedAccumulatorResult copy = CommonTestUtils.createCopySerializable(original);
 
         // Copy should have equivalent core fields
-        assertEquals(name, copy.getName());
-        assertEquals(type, copy.getType());
-        assertEquals(value, copy.getValue());
+        assertThat(copy.getName()).isEqualTo(name);
+        assertThat(copy.getType()).isEqualTo(type);
+        assertThat(copy.getValue()).isEqualTo(value);
     }
 
     @Test
-    public void stringifyingResultsShouldIncorporateAccumulatorLocalValueDirectly() {
+    void stringifyingResultsShouldIncorporateAccumulatorLocalValueDirectly() {
         final String name = "a";
         final int targetValue = 314159;
         final IntCounter acc = new IntCounter();
@@ -71,16 +70,16 @@ public class StringifiedAccumulatorResultTest {
         final StringifiedAccumulatorResult[] results =
                 StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 
-        assertEquals(1, results.length);
+        assertThat(results).hasSize(1);
 
         final StringifiedAccumulatorResult firstResult = results[0];
-        assertEquals(name, firstResult.getName());
-        assertEquals("IntCounter", firstResult.getType());
-        assertEquals(Integer.toString(targetValue), firstResult.getValue());
+        assertThat(firstResult.getName()).isEqualTo(name);
+        assertThat(firstResult.getType()).isEqualTo("IntCounter");
+        assertThat(firstResult.getValue()).isEqualTo(Integer.toString(targetValue));
     }
 
     @Test
-    public void stringifyingResultsShouldReportNullLocalValueAsNonnullValueString() {
+    void stringifyingResultsShouldReportNullLocalValueAsNonnullValueString() {
         final String name = "a";
         final NullBearingAccumulator acc = new NullBearingAccumulator();
         final Map<String, OptionalFailure<Accumulator<?, ?>>> accumulatorMap = new HashMap<>();
@@ -89,17 +88,17 @@ public class StringifiedAccumulatorResultTest {
         final StringifiedAccumulatorResult[] results =
                 StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 
-        assertEquals(1, results.length);
+        assertThat(results).hasSize(1);
 
         // Note the use of a String with a content of "null" rather than a null value
         final StringifiedAccumulatorResult firstResult = results[0];
-        assertEquals(name, firstResult.getName());
-        assertEquals("NullBearingAccumulator", firstResult.getType());
-        assertEquals("null", firstResult.getValue());
+        assertThat(firstResult.getName()).isEqualTo(name);
+        assertThat(firstResult.getType()).isEqualTo("NullBearingAccumulator");
+        assertThat(firstResult.getValue()).isEqualTo("null");
     }
 
     @Test
-    public void stringifyingResultsShouldReportNullAccumulatorWithNonnullValueAndTypeString() {
+    void stringifyingResultsShouldReportNullAccumulatorWithNonnullValueAndTypeString() {
         final String name = "a";
         final Map<String, OptionalFailure<Accumulator<?, ?>>> accumulatorMap = new HashMap<>();
         accumulatorMap.put(name, null);
@@ -107,17 +106,17 @@ public class StringifiedAccumulatorResultTest {
         final StringifiedAccumulatorResult[] results =
                 StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 
-        assertEquals(1, results.length);
+        assertThat(results).hasSize(1);
 
         // Note the use of String values with content of "null" rather than null values
         final StringifiedAccumulatorResult firstResult = results[0];
-        assertEquals(name, firstResult.getName());
-        assertEquals("null", firstResult.getType());
-        assertEquals("null", firstResult.getValue());
+        assertThat(firstResult.getName()).isEqualTo(name);
+        assertThat(firstResult.getType()).isEqualTo("null");
+        assertThat(firstResult.getValue()).isEqualTo("null");
     }
 
     @Test
-    public void stringifyingFailureResults() {
+    void stringifyingFailureResults() {
         final String name = "a";
         final Map<String, OptionalFailure<Accumulator<?, ?>>> accumulatorMap = new HashMap<>();
         accumulatorMap.put(name, OptionalFailure.ofFailure(new FlinkRuntimeException("Test")));
@@ -125,16 +124,14 @@ public class StringifiedAccumulatorResultTest {
         final StringifiedAccumulatorResult[] results =
                 StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 
-        assertEquals(1, results.length);
+        assertThat(results).hasSize(1);
 
         // Note the use of String values with content of "null" rather than null values
         final StringifiedAccumulatorResult firstResult = results[0];
-        assertEquals(name, firstResult.getName());
-        assertEquals("null", firstResult.getType());
-        assertTrue(
-                firstResult
-                        .getValue()
-                        .startsWith("org.apache.flink.util.FlinkRuntimeException: Test"));
+        assertThat(firstResult.getName()).isEqualTo(name);
+        assertThat(firstResult.getType()).isEqualTo("null");
+        assertThat(firstResult.getValue())
+                .startsWith("org.apache.flink.util.FlinkRuntimeException: Test");
     }
 
     private static class NullBearingAccumulator implements SimpleAccumulator<Serializable> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
@@ -21,57 +21,43 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.core.testutils.FlinkAssertions;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import javax.annotation.Nullable;
-
-import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Random;
+import java.nio.file.Path;
 
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests how GET requests react to corrupt files when downloaded via a {@link BlobCacheService}.
  *
  * <p>Successful GET requests are tested in conjunction wit the PUT requests.
  */
-public class BlobCacheCorruptionTest extends TestLogger {
+class BlobCacheCorruptionTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir private Path tempDir;
 
     @Test
-    public void testGetFailsFromCorruptFile1() throws IOException {
+    void testGetFailsFromCorruptFile1() throws IOException {
         testGetFailsFromCorruptFile(null, TRANSIENT_BLOB, false);
     }
 
     @Test
-    public void testGetFailsFromCorruptFile2() throws IOException {
+    void testGetFailsFromCorruptFile2() throws IOException {
         testGetFailsFromCorruptFile(new JobID(), TRANSIENT_BLOB, false);
     }
 
     @Test
-    public void testGetFailsFromCorruptFile3() throws IOException {
+    void testGetFailsFromCorruptFile3() throws IOException {
         testGetFailsFromCorruptFile(new JobID(), PERMANENT_BLOB, false);
     }
 
     @Test
-    public void testGetFailsFromCorruptFile4() throws IOException {
+    void testGetFailsFromCorruptFile4() throws IOException {
         testGetFailsFromCorruptFile(new JobID(), PERMANENT_BLOB, true);
     }
 
@@ -92,118 +78,24 @@ public class BlobCacheCorruptionTest extends TestLogger {
         final Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, TEMPORARY_FOLDER.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;
 
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
-            testGetFailsFromCorruptFile(
+            TestingBlobHelpers.testGetFailsFromCorruptFile(
                     jobId,
                     blobType,
                     corruptOnHAStore,
                     config,
                     blobStoreService,
-                    TEMPORARY_FOLDER.newFolder());
+                    TempDirUtils.newFolder(tempDir));
         } finally {
             if (blobStoreService != null) {
                 blobStoreService.closeAndCleanupAllData();
             }
-        }
-    }
-
-    /**
-     * Checks the GET operation fails when the downloaded file (from HA store) is corrupt, i.e. its
-     * content's hash does not match the {@link BlobKey}'s hash, using a permanent BLOB.
-     *
-     * @param jobId job ID
-     * @param config blob server configuration (including HA settings like {@link
-     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
-     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
-     * @param blobStore shared HA blob store to use
-     */
-    public static void testGetFailsFromCorruptFile(
-            JobID jobId, Configuration config, BlobStore blobStore, File blobStorage)
-            throws IOException {
-
-        testGetFailsFromCorruptFile(jobId, PERMANENT_BLOB, true, config, blobStore, blobStorage);
-    }
-
-    /**
-     * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
-     * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
-     *
-     * @param jobId job ID or <tt>null</tt> if job-unrelated
-     * @param blobType whether the BLOB should become permanent or transient
-     * @param corruptOnHAStore whether the file should be corrupt in the HA store (<tt>true</tt>,
-     *     required <tt>highAvailability</tt> to be set) or on the {@link BlobServer}'s local store
-     *     (<tt>false</tt>)
-     * @param config blob server configuration (including HA settings like {@link
-     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
-     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
-     * @param blobStore shared HA blob store to use
-     */
-    private static void testGetFailsFromCorruptFile(
-            @Nullable JobID jobId,
-            BlobKey.BlobType blobType,
-            boolean corruptOnHAStore,
-            Configuration config,
-            BlobStore blobStore,
-            File blobStorage)
-            throws IOException {
-
-        assertTrue(
-                "corrupt HA file requires a HA setup",
-                !corruptOnHAStore || blobType == PERMANENT_BLOB);
-
-        Random rnd = new Random();
-
-        try (BlobServer server =
-                        new BlobServer(config, new File(blobStorage, "server"), blobStore);
-                BlobCacheService cache =
-                        new BlobCacheService(
-                                config,
-                                new File(blobStorage, "cache"),
-                                corruptOnHAStore ? blobStore : new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server.getPort()))) {
-
-            server.start();
-
-            byte[] data = new byte[2000000];
-            rnd.nextBytes(data);
-
-            // put content addressable (like libraries)
-            BlobKey key = put(server, jobId, data, blobType);
-            assertNotNull(key);
-
-            // change server/HA store file contents to make sure that GET requests fail
-            byte[] data2 = Arrays.copyOf(data, data.length);
-            data2[0] ^= 1;
-            if (corruptOnHAStore) {
-                File tmpFile = Files.createTempFile("blob", ".jar").toFile();
-                try {
-                    FileUtils.writeByteArrayToFile(tmpFile, data2);
-                    blobStore.put(tmpFile, jobId, key);
-                } finally {
-                    //noinspection ResultOfMethodCallIgnored
-                    tmpFile.delete();
-                }
-
-                // delete local (correct) file on server to make sure that the GET request does not
-                // fall back to downloading the file from the BlobServer's local store
-                File blobFile = server.getStorageLocation(jobId, key);
-                assertTrue(blobFile.delete());
-            } else {
-                File blobFile = server.getStorageLocation(jobId, key);
-                assertTrue(blobFile.exists());
-                FileUtils.writeByteArrayToFile(blobFile, data2);
-            }
-
-            // issue a GET request that fails
-            assertThatThrownBy(() -> get(cache, jobId, key))
-                    .satisfies(
-                            FlinkAssertions.anyCauseMatches(IOException.class, "data corruption"));
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
@@ -19,21 +19,19 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,40 +48,38 @@ import static org.apache.flink.runtime.blob.BlobServerDeleteTest.delete;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests how DELETE requests behave. */
-public class BlobCacheDeleteTest extends TestLogger {
+class BlobCacheDeleteTest {
+
+    @TempDir private Path tempDir;
 
     private final Random rnd = new Random();
 
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
     @Test
-    public void testDeleteTransient1() throws IOException {
+    void testDeleteTransient1() throws IOException {
         testDelete(null, new JobID());
     }
 
     @Test
-    public void testDeleteTransient2() throws IOException {
+    void testDeleteTransient2() throws IOException {
         testDelete(new JobID(), null);
     }
 
     @Test
-    public void testDeleteTransient3() throws IOException {
+    void testDeleteTransient3() throws IOException {
         testDelete(null, null);
     }
 
     @Test
-    public void testDeleteTransient4() throws IOException {
+    void testDeleteTransient4() throws IOException {
         testDelete(new JobID(), new JobID());
     }
 
     @Test
-    public void testDeleteTransient5() throws IOException {
+    void testDeleteTransient5() throws IOException {
         JobID jobId = new JobID();
         testDelete(jobId, jobId);
     }
@@ -96,18 +92,11 @@ public class BlobCacheDeleteTest extends TestLogger {
      * @param jobId2 second job id
      */
     private void testDelete(@Nullable JobID jobId1, @Nullable JobID jobId2) throws IOException {
+        Tuple2<BlobServer, BlobCacheService> serverAndCache =
+                TestingBlobUtils.createServerAndCache(tempDir);
 
-        final Configuration config = new Configuration();
-
-        try (BlobServer server =
-                        new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
-                BlobCacheService cache =
-                        new BlobCacheService(
-                                config,
-                                temporaryFolder.newFolder(),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server.getPort()))) {
-
+        try (BlobServer server = serverAndCache.f0;
+                BlobCacheService cache = serverAndCache.f1) {
             server.start();
 
             byte[] data = new byte[2000000];
@@ -117,24 +106,24 @@ public class BlobCacheDeleteTest extends TestLogger {
 
             // put first BLOB
             TransientBlobKey key1 = (TransientBlobKey) put(server, jobId1, data, TRANSIENT_BLOB);
-            assertNotNull(key1);
+            assertThat(key1).isNotNull();
 
             // put two more BLOBs (same key, other key) for another job ID
             TransientBlobKey key2a = (TransientBlobKey) put(server, jobId2, data, TRANSIENT_BLOB);
-            assertNotNull(key2a);
+            assertThat(key2a).isNotNull();
             BlobKeyTest.verifyKeyDifferentHashEquals(key1, key2a);
             TransientBlobKey key2b = (TransientBlobKey) put(server, jobId2, data2, TRANSIENT_BLOB);
-            assertNotNull(key2b);
+            assertThat(key2b).isNotNull();
             BlobKeyTest.verifyKeyDifferentHashDifferent(key1, key2b);
 
             // issue a DELETE request
-            assertTrue(delete(cache, jobId1, key1));
+            assertThat(delete(cache, jobId1, key1)).isTrue();
 
             // delete only works on local cache!
-            assertTrue(server.getStorageLocation(jobId1, key1).exists());
+            assertThat(server.getStorageLocation(jobId1, key1)).exists();
             // delete on server so that the cache cannot re-download
-            assertTrue(server.deleteInternal(jobId1, key1));
-            assertFalse(server.getStorageLocation(jobId1, key1).exists());
+            assertThat(server.deleteInternal(jobId1, key1)).isTrue();
+            assertThat(server.getStorageLocation(jobId1, key1)).doesNotExist();
             verifyDeleted(cache, jobId1, key1);
             // deleting one BLOB should not affect another BLOB with a different key
             // (and keys are always different now)
@@ -142,31 +131,31 @@ public class BlobCacheDeleteTest extends TestLogger {
             verifyContents(server, jobId2, key2b, data2);
 
             // delete first file of second job
-            assertTrue(delete(cache, jobId2, key2a));
+            assertThat(delete(cache, jobId2, key2a)).isTrue();
             // delete only works on local cache
-            assertTrue(server.getStorageLocation(jobId2, key2a).exists());
+            assertThat(server.getStorageLocation(jobId2, key2a)).exists();
             // delete on server so that the cache cannot re-download
-            assertTrue(server.deleteInternal(jobId2, key2a));
+            assertThat(server.deleteInternal(jobId2, key2a)).isTrue();
             verifyDeleted(cache, jobId2, key2a);
             verifyContents(server, jobId2, key2b, data2);
 
             // delete second file of second job
-            assertTrue(delete(cache, jobId2, key2b));
+            assertThat(delete(cache, jobId2, key2b)).isTrue();
             // delete only works on local cache
-            assertTrue(server.getStorageLocation(jobId2, key2b).exists());
+            assertThat(server.getStorageLocation(jobId2, key2b)).exists();
             // delete on server so that the cache cannot re-download
-            assertTrue(server.deleteInternal(jobId2, key2b));
+            assertThat(server.deleteInternal(jobId2, key2b)).isTrue();
             verifyDeleted(cache, jobId2, key2b);
         }
     }
 
     @Test
-    public void testDeleteTransientAlreadyDeletedNoJob() throws IOException {
+    void testDeleteTransientAlreadyDeletedNoJob() throws IOException {
         testDeleteTransientAlreadyDeleted(null);
     }
 
     @Test
-    public void testDeleteTransientAlreadyDeletedForJob() throws IOException {
+    void testDeleteTransientAlreadyDeletedForJob() throws IOException {
         testDeleteTransientAlreadyDeleted(new JobID());
     }
 
@@ -177,17 +166,11 @@ public class BlobCacheDeleteTest extends TestLogger {
      * @param jobId job id
      */
     private void testDeleteTransientAlreadyDeleted(@Nullable final JobID jobId) throws IOException {
+        Tuple2<BlobServer, BlobCacheService> serverAndCache =
+                TestingBlobUtils.createServerAndCache(tempDir);
 
-        final Configuration config = new Configuration();
-        try (BlobServer server =
-                        new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
-                BlobCacheService cache =
-                        new BlobCacheService(
-                                config,
-                                temporaryFolder.newFolder(),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server.getPort()))) {
-
+        try (BlobServer server = serverAndCache.f0;
+                BlobCacheService cache = serverAndCache.f1) {
             server.start();
 
             byte[] data = new byte[2000000];
@@ -195,28 +178,28 @@ public class BlobCacheDeleteTest extends TestLogger {
 
             // put BLOB
             TransientBlobKey key = (TransientBlobKey) put(server, jobId, data, TRANSIENT_BLOB);
-            assertNotNull(key);
+            assertThat(key).isNotNull();
 
             File blobFile = server.getStorageLocation(jobId, key);
-            assertTrue(blobFile.delete());
+            assertThat(blobFile.delete()).isTrue();
 
             // DELETE operation should not fail if file is already deleted
-            assertTrue(delete(cache, jobId, key));
+            assertThat(delete(cache, jobId, key)).isTrue();
             verifyDeleted(cache, jobId, key);
 
             // one more delete call that should not fail
-            assertTrue(delete(cache, jobId, key));
+            assertThat(delete(cache, jobId, key)).isTrue();
             verifyDeleted(cache, jobId, key);
         }
     }
 
     @Test
-    public void testDeleteTransientLocalFailsNoJob() throws IOException, InterruptedException {
+    void testDeleteTransientLocalFailsNoJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(null);
     }
 
     @Test
-    public void testDeleteTransientLocalFailsForJob() throws IOException, InterruptedException {
+    void testDeleteTransientLocalFailsForJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(new JobID());
     }
 
@@ -229,20 +212,15 @@ public class BlobCacheDeleteTest extends TestLogger {
      */
     private void testDeleteTransientLocalFails(@Nullable final JobID jobId)
             throws IOException, InterruptedException {
-        assumeTrue(!OperatingSystem.isWindows()); // setWritable doesn't work on Windows.
+        assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();
 
-        final Configuration config = new Configuration();
+        Tuple2<BlobServer, BlobCacheService> serverAndCache =
+                TestingBlobUtils.createServerAndCache(tempDir);
+
         File blobFile = null;
         File directory = null;
-        try (BlobServer server =
-                        new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
-                BlobCacheService cache =
-                        new BlobCacheService(
-                                config,
-                                temporaryFolder.newFolder(),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server.getPort()))) {
-
+        try (BlobServer server = serverAndCache.f0;
+                BlobCacheService cache = serverAndCache.f1) {
             server.start();
 
             try {
@@ -251,7 +229,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
                 // put BLOB
                 TransientBlobKey key = (TransientBlobKey) put(server, jobId, data, TRANSIENT_BLOB);
-                assertNotNull(key);
+                assertThat(key).isNotNull();
 
                 // access from cache once to have it available there
                 verifyContents(cache, jobId, key, data);
@@ -259,11 +237,12 @@ public class BlobCacheDeleteTest extends TestLogger {
                 blobFile = cache.getTransientBlobService().getStorageLocation(jobId, key);
                 directory = blobFile.getParentFile();
 
-                assertTrue(blobFile.setWritable(false, false));
-                assertTrue(directory.setWritable(false, false));
+                assertThat(blobFile.setWritable(false, false)).isTrue();
+                assertThat(directory.setWritable(false, false)).isTrue();
 
                 // issue a DELETE request
-                assertFalse(delete(cache, jobId, key));
+
+                assertThat(delete(cache, jobId, key)).isFalse();
 
                 // the file should still be there on the cache
                 verifyContents(cache, jobId, key, data);
@@ -282,13 +261,13 @@ public class BlobCacheDeleteTest extends TestLogger {
     }
 
     @Test
-    public void testConcurrentDeleteOperationsNoJobTransient()
+    void testConcurrentDeleteOperationsNoJobTransient()
             throws IOException, ExecutionException, InterruptedException {
         testConcurrentDeleteOperations(null);
     }
 
     @Test
-    public void testConcurrentDeleteOperationsForJobTransient()
+    void testConcurrentDeleteOperationsForJobTransient()
             throws IOException, ExecutionException, InterruptedException {
         testConcurrentDeleteOperations(new JobID());
     }
@@ -306,7 +285,6 @@ public class BlobCacheDeleteTest extends TestLogger {
     private void testConcurrentDeleteOperations(@Nullable final JobID jobId)
             throws IOException, InterruptedException, ExecutionException {
 
-        final Configuration config = new Configuration();
         final int concurrentDeleteOperations = 3;
         final ExecutorService executor = Executors.newFixedThreadPool(concurrentDeleteOperations);
 
@@ -315,35 +293,30 @@ public class BlobCacheDeleteTest extends TestLogger {
 
         final byte[] data = {1, 2, 3};
 
-        try (BlobServer server =
-                        new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
-                BlobCacheService cache =
-                        new BlobCacheService(
-                                config,
-                                temporaryFolder.newFolder(),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server.getPort()))) {
-
+        Tuple2<BlobServer, BlobCacheService> serverAndCache =
+                TestingBlobUtils.createServerAndCache(tempDir);
+        try (BlobServer server = serverAndCache.f0;
+                BlobCacheService cache = serverAndCache.f1) {
             server.start();
 
             final TransientBlobKey blobKey =
                     (TransientBlobKey) put(server, jobId, data, TRANSIENT_BLOB);
 
-            assertTrue(server.getStorageLocation(jobId, blobKey).exists());
+            assertThat(server.getStorageLocation(jobId, blobKey)).exists();
 
             for (int i = 0; i < concurrentDeleteOperations; i++) {
                 CompletableFuture<Void> deleteFuture =
                         CompletableFuture.supplyAsync(
                                 () -> {
                                     try {
-                                        assertTrue(delete(cache, jobId, blobKey));
-                                        assertFalse(
-                                                cache.getTransientBlobService()
-                                                        .getStorageLocation(jobId, blobKey)
-                                                        .exists());
+                                        assertThat(delete(cache, jobId, blobKey)).isTrue();
+                                        assertThat(
+                                                        cache.getTransientBlobService()
+                                                                .getStorageLocation(jobId, blobKey))
+                                                .doesNotExist();
                                         // delete only works on local cache!
-                                        assertTrue(
-                                                server.getStorageLocation(jobId, blobKey).exists());
+                                        assertThat(server.getStorageLocation(jobId, blobKey))
+                                                .exists();
                                         return null;
                                     } catch (IOException e) {
                                         throw new CompletionException(
@@ -362,7 +335,7 @@ public class BlobCacheDeleteTest extends TestLogger {
             waitFuture.get();
 
             // delete only works on local cache!
-            assertTrue(server.getStorageLocation(jobId, blobKey).exists());
+            assertThat(server.getStorageLocation(jobId, blobKey)).exists();
 
         } finally {
             executor.shutdownNow();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -18,135 +18,41 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.Random;
-
-import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashDifferent;
-import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashEquals;
-import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Tests for the recovery of files of a {@link BlobCacheService} from a HA store. */
-public class BlobCacheRecoveryTest extends TestLogger {
+public class BlobCacheRecoveryTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir private java.nio.file.Path tempDir;
 
     /**
      * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from
      * any participating BlobServer.
      */
     @Test
-    public void testBlobCacheRecovery() throws Exception {
+    void testBlobCacheRecovery() throws Exception {
         Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, TEMPORARY_FOLDER.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;
 
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
-            testBlobCacheRecovery(config, blobStoreService, TEMPORARY_FOLDER.newFolder());
+            TestingBlobHelpers.testBlobCacheRecovery(
+                    config, blobStoreService, TempDirUtils.newFolder(tempDir));
         } finally {
             if (blobStoreService != null) {
                 blobStoreService.closeAndCleanupAllData();
             }
-        }
-    }
-
-    /**
-     * Helper to test that the {@link BlobServer} recovery from its HA store works.
-     *
-     * <p>Uploads two BLOBs to one {@link BlobServer} via a {@link BlobCacheService} and expects a
-     * second {@link BlobCacheService} to be able to retrieve them from a second {@link BlobServer}
-     * that is configured with the same HA store.
-     *
-     * @param config blob server configuration (including HA settings like {@link
-     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
-     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
-     * @param blobStore shared HA blob store to use
-     * @throws IOException in case of failures
-     */
-    public static void testBlobCacheRecovery(
-            final Configuration config, final BlobStore blobStore, final File blobStorage)
-            throws IOException {
-
-        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-        String storagePath =
-                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
-        Random rand = new Random();
-
-        try (BlobServer server0 =
-                        new BlobServer(config, new File(blobStorage, "server0"), blobStore);
-                BlobServer server1 =
-                        new BlobServer(config, new File(blobStorage, "server1"), blobStore);
-                // use VoidBlobStore as the HA store to force download from each server's HA store
-                BlobCacheService cache0 =
-                        new BlobCacheService(
-                                config,
-                                new File(blobStorage, "cache0"),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server0.getPort()));
-                BlobCacheService cache1 =
-                        new BlobCacheService(
-                                config,
-                                new File(blobStorage, "cache1"),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server1.getPort()))) {
-
-            server0.start();
-            server1.start();
-
-            // Random data
-            byte[] expected = new byte[1024];
-            rand.nextBytes(expected);
-            byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
-
-            BlobKey[] keys = new BlobKey[2];
-            BlobKey nonHAKey;
-
-            // Put job-related HA data
-            JobID[] jobId = new JobID[] {new JobID(), new JobID()};
-            keys[0] = put(cache0, jobId[0], expected, PERMANENT_BLOB); // Request 1
-            keys[1] = put(cache0, jobId[1], expected2, PERMANENT_BLOB); // Request 2
-
-            // put non-HA data
-            nonHAKey = put(cache0, jobId[0], expected2, TRANSIENT_BLOB);
-            verifyKeyDifferentHashDifferent(keys[0], nonHAKey);
-            verifyKeyDifferentHashEquals(keys[1], nonHAKey);
-
-            // check that the storage directory exists
-            final Path blobServerPath = new Path(storagePath, "blob");
-            FileSystem fs = blobServerPath.getFileSystem();
-            assertTrue("Unknown storage dir: " + blobServerPath, fs.exists(blobServerPath));
-
-            // Verify HA requests from cache1 (connected to server1) with no immediate access to the
-            // file
-            verifyContents(cache1, jobId[0], keys[0], expected);
-            verifyContents(cache1, jobId[1], keys[1], expected2);
-
-            // Verify non-HA file is not accessible from server1
-            verifyDeleted(cache1, jobId[0], nonHAKey);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSizeTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSizeTrackerTest.java
@@ -21,29 +21,25 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.blob.BlobKey.BlobType;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link BlobCacheSizeTracker}. */
-public class BlobCacheSizeTrackerTest extends TestLogger {
+class BlobCacheSizeTrackerTest {
 
     private BlobCacheSizeTracker tracker;
     private JobID jobId;
     private BlobKey blobKey;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         tracker = new BlobCacheSizeTracker(5L);
         jobId = new JobID();
         blobKey = BlobKey.createKey(BlobType.PERMANENT_BLOB);
@@ -52,31 +48,32 @@ public class BlobCacheSizeTrackerTest extends TestLogger {
     }
 
     @Test
-    public void testCheckLimit() {
+    void testCheckLimit() {
         List<Tuple2<JobID, BlobKey>> keys = tracker.checkLimit(3L);
 
-        assertEquals(1, keys.size());
-        assertEquals(jobId, keys.get(0).f0);
-        assertEquals(blobKey, keys.get(0).f1);
+        assertThat(keys).hasSize(1);
+        assertThat(keys.get(0).f0).isEqualTo(jobId);
+        assertThat(keys.get(0).f1).isEqualTo(blobKey);
     }
 
     /** If an empty BLOB is intended to be stored, no BLOBs should be removed. */
     @Test
-    public void testCheckLimitForEmptyBlob() {
+    void testCheckLimitForEmptyBlob() {
         List<Tuple2<JobID, BlobKey>> keys = tracker.checkLimit(0L);
 
-        assertEquals(0, keys.size());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testCheckLimitForBlobWithNegativeSize() {
-        tracker.checkLimit(-1L);
+        assertThat(keys).isEmpty();
     }
 
     @Test
-    public void testTrack() {
-        assertEquals(3L, (long) tracker.getSize(jobId, blobKey));
-        assertTrue(tracker.getBlobKeysByJobId(jobId).contains(blobKey));
+    void testCheckLimitForBlobWithNegativeSize() {
+        assertThatThrownBy(() -> tracker.checkLimit(-1L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testTrack() {
+        assertThat(tracker.getSize(jobId, blobKey)).isEqualTo(3L);
+        assertThat(tracker.getBlobKeysByJobId(jobId)).contains(blobKey);
     }
 
     /**
@@ -84,40 +81,45 @@ public class BlobCacheSizeTrackerTest extends TestLogger {
      * BlobUtils#moveTempFileToStore} does.
      */
     @Test
-    public void testTrackDuplicatedBlob() {
+    void testTrackDuplicatedBlob() {
         tracker.track(jobId, blobKey, 1L);
-        assertEquals(3L, (long) tracker.getSize(jobId, blobKey));
-        assertEquals(1, tracker.getBlobKeysByJobId(jobId).size());
+        assertThat(tracker.getSize(jobId, blobKey)).isEqualTo(3L);
+        assertThat(tracker.getBlobKeysByJobId(jobId)).hasSize(1);
     }
 
     @Test
-    public void testUntrack() {
-        assertEquals(1, tracker.checkLimit(3L).size());
+    void testUntrack() {
+        assertThat(tracker.checkLimit(3L)).hasSize(1);
         tracker.untrack(Tuple2.of(jobId, blobKey));
 
-        assertNull(tracker.getSize(jobId, blobKey));
-        assertEquals(0, tracker.getBlobKeysByJobId(jobId).size());
-        assertEquals(0, tracker.checkLimit(3L).size());
+        assertThat(tracker.getSize(jobId, blobKey)).isNull();
+        assertThat(tracker.getBlobKeysByJobId(jobId)).isEmpty();
+        assertThat(tracker.checkLimit(3L)).isEmpty();
     }
 
     /** Untracking a non-existing BLOB shouldn't change anything or throw any exceptions. */
     @Test
-    public void testUntrackNonExistingBlob() {
+    void testUntrackNonExistingBlob() {
         tracker.untrack(Tuple2.of(jobId, BlobKey.createKey(BlobType.PERMANENT_BLOB)));
-        assertEquals(1, tracker.getBlobKeysByJobId(jobId).size());
+        assertThat(tracker.getBlobKeysByJobId(jobId)).hasSize(1);
     }
 
     /**
      * Since the BlobCacheSizeLimitTracker only works in {@link PermanentBlobCache}, the JobID
      * shouldn't be null.
      */
-    @Test(expected = NullPointerException.class)
-    public void testUntrackBlobWithNullJobId() {
-        tracker.untrack(Tuple2.of(null, BlobKey.createKey(BlobType.PERMANENT_BLOB)));
+    @Test
+    void testUntrackBlobWithNullJobId() {
+        assertThatThrownBy(
+                        () ->
+                                tracker.untrack(
+                                        Tuple2.of(
+                                                null, BlobKey.createKey(BlobType.PERMANENT_BLOB))))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    public void testUpdate() {
+    void testUpdate() {
         BlobCacheSizeTracker tracker = new BlobCacheSizeTracker(5L);
         List<JobID> jobIds = new ArrayList<>();
         List<BlobKey> blobKeys = new ArrayList<>();
@@ -133,11 +135,10 @@ public class BlobCacheSizeTrackerTest extends TestLogger {
 
         List<Tuple2<JobID, BlobKey>> blobsToDelete = tracker.checkLimit(2);
 
-        assertThat(
-                blobsToDelete,
-                containsInAnyOrder(
+        assertThat(blobsToDelete)
+                .contains(
                         Tuple2.of(jobIds.get(0), blobKeys.get(0)),
-                        Tuple2.of(jobIds.get(3), blobKeys.get(3))));
+                        Tuple2.of(jobIds.get(3), blobKeys.get(3)));
     }
 
     /**
@@ -145,26 +146,26 @@ public class BlobCacheSizeTrackerTest extends TestLogger {
      * exceptions.
      */
     @Test
-    public void testUpdateNonExistingBlob() {
+    void testUpdateNonExistingBlob() {
         tracker.track(new JobID(), BlobKey.createKey(BlobType.PERMANENT_BLOB), 2L);
-        assertEquals(1, tracker.checkLimit(3L).size());
+        assertThat(tracker.checkLimit(3L)).hasSize(1);
 
         tracker.update(new JobID(), BlobKey.createKey(BlobType.PERMANENT_BLOB));
-        assertEquals(1, tracker.checkLimit(3L).size());
+        assertThat(tracker.checkLimit(3L)).hasSize(1);
     }
 
     @Test
-    public void testUntrackAll() {
+    void testUntrackAll() {
         tracker.track(jobId, BlobKey.createKey(BlobType.PERMANENT_BLOB), 1L);
 
         JobID anotherJobId = new JobID();
         tracker.track(anotherJobId, BlobKey.createKey(BlobType.PERMANENT_BLOB), 1L);
 
-        assertEquals(2, tracker.getBlobKeysByJobId(jobId).size());
+        assertThat(tracker.getBlobKeysByJobId(jobId)).hasSize(2);
         tracker.untrackAll(jobId);
 
-        assertEquals(0, tracker.getBlobKeysByJobId(jobId).size());
-        assertEquals(1, tracker.getBlobKeysByJobId(anotherJobId).size());
+        assertThat(tracker.getBlobKeysByJobId(jobId)).isEmpty();
+        assertThat(tracker.getBlobKeysByJobId(anotherJobId)).hasSize(1);
     }
 
     /**
@@ -172,12 +173,12 @@ public class BlobCacheSizeTrackerTest extends TestLogger {
      * exceptions.
      */
     @Test
-    public void testUntrackAllWithNonExistingJob() {
+    void testUntrackAllWithNonExistingJob() {
         tracker.track(jobId, BlobKey.createKey(BlobType.PERMANENT_BLOB), 1L);
 
-        assertEquals(2, tracker.getBlobKeysByJobId(jobId).size());
+        assertThat(tracker.getBlobKeysByJobId(jobId)).hasSize(2);
         tracker.untrackAll(new JobID());
 
-        assertEquals(2, tracker.getBlobKeysByJobId(jobId).size());
+        assertThat(tracker.getBlobKeysByJobId(jobId)).hasSize(2);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -19,19 +19,19 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
@@ -40,19 +40,18 @@ import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
 
 /** This class contains unit tests for the {@link BlobCacheService}. */
-public class BlobCacheSuccessTest extends TestLogger {
+class BlobCacheSuccessTest {
 
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir private Path tempDir;
 
     /**
      * BlobCache with no HA, job-unrelated BLOBs. BLOBs need to be downloaded form a working
      * BlobServer.
      */
     @Test
-    public void testBlobNoJobCache() throws IOException {
+    void testBlobNoJobCache() throws IOException {
         Configuration config = new Configuration();
-        config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+        config.setString(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
 
         uploadFileGetTest(config, null, false, false, TRANSIENT_BLOB);
     }
@@ -62,10 +61,9 @@ public class BlobCacheSuccessTest extends TestLogger {
      * BlobServer.
      */
     @Test
-    public void testBlobForJobCache() throws IOException {
+    void testBlobForJobCache() throws IOException {
         Configuration config = new Configuration();
-        config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+        config.setString(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
 
         uploadFileGetTest(config, new JobID(), false, false, TRANSIENT_BLOB);
     }
@@ -76,13 +74,14 @@ public class BlobCacheSuccessTest extends TestLogger {
      * the BLOB upload. Using job-related BLOBs.
      */
     @Test
-    public void testBlobForJobCacheHa() throws IOException {
+    void testBlobForJobCacheHa() throws IOException {
         Configuration config = new Configuration();
         config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+                BlobServerOptions.STORAGE_DIRECTORY,
+                TempDirUtils.newFolder(tempDir).getAbsolutePath());
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         uploadFileGetTest(config, new JobID(), true, true, PERMANENT_BLOB);
     }
@@ -93,13 +92,14 @@ public class BlobCacheSuccessTest extends TestLogger {
      * BLOB upload. Using job-related BLOBs.
      */
     @Test
-    public void testBlobForJobCacheHa2() throws IOException {
+    void testBlobForJobCacheHa2() throws IOException {
         Configuration config = new Configuration();
         config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+                BlobServerOptions.STORAGE_DIRECTORY,
+                TempDirUtils.newFolder(tempDir).getAbsolutePath());
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
         uploadFileGetTest(config, new JobID(), false, true, PERMANENT_BLOB);
     }
 
@@ -108,13 +108,14 @@ public class BlobCacheSuccessTest extends TestLogger {
      * thus needs to download BLOBs from the BlobServer. Using job-related BLOBs.
      */
     @Test
-    public void testBlobForJobCacheHaFallback() throws IOException {
+    void testBlobForJobCacheHaFallback() throws IOException {
         Configuration config = new Configuration();
         config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+                BlobServerOptions.STORAGE_DIRECTORY,
+                TempDirUtils.newFolder(tempDir).getAbsolutePath());
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         uploadFileGetTest(config, new JobID(), false, false, PERMANENT_BLOB);
     }
@@ -142,12 +143,13 @@ public class BlobCacheSuccessTest extends TestLogger {
 
         final Configuration cacheConfig = new Configuration(config);
         cacheConfig.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+                BlobServerOptions.STORAGE_DIRECTORY,
+                TempDirUtils.newFolder(tempDir).getAbsolutePath());
         if (!cacheHasAccessToFs) {
             // make sure the cache cannot access the HA store directly
             cacheConfig.setString(
                     HighAvailabilityOptions.HA_STORAGE_PATH,
-                    temporaryFolder.newFolder().getPath() + "/does-not-exist");
+                    TempDirUtils.newFolder(tempDir).getPath() + "/does-not-exist");
         }
 
         // First create two BLOBs and upload them to BLOB server
@@ -159,15 +161,11 @@ public class BlobCacheSuccessTest extends TestLogger {
 
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(cacheConfig);
-            try (BlobServer server =
-                            new BlobServer(config, temporaryFolder.newFolder(), blobStoreService);
-                    BlobCacheService cache =
-                            new BlobCacheService(
-                                    cacheConfig,
-                                    temporaryFolder.newFolder(),
-                                    blobStoreService,
-                                    new InetSocketAddress("localhost", server.getPort()))) {
-
+            Tuple2<BlobServer, BlobCacheService> serverAndCache =
+                    TestingBlobUtils.createServerAndCache(
+                            tempDir, config, cacheConfig, blobStoreService, blobStoreService);
+            try (BlobServer server = serverAndCache.f0;
+                    BlobCacheService cache = serverAndCache.f1) {
                 server.start();
 
                 // Upload BLOBs

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -22,24 +22,21 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.List;
@@ -49,17 +46,12 @@ import static org.apache.flink.runtime.blob.BlobCachePutTest.verifyDeletedEventu
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** This class contains unit tests for the {@link BlobClient}. */
-public class BlobClientTest extends TestLogger {
+class BlobClientTest {
 
     /** The buffer size used during the tests in bytes. */
     private static final int TEST_BUFFER_SIZE = 17 * 1000;
@@ -70,21 +62,20 @@ public class BlobClientTest extends TestLogger {
     /** The blob service (non-ssl) client configuration. */
     static Configuration clientConfig;
 
-    @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir static java.nio.file.Path tempDir;
 
     /** Starts the BLOB server. */
-    @BeforeClass
-    public static void startServer() throws IOException {
-        Configuration config = new Configuration();
-        blobServer = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
+    @BeforeAll
+    static void startServer() throws IOException {
+        blobServer = TestingBlobUtils.createServer(tempDir);
         blobServer.start();
 
         clientConfig = new Configuration();
     }
 
     /** Shuts the BLOB server down. */
-    @AfterClass
-    public static void stopServer() throws IOException {
+    @AfterAll
+    static void stopServer() throws IOException {
         if (blobServer != null) {
             blobServer.close();
         }
@@ -167,8 +158,8 @@ public class BlobClientTest extends TestLogger {
                 bytesReceived += read;
 
                 if (bytesReceived == receivedBuffer.length) {
-                    assertEquals(-1, actualInputStream.read());
-                    assertArrayEquals(expectedBuf, receivedBuffer);
+                    assertThat(actualInputStream.read()).isEqualTo(-1);
+                    assertThat(receivedBuffer).isEqualTo(expectedBuf);
                     return;
                 }
             }
@@ -193,7 +184,7 @@ public class BlobClientTest extends TestLogger {
                 final int r1 = actualInputStream.read();
                 final int r2 = expectedInputStream.read();
 
-                assertEquals(r2, r1);
+                assertThat(r1).isEqualTo(r2);
 
                 if (r1 < 0) {
                     break;
@@ -216,7 +207,7 @@ public class BlobClientTest extends TestLogger {
     @SuppressWarnings("WeakerAccess")
     static void validateGetAndClose(final InputStream actualInputStream, final File expectedFile)
             throws IOException {
-        validateGetAndClose(actualInputStream, new FileInputStream(expectedFile));
+        validateGetAndClose(actualInputStream, Files.newInputStream(expectedFile.toPath()));
     }
 
     protected boolean isSSLEnabled() {
@@ -224,13 +215,12 @@ public class BlobClientTest extends TestLogger {
     }
 
     @Test
-    public void testContentAddressableBufferTransientBlob()
-            throws IOException, InterruptedException {
+    void testContentAddressableBufferTransientBlob() throws IOException, InterruptedException {
         testContentAddressableBuffer(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testContentAddressableBufferPermantBlob() throws IOException, InterruptedException {
+    void testContentAddressableBufferPermantBlob() throws IOException, InterruptedException {
         testContentAddressableBuffer(PERMANENT_BLOB);
     }
 
@@ -259,13 +249,13 @@ public class BlobClientTest extends TestLogger {
             BlobKey receivedKey1 = null;
             if (blobType == TRANSIENT_BLOB) {
                 receivedKey1 = client.putBuffer(null, testBuffer, 0, testBuffer.length, blobType);
-                assertArrayEquals(digest, receivedKey1.getHash());
+                assertThat(receivedKey1.getHash()).isEqualTo(digest);
             }
 
             // try again with a job-related BLOB:
             BlobKey receivedKey2 =
                     client.putBuffer(jobId, testBuffer, 0, testBuffer.length, blobType);
-            assertArrayEquals(digest, receivedKey2.getHash());
+            assertThat(receivedKey2.getHash()).isEqualTo(digest);
             if (blobType == TRANSIENT_BLOB) {
                 verifyKeyDifferentHashEquals(receivedKey1, receivedKey2);
             }
@@ -284,20 +274,16 @@ public class BlobClientTest extends TestLogger {
             }
 
             // Check reaction to invalid keys for job-unrelated blobs
-            try (InputStream ignored = client.getInternal(null, BlobKey.createKey(blobType))) {
-                fail("Expected IOException did not occur");
-            } catch (IOException fnfe) {
-                // expected
-            }
+            final BlobClient finalClient1 = client;
+            assertThatThrownBy(() -> finalClient1.getInternal(null, BlobKey.createKey(blobType)))
+                    .isInstanceOf(IOException.class);
 
             // Check reaction to invalid keys for job-related blobs
             // new client needed (closed from failure above)
             client = new BlobClient(serverAddress, getBlobClientConfig());
-            try (InputStream ignored = client.getInternal(jobId, BlobKey.createKey(blobType))) {
-                fail("Expected IOException did not occur");
-            } catch (IOException fnfe) {
-                // expected
-            }
+            final BlobClient finalClient2 = client;
+            assertThatThrownBy(() -> finalClient2.getInternal(jobId, BlobKey.createKey(blobType)))
+                    .isInstanceOf(IOException.class);
         } finally {
             if (client != null) {
                 try {
@@ -317,14 +303,12 @@ public class BlobClientTest extends TestLogger {
     }
 
     @Test
-    public void testContentAddressableStreamTransientBlob()
-            throws IOException, InterruptedException {
+    void testContentAddressableStreamTransientBlob() throws IOException, InterruptedException {
         testContentAddressableStream(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testContentAddressableStreamPermanentBlob()
-            throws IOException, InterruptedException {
+    void testContentAddressableStreamPermanentBlob() throws IOException, InterruptedException {
         testContentAddressableStream(PERMANENT_BLOB);
     }
 
@@ -336,7 +320,7 @@ public class BlobClientTest extends TestLogger {
     private void testContentAddressableStream(BlobKey.BlobType blobType)
             throws IOException, InterruptedException {
 
-        File testFile = temporaryFolder.newFile();
+        File testFile = tempDir.resolve("test_file").toFile();
         byte[] digest = prepareTestFile(testFile);
 
         InputStream is = null;
@@ -351,13 +335,13 @@ public class BlobClientTest extends TestLogger {
 
             // Store the data (job-unrelated)
             if (blobType == TRANSIENT_BLOB) {
-                is = new FileInputStream(testFile);
+                is = Files.newInputStream(testFile.toPath());
                 receivedKey1 = client.putInputStream(null, is, blobType);
-                assertArrayEquals(digest, receivedKey1.getHash());
+                assertThat(receivedKey1.getHash()).isEqualTo(digest);
             }
 
             // try again with a job-related BLOB:
-            is = new FileInputStream(testFile);
+            is = Files.newInputStream(testFile.toPath());
             BlobKey receivedKey2 = client.putInputStream(jobId, is, blobType);
 
             is.close();
@@ -388,17 +372,17 @@ public class BlobClientTest extends TestLogger {
     }
 
     @Test
-    public void testGetFailsDuringStreamingNoJobTransientBlob() throws IOException {
+    void testGetFailsDuringStreamingNoJobTransientBlob() throws IOException {
         testGetFailsDuringStreaming(null, TRANSIENT_BLOB);
     }
 
     @Test
-    public void testGetFailsDuringStreamingForJobTransientBlob() throws IOException {
+    void testGetFailsDuringStreamingForJobTransientBlob() throws IOException {
         testGetFailsDuringStreaming(new JobID(), TRANSIENT_BLOB);
     }
 
     @Test
-    public void testGetFailsDuringStreamingForJobPermanentBlob() throws IOException {
+    void testGetFailsDuringStreamingForJobPermanentBlob() throws IOException {
         testGetFailsDuringStreaming(new JobID(), PERMANENT_BLOB);
     }
 
@@ -411,7 +395,9 @@ public class BlobClientTest extends TestLogger {
     private void testGetFailsDuringStreaming(@Nullable final JobID jobId, BlobKey.BlobType blobType)
             throws IOException {
 
-        assumeFalse("This test can deadlock when using SSL. See FLINK-19369.", isSSLEnabled());
+        assumeThat(isSSLEnabled())
+                .as("This test can deadlock when using SSL. See FLINK-19369.")
+                .isFalse();
 
         try (BlobClient client =
                 new BlobClient(
@@ -424,7 +410,7 @@ public class BlobClientTest extends TestLogger {
 
             // put content addressable (like libraries)
             BlobKey key = client.putBuffer(jobId, data, 0, data.length, blobType);
-            assertNotNull(key);
+            assertThat(key).isNotNull();
 
             // issue a GET request that succeeds
             InputStream is = client.getInternal(jobId, key);
@@ -448,7 +434,7 @@ public class BlobClientTest extends TestLogger {
                         null);
                 // we tolerate that this succeeds, as the receiver socket may have buffered
                 // everything already, but in this case, also verify the contents
-                assertArrayEquals(data, receiveBuffer);
+                assertThat(receiveBuffer).isEqualTo(data);
             } catch (IOException e) {
                 // expected
             }
@@ -460,7 +446,7 @@ public class BlobClientTest extends TestLogger {
      * List)} helper.
      */
     @Test
-    public void testUploadJarFilesHelper() throws Exception {
+    void testUploadJarFilesHelper() throws Exception {
         uploadJarFile(getBlobServer(), getBlobClientConfig());
     }
 
@@ -493,7 +479,7 @@ public class BlobClientTest extends TestLogger {
                         jobId,
                         Collections.singletonList(new Path(testFile.toURI())));
 
-        assertEquals(1, blobKeys.size());
+        assertThat(blobKeys).hasSize(1);
 
         try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
             validateGetAndClose(blobClient.getInternal(jobId, blobKeys.get(0)), testFile);
@@ -502,7 +488,7 @@ public class BlobClientTest extends TestLogger {
 
     /** Tests the socket operation timeout. */
     @Test
-    public void testSocketTimeout() throws IOException {
+    void testSocketTimeout() throws IOException {
         Configuration clientConfig = getBlobClientConfig();
         int oldSoTimeout = clientConfig.getInteger(BlobServerOptions.SO_TIMEOUT);
 
@@ -510,20 +496,20 @@ public class BlobClientTest extends TestLogger {
 
         try (final TestBlobServer testBlobServer =
                 new TestBlobServer(
-                        clientConfig, temporaryFolder.newFolder(), new VoidBlobStore(), 10_000L)) {
+                        clientConfig,
+                        tempDir.resolve("test_server").toFile(),
+                        new VoidBlobStore(),
+                        10_000L)) {
             testBlobServer.start();
             InetSocketAddress serverAddress =
                     new InetSocketAddress("localhost", testBlobServer.getPort());
 
             try (BlobClient client = new BlobClient(serverAddress, clientConfig)) {
-                client.getInternal(new JobID(), BlobKey.createKey(TRANSIENT_BLOB));
-
-                fail("Should throw an exception.");
-            } catch (Throwable t) {
-                assertThat(
-                        ExceptionUtils.findThrowable(t, java.net.SocketTimeoutException.class)
-                                .isPresent(),
-                        is(true));
+                assertThatThrownBy(
+                                () ->
+                                        client.getInternal(
+                                                new JobID(), BlobKey.createKey(TRANSIENT_BLOB)))
+                        .hasCauseInstanceOf(java.net.SocketTimeoutException.class);
             }
         } finally {
             clientConfig.setInteger(BlobServerOptions.SO_TIMEOUT, oldSoTimeout);
@@ -531,12 +517,12 @@ public class BlobClientTest extends TestLogger {
     }
 
     @Test
-    public void testUnresolvedInetSocketAddress() throws Exception {
+    void testUnresolvedInetSocketAddress() throws Exception {
         try (BlobClient client =
                 new BlobClient(
                         InetSocketAddress.createUnresolved("localhost", getBlobServer().getPort()),
                         getBlobClientConfig())) {
-            assertTrue(client.isConnected());
+            assertThat(client.isConnected()).isTrue();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
@@ -21,9 +21,8 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -31,21 +30,11 @@ import java.io.IOException;
 
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** This class contains unit tests for the {@link BlobKey} class. */
-public final class BlobKeyTest extends TestLogger {
+final class BlobKeyTest {
     /** The first key array to be used during the unit tests. */
     private static final byte[] KEY_ARRAY_1 = new byte[BlobKey.SIZE];
 
@@ -73,23 +62,23 @@ public final class BlobKeyTest extends TestLogger {
     }
 
     @Test
-    public void testCreateKey() {
+    void testCreateKey() {
         BlobKey key = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1);
         verifyType(PERMANENT_BLOB, key);
-        assertArrayEquals(KEY_ARRAY_1, key.getHash());
+        assertThat(key.getHash()).isEqualTo(KEY_ARRAY_1);
 
         key = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1);
         verifyType(TRANSIENT_BLOB, key);
-        assertArrayEquals(KEY_ARRAY_1, key.getHash());
+        assertThat(key.getHash()).isEqualTo(KEY_ARRAY_1);
     }
 
     @Test
-    public void testSerializationTransient() throws Exception {
+    void testSerializationTransient() throws Exception {
         testSerialization(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testSerializationPermanent() throws Exception {
+    void testSerializationPermanent() throws Exception {
         testSerialization(PERMANENT_BLOB);
     }
 
@@ -97,18 +86,18 @@ public final class BlobKeyTest extends TestLogger {
     private void testSerialization(BlobKey.BlobType blobType) throws Exception {
         final BlobKey k1 = BlobKey.createKey(blobType, KEY_ARRAY_1, RANDOM_ARRAY_1);
         final BlobKey k2 = CommonTestUtils.createCopySerializable(k1);
-        assertEquals(k1, k2);
-        assertEquals(k1.hashCode(), k2.hashCode());
-        assertEquals(0, k1.compareTo(k2));
+        assertThat(k2).isEqualTo(k1);
+        assertThat(k2).hasSameHashCodeAs(k1);
+        assertThat(k1).isEqualByComparingTo(k2);
     }
 
     @Test
-    public void testEqualsTransient() {
+    void testEqualsTransient() {
         testEquals(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testEqualsPermanent() {
+    void testEqualsPermanent() {
         testEquals(PERMANENT_BLOB);
     }
 
@@ -118,36 +107,35 @@ public final class BlobKeyTest extends TestLogger {
         final BlobKey k2 = BlobKey.createKey(blobType, KEY_ARRAY_1, RANDOM_ARRAY_1);
         final BlobKey k3 = BlobKey.createKey(blobType, KEY_ARRAY_2, RANDOM_ARRAY_1);
         final BlobKey k4 = BlobKey.createKey(blobType, KEY_ARRAY_1, RANDOM_ARRAY_2);
-        assertTrue(k1.equals(k2));
-        assertTrue(k2.equals(k1));
-        assertEquals(k1.hashCode(), k2.hashCode());
-        assertFalse(k1.equals(k3));
-        assertFalse(k3.equals(k1));
-        assertFalse(k1.equals(k4));
-        assertFalse(k4.equals(k1));
+        assertThat(k1).isEqualTo(k2);
+        assertThat(k2).isEqualTo(k1);
+        assertThat(k2).hasSameHashCodeAs(k1);
+        assertThat(k1).isNotEqualTo(k3);
+        assertThat(k3).isNotEqualTo(k1);
+        assertThat(k1).isNotEqualTo(k4);
+        assertThat(k4).isNotEqualTo(k1);
 
-        //noinspection ObjectEqualsNull
-        assertFalse(k1.equals(null));
-        //noinspection EqualsBetweenInconvertibleTypes
-        assertFalse(k1.equals(this));
+        assertThat(k1).isNotEqualTo(null);
+        //noinspection AssertBetweenInconvertibleTypes
+        assertThat(k1).isNotEqualTo(this);
     }
 
     /** Tests the equals method. */
     @Test
-    public void testEqualsDifferentBlobType() {
+    void testEqualsDifferentBlobType() {
         final BlobKey k1 = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1, RANDOM_ARRAY_1);
         final BlobKey k2 = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1, RANDOM_ARRAY_1);
-        assertFalse(k1.equals(k2));
-        assertFalse(k2.equals(k1));
+        assertThat(k1).isNotEqualTo(k2);
+        assertThat(k2).isNotEqualTo(k1);
     }
 
     @Test
-    public void testComparesTransient() {
+    void testComparesTransient() {
         testCompares(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testComparesPermanent() {
+    void testComparesPermanent() {
         testCompares(PERMANENT_BLOB);
     }
 
@@ -157,39 +145,39 @@ public final class BlobKeyTest extends TestLogger {
         final BlobKey k2 = BlobKey.createKey(blobType, KEY_ARRAY_1, RANDOM_ARRAY_1);
         final BlobKey k3 = BlobKey.createKey(blobType, KEY_ARRAY_2, RANDOM_ARRAY_1);
         final BlobKey k4 = BlobKey.createKey(blobType, KEY_ARRAY_1, RANDOM_ARRAY_2);
-        assertThat(k1.compareTo(k2), is(0));
-        assertThat(k2.compareTo(k1), is(0));
-        assertThat(k1.compareTo(k3), lessThan(0));
-        assertThat(k1.compareTo(k4), lessThan(0));
-        assertThat(k3.compareTo(k1), greaterThan(0));
-        assertThat(k4.compareTo(k1), greaterThan(0));
+        assertThat(k1).isEqualByComparingTo(k2);
+        assertThat(k2).isEqualByComparingTo(k1);
+        assertThat(k1).isLessThan(k3);
+        assertThat(k1).isLessThan(k4);
+        assertThat(k3).isGreaterThan(k1);
+        assertThat(k4).isGreaterThan(k1);
     }
 
     @Test
-    public void testComparesDifferentBlobType() {
+    void testComparesDifferentBlobType() {
         final BlobKey k1 = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1, RANDOM_ARRAY_1);
         final BlobKey k2 = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1, RANDOM_ARRAY_1);
-        assertThat(k1.compareTo(k2), greaterThan(0));
-        assertThat(k2.compareTo(k1), lessThan(0));
+        assertThat(k1).isGreaterThan(k2);
+        assertThat(k2).isLessThan(k1);
     }
 
     @Test
-    public void testStreamsTransient() throws Exception {
+    void testStreamsTransient() throws Exception {
         testStreams(TRANSIENT_BLOB);
     }
 
     @Test
-    public void testStreamsPermanent() throws Exception {
+    void testStreamsPermanent() throws Exception {
         testStreams(PERMANENT_BLOB);
     }
 
     @Test
-    public void testToFromStringPermanentKey() {
+    void testToFromStringPermanentKey() {
         testToFromString(BlobKey.createKey(PERMANENT_BLOB));
     }
 
     @Test
-    public void testToFromStringTransientKey() {
+    void testToFromStringTransientKey() {
         testToFromString(BlobKey.createKey(TRANSIENT_BLOB));
     }
 
@@ -197,21 +185,25 @@ public final class BlobKeyTest extends TestLogger {
         final String stringRepresentation = blobKey.toString();
         final BlobKey parsedBlobKey = BlobKey.fromString(stringRepresentation);
 
-        assertThat(blobKey, equalTo(parsedBlobKey));
+        assertThat(blobKey).isEqualTo(parsedBlobKey);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testFromStringFailsWithWrongInput() {
-        BlobKey.fromString("foobar");
+    @Test
+    void testFromStringFailsWithWrongInput() {
+        assertThatThrownBy(() -> BlobKey.fromString("foobar"))
+                .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testFromStringFailsWithInvalidBlobKeyType() {
-        BlobKey.fromString(
-                String.format(
-                        "x-%s-%s",
-                        StringUtils.byteToHexString(KEY_ARRAY_1),
-                        StringUtils.byteToHexString(RANDOM_ARRAY_1)));
+    @Test
+    void testFromStringFailsWithInvalidBlobKeyType() {
+        assertThatThrownBy(
+                        () ->
+                                BlobKey.fromString(
+                                        String.format(
+                                                "x-%s-%s",
+                                                StringUtils.byteToHexString(KEY_ARRAY_1),
+                                                StringUtils.byteToHexString(RANDOM_ARRAY_1))))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     /** Test the serialization/deserialization using input/output streams. */
@@ -225,7 +217,7 @@ public final class BlobKeyTest extends TestLogger {
         final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         final BlobKey k2 = BlobKey.readFromInputStream(bais);
 
-        assertEquals(k1, k2);
+        assertThat(k2).isEqualTo(k1);
     }
 
     /**
@@ -235,8 +227,8 @@ public final class BlobKeyTest extends TestLogger {
      * @param key2 second blob key
      */
     static void verifyKeyDifferentHashEquals(BlobKey key1, BlobKey key2) {
-        assertNotEquals(key1, key2);
-        assertThat(key1.getHash(), equalTo(key2.getHash()));
+        assertThat(key1).isNotEqualTo(key2);
+        assertThat(key1.getHash()).isEqualTo(key2.getHash());
     }
 
     /**
@@ -246,8 +238,8 @@ public final class BlobKeyTest extends TestLogger {
      * @param key2 second blob key
      */
     static void verifyKeyDifferentHashDifferent(BlobKey key1, BlobKey key2) {
-        assertNotEquals(key1, key2);
-        assertThat(key1.getHash(), not(equalTo(key2.getHash())));
+        assertThat(key1).isNotEqualTo(key2);
+        assertThat(key1.getHash()).isNotEqualTo(key2.getHash());
     }
 
     /**
@@ -258,9 +250,9 @@ public final class BlobKeyTest extends TestLogger {
      */
     static void verifyType(BlobKey.BlobType expected, BlobKey key) {
         if (expected == PERMANENT_BLOB) {
-            assertThat(key, is(instanceOf(PermanentBlobKey.class)));
+            assertThat(key).isInstanceOf(PermanentBlobKey.class);
         } else {
-            assertThat(key, is(instanceOf(TransientBlobKey.class)));
+            assertThat(key).isInstanceOf(TransientBlobKey.class);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.TriConsumerWithException;
 
@@ -58,12 +57,14 @@ import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
+import static org.apache.flink.runtime.blob.TestingBlobHelpers.checkFileCountForJob;
+import static org.apache.flink.runtime.blob.TestingBlobHelpers.checkFilesExist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 /** A few tests for the cleanup of transient BLOBs at the {@link BlobServer}. */
-public class BlobServerCleanupTest extends TestLogger {
+class BlobServerCleanupTest {
 
     private static final Random RANDOM = new Random();
 
@@ -92,13 +93,13 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testTransientBlobNoJobCleanup()
+    void testTransientBlobNoJobCleanup()
             throws IOException, InterruptedException, ExecutionException {
         testTransientBlobCleanup(null);
     }
 
     @Test
-    public void testTransientBlobForJobCleanup()
+    void testTransientBlobForJobCleanup()
             throws IOException, InterruptedException, ExecutionException {
         testTransientBlobCleanup(new JobID());
     }
@@ -210,7 +211,7 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testLocalCleanup() throws Exception {
+    void testLocalCleanup() throws Exception {
         final TestingBlobStore blobStore =
                 createTestingBlobStoreBuilder()
                         .setDeleteAllFunction(
@@ -227,7 +228,7 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testGlobalCleanup() throws Exception {
+    void testGlobalCleanup() throws Exception {
         final Set<JobID> actuallyDeletedJobData = new HashSet<>();
         final JobID jobId = new JobID();
         final TestingBlobStore blobStore =
@@ -248,7 +249,7 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testGlobalCleanupUnsuccessfulInBlobStore() throws Exception {
+    void testGlobalCleanupUnsuccessfulInBlobStore() throws Exception {
         final TestingBlobStore blobStore =
                 createTestingBlobStoreBuilder()
                         .setDeleteAllFunction(jobDataToDelete -> false)
@@ -268,7 +269,7 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testGlobalCleanupFailureInBlobStore() throws Exception {
+    void testGlobalCleanupFailureInBlobStore() throws Exception {
         final RuntimeException actualException = new RuntimeException("Expected RuntimeException");
         final TestingBlobStore blobStore =
                 createTestingBlobStoreBuilder()
@@ -364,12 +365,12 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testBlobServerExpiresRecoveredTransientJobBlob() throws Exception {
+    void testBlobServerExpiresRecoveredTransientJobBlob() throws Exception {
         runBlobServerExpiresRecoveredTransientBlob(new JobID());
     }
 
     @Test
-    public void testBlobServerExpiresRecoveredTransientNoJobBlob() throws Exception {
+    void testBlobServerExpiresRecoveredTransientNoJobBlob() throws Exception {
         runBlobServerExpiresRecoveredTransientBlob(null);
     }
 
@@ -389,7 +390,7 @@ public class BlobServerCleanupTest extends TestLogger {
     }
 
     @Test
-    public void testBlobServerRetainsJobs() throws Exception {
+    void testBlobServerRetainsJobs() throws Exception {
         final JobID jobId1 = new JobID();
         final JobID jobId2 = new JobID();
 
@@ -411,84 +412,6 @@ public class BlobServerCleanupTest extends TestLogger {
                     .isInstanceOf(NoSuchFileException.class);
         } finally {
             assertThat(executorService.shutdownNow()).isEmpty();
-        }
-    }
-
-    /**
-     * Checks how many of the files given by blob keys are accessible.
-     *
-     * @param jobId ID of a job
-     * @param keys blob keys to check
-     * @param blobService BLOB store to use
-     * @param doThrow whether exceptions should be ignored (<tt>false</tt>), or thrown
-     *     (<tt>true</tt>)
-     * @return number of files existing at {@link BlobServer#getStorageLocation(JobID, BlobKey)} and
-     *     {@link PermanentBlobCache#getStorageLocation(JobID, BlobKey)}, respectively
-     */
-    public static <T> int checkFilesExist(
-            JobID jobId, Collection<? extends BlobKey> keys, T blobService, boolean doThrow)
-            throws IOException {
-
-        int numFiles = 0;
-
-        for (BlobKey key : keys) {
-            final File storageDir;
-            if (blobService instanceof BlobServer) {
-                BlobServer server = (BlobServer) blobService;
-                storageDir = server.getStorageDir();
-            } else if (blobService instanceof PermanentBlobCache) {
-                PermanentBlobCache cache = (PermanentBlobCache) blobService;
-                storageDir = cache.getStorageDir();
-            } else if (blobService instanceof TransientBlobCache) {
-                TransientBlobCache cache = (TransientBlobCache) blobService;
-                storageDir = cache.getStorageDir();
-            } else {
-                throw new UnsupportedOperationException(
-                        "unsupported BLOB service class: "
-                                + blobService.getClass().getCanonicalName());
-            }
-
-            final File blobFile =
-                    new File(
-                            BlobUtils.getStorageLocationPath(
-                                    storageDir.getAbsolutePath(), jobId, key));
-            if (blobFile.exists()) {
-                ++numFiles;
-            } else if (doThrow) {
-                throw new IOException("File " + blobFile + " does not exist.");
-            }
-        }
-
-        return numFiles;
-    }
-
-    /**
-     * Checks how many of the files given by blob keys are accessible.
-     *
-     * @param expectedCount number of expected files in the blob service for the given job
-     * @param jobId ID of a job
-     * @param blobService BLOB store to use
-     */
-    public static void checkFileCountForJob(
-            int expectedCount, JobID jobId, PermanentBlobService blobService) throws IOException {
-
-        final File jobDir;
-        if (blobService instanceof BlobServer) {
-            BlobServer server = (BlobServer) blobService;
-            jobDir = server.getStorageLocation(jobId, new PermanentBlobKey()).getParentFile();
-        } else {
-            PermanentBlobCache cache = (PermanentBlobCache) blobService;
-            jobDir = cache.getStorageLocation(jobId, new PermanentBlobKey()).getParentFile();
-        }
-        File[] blobsForJob = jobDir.listFiles();
-        if (blobsForJob == null) {
-            if (expectedCount != 0) {
-                throw new IOException("File " + jobDir + " does not exist.");
-            }
-        } else {
-            assertThat(blobsForJob.length)
-                    .as("Too many/few files in job dir: " + Arrays.asList(blobsForJob))
-                    .isEqualTo(expectedCount);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
@@ -18,113 +18,52 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.core.testutils.FlinkAssertions;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Random;
-
-import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.nio.file.Path;
 
 /**
  * Tests how GET requests react to corrupt files when downloaded via a {@link BlobServer}.
  *
  * <p>Successful GET requests are tested in conjunction wit the PUT requests.
  */
-public class BlobServerCorruptionTest extends TestLogger {
+class BlobServerCorruptionTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir private Path tempDir;
 
     /**
      * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
      * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
      */
     @Test
-    public void testGetFailsFromCorruptFile() throws IOException {
+    void testGetFailsFromCorruptFile() throws IOException {
 
         final Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
                 BlobServerOptions.STORAGE_DIRECTORY,
-                TEMPORARY_FOLDER.newFolder().getAbsolutePath());
+                TempDirUtils.newFolder(tempDir).getAbsolutePath());
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, TEMPORARY_FOLDER.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;
 
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
-            testGetFailsFromCorruptFile(config, blobStoreService, TEMPORARY_FOLDER.newFolder());
+            TestingBlobHelpers.testGetFailsFromCorruptFile(
+                    config, blobStoreService, TempDirUtils.newFolder(tempDir));
         } finally {
             if (blobStoreService != null) {
                 blobStoreService.closeAndCleanupAllData();
             }
-        }
-    }
-
-    /**
-     * Checks the GET operation fails when the downloaded file (from HA store) is corrupt, i.e. its
-     * content's hash does not match the {@link BlobKey}'s hash.
-     *
-     * @param config blob server configuration (including HA settings like {@link
-     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
-     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
-     * @param blobStore shared HA blob store to use
-     */
-    public static void testGetFailsFromCorruptFile(
-            Configuration config, BlobStore blobStore, File blobStorage) throws IOException {
-
-        Random rnd = new Random();
-        JobID jobId = new JobID();
-
-        try (BlobServer server = new BlobServer(config, blobStorage, blobStore)) {
-
-            server.start();
-
-            byte[] data = new byte[2000000];
-            rnd.nextBytes(data);
-
-            // put content addressable (like libraries)
-            BlobKey key = put(server, jobId, data, PERMANENT_BLOB);
-            assertNotNull(key);
-
-            // delete local file to make sure that the GET requests downloads from HA
-            File blobFile = server.getStorageLocation(jobId, key);
-            assertTrue(blobFile.delete());
-
-            // change HA store file contents to make sure that GET requests fail
-            byte[] data2 = Arrays.copyOf(data, data.length);
-            data2[0] ^= 1;
-            File tmpFile = Files.createTempFile("blob", ".jar").toFile();
-            try {
-                FileUtils.writeByteArrayToFile(tmpFile, data2);
-                blobStore.put(tmpFile, jobId, key);
-            } finally {
-                //noinspection ResultOfMethodCallIgnored
-                tmpFile.delete();
-            }
-
-            assertThatThrownBy(() -> get(server, jobId, key))
-                    .satisfies(
-                            FlinkAssertions.anyCauseMatches(IOException.class, "data corruption"));
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -18,39 +18,18 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Random;
-
-import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashEquals;
-import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
-import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Tests for the recovery of files of a {@link BlobServer} from a HA store. */
-public class BlobServerRecoveryTest extends TestLogger {
+class BlobServerRecoveryTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir private java.nio.file.Path tempDir;
 
     /**
      * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from
@@ -61,100 +40,18 @@ public class BlobServerRecoveryTest extends TestLogger {
         Configuration config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
         config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, TEMPORARY_FOLDER.newFolder().getPath());
+                HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;
 
         try {
             blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
-            testBlobServerRecovery(config, blobStoreService, TEMPORARY_FOLDER.newFolder());
+            TestingBlobHelpers.testBlobServerRecovery(
+                    config, blobStoreService, TempDirUtils.newFolder(tempDir));
         } finally {
             if (blobStoreService != null) {
                 blobStoreService.closeAndCleanupAllData();
-            }
-        }
-    }
-
-    /**
-     * Helper to test that the {@link BlobServer} recovery from its HA store works.
-     *
-     * <p>Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to
-     * retrieve them via a shared HA store upon request of a {@link BlobCacheService}.
-     *
-     * @param config blob server configuration (including HA settings like {@link
-     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
-     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
-     * @param blobStore shared HA blob store to use
-     * @throws IOException in case of failures
-     */
-    public static void testBlobServerRecovery(
-            final Configuration config, final BlobStore blobStore, final File blobStorage)
-            throws Exception {
-        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-        String storagePath =
-                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
-        Random rand = new Random();
-
-        try (BlobServer server0 =
-                        new BlobServer(config, new File(blobStorage, "server0"), blobStore);
-                BlobServer server1 =
-                        new BlobServer(config, new File(blobStorage, "server1"), blobStore);
-                // use VoidBlobStore as the HA store to force download from server[1]'s HA store
-                BlobCacheService cache1 =
-                        new BlobCacheService(
-                                config,
-                                new File(blobStorage, "cache1"),
-                                new VoidBlobStore(),
-                                new InetSocketAddress("localhost", server1.getPort()))) {
-
-            server0.start();
-            server1.start();
-
-            // Random data
-            byte[] expected = new byte[1024];
-            rand.nextBytes(expected);
-            byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
-
-            BlobKey[] keys = new BlobKey[2];
-            BlobKey nonHAKey;
-
-            // Put job-related HA data
-            JobID[] jobId = new JobID[] {new JobID(), new JobID()};
-            keys[0] = put(server0, jobId[0], expected, PERMANENT_BLOB); // Request 1
-            keys[1] = put(server0, jobId[1], expected2, PERMANENT_BLOB); // Request 2
-
-            // put non-HA data
-            nonHAKey = put(server0, jobId[0], expected2, TRANSIENT_BLOB);
-            verifyKeyDifferentHashEquals(keys[1], nonHAKey);
-
-            // check that the storage directory exists
-            final Path blobServerPath = new Path(storagePath, "blob");
-            FileSystem fs = blobServerPath.getFileSystem();
-            assertTrue("Unknown storage dir: " + blobServerPath, fs.exists(blobServerPath));
-
-            // Verify HA requests from cache1 (connected to server1) with no immediate access to the
-            // file
-            verifyContents(cache1, jobId[0], keys[0], expected);
-            verifyContents(cache1, jobId[1], keys[1], expected2);
-
-            // Verify non-HA file is not accessible from server1
-            verifyDeleted(cache1, jobId[0], nonHAKey);
-
-            // Remove again
-            server1.globalCleanupAsync(jobId[0], Executors.directExecutor()).join();
-            server1.globalCleanupAsync(jobId[1], Executors.directExecutor()).join();
-
-            // Verify everything is clean
-            assertTrue("HA storage directory does not exist", fs.exists(new Path(storagePath)));
-            if (fs.exists(blobServerPath)) {
-                final org.apache.flink.core.fs.FileStatus[] recoveryFiles =
-                        fs.listStatus(blobServerPath);
-                ArrayList<String> filenames = new ArrayList<>(recoveryFiles.length);
-                for (org.apache.flink.core.fs.FileStatus file : recoveryFiles) {
-                    filenames.add(file.toString());
-                }
-                fail("Unclean state backend: " + filenames);
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
@@ -20,22 +20,19 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.apache.flink.util.ExceptionUtils.findThrowable;
-import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Testing a {@link BlobServer} would fail with improper SSL config. */
-public class BlobServerSSLTest extends TestLogger {
+class BlobServerSslTest {
 
     @Test
-    public void testFailedToInitWithTwoProtocolsSet() {
+    void testFailedToInitWithTwoProtocolsSet() {
         final Configuration config = new Configuration();
 
         config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
@@ -51,17 +48,13 @@ public class BlobServerSSLTest extends TestLogger {
         config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
         config.setString(SecurityOptions.SSL_ALGORITHMS, "TLSv1,TLSv1.1");
 
-        try (final BlobServer ignored =
-                new BlobServer(config, new File("foobar"), new VoidBlobStore())) {
-            fail();
-        } catch (Exception e) {
-            findThrowable(e, IOException.class);
-            findThrowableWithMessage(e, "Unable to open BLOB Server in specified port range: 0");
-        }
+        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Unable to open BLOB Server in specified port range: 0");
     }
 
     @Test
-    public void testFailedToInitWithInvalidSslKeystoreConfigured() {
+    void testFailedToInitWithInvalidSslKeystoreConfigured() {
         final Configuration config = new Configuration();
 
         config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
@@ -71,27 +64,19 @@ public class BlobServerSSLTest extends TestLogger {
         config.setString(SecurityOptions.SSL_TRUSTSTORE, "invalid.keystore");
         config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 
-        try (final BlobServer ignored =
-                new BlobServer(config, new File("foobar"), new VoidBlobStore())) {
-            fail();
-        } catch (Exception e) {
-            findThrowable(e, IOException.class);
-            findThrowableWithMessage(e, "Failed to initialize SSL for the blob server");
-        }
+        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Failed to initialize SSL for the blob server");
     }
 
     @Test
-    public void testFailedToInitWithMissingMandatorySslConfiguration() {
+    void testFailedToInitWithMissingMandatorySslConfiguration() {
         final Configuration config = new Configuration();
 
         config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
 
-        try (final BlobServer ignored =
-                new BlobServer(config, new File("foobar"), new VoidBlobStore())) {
-            fail();
-        } catch (Exception e) {
-            findThrowable(e, IOException.class);
-            findThrowableWithMessage(e, "Failed to initialize SSL for the blob server");
-        }
+        assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Failed to initialize SSL for the blob server");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -22,78 +22,78 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for {@link BlobUtils} working on non-writable directories. */
-public class BlobUtilsNonWritableTest extends TestLogger {
+class BlobUtilsNonWritableTest {
 
     private static final String CANNOT_CREATE_THIS = "cannot-create-this";
 
-    private File blobUtilsTestDirectory;
+    @TempDir private Path tempDir;
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Before
-    public void before() throws IOException {
-        assumeTrue(!OperatingSystem.isWindows()); // setWritable doesn't work on Windows.
+    @BeforeEach
+    void before() {
+        assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();
 
         // Prepare test directory
-        blobUtilsTestDirectory = temporaryFolder.newFolder();
-        assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
-        assertTrue(blobUtilsTestDirectory.setReadable(true, false));
-        assertTrue(blobUtilsTestDirectory.setWritable(false, false));
+        assertThat(tempDir.toFile().setExecutable(true, false)).isTrue();
+        assertThat(tempDir.toFile().setReadable(true, false)).isTrue();
+        assertThat(tempDir.toFile().setWritable(false, false)).isTrue();
     }
 
-    @After
-    public void after() {
-        // Cleanup test directory, ensure it was empty
-        assertTrue(blobUtilsTestDirectory.delete());
-    }
-
-    @Test(expected = IOException.class)
-    public void testExceptionOnCreateStorageDirectoryFailure() throws IOException {
+    @Test
+    void testExceptionOnCreateStorageDirectoryFailure() {
         Configuration config = new Configuration();
         config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY,
-                new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
-        // Should throw an Exception
-        BlobUtils.createBlobStorageDirectory(config, null);
+                BlobServerOptions.STORAGE_DIRECTORY, getStorageLocationFile().getAbsolutePath());
+
+        assertThatThrownBy(() -> BlobUtils.createBlobStorageDirectory(config, null))
+                .isInstanceOf(IOException.class);
     }
 
-    @Test(expected = IOException.class)
-    public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
-        // Should throw an Exception
-        BlobUtils.getStorageLocation(
-                new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new TransientBlobKey());
+    @Test
+    void testExceptionOnCreateCacheDirectoryFailureNoJob() {
+        assertThatThrownBy(
+                        () ->
+                                BlobUtils.getStorageLocation(
+                                        getStorageLocationFile(), null, new TransientBlobKey()))
+                .isInstanceOf(IOException.class);
     }
 
-    @Test(expected = IOException.class)
-    public void testExceptionOnCreateCacheDirectoryFailureForJobTransient() throws IOException {
-        // Should throw an Exception
-        BlobUtils.getStorageLocation(
-                new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS),
-                new JobID(),
-                new TransientBlobKey());
+    @Test
+    void testExceptionOnCreateCacheDirectoryFailureForJobTransient() {
+        assertThatThrownBy(
+                        () ->
+                                BlobUtils.getStorageLocation(
+                                        getStorageLocationFile(),
+                                        new JobID(),
+                                        new TransientBlobKey()))
+                .isInstanceOf(IOException.class);
     }
 
-    @Test(expected = IOException.class)
-    public void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() throws IOException {
-        // Should throw an Exception
-        BlobUtils.getStorageLocation(
-                new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS),
-                new JobID(),
-                new PermanentBlobKey());
+    @Test
+    void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() {
+        assertThatThrownBy(
+                        () ->
+                                BlobUtils.getStorageLocation(
+                                        getStorageLocationFile(),
+                                        new JobID(),
+                                        new PermanentBlobKey()))
+                .isInstanceOf(IOException.class);
+    }
+
+    private File getStorageLocationFile() {
+        return tempDir.resolve(CANNOT_CREATE_THIS).toFile();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -23,19 +23,21 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Reference;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -44,20 +46,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link BlobUtils}. */
-public class BlobUtilsTest extends TestLogger {
+class BlobUtilsTest {
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private static final Logger LOG = LoggerFactory.getLogger(BlobUtilsTest.class);
+
+    @TempDir private Path tempDir;
 
     /**
      * Tests {@link BlobUtils#createBlobStorageDirectory} using {@link
      * BlobServerOptions#STORAGE_DIRECTORY} per default.
      */
     @Test
-    public void testDefaultBlobStorageDirectory() throws IOException {
+    void testDefaultBlobStorageDirectory() throws IOException {
         Configuration config = new Configuration();
-        String blobStorageDir = temporaryFolder.newFolder().getAbsolutePath();
+        String blobStorageDir = TempDirUtils.newFolder(tempDir).getAbsolutePath();
         config.setString(BlobServerOptions.STORAGE_DIRECTORY, blobStorageDir);
-        config.setString(CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
+        config.setString(CoreOptions.TMP_DIRS, TempDirUtils.newFolder(tempDir).getAbsolutePath());
 
         File dir = BlobUtils.createBlobStorageDirectory(config, null).deref();
         assertThat(dir.getAbsolutePath()).startsWith(blobStorageDir);
@@ -65,9 +69,9 @@ public class BlobUtilsTest extends TestLogger {
 
     /** Tests {@link BlobUtils#createBlobStorageDirectory}'s fallback to the fall back directory. */
     @Test
-    public void testTaskManagerFallbackBlobStorageDirectory1() throws IOException {
+    void testTaskManagerFallbackBlobStorageDirectory1() throws IOException {
         Configuration config = new Configuration();
-        final File fallbackDirectory = new File(temporaryFolder.newFolder(), "foobar");
+        final File fallbackDirectory = TempDirUtils.newFile(tempDir, "foobar");
 
         File dir =
                 BlobUtils.createBlobStorageDirectory(config, Reference.borrowed(fallbackDirectory))
@@ -75,34 +79,34 @@ public class BlobUtilsTest extends TestLogger {
         assertThat(dir).isEqualTo(fallbackDirectory);
     }
 
-    @Test(expected = IOException.class)
-    public void testBlobUtilsFailIfNoStorageDirectoryIsSpecified() throws IOException {
-        BlobUtils.createBlobStorageDirectory(new Configuration(), null);
+    @Test
+    void testBlobUtilsFailIfNoStorageDirectoryIsSpecified() {
+        assertThatThrownBy(() -> BlobUtils.createBlobStorageDirectory(new Configuration(), null))
+                .isInstanceOf(IOException.class);
     }
 
     @Test
-    public void testCheckAndDeleteCorruptedBlobsDeletesCorruptedBlobs() throws IOException {
-        final File storageDir = temporaryFolder.newFolder();
+    void testCheckAndDeleteCorruptedBlobsDeletesCorruptedBlobs() throws IOException {
         final JobID jobId = new JobID();
 
         final byte[] validContent = "valid".getBytes(StandardCharsets.UTF_8);
         final BlobKey validPermanentBlobKey =
-                TestingBlobUtils.writePermanentBlob(storageDir.toPath(), jobId, validContent);
+                TestingBlobUtils.writePermanentBlob(tempDir, jobId, validContent);
         final BlobKey validTransientBlobKey =
-                TestingBlobUtils.writeTransientBlob(storageDir.toPath(), jobId, validContent);
+                TestingBlobUtils.writeTransientBlob(tempDir, jobId, validContent);
 
         final PermanentBlobKey corruptedBlobKey =
-                TestingBlobUtils.writePermanentBlob(storageDir.toPath(), jobId, validContent);
+                TestingBlobUtils.writePermanentBlob(tempDir, jobId, validContent);
         FileUtils.writeFileUtf8(
                 new File(
                         BlobUtils.getStorageLocationPath(
-                                storageDir.getAbsolutePath(), jobId, corruptedBlobKey)),
+                                tempDir.toString(), jobId, corruptedBlobKey)),
                 "corrupted");
 
-        BlobUtils.checkAndDeleteCorruptedBlobs(storageDir.toPath(), log);
+        BlobUtils.checkAndDeleteCorruptedBlobs(tempDir, LOG);
 
         final List<BlobKey> blobKeys =
-                BlobUtils.listBlobsInDirectory(storageDir.toPath()).stream()
+                BlobUtils.listBlobsInDirectory(tempDir).stream()
                         .map(BlobUtils.Blob::getBlobKey)
                         .collect(Collectors.toList());
         assertThat(blobKeys)
@@ -110,13 +114,13 @@ public class BlobUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testMoveTempFileToStoreSucceeds() throws IOException {
+    void testMoveTempFileToStoreSucceeds() throws IOException {
         final FileSystemBlobStore blobStore =
                 new FileSystemBlobStore(
-                        new LocalFileSystem(), temporaryFolder.newFolder().toString());
+                        new LocalFileSystem(), TempDirUtils.newFolder(tempDir).toString());
         final JobID jobId = new JobID();
-        final File storageFile = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
-        final File incomingFile = temporaryFolder.newFile();
+        final File storageFile = tempDir.resolve(UUID.randomUUID().toString()).toFile();
+        final File incomingFile = TempDirUtils.newFile(tempDir);
         final byte[] fileContent = {1, 2, 3, 4};
         final BlobKey blobKey =
                 BlobKey.createKey(
@@ -124,27 +128,26 @@ public class BlobUtilsTest extends TestLogger {
                         BlobUtils.createMessageDigest().digest(fileContent));
         Files.write(incomingFile.toPath(), fileContent);
 
-        BlobUtils.moveTempFileToStore(incomingFile, jobId, blobKey, storageFile, log, blobStore);
+        BlobUtils.moveTempFileToStore(incomingFile, jobId, blobKey, storageFile, LOG, blobStore);
 
         assertThat(incomingFile).doesNotExist();
         assertThat(storageFile).hasBinaryContent(fileContent);
 
-        final File blobStoreFile =
-                new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+        final File blobStoreFile = tempDir.resolve(UUID.randomUUID().toString()).toFile();
         assertThat(blobStore.get(jobId, blobKey, blobStoreFile)).isTrue();
         assertThat(blobStoreFile).hasBinaryContent(fileContent);
     }
 
     @Test
-    public void testCleanupIfMoveTempFileToStoreFails() throws IOException {
-        final File storageFile = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+    void testCleanupIfMoveTempFileToStoreFails() throws IOException {
+        final File storageFile = tempDir.resolve(UUID.randomUUID().toString()).toFile();
 
-        final File incomingFile = temporaryFolder.newFile();
+        final File incomingFile = TempDirUtils.newFile(tempDir);
         Files.write(incomingFile.toPath(), new byte[] {1, 2, 3, 4});
 
         final FileSystemBlobStore blobStore =
                 new FileSystemBlobStore(
-                        new LocalFileSystem(), temporaryFolder.newFolder().getAbsolutePath());
+                        new LocalFileSystem(), TempDirUtils.newFolder(tempDir).toString());
 
         final JobID jobId = new JobID();
         final BlobKey blobKey = BlobKey.createKey(BlobKey.BlobType.PERMANENT_BLOB);
@@ -155,7 +158,7 @@ public class BlobUtilsTest extends TestLogger {
                                         jobId,
                                         blobKey,
                                         storageFile,
-                                        log,
+                                        LOG,
                                         blobStore,
                                         (source, target) -> {
                                             throw new IOException("Test Failure");
@@ -167,9 +170,7 @@ public class BlobUtilsTest extends TestLogger {
                                 blobStore.get(
                                         jobId,
                                         blobKey,
-                                        new File(
-                                                temporaryFolder.getRoot(),
-                                                UUID.randomUUID().toString())))
+                                        tempDir.resolve(UUID.randomUUID().toString()).toFile()))
                 .isInstanceOf(FileNotFoundException.class);
         assertThat(incomingFile).doesNotExist();
         assertThat(storageFile).doesNotExist();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/FileSystemBlobStoreTest.java
@@ -24,19 +24,16 @@ import org.apache.flink.core.fs.local.LocalDataOutputStream;
 import org.apache.flink.runtime.state.filesystem.TestFs;
 import org.apache.flink.testutils.TestFileSystem;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -51,25 +48,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link FileSystemBlobStore}. */
-@ExtendWith(TestLoggerExtension.class)
 class FileSystemBlobStoreTest {
 
     private FileSystemBlobStore testInstance;
     private Path storagePath;
 
     @BeforeEach
-    public void createTestInstance(@TempDir Path storagePath) throws IOException {
+    void createTestInstance(@TempDir Path storagePath) throws IOException {
         this.testInstance = new FileSystemBlobStore(new TestFileSystem(), storagePath.toString());
         this.storagePath = storagePath;
     }
 
     @AfterEach
-    public void finalizeTestInstance() throws IOException {
+    void finalizeTestInstance() throws IOException {
         testInstance.close();
     }
 
     @Test
-    public void testSuccessfulPut() throws IOException {
+    void testSuccessfulPut() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("put");
 
         final JobID jobId = new JobID();
@@ -86,7 +82,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testMissingFilePut() throws IOException {
+    void testMissingFilePut() {
         assertThatThrownBy(
                         () ->
                                 testInstance.put(
@@ -97,7 +93,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testSuccessfulGet() throws IOException {
+    void testSuccessfulGet() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("get");
         final JobID jobId = new JobID();
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
@@ -113,7 +109,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testGetWithWrongJobId() throws IOException {
+    void testGetWithWrongJobId() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("get");
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
 
@@ -132,7 +128,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testGetWithWrongBlobKey() throws IOException {
+    void testGetWithWrongBlobKey() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("get");
 
         final JobID jobId = new JobID();
@@ -152,7 +148,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testSuccessfulDeleteOnlyBlob() throws IOException {
+    void testSuccessfulDeleteOnlyBlob() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("delete");
         final JobID jobId = new JobID();
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
@@ -169,7 +165,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testSuccessfulDeleteBlob() throws IOException {
+    void testSuccessfulDeleteBlob() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("delete");
         final JobID jobId = new JobID();
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
@@ -190,12 +186,12 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testDeleteWithNotExistingJobId() {
+    void testDeleteWithNotExistingJobId() {
         assertThat(testInstance.delete(new JobID(), new PermanentBlobKey())).isTrue();
     }
 
     @Test
-    public void testDeleteWithNotExistingBlobKey() throws IOException {
+    void testDeleteWithNotExistingBlobKey() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("delete");
         final JobID jobId = new JobID();
         final BlobKey blobKey = createPermanentBlobKeyFromFile(temporaryFile);
@@ -206,7 +202,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testDeleteAll() throws IOException {
+    void testDeleteAll() throws IOException {
         final Path temporaryFile = createTemporaryFileWithContent("delete");
         final JobID jobId = new JobID();
 
@@ -223,7 +219,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void testDeleteAllWithNotExistingJobId() {
+    void testDeleteAllWithNotExistingJobId() {
         final JobID jobId = new JobID();
         assertThat(testInstance.deleteAll(jobId)).isTrue();
         assertThat(getPath(jobId)).doesNotExist();
@@ -260,7 +256,7 @@ class FileSystemBlobStoreTest {
         Preconditions.checkArgument(Files.exists(path));
 
         MessageDigest md = BlobUtils.createMessageDigest();
-        try (InputStream is = new FileInputStream(path.toFile())) {
+        try (InputStream is = Files.newInputStream(path.toFile().toPath())) {
             final byte[] buf = new byte[1024];
             int bytesRead = is.read(buf);
             while (bytesRead >= 0) {
@@ -273,8 +269,7 @@ class FileSystemBlobStoreTest {
     }
 
     @Test
-    public void fileSystemBlobStoreCallsSyncOnPut(@TempDir Path storageDirectory)
-            throws IOException {
+    void fileSystemBlobStoreCallsSyncOnPut(@TempDir Path storageDirectory) throws IOException {
         final Path blobStoreDirectory = storageDirectory.resolve("blobStore");
 
         final AtomicReference<TestingLocalDataOutputStream> createdOutputStream =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/PermanentBlobCacheTest.java
@@ -22,11 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
-import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -39,11 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for the {@link PermanentBlobCache}. */
-@ExtendWith(TestLoggerExtension.class)
-public class PermanentBlobCacheTest {
+class PermanentBlobCacheTest {
 
     @Test
-    public void permanentBlobCacheCanServeFilesFromPrepopulatedStorageDirectory(
+    void permanentBlobCacheCanServeFilesFromPrepopulatedStorageDirectory(
             @TempDir Path storageDirectory) throws IOException {
 
         final JobID jobId = new JobID();
@@ -64,7 +61,7 @@ public class PermanentBlobCacheTest {
     }
 
     @Test
-    public void permanentBlobCacheChecksForCorruptedBlobsAtStart(@TempDir Path storageDirectory)
+    void permanentBlobCacheChecksForCorruptedBlobsAtStart(@TempDir Path storageDirectory)
             throws IOException {
         final JobID jobId = new JobID();
         final PermanentBlobKey blobKey =
@@ -90,8 +87,7 @@ public class PermanentBlobCacheTest {
     }
 
     @Test
-    public void permanentBlobCacheTimesOutRecoveredBlobs(@TempDir Path storageDirectory)
-            throws Exception {
+    void permanentBlobCacheTimesOutRecoveredBlobs(@TempDir Path storageDirectory) throws Exception {
         final JobID jobId = new JobID();
         final PermanentBlobKey permanentBlobKey =
                 TestingBlobUtils.writePermanentBlob(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.apache.commons.io.FileUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashDifferent;
+import static org.apache.flink.runtime.blob.BlobKeyTest.verifyKeyDifferentHashEquals;
+import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+/** Helper functions for testing and verifying BLOB related logic. */
+public final class TestingBlobHelpers {
+
+    private TestingBlobHelpers() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Checks how many of the files given by blob keys are accessible.
+     *
+     * @param jobId ID of a job
+     * @param keys blob keys to check
+     * @param blobService BLOB store to use
+     * @param doThrow whether exceptions should be ignored (<tt>false</tt>), or thrown
+     *     (<tt>true</tt>)
+     * @return number of files existing at {@link BlobServer#getStorageLocation(JobID, BlobKey)} and
+     *     {@link PermanentBlobCache#getStorageLocation(JobID, BlobKey)}, respectively
+     */
+    public static <T> int checkFilesExist(
+            JobID jobId, Collection<? extends BlobKey> keys, T blobService, boolean doThrow)
+            throws IOException {
+
+        int numFiles = 0;
+
+        for (BlobKey key : keys) {
+            final File storageDir;
+            if (blobService instanceof BlobServer) {
+                BlobServer server = (BlobServer) blobService;
+                storageDir = server.getStorageDir();
+            } else if (blobService instanceof PermanentBlobCache) {
+                PermanentBlobCache cache = (PermanentBlobCache) blobService;
+                storageDir = cache.getStorageDir();
+            } else if (blobService instanceof TransientBlobCache) {
+                TransientBlobCache cache = (TransientBlobCache) blobService;
+                storageDir = cache.getStorageDir();
+            } else {
+                throw new UnsupportedOperationException(
+                        "unsupported BLOB service class: "
+                                + blobService.getClass().getCanonicalName());
+            }
+
+            final File blobFile =
+                    new File(
+                            BlobUtils.getStorageLocationPath(
+                                    storageDir.getAbsolutePath(), jobId, key));
+            if (blobFile.exists()) {
+                ++numFiles;
+            } else if (doThrow) {
+                throw new IOException("File " + blobFile + " does not exist.");
+            }
+        }
+
+        return numFiles;
+    }
+
+    /**
+     * Checks how many of the files given by blob keys are accessible.
+     *
+     * @param expectedCount number of expected files in the blob service for the given job
+     * @param jobId ID of a job
+     * @param blobService BLOB store to use
+     */
+    public static void checkFileCountForJob(
+            int expectedCount, JobID jobId, PermanentBlobService blobService) throws IOException {
+
+        final File jobDir;
+        if (blobService instanceof BlobServer) {
+            BlobServer server = (BlobServer) blobService;
+            jobDir = server.getStorageLocation(jobId, new PermanentBlobKey()).getParentFile();
+        } else {
+            PermanentBlobCache cache = (PermanentBlobCache) blobService;
+            jobDir = cache.getStorageLocation(jobId, new PermanentBlobKey()).getParentFile();
+        }
+        File[] blobsForJob = jobDir.listFiles();
+        if (blobsForJob == null) {
+            if (expectedCount != 0) {
+                throw new IOException("File " + jobDir + " does not exist.");
+            }
+        } else {
+            assertThat(blobsForJob.length)
+                    .as("Too many/few files in job dir: " + Arrays.asList(blobsForJob))
+                    .isEqualTo(expectedCount);
+        }
+    }
+
+    /**
+     * Checks the GET operation fails when the downloaded file (from HA store) is corrupt, i.e. its
+     * content's hash does not match the {@link BlobKey}'s hash.
+     *
+     * @param config blob server configuration (including HA settings like {@link
+     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
+     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+     * @param blobStore shared HA blob store to use
+     */
+    public static void testGetFailsFromCorruptFile(
+            Configuration config, BlobStore blobStore, File blobStorage) throws IOException {
+
+        Random rnd = new Random();
+        JobID jobId = new JobID();
+
+        try (BlobServer server = new BlobServer(config, blobStorage, blobStore)) {
+
+            server.start();
+
+            byte[] data = new byte[2000000];
+            rnd.nextBytes(data);
+
+            // put content addressable (like libraries)
+            BlobKey key = put(server, jobId, data, PERMANENT_BLOB);
+            assertThat(key).isNotNull();
+
+            // delete local file to make sure that the GET requests downloads from HA
+            File blobFile = server.getStorageLocation(jobId, key);
+            assertThat(blobFile.delete()).isTrue();
+
+            // change HA store file contents to make sure that GET requests fail
+            byte[] data2 = Arrays.copyOf(data, data.length);
+            data2[0] ^= 1;
+            File tmpFile = Files.createTempFile("blob", ".jar").toFile();
+            try {
+                FileUtils.writeByteArrayToFile(tmpFile, data2);
+                blobStore.put(tmpFile, jobId, key);
+            } finally {
+                //noinspection ResultOfMethodCallIgnored
+                tmpFile.delete();
+            }
+
+            assertThatThrownBy(() -> get(server, jobId, key))
+                    .satisfies(
+                            FlinkAssertions.anyCauseMatches(IOException.class, "data corruption"));
+        }
+    }
+
+    /**
+     * Checks the GET operation fails when the downloaded file (from HA store) is corrupt, i.e. its
+     * content's hash does not match the {@link BlobKey}'s hash, using a permanent BLOB.
+     *
+     * @param jobId job ID
+     * @param config blob server configuration (including HA settings like {@link
+     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
+     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+     * @param blobStore shared HA blob store to use
+     */
+    public static void testGetFailsFromCorruptFile(
+            JobID jobId, Configuration config, BlobStore blobStore, File blobStorage)
+            throws IOException {
+
+        testGetFailsFromCorruptFile(jobId, PERMANENT_BLOB, true, config, blobStore, blobStorage);
+    }
+
+    /**
+     * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
+     * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
+     *
+     * @param jobId job ID or <tt>null</tt> if job-unrelated
+     * @param blobType whether the BLOB should become permanent or transient
+     * @param corruptOnHAStore whether the file should be corrupt in the HA store (<tt>true</tt>,
+     *     required <tt>highAvailability</tt> to be set) or on the {@link BlobServer}'s local store
+     *     (<tt>false</tt>)
+     * @param config blob server configuration (including HA settings like {@link
+     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
+     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+     * @param blobStore shared HA blob store to use
+     */
+    static void testGetFailsFromCorruptFile(
+            @Nullable JobID jobId,
+            BlobKey.BlobType blobType,
+            boolean corruptOnHAStore,
+            Configuration config,
+            BlobStore blobStore,
+            File blobStorage)
+            throws IOException {
+
+        assertThat(!corruptOnHAStore || blobType == PERMANENT_BLOB)
+                .as("Check HA setup for corrupt HA file")
+                .isTrue();
+
+        Random rnd = new Random();
+
+        try (BlobServer server =
+                        new BlobServer(config, new File(blobStorage, "server"), blobStore);
+                BlobCacheService cache =
+                        new BlobCacheService(
+                                config,
+                                new File(blobStorage, "cache"),
+                                corruptOnHAStore ? blobStore : new VoidBlobStore(),
+                                new InetSocketAddress("localhost", server.getPort()))) {
+
+            server.start();
+
+            byte[] data = new byte[2000000];
+            rnd.nextBytes(data);
+
+            // put content addressable (like libraries)
+            BlobKey key = put(server, jobId, data, blobType);
+            assertThat(key).isNotNull();
+
+            // change server/HA store file contents to make sure that GET requests fail
+            byte[] data2 = Arrays.copyOf(data, data.length);
+            data2[0] ^= 1;
+            if (corruptOnHAStore) {
+                File tmpFile = Files.createTempFile("blob", ".jar").toFile();
+                try {
+                    FileUtils.writeByteArrayToFile(tmpFile, data2);
+                    blobStore.put(tmpFile, jobId, key);
+                } finally {
+                    //noinspection ResultOfMethodCallIgnored
+                    tmpFile.delete();
+                }
+
+                // delete local (correct) file on server to make sure that the GET request does not
+                // fall back to downloading the file from the BlobServer's local store
+                File blobFile = server.getStorageLocation(jobId, key);
+                assertThat(blobFile.delete()).isTrue();
+            } else {
+                File blobFile = server.getStorageLocation(jobId, key);
+                assertThat(blobFile).exists();
+                FileUtils.writeByteArrayToFile(blobFile, data2);
+            }
+
+            // issue a GET request that fails
+            assertThatThrownBy(() -> get(cache, jobId, key))
+                    .satisfies(
+                            FlinkAssertions.anyCauseMatches(IOException.class, "data corruption"));
+        }
+    }
+
+    /**
+     * Helper to test that the {@link BlobServer} recovery from its HA store works.
+     *
+     * <p>Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to
+     * retrieve them via a shared HA store upon request of a {@link BlobCacheService}.
+     *
+     * @param config blob server configuration (including HA settings like {@link
+     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
+     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+     * @param blobStore shared HA blob store to use
+     * @throws IOException in case of failures
+     */
+    public static void testBlobServerRecovery(
+            final Configuration config, final BlobStore blobStore, final File blobStorage)
+            throws Exception {
+        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+        String storagePath =
+                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
+        Random rand = new Random();
+
+        try (BlobServer server0 =
+                        new BlobServer(config, new File(blobStorage, "server0"), blobStore);
+                BlobServer server1 =
+                        new BlobServer(config, new File(blobStorage, "server1"), blobStore);
+                // use VoidBlobStore as the HA store to force download from server[1]'s HA store
+                BlobCacheService cache1 =
+                        new BlobCacheService(
+                                config,
+                                new File(blobStorage, "cache1"),
+                                new VoidBlobStore(),
+                                new InetSocketAddress("localhost", server1.getPort()))) {
+
+            server0.start();
+            server1.start();
+
+            // Random data
+            byte[] expected = new byte[1024];
+            rand.nextBytes(expected);
+            byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
+
+            BlobKey[] keys = new BlobKey[2];
+            BlobKey nonHAKey;
+
+            // Put job-related HA data
+            JobID[] jobId = new JobID[] {new JobID(), new JobID()};
+            keys[0] = put(server0, jobId[0], expected, PERMANENT_BLOB); // Request 1
+            keys[1] = put(server0, jobId[1], expected2, PERMANENT_BLOB); // Request 2
+
+            // put non-HA data
+            nonHAKey = put(server0, jobId[0], expected2, TRANSIENT_BLOB);
+            verifyKeyDifferentHashEquals(keys[1], nonHAKey);
+
+            // check that the storage directory exists
+            final Path blobServerPath = new Path(storagePath, "blob");
+            FileSystem fs = blobServerPath.getFileSystem();
+            assertThat(fs.exists(blobServerPath)).isTrue();
+
+            // Verify HA requests from cache1 (connected to server1) with no immediate access to the
+            // file
+            verifyContents(cache1, jobId[0], keys[0], expected);
+            verifyContents(cache1, jobId[1], keys[1], expected2);
+
+            // Verify non-HA file is not accessible from server1
+            verifyDeleted(cache1, jobId[0], nonHAKey);
+
+            // Remove again
+            server1.globalCleanupAsync(jobId[0], Executors.directExecutor()).join();
+            server1.globalCleanupAsync(jobId[1], Executors.directExecutor()).join();
+
+            // Verify everything is clean
+            assertThat(fs.exists(new Path(storagePath))).isTrue();
+            if (fs.exists(blobServerPath)) {
+                final org.apache.flink.core.fs.FileStatus[] recoveryFiles =
+                        fs.listStatus(blobServerPath);
+                ArrayList<String> filenames = new ArrayList<>(recoveryFiles.length);
+                for (org.apache.flink.core.fs.FileStatus file : recoveryFiles) {
+                    filenames.add(file.toString());
+                }
+                fail("Unclean state backend: %s", filenames);
+            }
+        }
+    }
+
+    /**
+     * Helper to test that the {@link BlobServer} recovery from its HA store works.
+     *
+     * <p>Uploads two BLOBs to one {@link BlobServer} via a {@link BlobCacheService} and expects a
+     * second {@link BlobCacheService} to be able to retrieve them from a second {@link BlobServer}
+     * that is configured with the same HA store.
+     *
+     * @param config blob server configuration (including HA settings like {@link
+     *     HighAvailabilityOptions#HA_STORAGE_PATH} and {@link
+     *     HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+     * @param blobStore shared HA blob store to use
+     * @throws IOException in case of failures
+     */
+    public static void testBlobCacheRecovery(
+            final Configuration config, final BlobStore blobStore, final File blobStorage)
+            throws IOException {
+
+        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+        String storagePath =
+                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
+        Random rand = new Random();
+
+        try (BlobServer server0 =
+                        new BlobServer(config, new File(blobStorage, "server0"), blobStore);
+                BlobServer server1 =
+                        new BlobServer(config, new File(blobStorage, "server1"), blobStore);
+                // use VoidBlobStore as the HA store to force download from each server's HA store
+                BlobCacheService cache0 =
+                        new BlobCacheService(
+                                config,
+                                new File(blobStorage, "cache0"),
+                                new VoidBlobStore(),
+                                new InetSocketAddress("localhost", server0.getPort()));
+                BlobCacheService cache1 =
+                        new BlobCacheService(
+                                config,
+                                new File(blobStorage, "cache1"),
+                                new VoidBlobStore(),
+                                new InetSocketAddress("localhost", server1.getPort()))) {
+
+            server0.start();
+            server1.start();
+
+            // Random data
+            byte[] expected = new byte[1024];
+            rand.nextBytes(expected);
+            byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
+
+            BlobKey[] keys = new BlobKey[2];
+            BlobKey nonHAKey;
+
+            // Put job-related HA data
+            JobID[] jobId = new JobID[] {new JobID(), new JobID()};
+            keys[0] = put(cache0, jobId[0], expected, PERMANENT_BLOB); // Request 1
+            keys[1] = put(cache0, jobId[1], expected2, PERMANENT_BLOB); // Request 2
+
+            // put non-HA data
+            nonHAKey = put(cache0, jobId[0], expected2, TRANSIENT_BLOB);
+            verifyKeyDifferentHashDifferent(keys[0], nonHAKey);
+            verifyKeyDifferentHashEquals(keys[1], nonHAKey);
+
+            // check that the storage directory exists
+            final Path blobServerPath = new Path(storagePath, "blob");
+            FileSystem fs = blobServerPath.getFileSystem();
+            assertThat(fs.exists(blobServerPath)).isTrue();
+
+            // Verify HA requests from cache1 (connected to server1) with no immediate access to the
+            // file
+            verifyContents(cache1, jobId[0], keys[0], expected);
+            verifyContents(cache1, jobId[1], keys[1], expected2);
+
+            // Verify non-HA file is not accessible from server1
+            verifyDeleted(cache1, jobId[0], nonHAKey);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 
 import org.apache.commons.io.FileUtils;
 
@@ -26,10 +28,11 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Path;
 
 /** Utility class for testing methods for blobs. */
-public class TestingBlobUtils {
+class TestingBlobUtils {
     private TestingBlobUtils() {
         throw new UnsupportedOperationException(
                 String.format("Cannot instantiate %s.", TestingBlobUtils.class.getSimpleName()));
@@ -64,5 +67,145 @@ public class TestingBlobUtils {
         FileUtils.writeByteArrayToFile(storageLocation, fileContent);
 
         return blobKey;
+    }
+
+    @Nonnull
+    static BlobServer createServer(Path tempDir) throws IOException {
+        return createServer(tempDir, new Configuration(), new VoidBlobStore());
+    }
+
+    @Nonnull
+    static BlobServer createServer(Path tempDir, Configuration config) throws IOException {
+        return createServer(tempDir, config, new VoidBlobStore());
+    }
+
+    @Nonnull
+    static BlobServer createServer(Path tempDir, Configuration config, BlobStore serverStore)
+            throws IOException {
+        return new BlobServer(config, getServerDir(tempDir), serverStore);
+    }
+
+    @Nonnull
+    static PermanentBlobCache createPermanentCache(Path tempDir, BlobServer server)
+            throws IOException {
+        return createPermanentCache(tempDir, new Configuration(), getServerAddress(server));
+    }
+
+    @Nonnull
+    static PermanentBlobCache createPermanentCache(
+            Path tempDir, Configuration config, BlobServer server) throws IOException {
+        return createPermanentCache(tempDir, config, getServerAddress(server));
+    }
+
+    @Nonnull
+    static PermanentBlobCache createPermanentCache(
+            Path tempDir, Configuration config, BlobServer server, BlobCacheSizeTracker tracker)
+            throws IOException {
+        return createPermanentCache(tempDir, config, getServerAddress(server), tracker);
+    }
+
+    @Nonnull
+    static PermanentBlobCache createPermanentCache(
+            Path tempDir, Configuration config, InetSocketAddress serverAddress)
+            throws IOException {
+        return createPermanentCache(tempDir, config, serverAddress, null);
+    }
+
+    @Nonnull
+    static TransientBlobCache createTransientCache(Path tempDir, BlobServer server)
+            throws IOException {
+        return new TransientBlobCache(
+                new Configuration(), getCacheDir(tempDir), getServerAddress(server));
+    }
+
+    @Nonnull
+    static PermanentBlobCache createPermanentCache(
+            Path tempDir,
+            Configuration config,
+            InetSocketAddress serverAddress,
+            BlobCacheSizeTracker tracker)
+            throws IOException {
+        if (tracker == null) {
+            return new PermanentBlobCache(
+                    config, getCacheDir(tempDir), new VoidBlobStore(), serverAddress);
+        }
+
+        return new PermanentBlobCache(
+                config, getCacheDir(tempDir), new VoidBlobStore(), serverAddress, tracker);
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createServerAndCache(Path tempDir)
+            throws IOException {
+        return createServerAndCache(
+                tempDir, new Configuration(), new VoidBlobStore(), new VoidBlobStore());
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createServerAndCache(
+            Path tempDir, Configuration config) throws IOException {
+        return createServerAndCache(tempDir, config, new VoidBlobStore(), new VoidBlobStore());
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createServerAndCache(
+            Path tempDir, BlobStore serverStore, BlobStore cacheStore) throws IOException {
+        return createServerAndCache(tempDir, new Configuration(), serverStore, cacheStore);
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createServerAndCache(
+            Path tempDir, Configuration config, BlobStore serverStore, BlobStore cacheStore)
+            throws IOException {
+        return createServerAndCache(tempDir, config, config, serverStore, cacheStore);
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createServerAndCache(
+            Path tempDir,
+            Configuration serverConfig,
+            Configuration cacheConfig,
+            BlobStore serverStore,
+            BlobStore cacheStore)
+            throws IOException {
+        BlobServer server = createServer(tempDir, serverConfig, serverStore);
+        BlobCacheService cache =
+                new BlobCacheService(
+                        cacheConfig,
+                        getCacheDir(tempDir),
+                        cacheStore,
+                        new InetSocketAddress("localhost", server.getPort()));
+
+        return Tuple2.of(server, cache);
+    }
+
+    @Nonnull
+    static Tuple2<BlobServer, BlobCacheService> createFailingServerAndCache(
+            Path tempDir, BlobStore serverStore, int numAccept, int numFailures)
+            throws IOException {
+        Configuration config = new Configuration();
+        BlobServer server =
+                new TestingFailingBlobServer(
+                        config, getServerDir(tempDir), serverStore, numAccept, numFailures);
+        BlobCacheService cache =
+                new BlobCacheService(
+                        config,
+                        getCacheDir(tempDir),
+                        new VoidBlobStore(),
+                        new InetSocketAddress("localhost", server.getPort()));
+
+        return Tuple2.of(server, cache);
+    }
+
+    private static InetSocketAddress getServerAddress(BlobServer server) {
+        return new InetSocketAddress("localhost", server.getPort());
+    }
+
+    private static File getServerDir(Path tempDir) {
+        return tempDir.resolve("server").toFile();
+    }
+
+    private static File getCacheDir(Path tempDir) {
+        return tempDir.resolve("cache").toFile();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TransientBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TransientBlobCacheTest.java
@@ -22,11 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
-import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
@@ -36,11 +34,10 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link TransientBlobCache}. */
-@ExtendWith(TestLoggerExtension.class)
-public class TransientBlobCacheTest {
+class TransientBlobCacheTest {
 
     @Test
-    public void transientBlobCacheCanServeFilesFromPrepopulatedStorageDirectory(
+    void transientBlobCacheCanServeFilesFromPrepopulatedStorageDirectory(
             @TempDir Path storageDirectory) throws IOException {
         final JobID jobId = new JobID();
 
@@ -55,7 +52,7 @@ public class TransientBlobCacheTest {
     }
 
     @Test
-    public void transientBlobCacheChecksForCorruptedBlobsAtStart(@TempDir Path storageDirectory)
+    void transientBlobCacheChecksForCorruptedBlobsAtStart(@TempDir Path storageDirectory)
             throws IOException {
         final JobID jobId = new JobID();
 
@@ -76,8 +73,7 @@ public class TransientBlobCacheTest {
     }
 
     @Test
-    public void transientBlobCacheTimesOutRecoveredBlobs(@TempDir Path storageDirectory)
-            throws Exception {
+    void transientBlobCacheTimesOutRecoveredBlobs(@TempDir Path storageDirectory) throws Exception {
         final JobID jobId = new JobID();
         final TransientBlobKey transientBlobKey =
                 TestingBlobUtils.writeTransientBlob(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -49,8 +49,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.runtime.blob.BlobServerCleanupTest.checkFileCountForJob;
-import static org.apache.flink.runtime.blob.BlobServerCleanupTest.checkFilesExist;
+import static org.apache.flink.runtime.blob.TestingBlobHelpers.checkFileCountForJob;
+import static org.apache.flink.runtime.blob.TestingBlobHelpers.checkFilesExist;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
## What is the purpose of the change

Migrates JUnit4 unit tests in `org.apache.flink.runtime.accumulators` and `org.apache.flink.runtime.blob` packages to JUnit5.

## Brief change log
  - Made test methods and classes package-private.
  - Added `TestLoggerExtension` instead of extending JUnit4 `TestLogger` class.
  - Migrated to `@TempDir` from the temp. folder class rule that does not exist in JUnit5.
  - Added `BlobServer` and `BlobCache` instantiation utils to `TestingBlobUtils` to cut back code duplication.
  - Moved some blob test helper utils that were used by the `HDFSTest` class from `flink-fs-tests` to a new public class `TestingBlobHelpers`, so all unit test classes can be package-private.
  - Applied AssertJ for all assertion and assumption statements.

## Verifying this change

Any touched unit test should still run and verify the same thing as before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
