### PR TITLE
[FLINK-32909] [dist] fix the bug of Pass arguments to jobmanager.sh failed

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -51,7 +51,7 @@ ENTRYPOINT=standalonesession
 if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # Add JobManager-specific JVM options
     export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_JM}"
-    parseJmArgsAndExportLogs "${ARGS[@]}"
+    parseJmArgsAndExportLogs "${args[@]}"
 
     args=("--configDir" "${FLINK_CONF_DIR}" "--executionMode" "cluster" "${args[@]}")
     if [ ! -z $HOST ]; then


### PR DESCRIPTION
## What is the purpose of the change

Pass arguments to the script jobmanager.sh dynamically failed due to reference a wrong variable name as mentioned in FLINK-32909.


## Brief change log

change the wrong uppercase variable name ${ARGS[@]} to correct name: ${args[@]} at line 54 in the jobmanager.sh script.

## Verifying this change

This change is already covered by existing tests, such as org.apache.flink.dist.BashJavaUtilsITCase#testGetJmResourceParamsWithDynamicProperties.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
