### PR TITLE
[FLINK-32844][table-planner] Does not apply runtime filter and DPP on same key

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DynamicPartitionPruningUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DynamicPartitionPruningUtils.java
@@ -346,7 +346,8 @@ public class DynamicPartitionPruningUtils {
                         scan.getTraitSet(),
                         scan.getHints(),
                         tableSourceTable,
-                        dynamicFilteringDataCollector);
+                        dynamicFilteringDataCollector,
+                        acceptedFieldIndices);
             } else if (rel instanceof Exchange || rel instanceof Filter) {
                 return rel.copy(
                         rel.getTraitSet(),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalDynamicFilteringTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalDynamicFilteringTableSourceScan.scala
@@ -40,7 +40,8 @@ class BatchPhysicalDynamicFilteringTableSourceScan(
     traitSet: RelTraitSet,
     hints: util.List[RelHint],
     tableSourceTable: TableSourceTable,
-    var input: RelNode) // var for updating
+    var input: RelNode, // var for updating
+    val dynamicFilteringIndices: util.List[Integer])
   extends BatchPhysicalTableSourceScan(cluster, traitSet, hints, tableSourceTable) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
@@ -49,7 +50,8 @@ class BatchPhysicalDynamicFilteringTableSourceScan(
       traitSet,
       getHints,
       tableSourceTable,
-      inputs.get(0))
+      inputs.get(0),
+      dynamicFilteringIndices)
   }
 
   override def copy(
@@ -60,7 +62,8 @@ class BatchPhysicalDynamicFilteringTableSourceScan(
       traitSet,
       getHints,
       tableSourceTable,
-      input)
+      input,
+      dynamicFilteringIndices)
   }
 
   override def replaceInput(ordinalInParent: Int, rel: RelNode): Unit = {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgramTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgramTest.xml
@@ -1013,4 +1013,41 @@ HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id,
 ]]>
 		</Resource>
 	</TestCase>
+
+	<TestCase name="testDoesNotApplyRuntimeFilterAndDPPOnSameKey">
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(id=[$0], male=[$1], amount=[$2], price=[$3], dim_date_sk=[$4], id0=[$5], name=[$6], amount0=[$7], price0=[$8], fact_date_sk=[$9])
++- LogicalFilter(condition=[AND(=($9, $4), <($3, 500))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+      +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, male, amount, price, dim_date_sk, id0, name, amount0, price0, fact_date_sk], build=[left])
+:- Exchange(distribution=[hash[dim_date_sk]])
+:  +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
++- Exchange(distribution=[hash[fact_date_sk]])
+   +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part]], fields=[id, name, amount, price, fact_date_sk])
+      +- DynamicFilteringDataCollector(fields=[dim_date_sk])
+         +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+            +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, male, amount, price, dim_date_sk, id0, name, amount0, price0, fact_date_sk], build=[left])
+:- Exchange(distribution=[hash[dim_date_sk]])
+:  +- Calc(select=[id, male, amount, price, dim_date_sk], where=[(price < 500)])(reuse_id=[1])
+:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
++- Exchange(distribution=[hash[fact_date_sk]])
+   +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part]], fields=[id, name, amount, price, fact_date_sk])
+      +- DynamicFilteringDataCollector(fields=[dim_date_sk])
+         +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
 </Root>


### PR DESCRIPTION


## What is the purpose of the change

Fix FLINK-32844, does not apply runtime filter and DPP on same key

## Verifying this change

Add test `testDoesNotApplyRuntimeFilterAndDPPOnSameKey`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
