### PR TITLE
[FLINK-32523] Fix Timeout and Assert Error for NotifyCheckpointAbortedITCase#testNotifyCheckpointAborted

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -96,6 +96,7 @@ import static org.junit.Assert.assertEquals;
 public class NotifyCheckpointAbortedITCase extends TestLogger {
 
     private static final long DECLINE_CHECKPOINT_ID = 2L;
+    private static final OneShotLatch DECLINE_CHECKPOINT_WAIT_LATCH = new OneShotLatch();
     private static final long TEST_TIMEOUT = 100000;
     private static final String DECLINE_SINK_NAME = "DeclineSink";
     private static MiniClusterWithClientResource cluster;
@@ -184,7 +185,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         resetAllOperatorsNotifyAbortedLatches();
         verifyAllOperatorsNotifyAbortedTimes(1);
 
-        NormalSource.waitLatch.trigger();
+        DECLINE_CHECKPOINT_WAIT_LATCH.trigger();
         log.info("Verifying whether all operators have been notified of checkpoint-2 aborted.");
         verifyAllOperatorsNotifyAborted();
         log.info("Verified that all operators have been notified of checkpoint-2 aborted.");
@@ -214,7 +215,6 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
             implements SourceFunction<Tuple2<Integer, Integer>>, CheckpointedFunction {
         private static final long serialVersionUID = 1L;
         protected volatile boolean running;
-        private static final OneShotLatch waitLatch = new OneShotLatch();
 
         NormalSource() {
             this.running = true;
@@ -241,7 +241,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
             if (context.getCheckpointId() == DECLINE_CHECKPOINT_ID) {
-                waitLatch.await();
+                DECLINE_CHECKPOINT_WAIT_LATCH.await();
             }
         }
 
@@ -249,7 +249,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         public void initializeState(FunctionInitializationContext context) throws Exception {}
 
         static void reset() {
-            waitLatch.reset();
+            DECLINE_CHECKPOINT_WAIT_LATCH.reset();
         }
     }
 
@@ -287,7 +287,11 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         }
 
         @Override
-        public void snapshotState(FunctionSnapshotContext context) {}
+        public void snapshotState(FunctionSnapshotContext context) throws InterruptedException {
+            if (context.getCheckpointId() == DECLINE_CHECKPOINT_ID) {
+                DECLINE_CHECKPOINT_WAIT_LATCH.await();
+            }
+        }
 
         @Override
         public void initializeState(FunctionInitializationContext context) throws Exception {
@@ -327,7 +331,11 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
             implements SnapshotStrategy<OperatorStateHandle, SnapshotResources> {
 
         @Override
-        public SnapshotResources syncPrepareResources(long checkpointId) {
+        public SnapshotResources syncPrepareResources(long checkpointId)
+                throws InterruptedException {
+            if (checkpointId == DECLINE_CHECKPOINT_ID) {
+                DECLINE_CHECKPOINT_WAIT_LATCH.await();
+            }
             return null;
         }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -156,7 +156,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(200, CheckpointingMode.EXACTLY_ONCE);
         env.getCheckpointConfig().enableUnalignedCheckpoints(unalignedCheckpointEnabled);
-        env.getCheckpointConfig().setTolerableCheckpointFailureNumber(1);
+        env.getCheckpointConfig().setTolerableCheckpointFailureNumber(2);
         env.disableOperatorChaining();
         env.setParallelism(1);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pr wants to fix Timeout exception and assert error for NotifyCheckpointAbortedITCase#testNotifyCheckpointAborted

From the exception stack and attached logs, I saw:

1. the failure reason is not same, timeout and assert error
2. in the timeout cases, the job failed then restored, In the assert error cases, the job aborted two times (these cases are all enabling unaligned checkpoint), the job never failed and ran until finished for every success cases

So I think there are two exceptions in this ITCase:

1. Assert error -> All operators haven't snapshotState together strictly for marked decline checkpoint id in the teste case (This could be reproduced by adding Thread.sleep after first verifyAllOperatorsNotifyAborted() )
2. Timeout exception -> restarting (due to 1 tolerable checkpoint failure number) and notifying aborted occur in different threads, and the order is uncertain, if the job restart firstly, this will cause timeout exception (This could be reproduced by adding Thread.sleep in NormalMap#notifyCheckpointAborted)

For the first exception, we could just make them snapshotState together strictly which I think the ITCase should guarantee.

For the second one, I think it's acceptable that the abort function may not be called if the job failover (notifyCheckpointAborted is a best effort function). So we could just increase the tolerable checkpoint number.

 

Why timeout exception just occured in 1.18 ?

This is because [FLINK-32347](https://issues.apache.org/jira/browse/FLINK-32347) which fixes the exception that CompletedCheckpointStore are not registered by the CheckpointFailureManager, After this, the job could fail due to the tolerable checkpoint failure number.

## Brief change log

  - Guarantee all operators triggering marked decline checkpoint id together
  - Increase the tolerable checkpoint failure number to avoid aborting after job failing

## Verifying this change

This change just fix the error ITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
