### PR TITLE
[FLINK-32879][flink-runtime]Ignore slotmanager.max-total-resource.cpu…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -98,7 +98,7 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
             createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
                     throws ConfigurationException {
         return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
-                getConfigurationWithoutMaxSlotNumberIfSet(configuration),
+                getConfigurationWithoutMaxResourceIfSet(configuration),
                 ArbitraryWorkerResourceSpecFactory.INSTANCE);
     }
 
@@ -109,17 +109,35 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
      * @return the configuration for standalone ResourceManager
      */
     @VisibleForTesting
-    public static Configuration getConfigurationWithoutMaxSlotNumberIfSet(
+    public static Configuration getConfigurationWithoutMaxResourceIfSet(
             Configuration configuration) {
         final Configuration copiedConfig = new Configuration(configuration);
-        // The max slot limit should not take effect for standalone cluster, we overwrite the
+        removeMaxResourceConfig(copiedConfig);
+
+        return copiedConfig;
+    }
+
+    private static void removeMaxResourceConfig(Configuration configuration) {
+        // The max slot/cpu/memory limit should not take effect for standalone cluster, we
+        // overwrite the
         // configure in case user
         // sets this value by mistake.
-        if (copiedConfig.removeConfig(ResourceManagerOptions.MAX_SLOT_NUM)) {
+        if (configuration.removeConfig(ResourceManagerOptions.MAX_SLOT_NUM)) {
             LOG.warn(
                     "Config option {} will be ignored in standalone mode.",
                     ResourceManagerOptions.MAX_SLOT_NUM.key());
         }
-        return copiedConfig;
+
+        if (configuration.removeConfig(ResourceManagerOptions.MAX_TOTAL_CPU)) {
+            LOG.warn(
+                    "Config option {} will be ignored in standalone mode.",
+                    ResourceManagerOptions.MAX_TOTAL_CPU.key());
+        }
+
+        if (configuration.removeConfig(ResourceManagerOptions.MAX_TOTAL_MEM)) {
+            LOG.warn(
+                    "Config option {} will be ignored in standalone mode.",
+                    ResourceManagerOptions.MAX_TOTAL_MEM.key());
+        }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -239,7 +239,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
                 createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
                         throws ConfigurationException {
             return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
-                    StandaloneResourceManagerFactory.getConfigurationWithoutMaxSlotNumberIfSet(
+                    StandaloneResourceManagerFactory.getConfigurationWithoutMaxResourceIfSet(
                             configuration),
                     ArbitraryWorkerResourceSpecFactory.INSTANCE);
         }


### PR DESCRIPTION
## What is the purpose of the change

Just as slotmanager.number-of-slots.max, we should also ignore the cpu and memory limitation in standalone mode.

## Brief change log

- Add StandaloneResourceManagerFactory#overwriteMaxResourceNumConfig to remove both max slot/cpu/memory limit option.

## Verifying this change

This change added tests and can be verified as follows:


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager(StandaloneResourceManagerFactory)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 