### PR TITLE
[FLINK-32908][state-changelog] Fix wrong materialization id setting w…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -135,15 +135,18 @@ public interface ChangelogStateBackendHandle
             if (originKeyedStateHandle instanceof ChangelogStateBackendHandle) {
                 return (ChangelogStateBackendHandle) originKeyedStateHandle;
             } else {
+                long checkpointId =
+                        originKeyedStateHandle instanceof CheckpointBoundKeyedStateHandle
+                                ? ((CheckpointBoundKeyedStateHandle) originKeyedStateHandle)
+                                        .getCheckpointId()
+                                : 0L;
+
                 return new ChangelogStateBackendHandle.ChangelogStateBackendHandleImpl(
                         singletonList(castToAbsolutePath(originKeyedStateHandle)),
                         emptyList(),
                         originKeyedStateHandle.getKeyGroupRange(),
-                        originKeyedStateHandle instanceof CheckpointBoundKeyedStateHandle
-                                ? ((CheckpointBoundKeyedStateHandle) originKeyedStateHandle)
-                                        .getCheckpointId()
-                                : 0L,
-                        0L,
+                        checkpointId,
+                        checkpointId,
                         0L);
             }
         }


### PR DESCRIPTION
…hen switching from non-log-based checkpoint to log-based checkpoint


## What is the purpose of the change

Fix wrong materialization id setting when switching from non-log-based checkpoint to log-based checkpoint, detail see [FLINK-32908|https://issues.apache.org/jira/browse/FLINK-32908].

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no