### PR TITLE
[FLINK-32870][network] Tiered storage supports reading multiple small buffers by reading and slicing one large buffer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferReaderWriterUtil.java
@@ -252,7 +252,7 @@ public final class BufferReaderWriterUtil {
         }
     }
 
-    static void readByteBufferFully(FileChannel channel, ByteBuffer b) throws IOException {
+    public static void readByteBufferFully(FileChannel channel, ByteBuffer b) throws IOException {
         // the post-checked loop here gets away with one less check in the normal case
         do {
             if (channel.read(b) == -1) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -225,6 +225,11 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
         }
 
         @Override
+        public long getRegionFileEndOffset() {
+            throw new UnsupportedOperationException("This method is not supported.");
+        }
+
+        @Override
         public int getNumBuffers() {
             return numBuffers;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -220,12 +220,12 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
         }
 
         @Override
-        public long getRegionFileOffset() {
+        public long getRegionStartOffset() {
             return regionFileOffset;
         }
 
         @Override
-        public long getRegionFileEndOffset() {
+        public long getRegionEndOffset() {
             throw new UnsupportedOperationException("This method is not supported.");
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexRegionHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexRegionHelper.java
@@ -79,6 +79,9 @@ public interface FileDataIndexRegionHelper<T extends FileDataIndexRegionHelper.R
         /** Get the file start offset of this region. */
         long getRegionFileOffset();
 
+        /** Get the file end offset of the region. */
+        long getRegionFileEndOffset();
+
         /** Get the number of buffers in this region. */
         int getNumBuffers();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexRegionHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexRegionHelper.java
@@ -77,10 +77,10 @@ public interface FileDataIndexRegionHelper<T extends FileDataIndexRegionHelper.R
         int getFirstBufferIndex();
 
         /** Get the file start offset of this region. */
-        long getRegionFileOffset();
+        long getRegionStartOffset();
 
         /** Get the file end offset of the region. */
-        long getRegionFileEndOffset();
+        long getRegionEndOffset();
 
         /** Get the number of buffers in this region. */
         int getNumBuffers();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtils.java
@@ -59,7 +59,7 @@ public class FileRegionWriteReadUtils {
         headerBuffer.clear();
         headerBuffer.putInt(region.getFirstBufferIndex());
         headerBuffer.putInt(region.getNumBuffers());
-        headerBuffer.putLong(region.getRegionFileOffset());
+        headerBuffer.putLong(region.getRegionStartOffset());
         headerBuffer.flip();
 
         // write payload buffer.
@@ -122,8 +122,8 @@ public class FileRegionWriteReadUtils {
         regionBuffer.clear();
         regionBuffer.putInt(region.getFirstBufferIndex());
         regionBuffer.putInt(region.getNumBuffers());
-        regionBuffer.putLong(region.getRegionFileOffset());
-        regionBuffer.putLong(region.getRegionFileEndOffset());
+        regionBuffer.putLong(region.getRegionStartOffset());
+        regionBuffer.putLong(region.getRegionEndOffset());
         regionBuffer.flip();
         BufferReaderWriterUtil.writeBuffers(channel, regionBuffer.capacity(), regionBuffer);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtils.java
@@ -123,6 +123,7 @@ public class FileRegionWriteReadUtils {
         regionBuffer.putInt(region.getFirstBufferIndex());
         regionBuffer.putInt(region.getNumBuffers());
         regionBuffer.putLong(region.getRegionFileOffset());
+        regionBuffer.putLong(region.getRegionFileEndOffset());
         regionBuffer.flip();
         BufferReaderWriterUtil.writeBuffers(channel, regionBuffer.capacity(), regionBuffer);
     }
@@ -145,6 +146,8 @@ public class FileRegionWriteReadUtils {
         int firstBufferIndex = regionBuffer.getInt();
         int numBuffers = regionBuffer.getInt();
         long firstBufferOffset = regionBuffer.getLong();
-        return new FixedSizeRegion(firstBufferIndex, firstBufferOffset, numBuffers);
+        long lastBufferEndOffset = regionBuffer.getLong();
+        return new FixedSizeRegion(
+                firstBufferIndex, firstBufferOffset, lastBufferEndOffset, numBuffers);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFile.java
@@ -39,4 +39,32 @@ public class ProducerMergedPartitionFile {
             Path dataFilePath, ProducerMergedPartitionFileIndex partitionFileIndex) {
         return new ProducerMergedPartitionFileReader(dataFilePath, partitionFileIndex);
     }
+
+    /**
+     * The implementation of {@link PartitionFileReader.ReadProgress} mainly includes current
+     * reading offset, end of read offset, etc.
+     */
+    public static class ProducerMergedReadProgress implements PartitionFileReader.ReadProgress {
+        /**
+         * The current reading buffer file offset. Note the offset does not contain the length of
+         * the partial buffer, because the partial buffer may be dropped at anytime.
+         */
+        private final long currentBufferOffset;
+
+        /** The end of region file offset. */
+        private final long endOfRegionOffset;
+
+        public ProducerMergedReadProgress(long currentBufferOffset, long endOfRegionOffset) {
+            this.currentBufferOffset = currentBufferOffset;
+            this.endOfRegionOffset = endOfRegionOffset;
+        }
+
+        public long getCurrentBufferOffset() {
+            return currentBufferOffset;
+        }
+
+        public long getEndOfRegionOffset() {
+            return endOfRegionOffset;
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFile.java
@@ -39,32 +39,4 @@ public class ProducerMergedPartitionFile {
             Path dataFilePath, ProducerMergedPartitionFileIndex partitionFileIndex) {
         return new ProducerMergedPartitionFileReader(dataFilePath, partitionFileIndex);
     }
-
-    /**
-     * The implementation of {@link PartitionFileReader.ReadProgress} mainly includes current
-     * reading offset, end of read offset, etc.
-     */
-    public static class ProducerMergedReadProgress implements PartitionFileReader.ReadProgress {
-        /**
-         * The current reading buffer file offset. Note the offset does not contain the length of
-         * the partial buffer, because the partial buffer may be dropped at anytime.
-         */
-        private final long currentBufferOffset;
-
-        /** The end of region file offset. */
-        private final long endOfRegionOffset;
-
-        public ProducerMergedReadProgress(long currentBufferOffset, long endOfRegionOffset) {
-            this.currentBufferOffset = currentBufferOffset;
-            this.endOfRegionOffset = endOfRegionOffset;
-        }
-
-        public long getCurrentBufferOffset() {
-            return currentBufferOffset;
-        }
-
-        public long getEndOfRegionOffset() {
-            return endOfRegionOffset;
-        }
-    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
@@ -273,21 +273,21 @@ public class ProducerMergedPartitionFileIndex {
         private final int firstBufferIndex;
 
         /** The file offset of the region. */
-        private final long regionFileOffset;
+        private final long regionStartOffset;
 
-        private final long regionFileEndOffset;
+        private final long regionEndOffset;
 
         /** The number of buffers that the region contains. */
         private final int numBuffers;
 
         public FixedSizeRegion(
                 int firstBufferIndex,
-                long regionFileOffset,
-                long regionFileEndOffset,
+                long regionStartOffset,
+                long regionEndOffset,
                 int numBuffers) {
             this.firstBufferIndex = firstBufferIndex;
-            this.regionFileOffset = regionFileOffset;
-            this.regionFileEndOffset = regionFileEndOffset;
+            this.regionStartOffset = regionStartOffset;
+            this.regionEndOffset = regionEndOffset;
             this.numBuffers = numBuffers;
         }
 
@@ -303,13 +303,13 @@ public class ProducerMergedPartitionFileIndex {
         }
 
         @Override
-        public long getRegionFileOffset() {
-            return regionFileOffset;
+        public long getRegionStartOffset() {
+            return regionStartOffset;
         }
 
         @Override
-        public long getRegionFileEndOffset() {
-            return regionFileEndOffset;
+        public long getRegionEndOffset() {
+            return regionEndOffset;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
@@ -173,6 +173,8 @@ public class ProducerMergedPartitionFileIndex {
                         new FixedSizeRegion(
                                 firstBufferInRegion.getBufferIndex(),
                                 firstBufferInRegion.getFileOffset(),
+                                lastBufferInRegion.getFileOffset()
+                                        + lastBufferInRegion.getBufferSizeBytes(),
                                 lastBufferInRegion.getBufferIndex()
                                         - firstBufferInRegion.getBufferIndex()
                                         + 1));
@@ -193,10 +195,13 @@ public class ProducerMergedPartitionFileIndex {
         /** The file offset that the buffer begin with. */
         private final long fileOffset;
 
-        FlushedBuffer(int subpartitionId, int bufferIndex, long fileOffset) {
+        private final long bufferSizeBytes;
+
+        FlushedBuffer(int subpartitionId, int bufferIndex, long fileOffset, long bufferSizeBytes) {
             this.subpartitionId = subpartitionId;
             this.bufferIndex = bufferIndex;
             this.fileOffset = fileOffset;
+            this.bufferSizeBytes = bufferSizeBytes;
         }
 
         int getSubpartitionId() {
@@ -209,6 +214,10 @@ public class ProducerMergedPartitionFileIndex {
 
         long getFileOffset() {
             return fileOffset;
+        }
+
+        long getBufferSizeBytes() {
+            return bufferSizeBytes;
         }
     }
 
@@ -257,7 +266,8 @@ public class ProducerMergedPartitionFileIndex {
      */
     public static class FixedSizeRegion implements FileDataIndexRegionHelper.Region {
 
-        public static final int REGION_SIZE = Integer.BYTES + Long.BYTES + Integer.BYTES;
+        public static final int REGION_SIZE =
+                Integer.BYTES + Long.BYTES + Integer.BYTES + Long.BYTES;
 
         /** The buffer index of first buffer. */
         private final int firstBufferIndex;
@@ -265,12 +275,19 @@ public class ProducerMergedPartitionFileIndex {
         /** The file offset of the region. */
         private final long regionFileOffset;
 
+        private final long regionFileEndOffset;
+
         /** The number of buffers that the region contains. */
         private final int numBuffers;
 
-        public FixedSizeRegion(int firstBufferIndex, long regionFileOffset, int numBuffers) {
+        public FixedSizeRegion(
+                int firstBufferIndex,
+                long regionFileOffset,
+                long regionFileEndOffset,
+                int numBuffers) {
             this.firstBufferIndex = firstBufferIndex;
             this.regionFileOffset = regionFileOffset;
+            this.regionFileEndOffset = regionFileEndOffset;
             this.numBuffers = numBuffers;
         }
 
@@ -288,6 +305,11 @@ public class ProducerMergedPartitionFileIndex {
         @Override
         public long getRegionFileOffset() {
             return regionFileOffset;
+        }
+
+        @Override
+        public long getRegionFileEndOffset() {
+            return regionFileEndOffset;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReader.java
@@ -22,25 +22,33 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferHeader;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.IOUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
-import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.positionToNextBuffer;
-import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.readFromByteChannel;
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.HEADER_LENGTH;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * The implementation of {@link PartitionFileReader} with producer-merge mode. In this mode, the
@@ -51,25 +59,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class ProducerMergedPartitionFileReader implements PartitionFileReader {
 
-    /**
-     * Max number of caches.
-     *
-     * <p>The constant defines the maximum number of caches that can be created. Its value is set to
-     * 10000, which is considered sufficient for most parallel jobs. Each cache only contains
-     * references and numerical variables and occupies a minimal amount of memory so the value is
-     * not excessively large.
-     */
-    private static final int DEFAULT_MAX_CACHE_NUM = 10000;
-
-    /**
-     * Buffer offset caches stored in map.
-     *
-     * <p>The key is the combination of {@link TieredStorageSubpartitionId} and buffer index. The
-     * value is the buffer offset cache, which includes file offset of the buffer index, the region
-     * containing the buffer index and next buffer index to consume.
-     */
-    private final Map<Tuple2<TieredStorageSubpartitionId, Integer>, BufferOffsetCache>
-            bufferOffsetCaches;
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ProducerMergedPartitionFileReader.class);
 
     private final ByteBuffer reusedHeaderBuffer = BufferReaderWriterUtil.allocatedHeaderBuffer();
 
@@ -77,62 +68,58 @@ public class ProducerMergedPartitionFileReader implements PartitionFileReader {
 
     private final ProducerMergedPartitionFileIndex dataIndex;
 
-    private final int maxCacheNumber;
-
     private volatile FileChannel fileChannel;
-
-    /** The current number of caches. */
-    private int numCaches;
-
-    ProducerMergedPartitionFileReader(
-            Path dataFilePath, ProducerMergedPartitionFileIndex dataIndex) {
-        this(dataFilePath, dataIndex, DEFAULT_MAX_CACHE_NUM);
-    }
 
     @VisibleForTesting
     ProducerMergedPartitionFileReader(
-            Path dataFilePath, ProducerMergedPartitionFileIndex dataIndex, int maxCacheNumber) {
+            Path dataFilePath, ProducerMergedPartitionFileIndex dataIndex) {
         this.dataFilePath = dataFilePath;
         this.dataIndex = dataIndex;
-        this.bufferOffsetCaches = new HashMap<>();
-        this.maxCacheNumber = maxCacheNumber;
     }
 
     @Override
-    public Buffer readBuffer(
+    public ReadBufferResult readBuffer(
             TieredStoragePartitionId partitionId,
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
             int bufferIndex,
             MemorySegment memorySegment,
-            BufferRecycler recycler)
+            BufferRecycler recycler,
+            @Nullable ReadProgress readProgress,
+            @Nullable PartialBuffer partialBuffer)
             throws IOException {
 
         lazyInitializeFileChannel();
-        Tuple2<TieredStorageSubpartitionId, Integer> cacheKey =
-                Tuple2.of(subpartitionId, bufferIndex);
-        Optional<BufferOffsetCache> cache = tryGetCache(cacheKey, true);
-        if (!cache.isPresent()) {
+
+        // Get the read offset, including the start offset, the end offset
+        Tuple2<Long, Long> startAndEndOffset =
+                getReadStartAndEndOffset(subpartitionId, bufferIndex, readProgress, partialBuffer);
+        if (startAndEndOffset == null) {
             return null;
         }
-        fileChannel.position(cache.get().getFileOffset());
-        Buffer buffer =
-                readFromByteChannel(fileChannel, reusedHeaderBuffer, memorySegment, recycler);
-        boolean hasNextBuffer =
-                cache.get()
-                        .advance(
-                                checkNotNull(buffer).readableBytes()
-                                        + BufferReaderWriterUtil.HEADER_LENGTH);
-        if (hasNextBuffer) {
-            int nextBufferIndex = bufferIndex + 1;
-            // TODO: introduce the LRU cache strategy in the future to restrict the total
-            // cache number. Testing to prevent cache leaks has been implemented.
-            if (numCaches < maxCacheNumber) {
-                bufferOffsetCaches.put(Tuple2.of(subpartitionId, nextBufferIndex), cache.get());
-                numCaches++;
-            }
+        long readStartOffset = startAndEndOffset.f0;
+        long readEndOffset = startAndEndOffset.f1;
+
+        int numBytesToRead =
+                Math.min(memorySegment.size(), (int) (readEndOffset - readStartOffset));
+
+        if (numBytesToRead == 0) {
+            return null;
         }
-        return buffer;
+
+        List<Buffer> readBuffers = new LinkedList<>();
+        ByteBuffer byteBuffer = memorySegment.wrap(0, numBytesToRead);
+        fileChannel.position(readStartOffset);
+        // Read data to the memory segment, note the read size is numBytesToRead
+        readFileDataToBuffer(memorySegment, recycler, byteBuffer);
+
+        // Slice the read memory segment to multiple small network buffers and add them to
+        // readBuffers
+        Tuple2<PartialBuffer, Integer> partial =
+                sliceBuffer(byteBuffer, memorySegment, partialBuffer, recycler, readBuffers);
+
+        return getReadBufferResult(
+                readBuffers, readStartOffset, readEndOffset, numBytesToRead, partial);
     }
 
     @Override
@@ -142,10 +129,9 @@ public class ProducerMergedPartitionFileReader implements PartitionFileReader {
             int segmentId,
             int bufferIndex) {
         lazyInitializeFileChannel();
-        Tuple2<TieredStorageSubpartitionId, Integer> cacheKey =
-                Tuple2.of(subpartitionId, bufferIndex);
-        return tryGetCache(cacheKey, false)
-                .map(BufferOffsetCache::getFileOffset)
+        return dataIndex
+                .getRegion(subpartitionId, bufferIndex)
+                .map(ProducerMergedPartitionFileIndex.FixedSizeRegion::getRegionFileOffset)
                 .orElse(Long.MAX_VALUE);
     }
 
@@ -176,91 +162,179 @@ public class ProducerMergedPartitionFileReader implements PartitionFileReader {
     }
 
     /**
-     * Try to get the cache according to the key.
+     * Slice the read memory segment to multiple small network buffers.
      *
-     * <p>If the relevant buffer offset cache exists, it will be returned and subsequently removed.
-     * However, if the buffer offset cache does not exist, a new cache will be created using the
-     * data index and returned.
+     * <p>Note that although the method appears to be split into multiple buffers, the sliced
+     * buffers still share the same one actual underlying memory segment.
      *
-     * @param cacheKey the key of cache.
-     * @param removeKey boolean decides whether to remove key.
-     * @return returns the relevant buffer offset cache if it exists, otherwise return {@link
-     *     Optional#empty()}.
+     * @param byteBuffer the byte buffer to be sliced, it points to the underlying memorySegment
+     * @param memorySegment the underlying memory segment to be sliced
+     * @param partialBuffer the partial buffer, if the partial buffer is not null, it contains the
+     *     partial data buffer from the previous read
+     * @param readBuffers the read buffers list is to accept the sliced buffers
+     * @return the first field is the partial data buffer, the second field is the number of sliced
+     *     bytes.
      */
-    private Optional<BufferOffsetCache> tryGetCache(
-            Tuple2<TieredStorageSubpartitionId, Integer> cacheKey, boolean removeKey) {
-        BufferOffsetCache bufferOffsetCache = bufferOffsetCaches.remove(cacheKey);
-        if (bufferOffsetCache == null) {
-            Optional<ProducerMergedPartitionFileIndex.FixedSizeRegion> regionOpt =
-                    dataIndex.getRegion(cacheKey.f0, cacheKey.f1);
-            return regionOpt.map(region -> new BufferOffsetCache(cacheKey.f1, region));
-        } else {
-            if (removeKey) {
-                numCaches--;
-            } else {
-                bufferOffsetCaches.put(cacheKey, bufferOffsetCache);
+    private Tuple2<PartialBuffer, Integer> sliceBuffer(
+            ByteBuffer byteBuffer,
+            MemorySegment memorySegment,
+            @Nullable PartialBuffer partialBuffer,
+            BufferRecycler bufferRecycler,
+            List<Buffer> readBuffers) {
+        checkState(reusedHeaderBuffer.position() == 0);
+        checkState(partialBuffer == null || partialBuffer.missingLength() > 0);
+
+        NetworkBuffer buffer = new NetworkBuffer(memorySegment, bufferRecycler);
+        buffer.setSize(byteBuffer.remaining());
+
+        try {
+            int numSlicedBytes = 0;
+            if (partialBuffer != null) {
+                // If there is a previous small partial buffer, the current read operation should
+                // read additional data and combine it with the existing partial to construct a new
+                // complete buffer
+                buffer.retainBuffer();
+                int position = byteBuffer.position() + partialBuffer.missingLength();
+                int numPartialBytes = partialBuffer.missingLength();
+                partialBuffer.addPartialBuffer(
+                        buffer.readOnlySlice(byteBuffer.position(), numPartialBytes));
+                numSlicedBytes += numPartialBytes;
+                byteBuffer.position(position);
+                readBuffers.add(partialBuffer);
             }
-            return Optional.of(bufferOffsetCache);
+
+            partialBuffer = null;
+            while (byteBuffer.hasRemaining()) {
+                // Parse the small buffer's header
+                BufferHeader header = parseBufferHeader(byteBuffer);
+                if (header == null) {
+                    // If the remaining data length in the buffer is not enough to construct a new
+                    // complete buffer header, drop it directly.
+                    break;
+                } else {
+                    numSlicedBytes += HEADER_LENGTH;
+                }
+
+                if (header.getLength() <= byteBuffer.remaining()) {
+                    // The remaining data length in the buffer is enough to generate a new small
+                    // sliced network buffer. The small sliced buffer is not a partial buffer, we
+                    // should read the slice of the buffer directly
+                    buffer.retainBuffer();
+                    CompositeBuffer slicedBuffer = new CompositeBuffer(header);
+                    slicedBuffer.addPartialBuffer(
+                            buffer.readOnlySlice(byteBuffer.position(), header.getLength()));
+                    byteBuffer.position(byteBuffer.position() + header.getLength());
+                    numSlicedBytes += header.getLength();
+                    readBuffers.add(slicedBuffer);
+                } else {
+                    // The remaining data length in the buffer is smaller than the actual length of
+                    // the buffer, so we should generate a new partial buffer, allowing for
+                    // generating a new complete buffer during the next read operation
+                    buffer.retainBuffer();
+                    int numPartialBytes = byteBuffer.remaining();
+                    numSlicedBytes += numPartialBytes;
+                    partialBuffer = new PartialBuffer(header);
+                    partialBuffer.addPartialBuffer(
+                            buffer.readOnlySlice(byteBuffer.position(), numPartialBytes));
+                    readBuffers.add(partialBuffer);
+                    break;
+                }
+            }
+            return Tuple2.of(partialBuffer, numSlicedBytes);
+        } catch (Throwable throwable) {
+            LOG.error("Failed to slice the read buffer {}.", byteBuffer, throwable);
+            throw throwable;
+        } finally {
+            buffer.recycleBuffer();
         }
     }
 
     /**
-     * The {@link BufferOffsetCache} represents the file offset cache for a buffer index. Each cache
-     * includes file offset of the buffer index, the region containing the buffer index and next
-     * buffer index to consume.
+     * Return a tuple of the start and end file offset, or return null if the buffer is not found in
+     * the data index.
      */
-    private class BufferOffsetCache {
-
-        private final ProducerMergedPartitionFileIndex.FixedSizeRegion region;
-
-        private long fileOffset;
-
-        private int nextBufferIndex;
-
-        private BufferOffsetCache(
-                int bufferIndex, ProducerMergedPartitionFileIndex.FixedSizeRegion region) {
-            this.nextBufferIndex = bufferIndex;
-            this.region = region;
-            moveFileOffsetToBuffer(bufferIndex);
-        }
-
-        /**
-         * Get the file offset.
-         *
-         * @return the file offset.
-         */
-        private long getFileOffset() {
-            return fileOffset;
-        }
-
-        /**
-         * Updates the {@link BufferOffsetCache} upon the retrieval of a buffer from the file using
-         * the file offset in the {@link BufferOffsetCache}.
-         *
-         * @param bufferSize denotes the size of the buffer.
-         * @return return true if there are remaining buffers in the region, otherwise return false.
-         */
-        private boolean advance(long bufferSize) {
-            nextBufferIndex++;
-            fileOffset += bufferSize;
-            return nextBufferIndex < (region.getFirstBufferIndex() + region.getNumBuffers());
-        }
-
-        /**
-         * Relocates the file channel offset to the position of the specified buffer index.
-         *
-         * @param bufferIndex denotes the index of the buffer.
-         */
-        private void moveFileOffsetToBuffer(int bufferIndex) {
-            try {
-                checkNotNull(fileChannel).position(region.getRegionFileOffset());
-                for (int i = 0; i < (bufferIndex - region.getFirstBufferIndex()); ++i) {
-                    positionToNextBuffer(fileChannel, reusedHeaderBuffer);
-                }
-                fileOffset = fileChannel.position();
-            } catch (IOException e) {
-                ExceptionUtils.rethrow(e, "Failed to move file offset");
+    @Nullable
+    private Tuple2<Long, Long> getReadStartAndEndOffset(
+            TieredStorageSubpartitionId subpartitionId,
+            int bufferIndex,
+            @Nullable ReadProgress readProgress,
+            @Nullable PartialBuffer partialBuffer) {
+        long readStartOffset;
+        long readEndOffset;
+        if (readProgress == null) {
+            Optional<ProducerMergedPartitionFileIndex.FixedSizeRegion> regionOpt =
+                    dataIndex.getRegion(subpartitionId, bufferIndex);
+            if (!regionOpt.isPresent()) {
+                return null;
             }
+            readStartOffset = regionOpt.get().getRegionFileOffset();
+            readEndOffset = regionOpt.get().getRegionFileEndOffset();
+        } else {
+            readStartOffset =
+                    readProgress.getCurrentReadOffset() + partialBufferReadBytes(partialBuffer);
+            readEndOffset = readProgress.getEndOfReadOffset();
         }
+
+        checkState(readStartOffset <= readEndOffset);
+        return Tuple2.of(readStartOffset, readEndOffset);
+    }
+
+    private static ReadBufferResult getReadBufferResult(
+            List<Buffer> readBuffers,
+            long readStartOffset,
+            long readEndOffset,
+            int numBytesToRead,
+            Tuple2<PartialBuffer, Integer> partialAndReadBytes) {
+        PartialBuffer partialBuffer = partialAndReadBytes.f0;
+        int numBytesRealRead = partialAndReadBytes.f1;
+        boolean shouldContinueRead = readStartOffset + numBytesRealRead < readEndOffset;
+        ReadProgress readProgress =
+                new ReadProgress(
+                        readStartOffset + numBytesRealRead - partialBufferReadBytes(partialBuffer),
+                        readEndOffset);
+
+        checkState(
+                numBytesRealRead <= numBytesToRead
+                        && numBytesToRead - numBytesRealRead < HEADER_LENGTH);
+        checkState(shouldContinueRead || partialBuffer == null);
+
+        return new ReadBufferResult(readBuffers, shouldContinueRead, readProgress);
+    }
+
+    private void readFileDataToBuffer(
+            MemorySegment memorySegment, BufferRecycler recycler, ByteBuffer byteBuffer)
+            throws IOException {
+        try {
+            BufferReaderWriterUtil.readByteBufferFully(fileChannel, byteBuffer);
+            byteBuffer.flip();
+        } catch (Throwable throwable) {
+            recycler.recycle(memorySegment);
+            throw throwable;
+        }
+    }
+
+    private static int partialBufferReadBytes(@Nullable PartialBuffer partialBuffer) {
+        return partialBuffer == null ? 0 : partialBuffer.readableBytes() + HEADER_LENGTH;
+    }
+
+    private BufferHeader parseBufferHeader(ByteBuffer buffer) {
+        checkArgument(reusedHeaderBuffer.position() == 0);
+
+        BufferHeader header = null;
+        try {
+            if (buffer.remaining() >= HEADER_LENGTH) {
+                // The remaining data length in the buffer is enough to construct a new complete
+                // buffer, parse and create a new buffer header
+                header = BufferReaderWriterUtil.parseBufferHeader(buffer);
+            }
+            // If the remaining data length in the buffer is smaller than the header. Drop it
+            // directly
+        } catch (Throwable throwable) {
+            reusedHeaderBuffer.clear();
+            LOG.error("Failed to parse buffer header.", throwable);
+            throw throwable;
+        }
+        reusedHeaderBuffer.clear();
+        return header;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileWriter.java
@@ -156,7 +156,8 @@ public class ProducerMergedPartitionFileWriter implements PartitionFileWriter {
                             new ProducerMergedPartitionFileIndex.FlushedBuffer(
                                     subpartitionId,
                                     bufferWithIndex.f1,
-                                    totalBytesWritten + expectedBytes));
+                                    totalBytesWritten + expectedBytes,
+                                    buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH));
                     expectedBytes += buffer.readableBytes() + BufferReaderWriterUtil.HEADER_LENGTH;
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReader.java
@@ -141,7 +141,7 @@ public class SegmentPartitionFileReader implements PartitionFileReader {
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
             int bufferIndex,
-            ReadProgress readProgress) {
+            @Nullable ReadProgress readProgress) {
         // noop
         return -1;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReader.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferHeader;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
@@ -85,7 +86,7 @@ public class SegmentPartitionFileReader implements PartitionFileReader {
             MemorySegment memorySegment,
             BufferRecycler recycler,
             @Nullable ReadProgress readProgress,
-            @Nullable PartialBuffer partialBuffer)
+            @Nullable CompositeBuffer partialBuffer)
             throws IOException {
 
         // Get the channel of the segment file for a subpartition.
@@ -139,7 +140,8 @@ public class SegmentPartitionFileReader implements PartitionFileReader {
             TieredStoragePartitionId partitionId,
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
-            int bufferIndex) {
+            int bufferIndex,
+            ReadProgress readProgress) {
         // noop
         return -1;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartition.java
@@ -180,13 +180,13 @@ public class TieredResultPartition extends ResultPartition {
     @Override
     public void finish() throws IOException {
         broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+        tieredStorageProducerClient.close();
         checkState(!isReleased(), "Result partition is already released.");
         super.finish();
     }
 
     @Override
     public void close() {
-        tieredStorageProducerClient.close();
         super.close();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierConsumerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierConsumerAgent.java
@@ -32,8 +32,12 @@ import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** The data client is used to fetch data from remote tier. */
 public class RemoteTierConsumerAgent implements TierConsumerAgent {
@@ -87,21 +91,26 @@ public class RemoteTierConsumerAgent implements TierConsumerAgent {
 
         // Read buffer from the partition file in remote storage.
         MemorySegment memorySegment = MemorySegmentFactory.allocateUnpooledSegment(bufferSizeBytes);
-        Buffer buffer = null;
+        PartitionFileReader.ReadBufferResult readBufferResult = null;
         try {
-            buffer =
+            readBufferResult =
                     partitionFileReader.readBuffer(
                             partitionId,
                             subpartitionId,
                             segmentId,
                             currentBufferIndex,
                             memorySegment,
-                            FreeingBufferRecycler.INSTANCE);
+                            FreeingBufferRecycler.INSTANCE,
+                            null,
+                            null);
         } catch (IOException e) {
             memorySegment.free();
             ExceptionUtils.rethrow(e, "Failed to read buffer from partition file.");
         }
-        if (buffer != null) {
+        List<Buffer> readBuffers = checkNotNull(readBufferResult).getReadBuffers();
+        if (!readBuffers.isEmpty()) {
+            checkState(readBuffers.size() == 1);
+            Buffer buffer = readBuffers.get(0);
             currentBufferIndexAndSegmentIds
                     .get(partitionId)
                     .put(subpartitionId, Tuple2.of(++currentBufferIndex, segmentId));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
@@ -119,9 +119,12 @@ public class HybridShuffleTestUtils {
     }
 
     public static FileDataIndexRegionHelper.Region createSingleFixedSizeRegion(
-            int firstBufferIndex, long firstBufferOffset, int numBuffersPerRegion) {
+            int firstBufferIndex,
+            long firstBufferOffset,
+            long lastBufferEndOffset,
+            int numBuffersPerRegion) {
         return new ProducerMergedPartitionFileIndex.FixedSizeRegion(
-                firstBufferIndex, firstBufferOffset, numBuffersPerRegion);
+                firstBufferIndex, firstBufferOffset, lastBufferEndOffset, numBuffersPerRegion);
     }
 
     public static void assertRegionEquals(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
@@ -130,7 +130,7 @@ public class HybridShuffleTestUtils {
     public static void assertRegionEquals(
             FileDataIndexRegionHelper.Region expected, FileDataIndexRegionHelper.Region region) {
         assertThat(region.getFirstBufferIndex()).isEqualTo(expected.getFirstBufferIndex());
-        assertThat(region.getRegionFileOffset()).isEqualTo(expected.getRegionFileOffset());
+        assertThat(region.getRegionStartOffset()).isEqualTo(expected.getRegionStartOffset());
         assertThat(region.getNumBuffers()).isEqualTo(expected.getNumBuffers());
         if (expected instanceof InternalRegion) {
             assertThat(region).isInstanceOf(InternalRegion.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileDataIndexCacheTest.java
@@ -68,7 +68,7 @@ class FileDataIndexCacheTest {
                 .hasValueSatisfying(
                         (region) -> {
                             assertThat(region.getFirstBufferIndex()).isEqualTo(0);
-                            assertThat(region.getRegionFileOffset()).isEqualTo(0);
+                            assertThat(region.getRegionStartOffset()).isEqualTo(0);
                             assertThat(region.getNumBuffers()).isEqualTo(3);
                         });
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/FileRegionWriteReadUtilsTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion.HEADER_SIZE;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.assertRegionEquals;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createSingleFixedSizeRegion;
+import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.ProducerMergedPartitionFileIndex.FixedSizeRegion.REGION_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -83,9 +84,9 @@ class FileRegionWriteReadUtilsTest {
     @Test
     void testReadPrematureEndOfFileForFixedSizeRegion(@TempDir Path tmpPath) throws Exception {
         FileChannel channel = tmpFileChannel(tmpPath);
-        ByteBuffer buffer = FileRegionWriteReadUtils.allocateAndConfigureBuffer(HEADER_SIZE);
+        ByteBuffer buffer = FileRegionWriteReadUtils.allocateAndConfigureBuffer(REGION_SIZE);
         FileRegionWriteReadUtils.writeFixedSizeRegionToFile(
-                channel, buffer, createSingleFixedSizeRegion(0, 0L, 1));
+                channel, buffer, createSingleFixedSizeRegion(0, 0L, 10L, 1));
         channel.truncate(channel.position() - 1);
         buffer.flip();
         assertThatThrownBy(
@@ -98,8 +99,8 @@ class FileRegionWriteReadUtilsTest {
     @Test
     void testWriteAndReadFixedSizeRegion(@TempDir Path tmpPath) throws Exception {
         FileChannel channel = tmpFileChannel(tmpPath);
-        ByteBuffer buffer = FileRegionWriteReadUtils.allocateAndConfigureBuffer(HEADER_SIZE);
-        FileDataIndexRegionHelper.Region region = createSingleFixedSizeRegion(10, 100L, 1);
+        ByteBuffer buffer = FileRegionWriteReadUtils.allocateAndConfigureBuffer(REGION_SIZE);
+        FileDataIndexRegionHelper.Region region = createSingleFixedSizeRegion(10, 100L, 110L, 1);
         FileRegionWriteReadUtils.writeFixedSizeRegionToFile(channel, buffer, region);
         buffer.flip();
         ProducerMergedPartitionFileIndex.FixedSizeRegion readRegion =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/TestingFileDataIndexRegion.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/TestingFileDataIndexRegion.java
@@ -39,6 +39,8 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
 
     private final Supplier<Long> getRegionFileOffsetSupplier;
 
+    private final Supplier<Long> getRegionFileEndOffsetSupplier;
+
     private final Supplier<Integer> getNumBuffersSupplier;
 
     private final Function<Integer, Boolean> containBufferFunction;
@@ -47,11 +49,13 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
             Supplier<Integer> getSizeSupplier,
             Supplier<Integer> getFirstBufferIndexSupplier,
             Supplier<Long> getRegionFileOffsetSupplier,
+            Supplier<Long> getRegionFileEndOffsetSupplier,
             Supplier<Integer> getNumBuffersSupplier,
             Function<Integer, Boolean> containBufferFunction) {
         this.getSizeSupplier = getSizeSupplier;
         this.getFirstBufferIndexSupplier = getFirstBufferIndexSupplier;
         this.getRegionFileOffsetSupplier = getRegionFileOffsetSupplier;
+        this.getRegionFileEndOffsetSupplier = getRegionFileEndOffsetSupplier;
         this.getNumBuffersSupplier = getNumBuffersSupplier;
         this.containBufferFunction = containBufferFunction;
     }
@@ -69,6 +73,11 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
     @Override
     public long getRegionFileOffset() {
         return getRegionFileOffsetSupplier.get();
+    }
+
+    @Override
+    public long getRegionFileEndOffset() {
+        return getRegionFileEndOffsetSupplier.get();
     }
 
     @Override
@@ -130,6 +139,8 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
 
         private Supplier<Long> getRegionFileOffsetSupplier = () -> 0L;
 
+        private Supplier<Long> getRegionFileEndOffsetSupplier = () -> 0L;
+
         private Supplier<Integer> getNumBuffersSupplier = () -> 0;
 
         private Function<Integer, Boolean> containBufferFunction = bufferIndex -> false;
@@ -152,6 +163,12 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
             return this;
         }
 
+        public TestingFileDataIndexRegion.Builder setGetRegionFileEndOffsetSupplier(
+                Supplier<Long> getRegionFileEndOffsetSupplier) {
+            this.getRegionFileEndOffsetSupplier = getRegionFileEndOffsetSupplier;
+            return this;
+        }
+
         public TestingFileDataIndexRegion.Builder setGetNumBuffersSupplier(
                 Supplier<Integer> getNumBuffersSupplier) {
             this.getNumBuffersSupplier = getNumBuffersSupplier;
@@ -169,6 +186,7 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
                     getSizeSupplier,
                     getFirstBufferIndexSupplier,
                     getRegionFileOffsetSupplier,
+                    getRegionFileEndOffsetSupplier,
                     getNumBuffersSupplier,
                     containBufferFunction);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/TestingFileDataIndexRegion.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/index/TestingFileDataIndexRegion.java
@@ -71,12 +71,12 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
     }
 
     @Override
-    public long getRegionFileOffset() {
+    public long getRegionStartOffset() {
         return getRegionFileOffsetSupplier.get();
     }
 
     @Override
-    public long getRegionFileEndOffset() {
+    public long getRegionEndOffset() {
         return getRegionFileEndOffsetSupplier.get();
     }
 
@@ -96,7 +96,7 @@ public class TestingFileDataIndexRegion implements FileDataIndexRegionHelper.Reg
         regionBuffer.clear();
         regionBuffer.putInt(region.getFirstBufferIndex());
         regionBuffer.putInt(region.getNumBuffers());
-        regionBuffer.putLong(region.getRegionFileOffset());
+        regionBuffer.putLong(region.getRegionStartOffset());
         regionBuffer.flip();
         BufferReaderWriterUtil.writeBuffers(channel, regionBuffer.capacity(), regionBuffer);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/DiskIOSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/DiskIOSchedulerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,7 +98,12 @@ class DiskIOSchedulerTest {
                                 .setReadBufferSupplier(
                                         (bufferIndex, segmentId) -> {
                                             segmentIdFuture.complete(segmentId);
-                                            return BufferBuilderTestUtils.buildSomeBuffer(0);
+                                            return new PartitionFileReader.ReadBufferResult(
+                                                    Collections.singletonList(
+                                                            BufferBuilderTestUtils.buildSomeBuffer(
+                                                                    0)),
+                                                    true,
+                                                    null);
                                         })
                                 .setReleaseNotifier(() -> readerReleaseFuture.complete(null))
                                 .setPrioritySupplier(subpartitionId -> (long) subpartitionId)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndexTest.java
@@ -81,7 +81,7 @@ class ProducerMergedPartitionFileIndexTest {
                 boolean isNextRegionContinuous =
                         (j == 0 || random.nextBoolean()) && j != numBuffersPerSubpartition - 1;
                 flushedBuffers.add(
-                        new ProducerMergedPartitionFileIndex.FlushedBuffer(i, bufferIndex, 0));
+                        new ProducerMergedPartitionFileIndex.FlushedBuffer(i, bufferIndex, 0, 1));
                 bufferIndex++;
 
                 if (!isNextRegionContinuous) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
@@ -116,16 +116,17 @@ class ProducerMergedPartitionFileReaderTest {
 
     @Test
     void testGetPriority() throws IOException {
-        ProducerMergedPartitionFile.ProducerMergedReadProgress readProgress = null;
+        ProducerMergedPartitionFileReader.ProducerMergedReadProgress readProgress = null;
         CompositeBuffer partialBuffer = null;
         for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ) {
             PartitionFileReader.ReadBufferResult readBufferResult =
                     readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID, readProgress, partialBuffer);
             assertThat(readBufferResult).isNotNull();
             assertThat(readBufferResult.getReadProgress())
-                    .isInstanceOf(ProducerMergedPartitionFile.ProducerMergedReadProgress.class);
+                    .isInstanceOf(
+                            ProducerMergedPartitionFileReader.ProducerMergedReadProgress.class);
             readProgress =
-                    (ProducerMergedPartitionFile.ProducerMergedReadProgress)
+                    (ProducerMergedPartitionFileReader.ProducerMergedReadProgress)
                             readBufferResult.getReadProgress();
             for (Buffer buffer : readBufferResult.getReadBuffers()) {
                 if (buffer instanceof CompositeBuffer) {
@@ -140,8 +141,14 @@ class ProducerMergedPartitionFileReaderTest {
                     buffer.recycleBuffer();
                 }
             }
-            long expectedBufferOffset =
-                    readProgress == null ? 0 : readProgress.getCurrentBufferOffset();
+
+            long expectedBufferOffset;
+            if (bufferIndex < DEFAULT_BUFFER_NUMBER) {
+                expectedBufferOffset =
+                        readProgress == null ? 0 : readProgress.getCurrentBufferOffset();
+            } else {
+                expectedBufferOffset = Long.MAX_VALUE;
+            }
             assertThat(
                             partitionFileReader.getPriority(
                                     DEFAULT_PARTITION_ID,
@@ -156,16 +163,17 @@ class ProducerMergedPartitionFileReaderTest {
     @Test
     void testReadProgress() throws IOException {
         long currentFileOffset = 0;
-        ProducerMergedPartitionFile.ProducerMergedReadProgress readProgress = null;
+        ProducerMergedPartitionFileReader.ProducerMergedReadProgress readProgress = null;
         CompositeBuffer partialBuffer = null;
         for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ) {
             PartitionFileReader.ReadBufferResult readBufferResult =
                     readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID, readProgress, partialBuffer);
             assertThat(readBufferResult).isNotNull();
             assertThat(readBufferResult.getReadProgress())
-                    .isInstanceOf(ProducerMergedPartitionFile.ProducerMergedReadProgress.class);
+                    .isInstanceOf(
+                            ProducerMergedPartitionFileReader.ProducerMergedReadProgress.class);
             readProgress =
-                    (ProducerMergedPartitionFile.ProducerMergedReadProgress)
+                    (ProducerMergedPartitionFileReader.ProducerMergedReadProgress)
                             readBufferResult.getReadProgress();
             for (Buffer buffer : readBufferResult.getReadBuffers()) {
                 if (buffer instanceof CompositeBuffer) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileReaderTest.java
@@ -35,9 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.HEADER_LENGTH;
 import static org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageTestUtils.generateBuffersToWrite;
@@ -54,7 +52,7 @@ class ProducerMergedPartitionFileReaderTest {
 
     private static final int DEFAULT_BUFFER_NUMBER = 5;
 
-    private static final int DEFAULT_BUFFER_SIZE = 3;
+    private static final int DEFAULT_BUFFER_SIZE = 10;
 
     private static final String DEFAULT_TEST_FILE_NAME = "testFile";
 
@@ -96,9 +94,9 @@ class ProducerMergedPartitionFileReaderTest {
     @Test
     void testReadBuffer() throws IOException {
         for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ++bufferIndex) {
-            Buffer buffer = readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID);
-            assertThat(buffer).isNotNull();
-            buffer.recycleBuffer();
+            List<Buffer> buffers = readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID);
+            assertThat(buffers).isNotNull();
+            buffers.forEach(Buffer::recycleBuffer);
         }
         MemorySegment memorySegment =
                 MemorySegmentFactory.allocateUnpooledSegment(DEFAULT_BUFFER_SIZE);
@@ -109,58 +107,71 @@ class ProducerMergedPartitionFileReaderTest {
                                 DEFAULT_SEGMENT_ID,
                                 DEFAULT_BUFFER_NUMBER + 1,
                                 memorySegment,
-                                FreeingBufferRecycler.INSTANCE))
+                                FreeingBufferRecycler.INSTANCE,
+                                null,
+                                null))
                 .isNull();
     }
 
     @Test
     void testGetPriority() throws IOException {
-        int currentFileOffset = 0;
-        for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ++bufferIndex) {
-            Buffer buffer = readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID);
-            assertThat(buffer).isNotNull();
+        PartitionFileReader.ReadProgress readProgress = null;
+        PartitionFileReader.PartialBuffer partialBuffer = null;
+        for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ) {
+            PartitionFileReader.ReadBufferResult readBufferResult =
+                    readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID, readProgress, partialBuffer);
+            assertThat(readBufferResult).isNotNull();
+            readProgress = readBufferResult.getReadProgress();
+            for (Buffer buffer : readBufferResult.getReadBuffers()) {
+                if (buffer instanceof PartitionFileReader.PartialBuffer) {
+                    partialBuffer = (PartitionFileReader.PartialBuffer) buffer;
+                    if (partialBuffer.missingLength() == 0) {
+                        bufferIndex++;
+                        partialBuffer.recycleBuffer();
+                        partialBuffer = null;
+                    }
+                } else {
+                    bufferIndex++;
+                    buffer.recycleBuffer();
+                }
+            }
             assertThat(
                             partitionFileReader.getPriority(
                                     DEFAULT_PARTITION_ID,
                                     DEFAULT_SUBPARTITION_ID,
                                     DEFAULT_SEGMENT_ID,
                                     bufferIndex))
-                    .isEqualTo(currentFileOffset);
-            currentFileOffset += (HEADER_LENGTH + DEFAULT_BUFFER_SIZE);
-            buffer.recycleBuffer();
+                    .isEqualTo(bufferIndex < DEFAULT_BUFFER_NUMBER ? 0 : Long.MAX_VALUE);
         }
     }
 
     @Test
-    void testCacheExceedMaxNumber() throws IOException {
-        int cacheNumber = 3;
-        AtomicInteger indexQueryTime = new AtomicInteger(0);
-        TestingProducerMergedPartitionFileIndex partitionFileIndex =
-                new TestingProducerMergedPartitionFileIndex.Builder()
-                        .setIndexFilePath(new File(tempFolder.toFile(), "test-Index").toPath())
-                        .setGetRegionFunction(
-                                (subpartitionId, integer) -> {
-                                    indexQueryTime.incrementAndGet();
-                                    return Optional.of(
-                                            new ProducerMergedPartitionFileIndex.FixedSizeRegion(
-                                                    0, 0, 2));
-                                })
-                        .build();
-        partitionFileReader =
-                new ProducerMergedPartitionFileReader(
-                        testFilePath, partitionFileIndex, cacheNumber);
-        // Read different subpartitions from the reader and make cache reach max number.
-        for (int subpartitionId = 0; subpartitionId < cacheNumber * 2; ++subpartitionId) {
-            assertThat(
-                            readBuffer(
-                                    subpartitionId < cacheNumber ? 0 : 1,
-                                    new TieredStorageSubpartitionId(subpartitionId % cacheNumber)))
-                    .isNotNull();
+    void testReadProgress() throws IOException {
+        long currentFileOffset = 0;
+        PartitionFileReader.ReadProgress readProgress = null;
+        PartitionFileReader.PartialBuffer partialBuffer = null;
+        for (int bufferIndex = 0; bufferIndex < DEFAULT_BUFFER_NUMBER; ) {
+            PartitionFileReader.ReadBufferResult readBufferResult =
+                    readBuffer(bufferIndex, DEFAULT_SUBPARTITION_ID, readProgress, partialBuffer);
+            assertThat(readBufferResult).isNotNull();
+            readProgress = readBufferResult.getReadProgress();
+            for (Buffer buffer : readBufferResult.getReadBuffers()) {
+                if (buffer instanceof PartitionFileReader.PartialBuffer) {
+                    partialBuffer = (PartitionFileReader.PartialBuffer) buffer;
+                    if (partialBuffer.missingLength() == 0) {
+                        bufferIndex++;
+                        currentFileOffset += partialBuffer.readableBytes() + HEADER_LENGTH;
+                        partialBuffer.recycleBuffer();
+                        partialBuffer = null;
+                    }
+                } else {
+                    bufferIndex++;
+                    currentFileOffset += buffer.readableBytes() + HEADER_LENGTH;
+                    buffer.recycleBuffer();
+                }
+            }
+            assertThat(readProgress.getCurrentReadOffset()).isEqualTo(currentFileOffset);
         }
-        // The following buffer reading from other subpartitions can only query the index.
-        assertThat(readBuffer(0, new TieredStorageSubpartitionId(3))).isNotNull();
-        assertThat(readBuffer(0, new TieredStorageSubpartitionId(3))).isNotNull();
-        assertThat(indexQueryTime).hasValue(5);
     }
 
     @Test
@@ -170,7 +181,16 @@ class ProducerMergedPartitionFileReaderTest {
         assertThat(testFilePath.toFile().exists()).isFalse();
     }
 
-    private Buffer readBuffer(int bufferIndex, TieredStorageSubpartitionId subpartitionId)
+    private List<Buffer> readBuffer(int bufferIndex, TieredStorageSubpartitionId subpartitionId)
+            throws IOException {
+        return readBuffer(bufferIndex, subpartitionId, null, null).getReadBuffers();
+    }
+
+    private PartitionFileReader.ReadBufferResult readBuffer(
+            int bufferIndex,
+            TieredStorageSubpartitionId subpartitionId,
+            PartitionFileReader.ReadProgress readProgress,
+            PartitionFileReader.PartialBuffer partialBuffer)
             throws IOException {
         MemorySegment memorySegment =
                 MemorySegmentFactory.allocateUnpooledSegment(DEFAULT_BUFFER_SIZE);
@@ -180,6 +200,8 @@ class ProducerMergedPartitionFileReaderTest {
                 DEFAULT_SEGMENT_ID,
                 bufferIndex,
                 memorySegment,
-                FreeingBufferRecycler.INSTANCE);
+                FreeingBufferRecycler.INSTANCE,
+                readProgress,
+                partialBuffer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReaderTest.java
@@ -102,12 +102,12 @@ class SegmentPartitionFileReaderTest {
     void testGetPriority() throws IOException {
         assertThat(
                         partitionFileReader.getPriority(
-                                DEFAULT_PARTITION_ID, DEFAULT_SUBPARTITION_ID, 0, 0))
+                                DEFAULT_PARTITION_ID, DEFAULT_SUBPARTITION_ID, 0, 0, null))
                 .isEqualTo(-1);
         assertThat(readBuffer(0, DEFAULT_SUBPARTITION_ID, 0)).isNotNull();
         assertThat(
                         partitionFileReader.getPriority(
-                                DEFAULT_PARTITION_ID, DEFAULT_SUBPARTITION_ID, 0, 1))
+                                DEFAULT_PARTITION_ID, DEFAULT_SUBPARTITION_ID, 0, 1, null))
                 .isEqualTo(-1);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/SegmentPartitionFileReaderTest.java
@@ -116,12 +116,19 @@ class SegmentPartitionFileReaderTest {
             throws IOException {
         MemorySegment memorySegment =
                 MemorySegmentFactory.allocateUnpooledSegment(DEFAULT_BUFFER_SIZE);
-        return partitionFileReader.readBuffer(
-                DEFAULT_PARTITION_ID,
-                subpartitionId,
-                segmentId,
-                bufferIndex,
-                memorySegment,
-                FreeingBufferRecycler.INSTANCE);
+        PartitionFileReader.ReadBufferResult readBufferResult =
+                partitionFileReader.readBuffer(
+                        DEFAULT_PARTITION_ID,
+                        subpartitionId,
+                        segmentId,
+                        bufferIndex,
+                        memorySegment,
+                        FreeingBufferRecycler.INSTANCE,
+                        null,
+                        null);
+        if (readBufferResult == null) {
+            return null;
+        }
+        return readBufferResult.getReadBuffers().get(0);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
@@ -68,7 +68,7 @@ public class TestingPartitionFileReader implements PartitionFileReader {
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
             int bufferIndex,
-            ReadProgress readProgress) {
+            @Nullable ReadProgress readProgress) {
         return getPriorityFunction.apply(subpartitionId.getSubpartitionId());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
@@ -19,10 +19,11 @@
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
@@ -31,14 +32,14 @@ import java.util.function.Function;
 /** Testing implementation for {@link PartitionFileReader}. */
 public class TestingPartitionFileReader implements PartitionFileReader {
 
-    private final BiFunction<Integer, Integer, Buffer> readBufferFunction;
+    private final BiFunction<Integer, Integer, ReadBufferResult> readBufferFunction;
 
     private final Function<Integer, Long> getPriorityFunction;
 
     private final Runnable releaseRunnable;
 
     private TestingPartitionFileReader(
-            BiFunction<Integer, Integer, Buffer> readBufferFunction,
+            BiFunction<Integer, Integer, ReadBufferResult> readBufferFunction,
             Function<Integer, Long> getPriorityFunction,
             Runnable releaseRunnable) {
         this.readBufferFunction = readBufferFunction;
@@ -47,13 +48,15 @@ public class TestingPartitionFileReader implements PartitionFileReader {
     }
 
     @Override
-    public Buffer readBuffer(
+    public ReadBufferResult readBuffer(
             TieredStoragePartitionId partitionId,
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
             int bufferIndex,
             MemorySegment memorySegment,
-            BufferRecycler recycler)
+            BufferRecycler recycler,
+            @Nullable ReadProgress readProgress,
+            @Nullable PartialBuffer partialBuffer)
             throws IOException {
         return readBufferFunction.apply(bufferIndex, segmentId);
     }
@@ -74,7 +77,7 @@ public class TestingPartitionFileReader implements PartitionFileReader {
 
     /** Builder for {@link TestingPartitionFileReader}. */
     public static class Builder {
-        private BiFunction<Integer, Integer, Buffer> readBufferSupplier =
+        private BiFunction<Integer, Integer, ReadBufferResult> readBufferSupplier =
                 (bufferIndex, segmentId) -> null;
 
         private Function<Integer, Long> prioritySupplier = bufferIndex -> 0L;
@@ -82,7 +85,7 @@ public class TestingPartitionFileReader implements PartitionFileReader {
         private Runnable releaseNotifier = () -> {};
 
         public Builder setReadBufferSupplier(
-                BiFunction<Integer, Integer, Buffer> readBufferSupplier) {
+                BiFunction<Integer, Integer, ReadBufferResult> readBufferSupplier) {
             this.readBufferSupplier = readBufferSupplier;
             return this;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/TestingPartitionFileReader.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.file;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 
@@ -56,7 +57,7 @@ public class TestingPartitionFileReader implements PartitionFileReader {
             MemorySegment memorySegment,
             BufferRecycler recycler,
             @Nullable ReadProgress readProgress,
-            @Nullable PartialBuffer partialBuffer)
+            @Nullable CompositeBuffer partialBuffer)
             throws IOException {
         return readBufferFunction.apply(bufferIndex, segmentId);
     }
@@ -66,7 +67,8 @@ public class TestingPartitionFileReader implements PartitionFileReader {
             TieredStoragePartitionId partitionId,
             TieredStorageSubpartitionId subpartitionId,
             int segmentId,
-            int bufferIndex) {
+            int bufferIndex,
+            ReadProgress readProgress) {
         return getPriorityFunction.apply(subpartitionId.getSubpartitionId());
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when the file reader of tiered storage loads data from the disk file, it reads data in buffer granularity. Before compression, each buffer is 32K by default. After compressed, the size will become smaller (may less than 5K), which is pretty small for the network buffer and the file IO.
We should read multiple small buffers by reading and slicing one large buffer to decrease the buffer competition and the file IO, leading to better performance.


## Brief change log

  - *Tiered storage supports reading multiple small buffers by reading and slicing one large buffer*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *ProducerMergedPartitionFileReaderTest*.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
