### PR TITLE
[FLINK-32880][flink-runtime]Fulfill redundant taskmanagers periodical…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
@@ -48,15 +48,15 @@ public interface ResourceAllocationStrategy {
             BlockedTaskManagerChecker blockedTaskManagerChecker);
 
     /**
-     * Try to make a release decision to release unused PendingTaskManagers and TaskManagers. This
-     * is more light weighted than {@link #tryFulfillRequirements}, only consider empty registered /
-     * pending workers and assume all requirements are fulfilled by registered / pending workers.
+     * Try to make a decision to reconcile the cluster resources. This is more light weighted than
+     * {@link #tryFulfillRequirements}, only consider empty registered / pending workers and assume
+     * all requirements are fulfilled by registered / pending workers.
      *
      * @param taskManagerResourceInfoProvider provide the registered/pending resources of the
      *     current cluster
-     * @return a {@link ResourceReleaseResult} based on the current status, which contains the
+     * @return a {@link ResourceReconcileResult} based on the current status, which contains the
      *     actions to take
      */
-    ResourceReleaseResult tryReleaseUnusedResources(
+    ResourceReconcileResult tryReconcileClusterResources(
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
@@ -35,7 +35,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                     ResourceAllocationResult>
             tryFulfillRequirementsFunction;
 
-    private final Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+    private final Function<TaskManagerResourceInfoProvider, ResourceReconcileResult>
             tryReleaseUnusedResourcesFunction;
 
     private TestingResourceAllocationStrategy(
@@ -44,7 +44,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                             TaskManagerResourceInfoProvider,
                             ResourceAllocationResult>
                     tryFulfillRequirementsFunction,
-            Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+            Function<TaskManagerResourceInfoProvider, ResourceReconcileResult>
                     tryReleaseUnusedResourcesFunction) {
         this.tryFulfillRequirementsFunction =
                 Preconditions.checkNotNull(tryFulfillRequirementsFunction);
@@ -62,7 +62,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
     }
 
     @Override
-    public ResourceReleaseResult tryReleaseUnusedResources(
+    public ResourceReconcileResult tryReconcileClusterResources(
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
         return tryReleaseUnusedResourcesFunction.apply(taskManagerResourceInfoProvider);
     }
@@ -79,9 +79,9 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
                 tryFulfillRequirementsFunction =
                         (ignored0, ignored1) -> ResourceAllocationResult.builder().build();
 
-        private Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+        private Function<TaskManagerResourceInfoProvider, ResourceReconcileResult>
                 tryReleaseUnusedResourcesFunction =
-                        ignored -> ResourceReleaseResult.builder().build();
+                        ignored -> ResourceReconcileResult.builder().build();
 
         public Builder setTryFulfillRequirementsFunction(
                 BiFunction<
@@ -94,7 +94,7 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
         }
 
         public Builder setTryReleaseUnusedResourcesFunction(
-                Function<TaskManagerResourceInfoProvider, ResourceReleaseResult>
+                Function<TaskManagerResourceInfoProvider, ResourceReconcileResult>
                         tryReleaseUnusedResourcesFunction) {
             this.tryReleaseUnusedResourcesFunction = tryReleaseUnusedResourcesFunction;
             return this;


### PR DESCRIPTION
## What is the purpose of the change

Fix the issue that redundant taskManagers will not be fulfilled in FineGrainedSlotManager periodically.

## Brief change log

- Change ResourceAllocationStrategy#tryReleaseUnusedResources to ResourceAllocationStrategy#tryReconcileClusterResources
- Change  ResourceReleaseResult to ResourceReconcileResult and add field pendingTaskManagersToAdd to ResourceReconcileResult
- make the DefaultResourceAllocationStrategy#tryReconcileClusterResources not only release but also fulfill the redundant taskmanagers
- extract DefaultResourceAllocationStrategy::tryFulFillRedundantResourcesWithAction as a reused function for both tryFulfillRequirements and tryReconcileClusterResources

## Verifying this change

This change added tests and can be verified as follows:

- Added unit test DefaultResourceAllocationStrategyTest#testRedundantResourceShouldBeFulfilled


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 