### PR TITLE
[FLINK-32731][e2e] Add retry mechanism when fails to start the namenode

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainer.java
@@ -22,6 +22,11 @@ import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.test.parameters.ParameterProperty;
 import org.apache.flink.util.DockerImageVersions;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +61,7 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
     private static final String MYSQL_METASTORE_LOG_PATH = "/var/log/mysqld.log";
     private static final ParameterProperty<Path> DISTRIBUTION_LOG_BACKUP_DIRECTORY =
             new ParameterProperty<>("logBackupDir", Paths::get);
+    private static final int NAME_NODE_WEB_PORT = 50070;
 
     private String hiveWarehouseDir;
 
@@ -65,6 +71,7 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
                         HIVE_310_OR_LATER ? DockerImageVersions.HIVE3 : DockerImageVersions.HIVE2));
         withExtraHost(HOST_NAME, "127.0.0.1");
         addExposedPort(HIVE_METASTORE_PORT);
+        addExposedPort(NAME_NODE_WEB_PORT);
         mountHiveWarehouseDirToContainer(initTableNames);
     }
 
@@ -80,6 +87,28 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
     protected void finished(Description description) {
         backupLogs();
         super.finished(description);
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        final Request request =
+                new Request.Builder()
+                        .post(new FormBody.Builder().build())
+                        .url(
+                                String.format(
+                                        "http://127.0.0.1:%s", getMappedPort(NAME_NODE_WEB_PORT)))
+                        .build();
+        OkHttpClient client = new OkHttpClient();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new RuntimeException(
+                        String.format(
+                                "The rest request is not successful: %s", response.message()));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public String getHiveMetastoreURL() {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainer.java
@@ -70,6 +70,7 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
                 DockerImageName.parse(
                         HIVE_310_OR_LATER ? DockerImageVersions.HIVE3 : DockerImageVersions.HIVE2));
         withExtraHost(HOST_NAME, "127.0.0.1");
+        withStartupAttempts(3);
         addExposedPort(HIVE_METASTORE_PORT);
         addExposedPort(NAME_NODE_WEB_PORT);
         mountHiveWarehouseDirToContainer(initTableNames);

--- a/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
@@ -20,6 +20,11 @@ package org.apache.flink.table.gateway.containers;
 import org.apache.flink.test.parameters.ParameterProperty;
 import org.apache.flink.util.DockerImageVersions;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +44,7 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
 
     public static final String HOST_NAME = "hadoop-master";
     public static final int HIVE_METASTORE_PORT = 9083;
+    private static final int NAME_NODE_WEB_PORT = 50070;
 
     // Detailed log paths are from
     // https://github.com/prestodb/docker-images/tree/master/prestodb/hdp2.6-hive/files/etc/supervisord.d
@@ -53,7 +59,9 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
     public HiveContainer() {
         super(DockerImageName.parse(DockerImageVersions.HIVE2));
         withExtraHost(HOST_NAME, "127.0.0.1");
+        withStartupAttempts(3);
         addExposedPort(HIVE_METASTORE_PORT);
+        addExposedPort(NAME_NODE_WEB_PORT);
     }
 
     @Override
@@ -61,6 +69,28 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
         super.doStart();
         if (LOG.isInfoEnabled()) {
             followOutput(new Slf4jLogConsumer(LOG));
+        }
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        final Request request =
+                new Request.Builder()
+                        .post(new FormBody.Builder().build())
+                        .url(
+                                String.format(
+                                        "http://127.0.0.1:%s", getMappedPort(NAME_NODE_WEB_PORT)))
+                        .build();
+        OkHttpClient client = new OkHttpClient();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new RuntimeException(
+                        String.format(
+                                "The rest request is not successful: %s", response.message()));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently the SqlGatewayE2ECase uses Hive container to test the sql gateway behaviour. However, the container may fail to start the name node. It is caused by the docker will start the name node and then restart it. We can observe the following content in the log.

```
2018-09-24 19:35:28,571 ERROR [SIGTERM handler] namenode.NameNode (LogAdapter.java:error(71)) - RECEIVED SIGNAL 15: SIGTERM
2018-09-24 19:35:28,576 INFO  [pool-1-thread-1] namenode.NameNode (LogAdapter.java:info(47)) - SHUTDOWN_MSG: 


2023-08-11 17:53:43,364 INFO  [main] http.HttpServer2 (HttpServer2.java:start(937)) - HttpServer.start() threw a non Bind IOException
java.net.BindException: Port in use: 0.0.0.0:50070
	at org.apache.hadoop.http.HttpServer2.constructBindException(HttpServer2.java:998)
	at org.apache.hadoop.http.HttpServer2.bindForSinglePort(HttpServer2.java:1020)
	at org.apache.hadoop.http.HttpServer2.openListeners(HttpServer2.java:1077)
	at org.apache.hadoop.http.HttpServer2.start(HttpServer2.java:934)
	at org.apache.hadoop.hdfs.server.namenode.NameNodeHttpServer.start(NameNodeHttpServer.java:170)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.startHttpServer(NameNode.java:942)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.initialize(NameNode.java:755)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.<init>(NameNode.java:1001)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.<init>(NameNode.java:985)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.createNameNode(NameNode.java:1710)
	at org.apache.hadoop.hdfs.server.namenode.NameNode.main(NameNode.java:1778)
Caused by: java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Net.java:433)
	at sun.nio.ch.Net.bind(Net.java:425)
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
	at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
	at org.mortbay.jetty.nio.SelectChannelConnector.open(SelectChannelConnector.java:216)
	at org.apache.hadoop.http.HttpServer2.bindListener(HttpServer2.java:985)
	at org.apache.hadoop.http.HttpServer2.bindForSinglePort(HttpServer2.java:1016)
```

Therefore, we will check the NameNode status after container starts. If the namenode fails, restart the container again.


