### PR TITLE
[FLINK-32831][table-planner] RuntimeFilterProgram should aware join type when looking for the build side

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -85,7 +85,7 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
         </tr>
         <tr>
             <td><h5>table.optimizer.runtime-filter.max-build-data-size</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">100 mb</td>
+            <td style="word-wrap: break-word;">150 mb</td>
             <td>MemorySize</td>
             <td>Max data volume threshold of the runtime filter build side. Estimated data volume needs to be under this value to try to inject runtime filter.</td>
         </tr>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -186,7 +186,7 @@ public class OptimizerConfigOptions {
             TABLE_OPTIMIZER_RUNTIME_FILTER_MAX_BUILD_DATA_SIZE =
                     key("table.optimizer.runtime-filter.max-build-data-size")
                             .memoryType()
-                            .defaultValue(MemorySize.parse("100m"))
+                            .defaultValue(MemorySize.parse("150m"))
                             .withDescription(
                                     "Max data volume threshold of the runtime filter build side. "
                                             + "Estimated data volume needs to be under this value to try to inject runtime filter.");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalGlobalRuntimeFilterBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalGlobalRuntimeFilterBuilder.java
@@ -64,8 +64,8 @@ public class BatchPhysicalGlobalRuntimeFilterBuilder extends SingleRel implement
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new BatchPhysicalGlobalRuntimeFilterBuilder(
                 getCluster(),
-                getTraitSet(),
-                getInput(),
+                traitSet,
+                inputs.get(0),
                 buildFieldNames,
                 estimatedRowCount,
                 maxRowCount);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalLocalRuntimeFilterBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalLocalRuntimeFilterBuilder.java
@@ -69,8 +69,8 @@ public class BatchPhysicalLocalRuntimeFilterBuilder extends SingleRel implements
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new BatchPhysicalLocalRuntimeFilterBuilder(
                 getCluster(),
-                getTraitSet(),
-                getInput(),
+                traitSet,
+                inputs.get(0),
                 buildIndices,
                 buildFieldNames,
                 estimatedRowCount,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalRuntimeFilter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/batch/runtimefilter/BatchPhysicalRuntimeFilter.java
@@ -64,9 +64,9 @@ public class BatchPhysicalRuntimeFilter extends BiRel implements BatchPhysicalRe
     public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
         return new BatchPhysicalRuntimeFilter(
                 getCluster(),
-                getTraitSet(),
-                getLeft(),
-                getRight(),
+                traitSet,
+                inputs.get(0),
+                inputs.get(1),
                 probeIndices,
                 estimatedFilterRatio);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgram.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgram.java
@@ -158,10 +158,7 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
     private static Join tryInjectRuntimeFilter(Join join) {
 
         // check supported join type
-        if (join.getJoinType() != JoinRelType.INNER
-                && join.getJoinType() != JoinRelType.SEMI
-                && join.getJoinType() != JoinRelType.LEFT
-                && join.getJoinType() != JoinRelType.RIGHT) {
+        if (!(isSuitableJoinType(join.getJoinType()))) {
             return join;
         }
 
@@ -218,7 +215,7 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
             BuildSideInfo suitableBuildInfo = suitableBuildOpt.get();
             RelNode newProbe =
                     tryPushDownProbeAndInjectRuntimeFilter(
-                            probeSide, probeIndices, suitableBuildInfo);
+                            probeSide, probeIndices, suitableBuildInfo, false);
             if (leftIsBuild) {
                 return join.copy(join.getTraitSet(), Arrays.asList(buildSide, newProbe));
             } else {
@@ -328,13 +325,19 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
         } else if (rel instanceof Join) {
             // try to push the builder to one input of join
             Join join = (Join) rel;
-            if (!(join.getLeft() instanceof Exchange) && !(join.getRight() instanceof Exchange)) {
+            if (!isSuitableJoinType(join.getJoinType())) {
                 return Optional.empty();
             }
 
             Tuple2<ImmutableIntList, ImmutableIntList> tuple2 = getInputIndices(join, buildIndices);
             ImmutableIntList leftIndices = tuple2.f0;
             ImmutableIntList rightIndices = tuple2.f1;
+
+            if (join.getJoinType() == JoinRelType.LEFT) {
+                rightIndices = ImmutableIntList.of();
+            } else if (join.getJoinType() == JoinRelType.RIGHT) {
+                leftIndices = ImmutableIntList.of();
+            }
 
             if (leftIndices.isEmpty() && rightIndices.isEmpty()) {
                 return Optional.empty();
@@ -395,10 +398,16 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
      * @param rel the original probe side
      * @param probeIndices the probe indices
      * @param buildSideInfo the build side info
+     * @param filterHasBenefit Whether it has benefit to inject the filter at the current position.
+     *     We believe that only if the filter goes through an Exchange, Join or Agg is beneficial,
+     *     otherwise there is no benefit. We should inject the filter only if it has benefit.
      * @return the new probe side wit runtime filter
      */
     private static RelNode tryPushDownProbeAndInjectRuntimeFilter(
-            RelNode rel, ImmutableIntList probeIndices, BuildSideInfo buildSideInfo) {
+            RelNode rel,
+            ImmutableIntList probeIndices,
+            BuildSideInfo buildSideInfo,
+            boolean filterHasBenefit) {
         if (rel instanceof BatchPhysicalRuntimeFilter) {
             // do nothing, return current probe side directly. Because we don't inject more than
             // once runtime filter at the same place
@@ -410,7 +419,7 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
                     exchange.getTraitSet(),
                     Collections.singletonList(
                             tryPushDownProbeAndInjectRuntimeFilter(
-                                    exchange.getInput(), probeIndices, buildSideInfo)));
+                                    exchange.getInput(), probeIndices, buildSideInfo, true)));
         } else if (rel instanceof Calc) {
             // try to push the probe side to the input of projection
             Calc calc = ((Calc) rel);
@@ -425,7 +434,10 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
                         calc.getTraitSet(),
                         Collections.singletonList(
                                 tryPushDownProbeAndInjectRuntimeFilter(
-                                        calc.getInput(), inputIndices, buildSideInfo)));
+                                        calc.getInput(),
+                                        inputIndices,
+                                        buildSideInfo,
+                                        filterHasBenefit)));
             }
         } else if (rel instanceof Join) {
             // try to push the probe side to the all inputs of join
@@ -441,13 +453,13 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
                 if (!leftIndices.isEmpty()) {
                     leftSide =
                             tryPushDownProbeAndInjectRuntimeFilter(
-                                    leftSide, leftIndices, buildSideInfo);
+                                    leftSide, leftIndices, buildSideInfo, true);
                 }
 
                 if (!rightIndices.isEmpty()) {
                     rightSide =
                             tryPushDownProbeAndInjectRuntimeFilter(
-                                    rightSide, rightIndices, buildSideInfo);
+                                    rightSide, rightIndices, buildSideInfo, true);
                 }
 
                 return join.copy(join.getTraitSet(), Arrays.asList(leftSide, rightSide));
