### PR TITLE
[FLINK-26585][state-processor-api] replace implementation of MultiStateKeyIterator with Stream-free implementation

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
@@ -18,28 +18,57 @@
 
 package org.apache.flink.state.api.input;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.SavepointResources;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.state.ttl.mock.MockRestoreOperation;
 import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /** Test for the multi-state key iterator. */
 public class MultiStateKeyIteratorTest {
@@ -68,6 +97,37 @@ public class MultiStateKeyIteratorTest {
                 new CloseableRegistry());
     }
 
+    private static CountingKeysKeyedStateBackend createCountingKeysKeyedStateBackend(
+            Integer numKeys) {
+        Environment env = new DummyEnvironment();
+        TypeSerializer<Integer> keySerializer = IntSerializer.INSTANCE;
+        int numberOfKeyGroups = 129;
+        KeyGroupRange keyGroupRange = KeyGroupRange.of(0, 128);
+        TaskKvStateRegistry kvStateRegistry = null;
+        TtlTimeProvider ttlTimeProvider = TtlTimeProvider.DEFAULT;
+        @Nonnull Collection<KeyedStateHandle> stateHandles = Collections.emptyList();
+        CloseableRegistry cancelStreamRegistry = new CloseableRegistry();
+
+        Map<String, Map<Integer, Map<Object, Object>>> stateValues = new HashMap<>();
+        MockRestoreOperation<Integer> restoreOperation =
+                new MockRestoreOperation<>(stateHandles, stateValues);
+        restoreOperation.restore();
+
+        StateSerializerProvider<Integer> keySerializerProvider =
+                StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
+
+        return new CountingKeysKeyedStateBackend(
+                numKeys,
+                kvStateRegistry,
+                keySerializerProvider.currentSchemaSerializer(),
+                env.getUserCodeClassLoader().asClassLoader(),
+                env.getExecutionConfig(),
+                ttlTimeProvider,
+                LatencyTrackingStateConfig.disabled(),
+                cancelStreamRegistry,
+                new InternalKeyContextImpl<>(keyGroupRange, numberOfKeyGroups));
+    }
+
     private static void setKey(
             AbstractKeyedStateBackend<Integer> backend,
             ValueStateDescriptor<Integer> descriptor,
@@ -79,6 +139,17 @@ public class MultiStateKeyIteratorTest {
                 .update(0);
     }
 
+    private static void clearKey(
+            AbstractKeyedStateBackend<Integer> backend,
+            ValueStateDescriptor<Integer> descriptor,
+            int key)
+            throws Exception {
+        backend.setCurrentKey(key);
+        backend.getPartitionedState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor)
+                .clear();
+    }
+
     @Test
     public void testIteratorPullsKeyFromAllDescriptors() throws Exception {
         AbstractKeyedStateBackend<Integer> keyedStateBackend = createKeyedStateBackend();
@@ -88,6 +159,36 @@ public class MultiStateKeyIteratorTest {
 
         MultiStateKeyIterator<Integer> iterator =
                 new MultiStateKeyIterator<>(descriptors, keyedStateBackend);
+
+        List<Integer> keys = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            keys.add(iterator.next());
+        }
+
+        Assert.assertEquals("Unexpected number of keys", 2, keys.size());
+        Assert.assertEquals("Unexpected keys found", Arrays.asList(1, 2), keys);
+    }
+
+    @Test
+    public void testIteratorSkipsEmptyDescriptors() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedStateBackend = createKeyedStateBackend();
+
+        List<ValueStateDescriptor<Integer>> threeDescriptors = new ArrayList<>(3);
+        threeDescriptors.add(new ValueStateDescriptor<>("state-1", Types.INT));
+        threeDescriptors.add(new ValueStateDescriptor<>("state-2", Types.INT));
+        threeDescriptors.add(new ValueStateDescriptor<>("state-3", Types.INT));
+
+        setKey(keyedStateBackend, threeDescriptors.get(0), 1);
+
+        // initializes descriptor 1, but empties it immediately after
+        setKey(keyedStateBackend, threeDescriptors.get(1), 12);
+        clearKey(keyedStateBackend, threeDescriptors.get(1), 12);
+
+        setKey(keyedStateBackend, threeDescriptors.get(2), 2);
+
+        MultiStateKeyIterator<Integer> iterator =
+                new MultiStateKeyIterator<>(threeDescriptors, keyedStateBackend);
 
         List<Integer> keys = new ArrayList<>();
 
@@ -123,6 +224,119 @@ public class MultiStateKeyIteratorTest {
                     keyedStateBackend
                             .getKeys(descriptor.getName(), VoidNamespace.INSTANCE)
                             .count());
