### PR TITLE
[FLINK-32895][Scheduler] Introduce the max attempts for Exponential Delay Restart Strategy

### DIFF
--- a/docs/content.zh/docs/ops/state/task_failure_recovery.md
+++ b/docs/content.zh/docs/ops/state/task_failure_recovery.md
@@ -162,6 +162,7 @@ restart-strategy.exponential-delay.max-backoff: 2 min
 restart-strategy.exponential-delay.backoff-multiplier: 2.0
 restart-strategy.exponential-delay.reset-backoff-threshold: 10 min
 restart-strategy.exponential-delay.jitter-factor: 0.1
+restart-strategy.exponential-delay.attempts-before-reset-backoff: 10
 ```
 
 指数延迟重启策略可以在代码中被指定：

--- a/docs/content/docs/ops/state/task_failure_recovery.md
+++ b/docs/content/docs/ops/state/task_failure_recovery.md
@@ -167,6 +167,7 @@ restart-strategy.exponential-delay.max-backoff: 2 min
 restart-strategy.exponential-delay.backoff-multiplier: 2.0
 restart-strategy.exponential-delay.reset-backoff-threshold: 10 min
 restart-strategy.exponential-delay.jitter-factor: 0.1
+restart-strategy.exponential-delay.attempts-before-reset-backoff: 10
 ```
 
 The exponential delay restart strategy can also be set programmatically:

--- a/docs/layouts/shortcodes/generated/exponential_delay_restart_strategy_configuration.html
+++ b/docs/layouts/shortcodes/generated/exponential_delay_restart_strategy_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>restart-strategy.exponential-delay.attempts-before-reset-backoff</h5></td>
+            <td style="word-wrap: break-word;">infinite</td>
+            <td>Integer</td>
+            <td>The number of times that Flink retries the execution before failing the job if <code class="highlighter-rouge">restart-strategy.type</code> has been set to <code class="highlighter-rouge">exponential-delay</code>. The number will be reset once the backoff is reset to its initial value.</td>
+        </tr>
+        <tr>
             <td><h5>restart-strategy.exponential-delay.backoff-multiplier</h5></td>
             <td style="word-wrap: break-word;">2.0</td>
             <td>Double</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 
 import java.time.Duration;
@@ -219,6 +220,19 @@ public class RestartStrategyOptions {
                                             "Jitter specified as a portion of the backoff if %s has been set to %s. "
                                                     + "It represents how large random value will be added or subtracted to the backoff. "
                                                     + "Useful when you want to avoid restarting multiple jobs at the same time.",
+                                            code(RESTART_STRATEGY.key()), code("exponential-delay"))
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> RESTART_STRATEGY_EXPONENTIAL_DELAY_ATTEMPTS =
+            ConfigOptions.key("restart-strategy.exponential-delay.attempts-before-reset-backoff")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that Flink retries the execution before failing the job if %s has been set to %s. "
+                                                    + "The number will be reset once the backoff is reset to its initial value.",
                                             code(RESTART_STRATEGY.key()), code("exponential-delay"))
                                     .build());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
@@ -47,8 +47,6 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
 
     private final double jitterFactor;
 
-    private final String strategyString;
-
     private final Clock clock;
 
     private long currentBackoffMS;
@@ -84,7 +82,6 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
 
         this.clock = checkNotNull(clock);
         this.lastFailureTimestamp = 0;
-        this.strategyString = generateStrategyString();
     }
 
     @Override
@@ -111,7 +108,21 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
 
     @Override
     public String toString() {
-        return strategyString;
+        return "ExponentialDelayRestartBackoffTimeStrategy(initialBackoffMS="
+                + initialBackoffMS
+                + ", maxBackoffMS="
+                + maxBackoffMS
+                + ", backoffMultiplier="
+                + backoffMultiplier
+                + ", resetBackoffThresholdMS="
+                + resetBackoffThresholdMS
+                + ", jitterFactor="
+                + jitterFactor
+                + ", currentBackoffMS="
+                + currentBackoffMS
+                + ", lastFailureTimestamp="
+                + lastFailureTimestamp
+                + ")";
     }
 
     private void setInitialBackoff() {
@@ -140,24 +151,6 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
             long offset = (long) (currentBackoffMS * jitterFactor);
             return ThreadLocalRandom.current().nextLong(-offset, offset + 1);
         }
-    }
-
-    private String generateStrategyString() {
-        return "ExponentialDelayRestartBackoffTimeStrategy(initialBackoffMS="
-                + initialBackoffMS
-                + ", maxBackoffMS="
-                + maxBackoffMS
-                + ", backoffMultiplier="
-                + backoffMultiplier
-                + ", resetBackoffThresholdMS="
-                + resetBackoffThresholdMS
-                + ", jitterFactor="
-                + jitterFactor
-                + ", currentBackoffMS="
-                + currentBackoffMS
-                + ", lastFailureTimestamp="
-                + lastFailureTimestamp
-                + ")";
     }
 
     public static ExponentialDelayRestartBackoffTimeStrategyFactory createFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategyFactoryLoader.java
@@ -116,7 +116,9 @@ public final class RestartBackoffTimeStrategyFactoryLoader {
                             exponentialDelayConfig.getMaxBackoff().toMilliseconds(),
                             exponentialDelayConfig.getBackoffMultiplier(),
                             exponentialDelayConfig.getResetBackoffThreshold().toMilliseconds(),
-                            exponentialDelayConfig.getJitterFactor()));
+                            exponentialDelayConfig.getJitterFactor(),
+                            RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_ATTEMPTS
+                                    .defaultValue()));
         } else {
             throw new IllegalArgumentException(
                     "Unknown restart strategy configuration " + restartStrategyConfiguration + ".");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
@@ -50,7 +50,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     }
 
     @Test