@@ -466,7 +478,8 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
                                                 probeIndices.stream()
                                                         .map(index -> agg.grouping()[index])
                                                         .collect(Collectors.toList())),
-                                        buildSideInfo)));
+                                        buildSideInfo,
+                                        true)));
             }
         } else if (rel instanceof Union) {
             // try to push the probe side to all inputs of union
@@ -474,7 +487,8 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
             List<RelNode> newInputs = new ArrayList<>();
             for (RelNode input : union.getInputs()) {
                 newInputs.add(
-                        tryPushDownProbeAndInjectRuntimeFilter(input, probeIndices, buildSideInfo));
+                        tryPushDownProbeAndInjectRuntimeFilter(
+                                input, probeIndices, buildSideInfo, filterHasBenefit));
             }
             return union.copy(union.getTraitSet(), newInputs, union.all);
         } else if (rel instanceof BatchPhysicalDynamicFilteringTableSourceScan) {
@@ -492,11 +506,18 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
             // we may find more cases later
         }
 
-        return createNewProbeWithRuntimeFilter(
-                ignoreExchange(buildSideInfo.buildSide),
-                ignoreExchange(rel),
-                buildSideInfo.buildIndices,
-                probeIndices);
+        if (filterHasBenefit) {
+            return createNewProbeWithRuntimeFilter(
+                    ignoreExchange(buildSideInfo.buildSide),
+                    ignoreExchange(rel),
+                    buildSideInfo.buildIndices,
+                    probeIndices);
+        } else {
+            // If the probe side is a direct table source, or only simple Calc/Union, no other
+            // operations, we will not inject runtime filter, because we believe the benefit to be
+            // small or even negative
+            return rel;
+        }
     }
 
     private static BatchPhysicalExchange createExchange(
@@ -601,7 +622,7 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
         Optional<Double> probeSize = getEstimatedDataSize(probeSide);
 
         long maxBuildDataSize = getMaxBuildDataSize(buildSide);
-        long minProbeDataSize = getMaxBuildDataSize(buildSide);
+        long minProbeDataSize = getMinProbeDataSize(buildSide);
         double minFilterRatio = getMinFilterRatio(buildSide);
 
         if (!buildSize.isPresent() || !probeSize.isPresent()) {
@@ -687,5 +708,13 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
     private static double getMinFilterRatio(RelNode relNode) {
         return unwrapTableConfig(relNode)
                 .get(OptimizerConfigOptions.TABLE_OPTIMIZER_RUNTIME_FILTER_MIN_FILTER_RATIO);
+    }
+
+    public static boolean isSuitableJoinType(JoinRelType joinType) {
+        // check supported join type
+        return joinType == JoinRelType.INNER
+                || joinType == JoinRelType.SEMI
+                || joinType == JoinRelType.LEFT
+                || joinType == JoinRelType.RIGHT;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgram.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgram.java
@@ -622,7 +622,7 @@ public class FlinkRuntimeFilterProgram implements FlinkOptimizeProgram<BatchOpti
         Optional<Double> probeSize = getEstimatedDataSize(probeSide);
 
         long maxBuildDataSize = getMaxBuildDataSize(buildSide);
-        long minProbeDataSize = getMinProbeDataSize(buildSide);
+        long minProbeDataSize = getMinProbeDataSize(probeSide);
         double minFilterRatio = getMinFilterRatio(buildSide);
 
         if (!buildSize.isPresent() || !probeSize.isPresent()) {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgramTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/program/FlinkRuntimeFilterProgramTest.xml
@@ -75,32 +75,35 @@ LogicalProject(dim_date_sk=[$4])
 		</Resource>
 		<Resource name="optimized rel plan">
 			<![CDATA[
-HashJoin(joinType=[LeftSemiJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, name, amount, price, fact_date_sk], isBroadcast=[true], build=[right])
-:- RuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.99993896484375])
-:  :- Exchange(distribution=[broadcast])
-:  :  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
-:  :     +- Exchange(distribution=[single])
-:  :        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
-:  :           +- Calc(select=[dim_date_sk], where=[<(price, 500)])
-:  :              +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
-:  +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
-+- Exchange(distribution=[broadcast])
+HashJoin(joinType=[LeftSemiJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, name, amount, price, fact_date_sk], build=[right])
+:- Exchange(distribution=[hash[fact_date_sk]])
+:  +- RuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.99993896484375])
+:     :- Exchange(distribution=[broadcast])
+:     :  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
+:     :     +- Exchange(distribution=[single])
+:     :        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
+:     :           +- Calc(select=[dim_date_sk], where=[<(price, 500)])
+:     :              +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
+:     +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
++- Exchange(distribution=[hash[dim_date_sk]])
    +- Calc(select=[dim_date_sk], where=[<(price, 500)])
       +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
 ]]>
 		</Resource>
 		<Resource name="optimized exec plan">
 			<![CDATA[
-MultipleInput(readOrder=[0,0,1], members=[\nHashJoin(joinType=[LeftSemiJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, name, amount, price, fact_date_sk], isBroadcast=[true], build=[right])\n:- RuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.99993896484375])\n:  :- [#2] Exchange(distribution=[broadcast])\n:  +- [#3] TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])\n+- [#1] Exchange(distribution=[broadcast])\n])
-:- Exchange(distribution=[broadcast])
-:  +- Calc(select=[dim_date_sk], where=[(price < 500)])(reuse_id=[1])
-:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
-:- Exchange(distribution=[broadcast])
-:  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
-:     +- Exchange(distribution=[single])
-:        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
-:           +- Reused(reference_id=[1])
-+- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+HashJoin(joinType=[LeftSemiJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, name, amount, price, fact_date_sk], build=[right])
+:- Exchange(distribution=[hash[fact_date_sk]])
+:  +- MultipleInput(readOrder=[0,1], members=[\nRuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.99993896484375])\n:- [#1] Exchange(distribution=[broadcast])\n+- [#2] TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])\n])
+:     :- Exchange(distribution=[broadcast])
+:     :  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
+:     :     +- Exchange(distribution=[single])
+:     :        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[65536], maxRowCount=[655360])
+:     :           +- Calc(select=[dim_date_sk], where=[(price < 500)])(reuse_id=[1])
+:     :              +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
+:     +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
++- Exchange(distribution=[hash[dim_date_sk]])
+   +- Reused(reference_id=[1])
 ]]>
 		</Resource>
 	</TestCase>
@@ -426,6 +429,105 @@ MultipleInput(readOrder=[2,0,1], members=[\nHashJoin(joinType=[InnerJoin], where
    +- MultipleInput(readOrder=[0,1], members=[\nRuntimeFilter(select=[amount], estimatedFilterRatio=[0.99993896484375])\n:- [#1] Exchange(distribution=[broadcast])\n+- [#2] TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])\n])
       :- Reused(reference_id=[2])
       +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+]]>
+		</Resource>
+	</TestCase>
+
+	<TestCase name="testBuildSideIsJoinWithTwoAggInputs">
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(id=[$0], name=[$1], amount=[$2], price=[$3], fact_date_sk=[$4], dim_date_sk=[$5], EXPR$1=[$6], dim_date_sk0=[$7], EXPR$10=[$8])
++- LogicalJoin(condition=[=($4, $5)], joinType=[inner])
+   :- LogicalTableScan(table=[[testCatalog, test_database, fact]])
+   +- LogicalProject(dim_date_sk=[$0], EXPR$1=[$1], dim_date_sk0=[$2], EXPR$10=[$3])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+         :- LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
+         :  +- LogicalProject(dim_date_sk=[$4], price=[$3])
+         :     +- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+         +- LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
+            +- LogicalProject(dim_date_sk=[$4], amount=[$2])
+               +- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, name, amount, price, fact_date_sk, dim_date_sk, EXPR$1, dim_date_sk0, EXPR$10], build=[right])
+:- Exchange(distribution=[hash[fact_date_sk]])
+:  +- RuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.9998779296875])
+:     :- Exchange(distribution=[broadcast])
+:     :  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[131072], maxRowCount=[436907])
+:     :     +- Exchange(distribution=[single])
+:     :        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[131072], maxRowCount=[436907])
+:     :           +- Calc(select=[dim_date_sk, amount])
+:     :              +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[amount, price, dim_date_sk], metadata=[]]], fields=[amount, price, dim_date_sk])
+:     +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
++- HashJoin(joinType=[InnerJoin], where=[=(dim_date_sk, dim_date_sk0)], select=[dim_date_sk, EXPR$1, dim_date_sk0, EXPR$10], build=[right])
+   :- HashAggregate(isMerge=[false], groupBy=[dim_date_sk], select=[dim_date_sk, SUM(price) AS EXPR$1])
+   :  +- Exchange(distribution=[hash[dim_date_sk]])
+   :     +- Calc(select=[dim_date_sk, price])
+   :        +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[amount, price, dim_date_sk], metadata=[]]], fields=[amount, price, dim_date_sk])
+   +- HashAggregate(isMerge=[false], groupBy=[dim_date_sk], select=[dim_date_sk, SUM(amount) AS EXPR$1])
+      +- Exchange(distribution=[hash[dim_date_sk]])
+         +- Calc(select=[dim_date_sk, amount])
+            +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[amount, price, dim_date_sk], metadata=[]]], fields=[amount, price, dim_date_sk])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+MultipleInput(readOrder=[2,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id, name, amount, price, fact_date_sk, dim_date_sk, EXPR$1, dim_date_sk0, EXPR$10], build=[right])\n:- [#1] Exchange(distribution=[hash[fact_date_sk]])\n+- HashJoin(joinType=[InnerJoin], where=[(dim_date_sk = dim_date_sk0)], select=[dim_date_sk, EXPR$1, dim_date_sk0, EXPR$10], build=[right])\n   :- HashAggregate(isMerge=[false], groupBy=[dim_date_sk], select=[dim_date_sk, SUM(price) AS EXPR$1])\n   :  +- [#2] Exchange(distribution=[hash[dim_date_sk]])\n   +- HashAggregate(isMerge=[false], groupBy=[dim_date_sk], select=[dim_date_sk, SUM(amount) AS EXPR$1])\n      +- [#3] Exchange(distribution=[hash[dim_date_sk]])\n])
+:- Exchange(distribution=[hash[fact_date_sk]])
+:  +- MultipleInput(readOrder=[0,1], members=[\nRuntimeFilter(select=[fact_date_sk], estimatedFilterRatio=[0.9998779296875])\n:- [#1] Exchange(distribution=[broadcast])\n+- [#2] TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])\n])
+:     :- Exchange(distribution=[broadcast])
+:     :  +- GlobalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[131072], maxRowCount=[436907])
+:     :     +- Exchange(distribution=[single])
+:     :        +- LocalRuntimeFilterBuilder(select=[dim_date_sk], estimatedRowCount=[131072], maxRowCount=[436907])
+:     :           +- Calc(select=[dim_date_sk, amount])(reuse_id=[2])
+:     :              +- TableSourceScan(table=[[testCatalog, test_database, dim, project=[amount, price, dim_date_sk], metadata=[]]], fields=[amount, price, dim_date_sk])(reuse_id=[1])
+:     +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+:- Exchange(distribution=[hash[dim_date_sk]])
+:  +- Calc(select=[dim_date_sk, price])
+:     +- Reused(reference_id=[1])
++- Exchange(distribution=[hash[dim_date_sk]])
+   +- Reused(reference_id=[2])
+]]>
+		</Resource>
+	</TestCase>
+
+	<TestCase name="testBuildSideIsLeftJoinWithoutExchange">
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(id=[$0], amount=[$1], price=[$2], fact_date_sk=[$3], id0=[$4], name=[$5], amount0=[$6], price0=[$7], fact_date_sk0=[$8], id00=[$9], male=[$10], amount00=[$11], price00=[$12], dim_date_sk=[$13])
++- LogicalJoin(condition=[=($1, $6)], joinType=[inner])
+   :- LogicalTableScan(table=[[testCatalog, test_database, fact2]])
+   +- LogicalProject(id=[$0], name=[$1], amount=[$2], price=[$3], fact_date_sk=[$4], id0=[$5], male=[$6], amount0=[$7], price0=[$8], dim_date_sk=[$9])
+      +- LogicalJoin(condition=[AND(=($7, $2), <($8, 500))], joinType=[left])
+         :- LogicalTableScan(table=[[testCatalog, test_database, fact]])
+         +- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(amount, amount0)], select=[id, amount, price, fact_date_sk, id0, name, amount0, price0, fact_date_sk0, id00, male, amount00, price00, dim_date_sk], build=[left])
+:- Exchange(distribution=[hash[amount]])
+:  +- TableSourceScan(table=[[testCatalog, test_database, fact2]], fields=[id, amount, price, fact_date_sk])
++- HashJoin(joinType=[LeftOuterJoin], where=[=(amount0, amount)], select=[id, name, amount, price, fact_date_sk, id0, male, amount0, price0, dim_date_sk], build=[right])
+   :- Exchange(distribution=[hash[amount]])
+   :  +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+   +- Exchange(distribution=[hash[amount]])
+      +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+         +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(amount = amount0)], select=[id, amount, price, fact_date_sk, id0, name, amount0, price0, fact_date_sk0, id00, male, amount00, price00, dim_date_sk], build=[left])\n:- [#1] Exchange(distribution=[hash[amount]])\n+- HashJoin(joinType=[LeftOuterJoin], where=[(amount0 = amount)], select=[id, name, amount, price, fact_date_sk, id0, male, amount0, price0, dim_date_sk], build=[right])\n   :- [#2] Exchange(distribution=[hash[amount]])\n   +- [#3] Exchange(distribution=[hash[amount]])\n])
+:- Exchange(distribution=[hash[amount]])
+:  +- TableSourceScan(table=[[testCatalog, test_database, fact2]], fields=[id, amount, price, fact_date_sk])
+:- Exchange(distribution=[hash[amount]])
+:  +- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
++- Exchange(distribution=[hash[amount]])
+   +- Calc(select=[id, male, amount, price, dim_date_sk], where=[(price < 500)])
+      +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
 ]]>
 		</Resource>
 	</TestCase>
