### PR TITLE
[FLINK-32881][checkpoint] Support triggering savepoint in detach mode for CLI and dumping all pending savepoint ids by rest api 

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -125,6 +125,43 @@ Lastly, you can optionally provide what should be the [binary format]({{< ref "d
 
 The path to the savepoint can be used later on to [restart the Flink job](#starting-a-job-from-a-savepoint).
 
+If the state size of the job is quite big, the client will get a timeout exception since it has to wait for the savepoint finished.
+```
+Triggering savepoint for job bec5244e09634ad71a80785937a9732d.
+Waiting for response...
+
+--------------------------------------------------------------
+The program finished with the following exception:
+
+org.apache.flink.util.FlinkException: Triggering a savepoint for the job bec5244e09634ad71a80785937a9732d failed.
+        at org.apache.flink.client.cli.CliFrontend.triggerSavepoint(CliFrontend. java:828)
+        at org.apache.flink.client.cli.CliFrontend.lambda$savepopint$8(CliFrontend.java:794)
+        at org.apache.flink.client.cli.CliFrontend.runClusterAction(CliFrontend.java:1078)
+        at org.apache.flink.client.cli.CliFrontend.savepoint(CliFrontend.java:779)
+        at org.apache.flink.client.cli.CliFrontend.parseAndRun(CliFrontend.java:1150)
+        at org.apache.flink.client.cli.CliFrontend.lambda$mainInternal$9(CliFrontend.java:1226)
+        at org.apache.flink.runtime.security.contexts.NoOpSecurityContext.runSecured(NoOpSecurityContext.java:28)
+        at org.apache.flink.client.cli.CliFrontend.mainInternal(CliFrontend.java:1226)
+        at org.apache.flink.client.cli.CliFrontend.main(CliFronhtend.java:1194)
+Caused by: java.util.concurrent.TimeoutException
+        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
+        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
+        at org.apache.flink.client.cli.CliFrontend.triggerSavepoint(CliFrontend.java:822)
+        ... 8 more
+```
+In this case, we could use "-detached" option to trigger a detached savepoint, the client will return the trigger id immediately.
+```bash
+$ ./bin/flink savepoint \
+      $JOB_ID \ 
+      /tmp/flink-savepoints
+      -detached
+```
+```
+Triggering savepoint in detached mode for job bec5244e09634ad71a80785937a9732d.
+Successfully trigger manual savepoint, triggerId: 2505bbd12c5b58fd997d0f193db44b97
+```
+We can get the status of the detached savepoint by [rest api]({{< ref "docs/ops/rest_api" >}}/#jobs-jobid-checkpoints-triggerid).
+
 #### Disposing a Savepoint
 
 The `savepoint` action can be also used to remove savepoints. `--dispose` with the corresponding 
@@ -213,6 +250,8 @@ records to process after the savepoint taken while stopping.
 Use the `--drain` flag if you want to terminate the job permanently.
 If you want to resume the job at a later point in time, then do not drain the pipeline because it could lead to incorrect results when the job is resumed.
 {{< /hint >}}
+
+If you want to trigger the savepoint in detached mode, add option `-detached` to the command.
 
 Lastly, you can optionally provide what should be the [binary format]({{< ref "docs/ops/state/savepoints" >}}#savepoint-format) of the savepoint.
 

--- a/docs/content.zh/docs/ops/state/savepoints.md
+++ b/docs/content.zh/docs/ops/state/savepoints.md
@@ -142,6 +142,14 @@ $ bin/flink savepoint :jobId [:targetDirectory]
 $ bin/flink savepoint --type [native/canonical] :jobId [:targetDirectory]
 ```
 
+使用上述命令触发savepoint时，client需要等待savepoint制作完成，因此当任务的状态较大时，可能会导致client出现超时的情况。在这种情况下可以使用detach模式来触发savepoint。
+
+```shell
+$ bin/flink savepoint :jobId [:targetDirectory] -detached
+```
+
+使用该命令时，client拿到本次savepoint的trigger id后立即返回，可以通过[REST API]({{< ref "docs/ops/rest_api" >}}/#jobs-jobid-checkpoints-triggerid)来监控本次savepoint的制作情况。
+
 #### 使用 YARN 触发 Savepoint
 
 ```shell
@@ -159,6 +167,8 @@ $ bin/flink stop --type [native/canonical] --savepointPath [:targetDirectory] :j
 ```
 
 这将自动触发 ID 为 `:jobid` 的作业的 Savepoint，并停止该作业。此外，你可以指定一个目标文件系统目录来存储 Savepoint 。该目录需要能被 JobManager(s) 和 TaskManager(s) 访问。你也可以指定创建 Savepoint 的格式。如果没有指定，会采用标准格式创建 Savepoint。
+
+如果你想使用detach模式触发Savepoint，在命令行后添加选项`-detached`即可。
 
 ### 从 Savepoint 恢复
 

--- a/docs/content.zh/docs/ops/upgrading.md
+++ b/docs/content.zh/docs/ops/upgrading.md
@@ -70,6 +70,8 @@ That same code would have to be recompiled when upgrading to 1.16.0 though.
 ```
 建议定期获取 Savepoint ，以便能够从之前的时间点重新启动应用程序。
 
+如果你想使用detach模式触发 Savepoint，只需添加选项`-detached`。
+
 * 作获取 Savepoint 并停止应用程序。
 ```bash
 > ./bin/flink cancel -s [ Savepoint 的路径] <jobID>
@@ -216,6 +218,7 @@ val mappedEvents: DataStream[(Int, Long)] = events
 ```shell
 $ bin/flink stop [--savepointPath :savepointPath] :jobId
 ```
+如果你想使用detach模式触发Savepoint，在命令行后添加选项`-detached`即可。
 
 更多详情，请阅读 [savepoint documentation]({{< ref "docs/ops/state/savepoints" >}}).
 

--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -167,6 +167,16 @@ the savepoint should be taken. By default the savepoint will be taken in canonic
 $ bin/flink savepoint --type [native/canonical] :jobId [:targetDirectory]
 ```
 
+When using the above command to trigger a savepoint, the client needs to wait for the savepoint 
+to be completed. Therefore, the client may time out when the state size of the task is large.
+In this case, you can trigger the savepoint in detached mode.
+
+```shell
+$ bin/flink savepoint :jobId [:targetDirectory] -detached
+```
+When using this command, the client returns immediately after getting the trigger id of 
+the savepoint. You can monitor the status of the savepoint through the REST API [rest api]({{< ref "docs/ops/rest_api" >}}/#jobs-jobid-checkpoints-triggerid).
+
 #### Trigger a Savepoint with YARN
 
 ```shell
@@ -185,6 +195,8 @@ This will atomically trigger a savepoint for the job with ID `:jobid` and stop t
 you can specify a target file system directory to store the savepoint in. The directory needs to be
 accessible by the JobManager(s) and TaskManager(s). You can also pass a type in which the savepoint
 should be taken. By default the savepoint will be taken in canonical format.
+
+If you want to trigger the savepoint in detached mode, add option `-detached` to the command.
 
 ### Resuming from Savepoints
 

--- a/docs/content/docs/ops/upgrading.md
+++ b/docs/content/docs/ops/upgrading.md
@@ -71,6 +71,7 @@ There are two ways of taking a savepoint from a running streaming application.
 > ./bin/flink savepoint <jobID> [pathToSavepoint]
 ```
 It is recommended to periodically take savepoints in order to be able to restart an application from a previous point in time.
+If you want to trigger a savepoint in detached mode, just add the option `-detached`.
 
 * Taking a savepoint and stopping the application as a single action. 
 ```bash
@@ -218,6 +219,8 @@ You can do this with the command:
 ```shell
 $ bin/flink stop [--savepointPath :savepointPath] :jobId
 ```
+
+If you want to trigger the savepoint in detached mode, add option `-detached` to the command.
 
 For more details, please read the [savepoint documentation]({{< ref "docs/ops/state/savepoints" >}}).
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -164,6 +164,14 @@ public class CliFrontendParser {
                     false,
                     "Defines whether to trigger this checkpoint as a full one.");
 
+    static final Option SAVEPOINT_DETACHED_OPTION =
+            new Option(
+                    "detached",
+                    false,
+                    "Triggering savepoint in detached mode, client and JM are decoupled,"
+                            + " return the savepoint trigger id as the unique identification of"
+                            + " the detached savepoint.");
+
     // list specific options
     static final Option RUNNING_OPTION =
             new Option("r", "running", false, "Show only running programs and their JobIDs");
@@ -446,7 +454,8 @@ public class CliFrontendParser {
         return buildGeneralOptions(new Options())
                 .addOption(SAVEPOINT_DISPOSE_OPTION)
                 .addOption(JAR_OPTION)
-                .addOption(SAVEPOINT_FORMAT_OPTION);
+                .addOption(SAVEPOINT_FORMAT_OPTION)
+                .addOption(SAVEPOINT_DETACHED_OPTION);
     }
 
     static Options getCheckpointCommandOptions() {
@@ -490,7 +499,8 @@ public class CliFrontendParser {
     private static Options getSavepointOptionsWithoutDeprecatedOptions(Options options) {
         return options.addOption(SAVEPOINT_DISPOSE_OPTION)
                 .addOption(SAVEPOINT_FORMAT_OPTION)
-                .addOption(JAR_OPTION);
+                .addOption(JAR_OPTION)
+                .addOption(SAVEPOINT_DETACHED_OPTION);
     }
 
     private static Options getCheckpointOptionsWithoutDeprecatedOptions(Options options) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -447,7 +447,8 @@ public class CliFrontendParser {
         return buildGeneralOptions(new Options())
                 .addOption(STOP_WITH_SAVEPOINT_PATH)
                 .addOption(STOP_AND_DRAIN)
-                .addOption(SAVEPOINT_FORMAT_OPTION);
+                .addOption(SAVEPOINT_FORMAT_OPTION)
+                .addOption(SAVEPOINT_DETACHED_OPTION);
     }
 
     static Options getSavepointCommandOptions() {
@@ -493,7 +494,8 @@ public class CliFrontendParser {
     private static Options getStopOptionsWithoutDeprecatedOptions(Options options) {
         return options.addOption(STOP_WITH_SAVEPOINT_PATH)
                 .addOption(STOP_AND_DRAIN)
-                .addOption(SAVEPOINT_FORMAT_OPTION);
+                .addOption(SAVEPOINT_FORMAT_OPTION)
+                .addOption(SAVEPOINT_DETACHED_OPTION);
     }
 
     private static Options getSavepointOptionsWithoutDeprecatedOptions(Options options) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.commons.cli.CommandLine;
 
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_FORMAT_OPTION;
 
@@ -35,6 +36,7 @@ public class SavepointOptions extends CommandLineOptions {
     private boolean dispose;
     private String disposeSavepointPath;
     private String jarFile;
+    private boolean isDetached;
 
     public SavepointOptions(CommandLine line) {
         super(line);
@@ -42,6 +44,7 @@ public class SavepointOptions extends CommandLineOptions {
         dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
         disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
         jarFile = line.getOptionValue(JAR_OPTION.getOpt());
+        isDetached = line.hasOption(SAVEPOINT_DETACHED_OPTION.getOpt());
         if (line.hasOption(SAVEPOINT_FORMAT_OPTION)) {
             formatType =
                     ConfigurationUtils.convertValue(
@@ -70,5 +73,9 @@ public class SavepointOptions extends CommandLineOptions {
 
     public SavepointFormatType getFormatType() {
         return formatType;
+    }
+
+    public boolean isDetached() {
+        return isDetached;
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 
 import org.apache.commons.cli.CommandLine;
 
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_FORMAT_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_AND_DRAIN;
 import static org.apache.flink.client.cli.CliFrontendParser.STOP_WITH_SAVEPOINT_PATH;
@@ -41,6 +42,8 @@ class StopOptions extends CommandLineOptions {
 
     private final SavepointFormatType formatType;
 
+    private boolean isDetached;
+
     StopOptions(CommandLine line) {
         super(line);
         this.args = line.getArgs();
@@ -58,6 +61,8 @@ class StopOptions extends CommandLineOptions {
         } else {
             formatType = SavepointFormatType.DEFAULT;
         }
+
+        this.isDetached = line.hasOption(SAVEPOINT_DETACHED_OPTION.getOpt());
     }
 
     String[] getArgs() {
@@ -78,5 +83,9 @@ class StopOptions extends CommandLineOptions {
 
     public SavepointFormatType getFormatType() {
         return formatType;
+    }
+
+    public boolean isDetached() {
+        return isDetached;
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -189,6 +189,21 @@ public interface ClusterClient<T> extends AutoCloseable {
     CompletableFuture<Long> triggerCheckpoint(JobID jobId, CheckpointType checkpointType);
 
     /**
+     * Triggers a detached savepoint for the job identified by the job id. The savepoint will be
+     * written to the given savepoint directory, or {@link
+     * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
+     * Notice that: the detached savepoint will return with a savepoint trigger id instead of the
+     * path future, that means the client will return very quickly.
+     *
+     * @param jobId job id
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param formatType a binary format of the savepoint
+     * @return the savepoint trigger id
+     */
+    CompletableFuture<String> triggerDetachedSavepoint(
+            JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType);
+
+    /**
      * Sends out a request to a specified coordinator and return the response.
      *
      * @param jobId specifies the job which the coordinator belongs to

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -167,6 +167,25 @@ public interface ClusterClient<T> extends AutoCloseable {
             final SavepointFormatType formatType);
 
     /**
+     * Stops a program on Flink cluster whose job-manager is configured in this client's
+     * configuration. Stopping works only for streaming programs. Be aware, that the program might
+     * continue to run for a while after sending the stop command, because after sources stopped to
+     * emit data all operators need to finish processing.
+     *
+     * @param jobId the job ID of the streaming program to stop
+     * @param advanceToEndOfEventTime flag indicating if the source should inject a {@code
+     *     MAX_WATERMARK} in the pipeline
+     * @param savepointDirectory directory the savepoint should be written to
+     * @param formatType a binary format of the savepoint
+     * @return the savepoint trigger id
+     */
+    CompletableFuture<String> stopWithDetachedSavepoint(
+            final JobID jobId,
+            final boolean advanceToEndOfEventTime,
+            @Nullable final String savepointDirectory,
+            final SavepointFormatType formatType);
+
+    /**
      * Triggers a savepoint for the job identified by the job id. The savepoint will be written to
      * the given savepoint directory, or {@link
      * org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -116,6 +116,12 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
     }
 
     @Override
+    public CompletableFuture<String> triggerDetachedSavepoint(
+            JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType) {
+        return miniCluster.triggerDetachedSavepoint(jobId, savepointDirectory, false, formatType);
+    }
+
+    @Override
     public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {
         return miniCluster.disposeSavepoint(savepointPath);
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -105,6 +105,16 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
     }
 
     @Override
+    public CompletableFuture<String> stopWithDetachedSavepoint(
+            JobID jobId,
+            boolean advanceToEndOfEventTime,
+            @Nullable String savepointDirectory,
+            SavepointFormatType formatType) {
+        return miniCluster.stopWithDetachedSavepoint(
+                jobId, savepointDirectory, advanceToEndOfEventTime, formatType);
+    }
+
+    @Override
     public CompletableFuture<String> triggerSavepoint(
             JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType) {
         return miniCluster.triggerSavepoint(jobId, savepointDirectory, false, formatType);

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -209,6 +209,34 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
         }
     }
 
+    // ------------------------------------------------------------------------
+    // detached savepoint
+    // ------------------------------------------------------------------------
+
+    @Test
+    void testTriggerDetachedSavepointSuccess() throws Exception {
+
+        JobID jobId = new JobID();
+
+        String savepointPath = "expectedSavepointPath";
+
+        final ClusterClient<String> clusterClient = createDetachClusterClient(savepointPath);
+
+        try {
+            MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
+
+            String[] parameters = {"-detached", jobId.toString()};
+            frontend.savepoint(parameters);
+
+            verify(clusterClient, times(1))
+                    .triggerDetachedSavepoint(eq(jobId), isNull(), eq(SavepointFormatType.DEFAULT));
+
+            assertThat(buffer.toString()).contains(savepointPath);
+        } finally {
+            clusterClient.close();
+        }
+    }
+
     /** Tests disposal with a JAR file. */
     @Test
     void testDisposeWithJar(@TempDir java.nio.file.Path tmp) throws Exception {
@@ -307,6 +335,18 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
         final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
         when(clusterClient.triggerSavepoint(
+                        any(JobID.class),
+                        nullable(String.class),
+                        nullable(SavepointFormatType.class)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        return clusterClient;
+    }
+
+    private static ClusterClient<String> createDetachClusterClient(String expectedResponse) {
+        final ClusterClient<String> clusterClient = mock(ClusterClient.class);
+
+        when(clusterClient.triggerDetachedSavepoint(
                         any(JobID.class),
                         nullable(String.class),
                         nullable(SavepointFormatType.class)))

--- a/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
@@ -56,6 +56,11 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
             stopWithSavepointFunction =
                     (ignore1, ignore2, savepointPath, formatType) ->
                             CompletableFuture.completedFuture(savepointPath);
+    private QuadFunction<JobID, Boolean, String, SavepointFormatType, CompletableFuture<String>>
+            stopWithDetachedSavepointFunction =
+                    (ignore1, ignore2, savepointPath, formatType) ->
+                            CompletableFuture.completedFuture(new TriggerId().toString());
+
     private TriFunction<JobID, String, SavepointFormatType, CompletableFuture<String>>
             triggerSavepointFunction =
                     (ignore, savepointPath, formatType) ->
@@ -82,6 +87,12 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
             QuadFunction<JobID, Boolean, String, SavepointFormatType, CompletableFuture<String>>
                     stopWithSavepointFunction) {
         this.stopWithSavepointFunction = stopWithSavepointFunction;
+    }
+
+    public void setStopWithDetachedSavepointFunction(
+            QuadFunction<JobID, Boolean, String, SavepointFormatType, CompletableFuture<String>>
+                    stopWithDetachedSavepointFunction) {
+        this.stopWithDetachedSavepointFunction = stopWithDetachedSavepointFunction;
     }
 
     public void setTriggerSavepointFunction(
@@ -169,6 +180,16 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
             @Nullable String savepointDirectory,
             SavepointFormatType formatType) {
         return stopWithSavepointFunction.apply(
+                jobId, advanceToEndOfEventTime, savepointDirectory, formatType);
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithDetachedSavepoint(
+            JobID jobId,
+            boolean advanceToEndOfEventTime,
+            @org.jetbrains.annotations.Nullable String savepointDirectory,
+            SavepointFormatType formatType) {
+        return stopWithDetachedSavepointFunction.apply(
                 jobId, advanceToEndOfEventTime, savepointDirectory, formatType);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -891,6 +891,26 @@ public class MiniCluster implements AutoCloseableAsync {
                                 rpcTimeout));
     }
 
+    public CompletableFuture<String> triggerDetachedSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            boolean cancelJob,
+            SavepointFormatType formatType) {
+        return runDispatcherCommand(
+                dispatcherGateway -> {
+                    dispatcherGateway.triggerSavepointAndGetLocation(
+                            jobId,
+                            targetDirectory,
+                            formatType,
+                            cancelJob
+                                    ? TriggerSavepointMode.CANCEL_WITH_SAVEPOINT
+                                    : TriggerSavepointMode.SAVEPOINT,
+                            rpcTimeout);
+                    // return immediately, no need to wait for the future savepoint path
+                    return CompletableFuture.completedFuture("");
+                });
+    }
+
     public CompletableFuture<String> triggerCheckpoint(JobID jobID) {
         return runDispatcherCommand(
                 dispatcherGateway -> dispatcherGateway.triggerCheckpoint(jobID, rpcTimeout));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -940,6 +940,26 @@ public class MiniCluster implements AutoCloseableAsync {
                                 rpcTimeout));
     }
 
+    public CompletableFuture<String> stopWithDetachedSavepoint(
+            JobID jobId,
+            String targetDirectory,
+            boolean terminate,
+            SavepointFormatType formatType) {
+        return runDispatcherCommand(
+                dispatcherGateway -> {
+                    dispatcherGateway.stopWithSavepointAndGetLocation(
+                            jobId,
+                            targetDirectory,
+                            formatType,
+                            terminate
+                                    ? TriggerSavepointMode.TERMINATE_WITH_SAVEPOINT
+                                    : TriggerSavepointMode.SUSPEND_WITH_SAVEPOINT,
+                            rpcTimeout);
+                    // return immediately, no need to wait for the future savepoint path
+                    return CompletableFuture.completedFuture("");
+                });
+    }
+
     public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {
         return runDispatcherCommand(
                 dispatcherGateway -> dispatcherGateway.disposeSavepoint(savepointPath, rpcTimeout));

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -282,6 +282,14 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
         }
 
         @Override
+        public CompletableFuture<String> triggerDetachedSavepoint(
+                JobID jobId,
+                @org.jetbrains.annotations.Nullable String savepointDirectory,
+                SavepointFormatType formatType) {
+            return null;
+        }
+
+        @Override
         public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
                 JobID jobId, OperatorID operatorId, CoordinationRequest request) {
             return null;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -270,6 +270,15 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
         }
 
         @Override
+        public CompletableFuture<String> stopWithDetachedSavepoint(
+                JobID jobId,
+                boolean advanceToEndOfEventTime,
+                @org.jetbrains.annotations.Nullable String savepointDirectory,
+                SavepointFormatType formatType) {
+            return null;
+        }
+
+        @Override
         public CompletableFuture<String> triggerSavepoint(
                 JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType) {
             return null;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support triggering savepoint in detach mode for CLI to avoid a timeout when the state of the job is enormous.

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*

Trigger a detach savepoint in CLI, and return the savepoint id (generated by client) immediately.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

-Added test that validates that detach savepoint can be triggered successfully.
`CliFrontendSavepointTest.testTriggerDetachSavepointSuccess`

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
