### PR TITLE
[FLINK-20681][yarn] Support specifying the hdfs path when ship archives or files

### DIFF
--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -162,13 +162,13 @@
             <td><h5>yarn.ship-archives</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and/or remote file system. They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, "/path/to/local/archive.jar;hdfs://$namenode_address/path/to/archive.jar"</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and/or HDFS. They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, "/path/to/local/archive.jar;hdfs://$namenode_address/path/to/archive.jar"</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local client and/or remote file system. For example, "/path/to/local/file;/path/to/local/directory;hdfs://$namenode_address/path/of/file;hdfs://$namenode_address/path/of/directory"</td>
+            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local path of flink client or HDFS. For example, "/path/to/local/file;/path/to/local/directory;hdfs://$namenode_address/path/of/file;hdfs://$namenode_address/path/of/directory"</td>
         </tr>
         <tr>
             <td><h5>yarn.staging-directory</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -162,7 +162,7 @@
             <td><h5>yarn.ship-archives</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and/or HDFS. They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, "/path/to/local/archive.jar;hdfs://$namenode_address/path/to/archive.jar"</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local path of flink client or HDFS. They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, "/path/to/local/archive.jar;hdfs://$namenode_address/path/to/archive.jar"</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-files</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -162,13 +162,13 @@
             <td><h5>yarn.ship-archives</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip".</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and/or remote file system. They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, "/path/to/local/archive.jar;hdfs://$namenode_address/path/to/archive.jar"</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster.</td>
+            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local client and/or remote file system. For example, "/path/to/local/file;/path/to/local/directory;hdfs://$namenode_address/path/of/file;hdfs://$namenode_address/path/of/directory"</td>
         </tr>
         <tr>
             <td><h5>yarn.staging-directory</h5></td>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
@@ -43,7 +43,9 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +83,10 @@ class YARNFileReplicationITCase extends YarnTestBase {
                 createYarnClusterDescriptor(configuration)) {
 
             yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-            yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+            yarnClusterDescriptor.addShipFiles(
+                    Arrays.stream(Objects.requireNonNull(flinkLibFolder.listFiles()))
+                            .map(file -> new Path(file.toURI()))
+                            .collect(Collectors.toList()));
 
             final int masterMemory =
                     yarnClusterDescriptor

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -53,7 +53,9 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.yarn.util.TestUtils.getTestJarPath;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,7 +95,10 @@ class YarnConfigurationITCase extends YarnTestBase {
                                     true);
 
                     clusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-                    clusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+                    clusterDescriptor.addShipFiles(
+                            Arrays.stream(Objects.requireNonNull(flinkLibFolder.listFiles()))
+                                    .map(file -> new Path(file.toURI()))
+                                    .collect(Collectors.toList()));
 
                     final File streamingWordCountFile = getTestJarPath("WindowJoin.jar");
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -404,7 +404,8 @@ public abstract class YarnTestBase {
             org.apache.flink.configuration.Configuration flinkConfiguration) {
         final YarnClusterDescriptor yarnClusterDescriptor =
                 createYarnClusterDescriptorWithoutLibDir(flinkConfiguration);
-        yarnClusterDescriptor.addShipFiles(Collections.singletonList(flinkLibFolder));
+        yarnClusterDescriptor.addShipFiles(
+                Collections.singletonList(new Path(flinkLibFolder.toURI())));
         return yarnClusterDescriptor;
     }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -667,4 +667,12 @@ public final class Utils {
                             acl));
         }
     }
+
+    public static Path getPathFromLocalFile(File localFile) {
+        return new Path(localFile.toURI());
+    }
+
+    public static Path getPathFromLocalFilePathStr(String localPathStr) {
+        return getPathFromLocalFile(new File(localPathStr));
+    }
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -272,7 +272,11 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDeprecatedKeys("yarn.ship-directories")
                     .withDescription(
-                            "A semicolon-separated list of files and/or directories to be shipped to the YARN cluster.");
+                            "A semicolon-separated list of files and/or directories to be shipped to the YARN "
+                                    + "cluster. These files/directories can come from the local client and/or remote "
+                                    + "file system. For example, \"/path/to/local/file;/path/to/local/directory;"
+                                    + "hdfs://$namenode_address/path/of/file;"
+                                    + "hdfs://$namenode_address/path/of/directory\"");
 
     public static final ConfigOption<List<String>> SHIP_ARCHIVES =
             key("yarn.ship-archives")