@@ -1047,6 +1149,38 @@ HashJoin(joinType=[InnerJoin], where=[(fact_date_sk = dim_date_sk)], select=[id,
    +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part]], fields=[id, name, amount, price, fact_date_sk])
       +- DynamicFilteringDataCollector(fields=[dim_date_sk])
          +- Reused(reference_id=[1])
+]]>
+		</Resource>
+	</TestCase>
+
+	<TestCase name="testProbeSideIsTableSourceWithoutExchange">
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(id=[$0], name=[$1], amount=[$2], price=[$3], fact_date_sk=[$4], id0=[$5], male=[$6], amount0=[$7], price0=[$8], dim_date_sk=[$9])
++- LogicalFilter(condition=[AND(=($2, $7), =($8, 500))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[testCatalog, test_database, fact]])
+      +- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+Calc(select=[id, name, amount, price, fact_date_sk, id0, male, amount0, CAST(500 AS BIGINT) AS price0, dim_date_sk])
++- HashJoin(joinType=[InnerJoin], where=[=(amount, amount0)], select=[id, name, amount, price, fact_date_sk, id0, male, amount0, dim_date_sk], isBroadcast=[true], build=[right])
+   :- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[id, male, amount, dim_date_sk], where=[=(price, 500)])
+         +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[id, name, amount, price, fact_date_sk, id0, male, amount0, CAST(500 AS BIGINT) AS price0, dim_date_sk])
++- MultipleInput(readOrder=[1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(amount = amount0)], select=[id, name, amount, price, fact_date_sk, id0, male, amount0, dim_date_sk], isBroadcast=[true], build=[right])\n:- [#1] TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])\n+- [#2] Exchange(distribution=[broadcast])\n])
+   :- TableSourceScan(table=[[testCatalog, test_database, fact]], fields=[id, name, amount, price, fact_date_sk])
+   +- Exchange(distribution=[broadcast])
+      +- Calc(select=[id, male, amount, dim_date_sk], where=[(price = 500)])
+         +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
 ]]>
 		</Resource>
 	</TestCase>


### PR DESCRIPTION
## What is the purpose of the change
Currently, runtime filter program will try to look for an Exchange as build side to avoid affecting MultiInput. It will try to push down the runtime filter builder if the original build side is not Exchange.

Currenlty, the builder-push-down does not aware the join type, which may lead to incorrect results(For example, push down the builder to the right input of left-join).

We should only support following cases:

1. Inner join: builder can push to left + right input
2. semi join: builder can push to left + right input
3. left join: builder can only push to the left input
4. right join: builder can only push to the right input

## Verifying this change

Add test `testBuildSideIsLeftJoinWithoutExchange`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