-    void testInitialBackoff() throws Exception {
+    void testInitialBackoff() {
         long initialBackoffMS = 42L;
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
@@ -61,7 +61,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     }
 
     @Test
-    void testMaxBackoff() throws Exception {
+    void testMaxBackoff() {
         final long maxBackoffMS = 6L;
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
@@ -75,7 +75,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     }
 
     @Test
-    void testResetBackoff() throws Exception {
+    void testResetBackoff() {
         final long initialBackoffMS = 1L;
         final long resetBackoffThresholdMS = 8L;
         final ManualClock clock = new ManualClock();
@@ -107,7 +107,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     }
 
     @Test
-    void testBackoffMultiplier() throws Exception {
+    void testBackoffMultiplier() {
         long initialBackoffMS = 4L;
         double jitterFactor = 0;
         double backoffMultiplier = 2.3;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
@@ -36,15 +36,17 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     private final Exception failure = new Exception();
 
     @Test
-    void testAlwaysRestart() throws Exception {
+    void testMaxAttempts() {
+        int maxAttempts = 13;
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), 1L, 3L, 2.0, 4L, 0.25);
+                        new ManualClock(), 1L, 3L, 1.2, 4L, 0.25, maxAttempts);
 
-        for (int i = 0; i < 13; i++) {
+        for (int i = 0; i <= maxAttempts; i++) {
             assertThat(restartStrategy.canRestart()).isTrue();
             restartStrategy.notifyFailure(failure);
         }
+        assertThat(restartStrategy.canRestart()).isFalse();
     }
 
     @Test
@@ -53,7 +55,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), initialBackoffMS, 45L, 2.0, 8L, 0);
+                        new ManualClock(), initialBackoffMS, 45L, 2.0, 8L, 0, Integer.MAX_VALUE);
 
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(initialBackoffMS);
     }
@@ -64,7 +66,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), 1L, maxBackoffMS, 2.0, 8L, 0.25);
+                        new ManualClock(), 1L, maxBackoffMS, 2.0, 8L, 0.25, Integer.MAX_VALUE);
 
         for (int i = 0; i < 10; i++) {
             restartStrategy.notifyFailure(failure);
@@ -80,7 +82,13 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        clock, initialBackoffMS, 5L, 2.0, resetBackoffThresholdMS, 0.25);
+                        clock,
+                        initialBackoffMS,
+                        5L,
+                        2.0,
+                        resetBackoffThresholdMS,
+                        0.25,
+                        Integer.MAX_VALUE);
 
         clock.advanceTime(
                 resetBackoffThresholdMS + restartStrategy.getBackoffTime() - 1,
@@ -112,7 +120,8 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
                         maxBackoffMS,
                         backoffMultiplier,
                         8L,
-                        jitterFactor);
+                        jitterFactor,
+                        10);
 
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(9L); // 4 * 2.3
@@ -128,7 +137,13 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), initialBackoffMS, maxBackoffMS, 2.0, 1L, 0.25);
+                        new ManualClock(),
+                        initialBackoffMS,
+                        maxBackoffMS,
+                        2.0,
+                        1L,
+                        0.25,
+                        Integer.MAX_VALUE);
 
         restartStrategy.notifyFailure(failure);
         assertCorrectRandomRange(restartStrategy::getBackoffTime, 3L, 4L, 5L);
@@ -147,7 +162,13 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), 1L, maxBackoffMS, 2.0, 8L, jitterFactor);
+                        new ManualClock(),
+                        1L,
+                        maxBackoffMS,
+                        2.0,
+                        8L,
+                        jitterFactor,
+                        Integer.MAX_VALUE);
 
         assertCorrectRandomRange(restartStrategy::getBackoffTime, 0L, 1L, 2L);
 
@@ -174,7 +195,8 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
                         maxBackoffMS,
                         backoffMultiplier,
                         resetBackoffThresholdMS,
-                        jitterFactor);
+                        jitterFactor,
+                        Integer.MAX_VALUE);
 
         // ensure initial data
         assertThat(restartStrategy.canRestart()).isTrue();


### PR DESCRIPTION
## What is the purpose of the change

See [FLIP-364: Improve the exponential-delay restart-strategy](https://cwiki.apache.org/confluence/x/uJqzDw) . This PR  includes the subtask2 of FLIP-364.

## Brief change log

- [FLINK-32895][Scheduler][hotfix] Generate latest strategy string for ExponentialDelayRestartBackoffTimeStrategy due to some information will be updated, such as: `currentBackoffMS` and `lastFailureTimestamp`
- [FLINK-32895][Scheduler] Introduce the max attempts for Exponential Delay Restart Strategy
  - Add the option: `restart-strategy.exponential-delay.attempts-before-reset-backoff`
- [FLINK-32895][Scheduler][refactor] Remove some unused throws

## Verifying this change

- Improve some tests in `ExponentialDelayRestartBackoffTimeStrategyTest`.
- Change the `testAlwaysRestart` to `testMaxAttempts` in `ExponentialDelayRestartBackoffTimeStrategyTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Java doc and config doc are updated, and updated a little official web doc related to `restart-strategy.exponential-delay.attempts-before-reset-backoff`.
