### PR TITLE
[BP-1.18][FLINK-32909][dist]fix the bug of Pass arguments to jobmanager.sh failed

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -51,7 +51,7 @@ ENTRYPOINT=standalonesession
 if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # Add JobManager-specific JVM options
     export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_JM}"
-    parseJmArgsAndExportLogs "${ARGS[@]}"
+    parseJmArgsAndExportLogs "${args[@]}"
 
     args=("--configDir" "${FLINK_CONF_DIR}" "--executionMode" "cluster" "${args[@]}")
     if [ ! -z $HOST ]; then


### PR DESCRIPTION
## What is the purpose of the change

See #23271 . This is a backport for 1.18.