### PR TITLE
[BP-1.17][FLINK-32296][table] Support cast of collections with row element types

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RowToRowCastRule.java
@@ -221,7 +221,8 @@ class RowToRowCastRule extends AbstractNullAwareCodeGeneratorCastRule<RowData, R
                                     elseBodyWriter.stmt(writeNull));
         }
 
-        writer.stmt(methodCall(writerTerm, "complete")).assignStmt(returnVariable, rowTerm);
+        writer.stmt(methodCall(writerTerm, "complete"))
+                .assignStmt(returnVariable, methodCall(rowTerm, "copy"));
         return writer.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1206,6 +1206,18 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                 CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().notNull()))
                         .fromCase(ARRAY(INT().notNull()), new Integer[] {1, 2}, new Long[] {1L, 2L})
                         .build(),
+                CastTestSpecBuilder.testCastTo(ARRAY(ROW(INT(), STRING()).notNull()))
+                        .fromCase(
+                                ARRAY(ROW(INT(), VARCHAR(4)).notNull()),
+                                new Row[] {Row.of(1, "two"), Row.of(3, "four")},
+                                new Row[] {Row.of(1, "two"), Row.of(3, "four")})
+                        .build(),
+                CastTestSpecBuilder.testCastTo(MAP(ROW(INT()), STRING()))
+                        .fromCase(
+                                MAP(ROW(INT()), VARCHAR(4)),
+                                map(entry(Row.of(1), "two"), entry(Row.of(3), "four")),
+                                map(entry(Row.of(1), "two"), entry(Row.of(3), "four")))
+                        .build(),
                 CastTestSpecBuilder.testCastTo(ROW(BIGINT(), BIGINT(), STRING(), ARRAY(STRING())))
                         .fromCase(
                                 ROW(INT(), INT(), TIME(), ARRAY(CHAR(1))),


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apache/flink/pull/22923 backport to 1.17