+        }
+    }
+
+    /** Test for lazy enumeration of inner iterators. */
+    @Test
+    public void testIteratorPullsSingleKeyFromAllDescriptors() throws AssertionError {
+        CountingKeysKeyedStateBackend keyedStateBackend =
+                createCountingKeysKeyedStateBackend(100_000_000);
+        MultiStateKeyIterator<Integer> testedIterator =
+                new MultiStateKeyIterator<>(descriptors, keyedStateBackend);
+
+        testedIterator.hasNext();
+
+        Assert.assertEquals(
+                "Unexpected number of keys enumerated",
+                1,
+                keyedStateBackend.numberOfKeysEnumerated);
+    }
+
+    /**
+     * Mockup {@link AbstractKeyedStateBackend} that counts how many keys are enumerated.
+     *
+     * <p>Generates a configured number of integer keys, only method actually implemented is {@link
+     * CountingKeysKeyedStateBackend#getKeys(java.lang.String, java.lang.Object)}
+     */
+    static class CountingKeysKeyedStateBackend extends AbstractKeyedStateBackend<Integer> {
+        int numberOfKeysGenerated;
+        public long numberOfKeysEnumerated;
+
+        public CountingKeysKeyedStateBackend(
+                int numberOfKeysGenerated,
+                TaskKvStateRegistry kvStateRegistry,
+                TypeSerializer<Integer> keySerializer,
+                ClassLoader userCodeClassLoader,
+                ExecutionConfig executionConfig,
+                TtlTimeProvider ttlTimeProvider,
+                LatencyTrackingStateConfig latencyTrackingStateConfig,
+                CloseableRegistry cancelStreamRegistry,
+                InternalKeyContext<Integer> keyContext) {
+            super(
+                    kvStateRegistry,
+                    keySerializer,
+                    userCodeClassLoader,
+                    executionConfig,
+                    ttlTimeProvider,
+                    latencyTrackingStateConfig,
+                    cancelStreamRegistry,
+                    keyContext);
+            this.numberOfKeysGenerated = numberOfKeysGenerated;
+            numberOfKeysEnumerated = 0;
+        }
+
+        @Override
+        public <N> Stream<Integer> getKeys(String state, N namespace) {
+            return IntStream.range(0, this.numberOfKeysGenerated)
+                    .boxed()
+                    .peek(i -> numberOfKeysEnumerated++);
+        }
+
+        @Override
+        public int numKeyValueStateEntries() {
+            return numberOfKeysGenerated;
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            throw new UnsupportedOperationException(
+                    "Operations other than getKeys() are not supported on this testing StateBackend.");
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+
+        @Nonnull
+        @Override
+        public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                long checkpointId,
+                long timestamp,
+                @Nonnull CheckpointStreamFactory streamFactory,
+                @Nonnull CheckpointOptions checkpointOptions)
+                throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "Operations other than getKeys() are not supported on this testing StateBackend.");
+        }
+
+        @Nonnull
+        @Override
+        public <N, SV, SEV, S extends State, IS extends S> IS createOrUpdateInternalState(
+                @Nonnull TypeSerializer<N> namespaceSerializer,
+                @Nonnull StateDescriptor<S, SV> stateDesc,
+                @Nonnull
+                        StateSnapshotTransformer.StateSnapshotTransformFactory<SEV>
+                                snapshotTransformFactory)
+                throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "Operations other than getKeys() are not supported on this testing StateBackend.");
+        }
+
+        @Override
+        public <N> Stream<Tuple2<Integer, N>> getKeysAndNamespaces(String state) {
+            throw new UnsupportedOperationException(
+                    "Operations other than getKeys() are not supported on this testing StateBackend.");
+        }
+
+        @Nonnull
+        @Override
+        public SavepointResources<Integer> savepoint() throws UnsupportedOperationException {
+            throw new UnsupportedOperationException(
+                    "Operations other than getKeys() are not supported on this testing StateBackend.");
         }
     }
 }


### PR DESCRIPTION
## Contribution Checklist

  - `Pending:` Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

## What is the purpose of the change

Avoids a known flaw in Stream.flatMap, see https://bugs.openjdk.org/browse/JDK-8267359. Avoids potential OOM Error for
keyed state with many keys when reading them with state processor api.

## Brief change log

  - replaced the original implementation of MultiStateKeyIterator with a Java-Stream-free implementation.
  - this fixes a known flaw in Stream.flatMap which leads to complete enumeration of inner iterator 
    and buffering of all elements with potential for a OOM error for state with many keys
  - manual implementation of nested iterator avoids this problem

## Verifying this change

This change adds a tests MultiStateKeyIteratorTest#testIteratorPullsSingleKeyFromAllDescriptors that fails with the previous implementation and succeeds with the new implementation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
    - new code should be marginally faster (not verified)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
