### PR TITLE
[FLINK-32945][runtime] Fix NPE when task reached end-of-data but checkpoint failed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -402,6 +402,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
     protected void restoreState(
             final Set<ExecutionVertexID> vertices, final boolean isGlobalRecovery)
             throws Exception {
+        vertexEndOfDataListener.restoreVertices(vertices);
+
         final CheckpointCoordinator checkpointCoordinator =
                 executionGraph.getCheckpointCoordinator();
 
@@ -1106,5 +1108,10 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
     @VisibleForTesting
     JobID getJobId() {
         return jobGraph.getJobID();
+    }
+
+    @VisibleForTesting
+    VertexEndOfDataListener getVertexEndOfDataListener() {
+        return vertexEndOfDataListener;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexEndOfDataListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/VertexEndOfDataListener.java
@@ -23,11 +23,13 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Records the end of data event of each task, and allows for checking whether all tasks of a {@link
@@ -72,5 +74,13 @@ public class VertexEndOfDataListener {
             }
         }
         return true;
+    }
+
+    public void restoreVertices(Set<ExecutionVertexID> executionVertices) {
+        for (ExecutionVertexID executionVertex : executionVertices) {
+            JobVertexID jobVertexId = executionVertex.getJobVertexId();
+            tasksReachedEndOfData.putIfAbsent(jobVertexId, new BitSet());
+            tasksReachedEndOfData.get(jobVertexId).set(executionVertex.getSubtaskIndex(), false);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -108,18 +108,35 @@ public class SchedulerTestingUtils {
             final JobGraph jobGraph,
             @Nullable StateBackend stateBackend,
             @Nullable CheckpointStorage checkpointStorage) {
+        enableCheckpointing(
+                jobGraph,
+                stateBackend,
+                checkpointStorage,
+                Long.MAX_VALUE, // disable periodical checkpointing
+                false);
+    }
+
+    public static void enableCheckpointing(
+            final JobGraph jobGraph,
+            @Nullable StateBackend stateBackend,
+            @Nullable CheckpointStorage checkpointStorage,
+            long checkpointInterval,
+            boolean enableCheckpointsAfterTasksFinish) {
 
         final CheckpointCoordinatorConfiguration config =
-                new CheckpointCoordinatorConfiguration(
-                        Long.MAX_VALUE, // disable periodical checkpointing
-                        DEFAULT_CHECKPOINT_TIMEOUT_MS,
-                        0,
-                        1,
-                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
-                        false,
-                        false,
-                        0,
-                        0);
+                new CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(checkpointInterval)
+                        .setCheckpointTimeout(DEFAULT_CHECKPOINT_TIMEOUT_MS)
+                        .setMinPauseBetweenCheckpoints(0)
+                        .setMaxConcurrentCheckpoints(1)
+                        .setCheckpointRetentionPolicy(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION)
+                        .setExactlyOnce(false)
+                        .setUnalignedCheckpointsEnabled(false)
+                        .setTolerableCheckpointFailureNumber(0)
+                        .setCheckpointIdOfIgnoredInFlightData(0)
+                        .setEnableCheckpointsAfterTasksFinish(enableCheckpointsAfterTasksFinish)
+                        .build();
 
         SerializedValue<StateBackend> serializedStateBackend = null;
         if (stateBackend != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAfterAllTasksFinishedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAfterAllTasksFinishedITCase.java
@@ -71,15 +71,15 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
     public void setUp() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(4);
-        env.setRestartStrategy(RestartStrategies.noRestart());
         smallResult = sharedObjects.add(new CopyOnWriteArrayList<>());
         bigResult = sharedObjects.add(new CopyOnWriteArrayList<>());
     }
 
     @Test
     public void testImmediateCheckpointing() throws Exception {
+        env.setRestartStrategy(RestartStrategies.noRestart());
         env.enableCheckpointing(Long.MAX_VALUE - 1);
-        StreamGraph streamGraph = getStreamGraph(env, false);
+        StreamGraph streamGraph = getStreamGraph(env, false, false);
         env.execute(streamGraph);
         assertThat(smallResult.get().size()).isEqualTo(SMALL_SOURCE_NUM_RECORDS);
         assertThat(bigResult.get().size()).isEqualTo(BIG_SOURCE_NUM_RECORDS);
@@ -96,9 +96,10 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
         try (MiniCluster miniCluster = new MiniCluster(cfg)) {
             miniCluster.start();
 
+            env.setRestartStrategy(RestartStrategies.noRestart());
             env.enableCheckpointing(100);
             IntegerStreamSource.latch = new CountDownLatch(1);
-            JobGraph jobGraph = getStreamGraph(env, true).getJobGraph();
+            JobGraph jobGraph = getStreamGraph(env, true, false).getJobGraph();
             miniCluster.submitJob(jobGraph).get();
 
             CommonTestUtils.waitForSubtasksToFinish(
@@ -118,7 +119,7 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
             bigResult.get().clear();
 
             env.enableCheckpointing(Long.MAX_VALUE - 1);
-            JobGraph restoredJobGraph = getStreamGraph(env, true).getJobGraph();
+            JobGraph restoredJobGraph = getStreamGraph(env, true, false).getJobGraph();
             restoredJobGraph.setSavepointRestoreSettings(
                     SavepointRestoreSettings.forPath(savepointPath, false));
             miniCluster.submitJob(restoredJobGraph).get();
@@ -128,16 +129,52 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
             miniCluster.requestJobResult(restoredJobGraph.getJobID()).get();
             assertThat(smallResult.get().size()).isEqualTo(SMALL_SOURCE_NUM_RECORDS);
             assertThat(bigResult.get().size()).isEqualTo(BIG_SOURCE_NUM_RECORDS);
+        } finally {
+            IntegerStreamSource.latch = null;
         }
     }
 
-    private StreamGraph getStreamGraph(StreamExecutionEnvironment env, boolean block) {
-        env.addSource(new IntegerStreamSource(SMALL_SOURCE_NUM_RECORDS, false))
+    @Test
+    public void testFailoverAfterSomeTasksFinished() throws Exception {
+        final MiniClusterConfiguration cfg =
+                new MiniClusterConfiguration.Builder()
+                        .withRandomPorts()
+                        .setNumTaskManagers(1)
+                        .setNumSlotsPerTaskManager(4)
+                        .build();
+        try (MiniCluster miniCluster = new MiniCluster(cfg)) {
+            miniCluster.start();
+
+            env.enableCheckpointing(100);
+            IntegerStreamSource.latch = new CountDownLatch(1);
+            JobGraph jobGraph = getStreamGraph(env, true, true).getJobGraph();
+            miniCluster.submitJob(jobGraph).get();
+
+            CommonTestUtils.waitForSubtasksToFinish(
+                    miniCluster,
+                    jobGraph.getJobID(),
+                    findVertexByName(jobGraph, "passA -> Sink: sinkA").getID(),
+                    false);
+            bigResult.get().clear();
+            IntegerStreamSource.latch.countDown();
+
+            miniCluster.requestJobResult(jobGraph.getJobID()).get();
+            assertThat(smallResult.get().size()).isEqualTo(SMALL_SOURCE_NUM_RECORDS);
+            assertThat(bigResult.get().size()).isEqualTo(BIG_SOURCE_NUM_RECORDS);
+        } finally {
+            IntegerStreamSource.latch = null;
+        }
+    }
+
+    private StreamGraph getStreamGraph(
+            StreamExecutionEnvironment env, boolean block, boolean needFailover) {
+
+        env.addSource(new IntegerStreamSource(SMALL_SOURCE_NUM_RECORDS, false, false))
                 .transform("passA", Types.INT, new PassThroughOperator())
                 .addSink(new CollectSink(smallResult))
                 .name("sinkA");
 
-        env.addSource(new IntegerStreamSource(BIG_SOURCE_NUM_RECORDS, block))
+        env.addSource(new IntegerStreamSource(BIG_SOURCE_NUM_RECORDS, block, needFailover))
                 .transform("passB", Types.INT, new PassThroughOperator())
                 .addSink(new CollectSink(bigResult))
                 .name("sinkB");
@@ -157,16 +194,19 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
 
         private static final long serialVersionUID = 1L;
         private static CountDownLatch latch;
+        private static boolean failedBefore;
 
         private final int numRecords;
         private boolean block;
         private volatile boolean running;
         private int emittedCount;
+        private boolean needFailover;
 
-        public IntegerStreamSource(int numRecords, boolean block) {
+        public IntegerStreamSource(int numRecords, boolean block, boolean needFailover) {
             this.numRecords = numRecords;
             this.running = true;
             this.block = block;
+            this.needFailover = needFailover;
             this.emittedCount = 0;
         }
 
@@ -180,6 +220,10 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
             }
             if (block && latch != null) {
                 latch.await();
+            }
+            if (needFailover && !failedBefore) {
+                failedBefore = true;
+                throw new RuntimeException("forced failure");
             }
         }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix NullPointerException when executing TopSpeedWindowing example with checkpointing enabled. 

The bug happens when some vertices have reached the end of data but do not transform to FINISHED because their final checkpoint fails and causes a failover. The `VertexEndOfDataListener` would remove the end-of-data vertices from its state, however, in such case these vertices would be restarted and try to access the `VertexEndOfDataListener` again, which causes the NPE.

## Brief change log

  - Restore the state of VertexEndOfDataListener when some tasks are going to be restarted.

## Verifying this change

This change added tests and can be verified as follows:

  - Added test that validates that the state of VertexEndOfDataListener would be restored when failover happens.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
