### PR TITLE
[FLINK-32910][build] Set default parameters for curl and wget

### DIFF
--- a/docs/setup_hugo.sh
+++ b/docs/setup_hugo.sh
@@ -20,7 +20,7 @@
 # setup hugo
 HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
 HUGO_ARTIFACT=hugo_extended_0.110.0_Linux-64bit.tar.gz
-if ! curl --fail -OL $HUGO_REPO ; then
+if ! curl --silent --show-error --fail -OL $HUGO_REPO ; then
 	echo "Failed to download Hugo binary"
 	exit 1
 fi

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -67,6 +67,13 @@ cat << EOT >> ${HOME}/.curlrc
 --retry 10
 EOT
 
+cat << EOT >> ${HOME}/.wgetrc
+# only print basic information (no progress bar)
+verbose=off
+# retries in case of errors
+tries=10
+EOT
+
 # REST_PROTOCOL and CURL_SSL_ARGS can be modified in common_ssl.sh if SSL is activated
 # they should be used in curl command to query Flink REST API
 REST_PROTOCOL="http"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -53,6 +53,20 @@ source "${TEST_INFRA_DIR}/common_utils.sh"
 
 NODENAME=${NODENAME:-"localhost"}
 
+# common cUrl parameters
+cat << EOT >> ${HOME}/.curlrc
+# makes the curl command fail if a HTTP error code is returned
+--fail
+# prints the error
+--show-error
+# but omits other output (e.g. progress bar)
+--silent
+# retries if the server indicates that the requested artifact was moved
+--location
+# retries in case of common errors
+--retry 10
+EOT
+
 # REST_PROTOCOL and CURL_SSL_ARGS can be modified in common_ssl.sh if SSL is activated
 # they should be used in curl command to query Flink REST API
 REST_PROTOCOL="http"
