### PR TITLE
[FLINK-32888] Handle hasNext() throwing EndOfDataDecoderException 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -148,7 +148,7 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
                 currentHttpPostRequestDecoder.offer(httpContent);
 
                 while (httpContent != LastHttpContent.EMPTY_LAST_CONTENT
-                        && currentHttpPostRequestDecoder.hasNext()) {
+                        && hasNext(currentHttpPostRequestDecoder)) {
                     final InterfaceHttpData data = currentHttpPostRequestDecoder.next();
                     if (data.getHttpDataType() == InterfaceHttpData.HttpDataType.FileUpload) {
                         final DiskFileUpload fileUpload = (DiskFileUpload) data;
@@ -209,6 +209,16 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
             }
         } catch (Exception e) {
             handleError(ctx, "File upload failed.", HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    private static boolean hasNext(HttpPostRequestDecoder decoder) {
+        try {
+            return decoder.hasNext();
+        } catch (HttpPostRequestDecoder.EndOfDataDecoderException e) {
+            // this can occur if the final chuck wasn't empty, but didn't contain any attribute data
+            // unfortunately the Netty APIs don't give us any way to check this
+            return false;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadExtension.java
@@ -138,34 +138,33 @@ public class MultipartUploadExtension implements CustomExtension {
                 (request, restfulGateway) -> {
                     // the default verifier checks for identiy (i.e. same name and content) of all
                     // uploaded files
-                    List<Path> expectedFiles =
-                            getFilesToUpload().stream()
-                                    .map(File::toPath)
-                                    .collect(Collectors.toList());
-                    List<Path> uploadedFiles =
-                            request.getUploadedFiles().stream()
-                                    .map(File::toPath)
-                                    .collect(Collectors.toList());
-
-                    assertThat(uploadedFiles).hasSameSizeAs(expectedFiles);
-
-                    List<Path> expectedList = new ArrayList<>(expectedFiles);
-                    List<Path> actualList = new ArrayList<>(uploadedFiles);
-                    expectedList.sort(Comparator.comparing(Path::toString));
-                    actualList.sort(Comparator.comparing(Path::toString));
-
-                    for (int x = 0; x < expectedList.size(); x++) {
-                        Path expected = expectedList.get(x);
-                        Path actual = actualList.get(x);
-
-                        assertThat(actual.getFileName())
-                                .hasToString(expected.getFileName().toString());
-
-                        byte[] originalContent = Files.readAllBytes(expected);
-                        byte[] receivedContent = Files.readAllBytes(actual);
-                        assertThat(receivedContent).isEqualTo(originalContent);
-                    }
+                    assertUploadedFilesEqual(request, getFilesToUpload());
                 });
+    }
+
+    public static void assertUploadedFilesEqual(HandlerRequest<?> request, Collection<File> files)
+            throws IOException {
+        List<Path> expectedFiles = files.stream().map(File::toPath).collect(Collectors.toList());
+        List<Path> uploadedFiles =
+                request.getUploadedFiles().stream().map(File::toPath).collect(Collectors.toList());
+
+        assertThat(uploadedFiles).hasSameSizeAs(expectedFiles);
+
+        List<Path> expectedList = new ArrayList<>(expectedFiles);
+        List<Path> actualList = new ArrayList<>(uploadedFiles);
+        expectedList.sort(Comparator.comparing(Path::toString));
+        actualList.sort(Comparator.comparing(Path::toString));
+
+        for (int x = 0; x < expectedList.size(); x++) {
+            Path expected = expectedList.get(x);
+            Path actual = actualList.get(x);
+
+            assertThat(actual.getFileName()).hasToString(expected.getFileName().toString());
+
+            byte[] originalContent = Files.readAllBytes(expected);
+            byte[] receivedContent = Files.readAllBytes(actual);
+            assertThat(receivedContent).isEqualTo(originalContent);
+        }
     }
 
     public void setFileUploadVerifier(


### PR DESCRIPTION
HttpPostRequestDecoder#hasNext() throws an `EndOfDataDecoderException` when called if all attributes were already read. There is apparently an edge-case where the a non empty HttpContent is received, but we already retrieved all attributes (so I guess it's just multipart metadata).

We now assume that this isn't a problem; if it is the application layer should notice it (e.g., if a file/attribute is missing).