### PR TITLE
[FLINK-32942][test-utils] ParameterizedTestExtension's parameter provider can be private

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/ParameterizedTestExtension.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/parameterized/ParameterizedTestExtension.java
@@ -83,6 +83,7 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
         // Get parameter values
         final Object parameterValues;
         try {
+            parameterProvider.setAccessible(true);
             parameterValues = parameterProvider.invoke(null);
             context.getStore(NAMESPACE).put(PARAMETERS_STORE_KEY, parameterValues);
         } catch (Exception e) {

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/ParameterizedTestExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/ParameterizedTestExtensionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for parameterized test on JUnit5 {@link ParameterizedTestExtension}. */
+@ExtendWith(ParameterizedTestExtension.class)
+class ParameterizedTestExtensionTest {
+
+    private static final List<Integer> PARAMETERS = Arrays.asList(1, 2);
+
+    @Parameters
+    private static List<Integer> parameters() {
+        return PARAMETERS;
+    }
+
+    @TestTemplate
+    void testWithParameters(int parameter) {
+        assertThat(parameter).isIn(PARAMETERS);
+    }
+}


### PR DESCRIPTION
ParameterizedTestExtension's parameter provider can be private

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

ParameterizedTestExtension's parameter provider can be private to make test cases have better isolation.

## Brief change log

ParameterizedTestExtension's parameter provider can be private.

Old
```java
@ExtendWith(ParameterizedTestExtension.class)
public class ParameterizedTestExtensionTest {

    private static final List<Integer> PARAMETERS = Arrays.asList(1, 2);

    @Parameters
    public static List<Integer> parameters() {
        return PARAMETERS;
    }

    @TestTemplate
    void testWithParameters(int parameter) {
        assertThat(parameter).isIn(PARAMETERS);
    }
}
```

After change
```java
@ExtendWith(ParameterizedTestExtension.class)
class ParameterizedTestExtensionTest {

    private static final List<Integer> PARAMETERS = Arrays.asList(1, 2);

    @Parameters
    private static List<Integer> parameters() {
        return PARAMETERS;
    }

    @TestTemplate
    void testWithParameters(int parameter) {
        assertThat(parameter).isIn(PARAMETERS);
    }
}
```

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

Added unit test to check parameters provider can be private.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
