### PR TITLE
[FLINK-32668][e2e] fix up watchdog timeout error msg in common.sh

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -935,8 +935,12 @@ function extract_job_id_from_job_submission_return() {
 
 kill_test_watchdog() {
     local watchdog_pid=$(cat $TEST_DATA_DIR/job_watchdog.pid)
-    echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
-    kill $watchdog_pid
+    if kill -0 $watchdog_pid > /dev/null 2>&1; then
+        echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
+        kill $watchdog_pid
+    else
+        echo "No watchdog process with pid=$watchdog_pid present, anymore. No action required to clean the watchdog process up."
+    fi
 }
 
 #


### PR DESCRIPTION
### What is the purpose of the change
As showed in [FLINK-32668](https://issues.apache.org/jira/browse/FLINK-32668), an error occurs when watch dog thread exits before killed.

### Brief change log
Check if watch dog thread exists before kill it

### Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, * ZooKeeper: (no)
* The S3 file system connector: (no)

### Documentation
* Does this pull request introduce a new feature? (no)
