### PR TITLE
[FLINK-32882][SlotManager] Fix NPE when PendingTaskmanager clear pending allocations twice.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
@@ -83,7 +83,9 @@ public class PendingTaskManager {
 
     public void clearPendingAllocationsOfJob(JobID jobId) {
         ResourceCounter resourceCounter = pendingSlotAllocationRecords.remove(jobId);
-        unusedResource = unusedResource.merge(resourceCounter.getTotalResource());
+        if (resourceCounter != null) {
+            unusedResource = unusedResource.merge(resourceCounter.getTotalResource());
+        }
     }
 
     private ResourceProfile calculateUnusedResourceProfile() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /** Represents a pending task manager in the {@link SlotManager}. */
 public class PendingTaskManager {
@@ -82,10 +83,11 @@ public class PendingTaskManager {
     }
 
     public void clearPendingAllocationsOfJob(JobID jobId) {
-        ResourceCounter resourceCounter = pendingSlotAllocationRecords.remove(jobId);
-        if (resourceCounter != null) {
-            unusedResource = unusedResource.merge(resourceCounter.getTotalResource());
-        }
+        Optional.ofNullable(pendingSlotAllocationRecords.remove(jobId))
+                .ifPresent(
+                        resourceCounter ->
+                                unusedResource =
+                                        unusedResource.merge(resourceCounter.getTotalResource()));
     }
 
     private ResourceProfile calculateUnusedResourceProfile() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -1019,7 +1019,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                 runTest(
                         () -> {
                             // assign allocations to pending task managers
-                            runInMainThreadAndWait(
+                            runInMainThread(
                                     () ->
                                             getSlotManager()
                                                     .processResourceRequirements(
@@ -1037,11 +1037,17 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
                             // disconnect to job master,will trigger
                             // PendingTaskManager#clearPendingAllocationsOfJob again
-                            CompletableFuture<Void> clearFuture =
-                                    runInMainThreadAndReturn(
-                                            () ->
-                                                    getSlotManager()
-                                                            .clearResourceRequirements(jobId));
+                            CompletableFuture<Void> clearFuture = new CompletableFuture<>();
+                            runInMainThread(
+                                    () -> {
+                                        try {
+                                            getSlotManager().clearResourceRequirements(jobId);
+                                        } catch (Exception e) {
+                                            clearFuture.completeExceptionally(e);
+                                        }
+                                        clearFuture.complete(null);
+                                    });
+
                             assertFutureCompleteAndReturn(clearFuture);
                         });
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -199,6 +199,20 @@ abstract class FineGrainedSlotManagerTestBase {
             mainThreadExecutor.execute(runnable);
         }
 
+        CompletableFuture<Void> runInMainThreadAndReturn(Runnable runnable) {
+            CompletableFuture<Void> runFuture = new CompletableFuture<>();
+            mainThreadExecutor.execute(
+                    () -> {
+                        try {
+                            runnable.run();
+                        } catch (Exception e) {
+                            runFuture.completeExceptionally(e);
+                        }
+                        runFuture.complete(null);
+                    });
+            return runFuture;
+        }
+
         void runInMainThreadAndWait(Runnable runnable) throws InterruptedException {
             final OneShotLatch latch = new OneShotLatch();
             mainThreadExecutor.execute(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -199,20 +199,6 @@ abstract class FineGrainedSlotManagerTestBase {
             mainThreadExecutor.execute(runnable);
         }
 
-        CompletableFuture<Void> runInMainThreadAndReturn(Runnable runnable) {
-            CompletableFuture<Void> runFuture = new CompletableFuture<>();
-            mainThreadExecutor.execute(
-                    () -> {
-                        try {
-                            runnable.run();
-                        } catch (Exception e) {
-                            runFuture.completeExceptionally(e);
-                        }
-                        runFuture.complete(null);
-                    });
-            return runFuture;
-        }
-
         void runInMainThreadAndWait(Runnable runnable) throws InterruptedException {
             final OneShotLatch latch = new OneShotLatch();
             mainThreadExecutor.execute(


### PR DESCRIPTION
## What is the purpose of the change
Fix NPE when PendingTaskmanager clear pending allocations twice.


## Brief change log
  - check whether pending allocations already clear when PendingTaskManager#clearPendingAllocationsOfJob triggered


## Verifying this change
This change added tests and can be verified as follows:
  - Added test that validates that PendingTaskManager#clearPendingAllocationsOfJob triggered twice

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:(no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
