### PR TITLE
Refactor @Test(expected) with assertThrows

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link SlotSharingGroup}. */
@@ -68,17 +69,21 @@ public class SlotSharingGroupTest {
         assertTrue(slotSharingGroup.getExternalResources().isEmpty());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildSlotSharingGroupWithIllegalConfig() {
-        SlotSharingGroup.newBuilder("ssg")
-                .setCpuCores(1)
-                .setTaskHeapMemory(MemorySize.ZERO)
-                .setTaskOffHeapMemoryMB(10)
-                .build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            SlotSharingGroup.newBuilder("ssg")
+                    .setCpuCores(1)
+                    .setTaskHeapMemory(MemorySize.ZERO)
+                    .setTaskOffHeapMemoryMB(10)
+                    .build();
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildSlotSharingGroupWithoutAllRequiredConfig() {
-        SlotSharingGroup.newBuilder("ssg").setCpuCores(1).setTaskOffHeapMemoryMB(10).build();
+        assertThrows(IllegalArgumentException.class, () -> {
+            SlotSharingGroup.newBuilder("ssg").setCpuCores(1).setTaskOffHeapMemoryMB(10).build();
+        });
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
@@ -71,19 +71,26 @@ public class SlotSharingGroupTest {
 
     @Test
     public void testBuildSlotSharingGroupWithIllegalConfig() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            SlotSharingGroup.newBuilder("ssg")
-                    .setCpuCores(1)
-                    .setTaskHeapMemory(MemorySize.ZERO)
-                    .setTaskOffHeapMemoryMB(10)
-                    .build();
-        });
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    SlotSharingGroup.newBuilder("ssg")
+                            .setCpuCores(1)
+                            .setTaskHeapMemory(MemorySize.ZERO)
+                            .setTaskOffHeapMemoryMB(10)
+                            .build();
+                });
     }
 
     @Test
     public void testBuildSlotSharingGroupWithoutAllRequiredConfig() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            SlotSharingGroup.newBuilder("ssg").setCpuCores(1).setTaskOffHeapMemoryMB(10).build();
-        });
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+                SlotSharingGroup.newBuilder("ssg")
+                        .setCpuCores(1)
+                        .setTaskOffHeapMemoryMB(10)
+                        .build();
+            });
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
@@ -85,12 +85,12 @@ public class SlotSharingGroupTest {
     @Test
     public void testBuildSlotSharingGroupWithoutAllRequiredConfig() {
         assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                SlotSharingGroup.newBuilder("ssg")
-                        .setCpuCores(1)
-                        .setTaskOffHeapMemoryMB(10)
-                        .build();
-            });
+                IllegalArgumentException.class,
+                () -> {
+                    SlotSharingGroup.newBuilder("ssg")
+                            .setCpuCores(1)
+                            .setTaskOffHeapMemoryMB(10)
+                            .build();
+                });
     }
 }


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice.

For example, the smell in [SlotSharingGroupTest.java](https://github.com/apache/flink/commit/998a2e1a6bb835bceffc405e82acc815be87b3d9#diff-2eebec7df0b04130e47f4cc9c012deed0b3e048f0bddd62a1915465d313ba46e) occurs when exception handling can alternatively be implemented using assertion rather than annotation: using `assertThrows(IllegalArgumentException.class, () -> {...});` instead of `@Test(expected = IllegalArgumentException.class)`.

While there are many cases like this, we aim in this pull request to get your feedback on this particular test smell and its refactoring. Thanks in advance for your input.