### PR TITLE
[FLINK-32905][table-runtime] Fix the bug of broadcast hash join doesn't support spill to disk when enabling operator fusion codegen

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/CalcFusionCodegenSpec.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/fusion/spec/CalcFusionCodegenSpec.scala
@@ -64,6 +64,7 @@ class CalcFusionCodegenSpec(
     } else if (condition.isEmpty) { // only projection
       val projectionExprs = projection.map(getExprCodeGenerator.generateExpression)
       s"""
+         |${opCodegenCtx.reuseLocalVariableCode()}
          |${evaluateRequiredVariables(toScala(inputVars), projectionUsedColumns)}
          |${fusionContext.processConsume(toJava(projectionExprs))}
          |""".stripMargin

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OperatorFusionCodegenITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OperatorFusionCodegenITCase.scala
@@ -157,6 +157,15 @@ class OperatorFusionCodegenITCase extends BatchTestBase {
   }
 
   @TestTemplate
+  def testHashJoinWithOnlyProjection(): Unit = {
+    checkOpFusionCodegenResult("""
+                                 |SELECT * FROM (SELECT a, nx + ny AS nt FROM x
+                                 |  JOIN y ON x.a = y.ny) t
+                                 |JOIN z ON t.a = z.nz WHERE t.nt -10 > z.nz
+                                 |""".stripMargin)
+  }
+
+  @TestTemplate
   def testHashJoinWithDeadlockCausedByExchangeInAncestor(): Unit = {
     checkOpFusionCodegenResult(
       """

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -100,12 +100,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
     public final boolean tryDistinctBuildRow;
 
     /**
-     * In operator fusion codegen case, we don't support spill to disk for broadcast hashjoin, so
-     * this flag is introduced.
-     */
-    protected final boolean spillEnabled;
-
-    /**
      * The recursion depth of the partition that is currently processed. The initial table has a
      * recursion depth of 0. Partitions spilled from a table that is built for a partition with
      * recursion depth <i>n</i> have a recursion depth of <i>n+1</i>.
@@ -147,8 +141,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
             IOManager ioManager,
             int avgRecordLen,
             long buildRowCount,
-            boolean tryDistinctBuildRow,
-            boolean spillEnabled) {
+            boolean tryDistinctBuildRow) {
         this.compressionEnabled = compressionEnabled;
         this.compressionCodecFactory =
                 this.compressionEnabled
@@ -174,7 +167,6 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 
         this.segmentSizeBits = MathUtils.log2strict(segmentSize);
         this.segmentSizeMask = segmentSize - 1;
-        this.spillEnabled = spillEnabled;
 
         // open builds the initial table by consuming the build-side input
         this.currentRecursionDepth = 0;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
@@ -41,7 +41,6 @@ import org.apache.flink.table.runtime.util.RowIterator;
 import org.apache.flink.util.MathUtils;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -170,8 +169,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
                 ioManager,
                 avgRecordLen,
                 buildRowCount,
-                !type.buildLeftSemiOrAnti() && tryDistinctBuildRow,
-                true);
+                !type.buildLeftSemiOrAnti() && tryDistinctBuildRow);
         // assign the members
         this.originBuildSideSerializer = buildSideSerializer;
         this.binaryBuildSideSerializer =
@@ -670,11 +668,6 @@ public class BinaryHashTable extends BaseHybridHashTable {
      */
     @Override
     protected int spillPartition() throws IOException {
-        if (!spillEnabled) {
-            throw new UnsupportedEncodingException(
-                    "Currently doesn't support spill to disk for grace hash join "
-                            + "when broadcast hash join strategy is chosen and operator fusion codegen is enabled simultaneously.");
-        }
         // find the largest partition
         int largestNumBlocks = 0;
         int largestPartNum = -1;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/LongHybridHashTable.java
@@ -37,7 +37,6 @@ import javax.annotation.Nullable;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -84,32 +83,6 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
             IOManager ioManager,
             int avgRecordLen,
             long buildRowCount) {
-        this(
-                owner,
-                compressionEnabled,
-                compressionBlockSize,
-                buildSideSerializer,
-                probeSideSerializer,
-                memManager,
-                reservedMemorySize,
-                ioManager,
-                avgRecordLen,
-                buildRowCount,
-                true);
-    }
-
-    public LongHybridHashTable(
-            Object owner,
-            boolean compressionEnabled,
-            int compressionBlockSize,
-            BinaryRowDataSerializer buildSideSerializer,
-            BinaryRowDataSerializer probeSideSerializer,
-            MemoryManager memManager,
-            long reservedMemorySize,
-            IOManager ioManager,
-            int avgRecordLen,
-            long buildRowCount,
-            boolean spillEnabled) {
         super(
                 owner,
                 compressionEnabled,
@@ -119,8 +92,7 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
                 ioManager,
                 avgRecordLen,
                 buildRowCount,
-                false,
-                spillEnabled);
+                false);
         this.buildSideSerializer = buildSideSerializer;
         this.probeSideSerializer = probeSideSerializer;
 
@@ -621,11 +593,6 @@ public abstract class LongHybridHashTable extends BaseHybridHashTable {
 
     @Override
     public int spillPartition() throws IOException {
-        if (!spillEnabled) {
-            throw new UnsupportedEncodingException(
-                    "Currently doesn't support spill to disk for grace hash join "
-                            + "when broadcast hash join strategy is chosen and operator fusion codegen is enabled simultaneously.");
-        }
         // find the largest partition
         int largestNumBlocks = 0;
         int largestPartNum = -1;


### PR DESCRIPTION
## What is the purpose of the change

In the predecessor PR, for the purpose of lazy computation, for Broadcast HashJoin, we strongly assume that the build side won' spill to disk because it less than 10MB. However, during the testing of TPC-DS, part of the query, due to the problem of the inaccurate derivation of statistics by the optimizer, although the optimizer chose Broadcast HashJoin, the spill behavior happened during actual runtime pahse, so we need to remove this assumption and make it support spill as well. For this fix, the gains obtained through TPC-DS are basically the same as expected


## Brief change log

  - *Fix the bug of broadcast hash join doesn't support spill to disk when enabling operator fusion codegen*


## Verifying this change

This change is already covered by existing tests in OperatorFusionCodegenITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