@@ -280,9 +284,12 @@ public class YarnConfigOptions {
                     .asList()
                     .noDefaultValue()
                     .withDescription(
-                            "A semicolon-separated list of archives to be shipped to the YARN cluster."
-                                    + " These archives will be un-packed when localizing and they can be any of the following types: "
-                                    + "\".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\".");
+                            "A semicolon-separated list of archives to be shipped to the YARN cluster. "
+                                    + "These archives can come from the local client and/or remote file system. "
+                                    + "They will be un-packed when localizing and they can be any of the following "
+                                    + "types: \".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\". "
+                                    + "For example, \"/path/to/local/archive.jar;"
+                                    + "hdfs://$namenode_address/path/to/archive.jar\"");
 
     public static final ConfigOption<String> FLINK_DIST_JAR =
             key("yarn.flink-dist-jar")

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -273,8 +273,9 @@ public class YarnConfigOptions {
                     .withDeprecatedKeys("yarn.ship-directories")
                     .withDescription(
                             "A semicolon-separated list of files and/or directories to be shipped to the YARN "
-                                    + "cluster. These files/directories can come from the local client and/or remote "
-                                    + "file system. For example, \"/path/to/local/file;/path/to/local/directory;"
+                                    + "cluster. These files/directories can come from the local path of flink client "
+                                    + "or HDFS. For example, "
+                                    + "\"/path/to/local/file;/path/to/local/directory;"
                                     + "hdfs://$namenode_address/path/of/file;"
                                     + "hdfs://$namenode_address/path/of/directory\"");
 
@@ -285,7 +286,7 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "A semicolon-separated list of archives to be shipped to the YARN cluster. "
-                                    + "These archives can come from the local client and/or remote file system. "
+                                    + "These archives can come from the local client and/or HDFS. "
                                     + "They will be un-packed when localizing and they can be any of the following "
                                     + "types: \".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\". "
                                     + "For example, \"/path/to/local/archive.jar;"

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -286,7 +286,7 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "A semicolon-separated list of archives to be shipped to the YARN cluster. "
-                                    + "These archives can come from the local client and/or HDFS. "
+                                    + "These archives can come from the local path of flink client or HDFS. "
                                     + "They will be un-packed when localizing and they can be any of the following "
                                     + "types: \".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\". "
                                     + "For example, \"/path/to/local/archive.jar;"

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -565,7 +565,8 @@ class FlinkYarnSessionCliTest {
         YarnClusterDescriptor flinkYarnDescriptor =
                 (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
-        assertThat(flinkYarnDescriptor.getShipFiles()).isEqualTo(Lists.newArrayList(tmpFile));
+        assertThat(flinkYarnDescriptor.getShipFiles())
+                .isEqualTo(Lists.newArrayList(new org.apache.hadoop.fs.Path(tmpFile.toURI())));
     }
 
     @Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -42,8 +42,6 @@ import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.executors.YarnJobClusterExecutor;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -60,6 +58,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.UUID;
 
+import static org.apache.flink.yarn.Utils.getPathFromLocalFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -566,7 +565,7 @@ class FlinkYarnSessionCliTest {
                 (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
         assertThat(flinkYarnDescriptor.getShipFiles())
-                .isEqualTo(Lists.newArrayList(new org.apache.hadoop.fs.Path(tmpFile.toURI())));
+                .containsExactly(getPathFromLocalFile(tmpFile));
     }
 
     @Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -640,7 +640,7 @@ class YarnClusterDescriptorTest {
             // only add the ship the folder, not the contents
             assertThat(effectiveShipFiles)
                     .doesNotContain(new Path(libFile.getAbsolutePath()))
-                    .contains(new Path(libFolder.getAbsolutePath()));
+                    .contains(new Path(libFolder.toURI()));
             assertThat(descriptor.getShipFiles())
                     .doesNotContain(
                             new Path(libFile.getAbsolutePath()),

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -567,7 +567,11 @@ class YarnClusterDescriptorTest {
                     .hasSize(2)
                     .contains(getPathFromLocalFile(libFile), getPathFromLocalFile(libFolder));
         }
+    }
 
+    /** Tests to ship files through the {@link YarnConfigOptions#SHIP_FILES}. */
+    @Test
+    void testShipFiles() throws IOException {
         String hdfsDir = "hdfs:///flink/hdfs_dir";
         String hdfsFile = "hdfs:///flink/hdfs_file";
         File libFile = Files.createTempFile(temporaryFolder, "libFile", ".jar").toFile();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request support specifying the HDFS path when ship archives or files.*


## Brief change log

  - *Support specifying the hdfs path when ship archives or files*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *Added test that add HDFS file by parameter `yarn.ship-files`*
  - *Added test that add HDFS archive file by parameter `yarn.ship-archives`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