@@ -339,7 +353,7 @@ function start_and_wait_for_tm {
 
 function query_running_tms {
   local url="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
-  curl ${CURL_SSL_ARGS} -s "${url}"
+  curl ${CURL_SSL_ARGS} "${url}"
 }
 
 function query_number_of_running_tms {
@@ -695,7 +709,7 @@ function get_job_metric {
   local job_id=$1
   local metric_name=$2
 
-  local json=$(curl ${CURL_SSL_ARGS} -s ${REST_PROTOCOL}://${NODENAME}:8081/jobs/${job_id}/metrics?get=${metric_name})
+  local json=$(curl ${CURL_SSL_ARGS} ${REST_PROTOCOL}://${NODENAME}:8081/jobs/${job_id}/metrics?get=${metric_name})
   local metric_value=$(echo ${json} | sed -n 's/.*"value":"\(.*\)".*/\1/p')
 
   echo ${metric_value}

--- a/flink-end-to-end-tests/test-scripts/common_artifact_download_cacher.sh
+++ b/flink-end-to-end-tests/test-scripts/common_artifact_download_cacher.sh
@@ -36,7 +36,7 @@ function get_artifact {
     local ARTIFACT_URL=$1
     BASENAME="`basename $ARTIFACT_URL`"
     if [ ! -f "$E2E_TARBALL_CACHE/$BASENAME" ]; then
-        curl $ARTIFACT_URL --retry 10 --retry-max-time 120 --output $E2E_TARBALL_CACHE/$BASENAME
+        curl $ARTIFACT_URL --retry-max-time 120 --output $E2E_TARBALL_CACHE/$BASENAME
         local res=$?
         if [ ! 0 -eq $res ]; then
             exit 1

--- a/flink-end-to-end-tests/test-scripts/common_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ha.sh
@@ -154,7 +154,7 @@ function ha_tm_watchdog() {
         # check how many successful checkpoints we have
         # and kill a TM only if the previous one already had some
 
-        local CHECKPOINTS=`curl -s "http://localhost:8081/jobs/${JOB_ID}/checkpoints" | cut -d ":" -f 6 | sed 's/,.*//'`
+        local CHECKPOINTS=`curl "http://localhost:8081/jobs/${JOB_ID}/checkpoints" | cut -d ":" -f 6 | sed 's/,.*//'`
 
         if [[ ${CHECKPOINTS} == "" ]]; then
 

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -38,8 +38,8 @@ function setup_kubernetes_for_linux {
     # Download kubectl, which is a requirement for using minikube.
     if ! [ -x "$(command -v kubectl)" ]; then
         echo "Installing kubectl ..."
-        local version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$version/bin/linux/$arch/kubectl && \
+        local version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+        curl -o kubectl https://storage.googleapis.com/kubernetes-release/release/$version/bin/linux/$arch/kubectl && \
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
     fi
     # Download minikube when it is not installed beforehand.
@@ -50,7 +50,7 @@ function setup_kubernetes_for_linux {
 
     if ! [ -x "$(command -v minikube)" ]; then
       echo "Installing minikube $MINIKUBE_VERSION ..."
-      curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-$arch && \
+      curl -o minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-$arch && \
           chmod +x minikube && sudo mv minikube /usr/bin/minikube
     fi
 

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -60,7 +60,7 @@ function setup_kubernetes_for_linux {
     local crictl_version crictl_archive
     crictl_version="v1.24.2"
     crictl_archive="crictl-$crictl_version-linux-${arch}.tar.gz"
-    wget -nv "https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictl_version}/${crictl_archive}"
+    wget "https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictl_version}/${crictl_archive}"
     sudo tar zxvf ${crictl_archive} -C /usr/local/bin
     rm -f ${crictl_archive}
 
@@ -69,13 +69,13 @@ function setup_kubernetes_for_linux {
     cri_dockerd_version="0.2.3"
     cri_dockerd_archive="cri-dockerd-${cri_dockerd_version}.${arch}.tgz"
     cri_dockerd_binary="cri-dockerd"
-    wget -nv "https://github.com/Mirantis/cri-dockerd/releases/download/v${cri_dockerd_version}/${cri_dockerd_archive}"
+    wget "https://github.com/Mirantis/cri-dockerd/releases/download/v${cri_dockerd_version}/${cri_dockerd_archive}"
     tar xzvf $cri_dockerd_archive "cri-dockerd/${cri_dockerd_binary}" --strip-components=1
     sudo install -o root -g root -m 0755 "${cri_dockerd_binary}" "/usr/local/bin/${cri_dockerd_binary}"
     rm ${cri_dockerd_binary}
 
-    wget -nv https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${cri_dockerd_version}/packaging/systemd/cri-docker.service
-    wget -nv https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${cri_dockerd_version}/packaging/systemd/cri-docker.socket
+    wget https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${cri_dockerd_version}/packaging/systemd/cri-docker.service
+    wget https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${cri_dockerd_version}/packaging/systemd/cri-docker.socket
     sudo mv cri-docker.socket cri-docker.service /etc/systemd/system/
     sudo sed -i -e "s,/usr/bin/${cri_dockerd_binary},/usr/local/bin/${cri_dockerd_binary}," /etc/systemd/system/cri-docker.service
 

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/entrypoint.sh
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/entrypoint.sh
@@ -24,7 +24,7 @@ $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 MAX_RETRY_SECONDS=800
 
 # installing libraries if any - (resource urls added comma separated to the ACP system variable)
-cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; curl -LO $cp ; done; cd -
+cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; curl -O $cp ; done; cd -
 
 # kerberos client
 sed -i "s/EXAMPLE.COM/${KRB_REALM}/g" /etc/krb5.conf

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -156,7 +156,7 @@ function wait_for_number_of_checkpoints {
 
 function get_completed_number_of_checkpoints {
     local job_id=$1
-    local json_res=$(curl -s http://localhost:8081/jobs/${job_id}/checkpoints)
+    local json_res=$(curl http://localhost:8081/jobs/${job_id}/checkpoints)
 
     echo ${json_res}    | # {"counts":{"restored":0,"total":25,"in_progress":1,"completed":24,"failed":0} ...
         cut -d ":" -f 6 | # 24,"failed"

--- a/tools/azure-pipelines/build_properties.sh
+++ b/tools/azure-pipelines/build_properties.sh
@@ -27,7 +27,7 @@ function github_num_commits() {
 	fi
 	# check if it is docs only pull request
 	# 1. Get PR details
-	GITHUB_PULL_DETAIL=`curl --silent "https://api.github.com/repos/apache/flink/pulls/$PR_ID"`
+	GITHUB_PULL_DETAIL=`curl --retry 10 --fail --show-error --silent "https://api.github.com/repos/apache/flink/pulls/$PR_ID"`
 
 	# 2. Check if this build is in sync with the PR
 	GITHUB_PULL_HEAD_SHA=`echo $GITHUB_PULL_DETAIL | jq -r ".head.sha"`

--- a/tools/ci/deploy_nightly_to_s3.sh
+++ b/tools/ci/deploy_nightly_to_s3.sh
@@ -26,7 +26,7 @@ function upload_to_s3() {
 
 	echo "Installing artifacts deployment script"	
 	export ARTIFACTS_DEST="$HOME/bin/artifacts"	
-	curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash	
+	curl --fail --silent --show-error --location --retry 10 https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 	PATH="$(dirname "$ARTIFACTS_DEST"):$PATH"	
 
 	echo "Uploading contents of $FILES_DIR to S3:"	


### PR DESCRIPTION
## What is the purpose of the change

The CI build contains a few commands where curl or wget are used with verbose output. Especially the progress bars don't help in the CI context because `\r` is not supported.

## Brief change log

* Added common parameters to `${HOME}/.curlrc` and `${HOME}/.wgetrc`
* Removed obsolete parameters from `curl` and `wget` usages (some are kept because the default config for the two commands only works with e2e tests)

## Verifying this change

* Checking the CI build

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable