### PR TITLE
[FLINK-32897][table-runtime]Fix RowToRowCastRule get wrong result error while cast Array(Row()) type

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -221,7 +221,8 @@ class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, R
                                     elseBodyWriter.stmt(writeNull));
         }
 
-        writer.stmt(methodCall(writerTerm, "complete")).assignStmt(returnVariable, rowTerm);
+        writer.stmt(methodCall(writerTerm, "complete"))
+                .assignStmt(returnVariable, rowTerm + ".copy()");
         return writer.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1217,6 +1217,19 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                                 ROW(INT(), INT(), TIME(), ARRAY(CHAR(1))),
                                 Row.of(10, null, DEFAULT_TIME, new String[] {"a", "b", "c"}),
                                 Row.of(10L, null, "12:34:56", new String[] {"a", "b", "c"}))
+                        .build(),
+                CastTestSpecBuilder.testCastTo(
+                                ARRAY(ROW(BIGINT(), BIGINT(), STRING(), ARRAY(STRING()))))
+                        .fromCase(
+                                ARRAY(ROW(INT(), INT(), TIME(), ARRAY(CHAR(2)))),
+                                new Row[] {
+                                    Row.of(10, 1, DEFAULT_TIME, new String[] {"a1", "b1", "c1"}),
+                                    Row.of(11, 2, DEFAULT_TIME, new String[] {"a2", "b2", "c2"})
+                                },
+                                new Row[] {
+                                    Row.of(10L, 1L, "12:34:56", new String[] {"a1", "b1", "c1"}),
+                                    Row.of(11L, 2L, "12:34:56", new String[] {"a2", "b2", "c2"})
+                                })
                         .build());
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pr is aims to fix RowToRowCastRule get wrong result error while cast Array(Row()) type. For the below case:
`CREATE TABLE print_sink (
  a STRING NOT NULL,
  config ARRAY<ROW<notificationTypeOptInReference STRING NOT NULL,cso STRING NOT NULL,autocreate BOOLEAN NOT NULL> NOT NULL> NOT NULL,
  ingestionTime TIMESTAMP(3)
) WITH (
    'connector' = 'print'
);`

If we insert into `('Transaction', ARRAY[ROW('G', 'IT', true),ROW('H', 'FR', true), ROW('I', 'IT', false)], TIMESTAMP '2023-08-30 14:01:00')`, we will get a wrong result of `('Transaction', ARRAY[ROW('I', 'IT', false),ROW('I', 'IT', false), ROW('I', 'IT', false)], TIMESTAMP '2023-08-30 14:01:00')`, which the last value in array will replace the former.

This error is caused by the  wrong codegen code as we try to reuse the result value.


## Brief change log

- adding tests to cover Array(Row()) cast.


## Verifying this change

- adding tests to cover Array(Row()) cast.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  no docs.