### PR TITLE
[FLINK-32951][tests] Make VertexFlameGraphFactoryTest#testLambdaClassNamesCleanUp working with jdk 11+

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.TestLogger;
 
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
 import java.lang.management.ManagementFactory;
@@ -67,7 +68,17 @@ public class VertexFlameGraphFactoryTest extends TestLogger {
             String className =
                     locationWithoutLineNumber.substring(
                             0, locationWithoutLineNumber.lastIndexOf("."));
-            assertThat(className).endsWith("$Lambda$0/0");
+            assertThat(className)
+                    .is(
+                            new Condition<String>() {
+                                @Override
+                                public boolean matches(String value) {
+                                    String javaVersion = System.getProperty("java.version");
+                                    return javaVersion.startsWith("1.8")
+                                                    && value.endsWith("$Lambda$0/0")
+                                            || value.endsWith("$Lambda$0/0x0");
+                                }
+                            });
         }
         return lambdas + node.getChildren().stream().mapToInt(this::verifyRecursively).sum();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraphID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
@@ -41,10 +40,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link VertexFlameGraphFactory}. */
-public class VertexFlameGraphFactoryTest extends TestLogger {
+class VertexFlameGraphFactoryTest {
     /** Tests that lambda class names are cleaned up inside the stack traces. */
     @Test
-    public void testLambdaClassNamesCleanUp() {
+    void testLambdaClassNamesCleanUp() {
         Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samplesBySubtask = generateSamples();
 
         VertexThreadInfoStats sample = new VertexThreadInfoStats(0, 0, 0, samplesBySubtask);


### PR DESCRIPTION

## What is the purpose of the change
The problem of `VertexFlameGraphFactoryTest#testLambdaClassNamesCleanUp` is that it assumes that lambda's classnames end with `$Lambda$0` while in fact for jdk 11 and jdk 17 it ends with `$Lambda$0x0`.

That is the reason of build failure during nightly tests

The PR is aiming to fix that


## Brief change log

 -*org.apache.flink.runtime.webmonitor.threadinfo.VertexFlameGraphFactoryTest*


## Verifying this change

The change is a test itself

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
