### PR TITLE
[FLINK-32954][Metrics] Metrics expose number of heap timer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/InternalPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/InternalPriorityQueue.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Interface for collection that gives in order access to elements w.r.t their priority.
@@ -94,6 +95,16 @@ public interface InternalPriorityQueue<T> {
      */
     @Nonnegative
     int size();
+
+    /**
+     * Lightweight peek the number of elements in this set. Only heap priority queue support
+     * lightweight peek right now.
+     *
+     * @return the number of elements in this set if lightweight size peek is supported.
+     */
+    default Optional<Integer> peekSize() {
+        return Optional.empty();
+    }
 
     /** Adds all the given elements to the set. */
     void addAll(@Nullable Collection<? extends T> toAdd);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapPriorityQueue.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.apache.flink.util.CollectionUtil.MAX_ARRAY_SIZE;
 
@@ -87,6 +88,11 @@ public abstract class AbstractHeapPriorityQueue<T extends HeapPriorityQueueEleme
     @Override
     public int size() {
         return size;
+    }
+
+    @Override
+    public Optional<Integer> peekSize() {
+        return Optional.of(size);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/KeyGroupPartitionedPriorityQueue.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -153,6 +154,18 @@ public class KeyGroupPartitionedPriorityQueue<
             sizeSum += list.size();
         }
         return sizeSum;
+    }
+
+    @Override
+    public Optional<Integer> peekSize() {
+        int sizeSum = 0;
+        for (PQ list : keyGroupedHeaps) {
+            sizeSum += list.peekSize().orElse(-sizeSum - 1);
+            if (sizeSum < 0) {
+                break;
+            }
+        }
+        return sizeSum < 0 ? Optional.empty() : Optional.of(sizeSum);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
@@ -78,7 +79,8 @@ public interface InternalTimeServiceManager<K> {
                 KeyContext keyContext,
                 ProcessingTimeService processingTimeService,
                 Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-                StreamTaskCancellationContext cancellationContext)
+                StreamTaskCancellationContext cancellationContext,
+                MetricGroup metricGroup)
                 throws Exception;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.function.BiConsumerWithException;
 
+import java.util.Optional;
+
 /**
  * Interface for working with time and timers.
  *
@@ -69,4 +71,9 @@ public interface InternalTimerService<N> {
      */
     void forEachProcessingTimeTimer(BiConsumerWithException<N, Long, Exception> consumer)
             throws Exception;
+
+    /** Perform a lightweight peek at the summation of event-time and processing-time timers. */
+    default Optional<Integer> peekNumTimers() {
+        return Optional.empty();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -34,6 +34,7 @@ import org.apache.flink.util.function.BiConsumerWithException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 
@@ -262,6 +263,17 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
     public void forEachProcessingTimeTimer(BiConsumerWithException<N, Long, Exception> consumer)
             throws Exception {
         foreachTimer(consumer, processingTimeTimersQueue);
+    }
+
+    @Override
+    public Optional<Integer> peekNumTimers() {
+        int numEventTimeTimers = eventTimeTimersQueue.peekSize().orElse(-1);
+        int numProcessingTimeTimers = processingTimeTimersQueue.peekSize().orElse(-1);
+        if (numEventTimeTimers != -1 && numProcessingTimeTimers != -1) {
+            return Optional.of(numEventTimeTimers + numProcessingTimeTimers);
+        } else {
+            return Optional.empty();
+        }
     }
 
     private void foreachTimer(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -215,7 +215,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
                                 keyContext,
                                 processingTimeService,
                                 restoredRawKeyedStateTimers,
-                                cancellationContext);
+                                cancellationContext,
+                                environment.getMetricGroup());
             } else {
                 timeServiceManager = null;
             }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators.sorted.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -90,7 +91,8 @@ public class BatchExecutionInternalTimeServiceManager<K>
             KeyContext keyContext, // the operator
             ProcessingTimeService processingTimeService,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-            StreamTaskCancellationContext cancellationContext) {
+            StreamTaskCancellationContext cancellationContext,
+            MetricGroup metricGroup) {
         checkState(
                 keyedStatedBackend instanceof BatchExecutionKeyedStateBackend,
                 "Batch execution specific time service can work only with BatchExecutionKeyedStateBackend");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImplTest.java
@@ -18,10 +18,36 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /** Tests for {@link InternalTimeServiceManagerImpl}. */
 public class InternalTimeServiceManagerImplTest extends TestLogger {
@@ -38,5 +64,163 @@ public class InternalTimeServiceManagerImplTest extends TestLogger {
         Assert.assertEquals(
                 expectedTimerStatePrefix + "/event_",
                 InternalTimeServiceManagerImpl.EVENT_TIMER_PREFIX);
+    }
+
+    /** Tests the registration of the timer metrics. */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMetricsRegistration() throws Exception {
+        final ArrayList<String> addGroupNames = new ArrayList<>();
+        final ArrayList<String> registeredGaugeNames = new ArrayList<>();
+
+        MetricGroup metricGroup =
+                new UnregisteredMetricsGroup() {
+                    @Override
+                    public MetricGroup addGroup(String name) {
+                        addGroupNames.add(name);
+                        return new UnregisteredMetricsGroup() {
+                            @Override
+                            public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+                                if (gauge != null) {
+                                    registeredGaugeNames.add(name);
+                                }
+                                return gauge;
+                            }
+                        };
+                    }
+                };
+
+        // Assert timer metric group
+        InternalTimeServiceManager<Integer> timeServiceManager =
+                createInternalTimeServiceManager(
+                        IntSerializer.INSTANCE,
+                        1,
+                        new KeyGroupRange(0, 0),
+                        new TestProcessingTimeService(),
+                        metricGroup);
+        Assert.assertEquals(1, addGroupNames.size());
+        Assert.assertEquals(addGroupNames.get(0), "numberOfTimers");
+
+        // Assert time-service metric
+        timeServiceManager.getInternalTimerService(
+                "timer-service-1",
+                IntSerializer.INSTANCE,
+                IntSerializer.INSTANCE,
+                mock(Triggerable.class));
+        Assert.assertEquals(1, registeredGaugeNames.size());
+        Assert.assertEquals(registeredGaugeNames.get(0), "timer-service-1");
+
+        // Assert co-exist time-service metric
+        timeServiceManager.getInternalTimerService(
+                "timer-service-2",
+                IntSerializer.INSTANCE,
+                IntSerializer.INSTANCE,
+                mock(Triggerable.class));
+        Assert.assertEquals(2, registeredGaugeNames.size());
+        Assert.assertEquals(registeredGaugeNames.get(0), "timer-service-1");
+        Assert.assertEquals(registeredGaugeNames.get(1), "timer-service-2");
+    }
+
+    /** Tests that the metrics are updated properly. */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMetricsAreUpdated() throws Exception {
+        final Map<String, Gauge<?>> registeredGauges = new HashMap<>();
+        String timeServiceName = "time-service";
+        TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+
+        MetricGroup metricGroup =
+                new UnregisteredMetricsGroup() {
+                    @Override
+                    public MetricGroup addGroup(String name) {
+                        return new UnregisteredMetricsGroup() {
+                            @Override
+                            public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+                                registeredGauges.put(name, gauge);
+                                return gauge;
+                            }
+                        };
+                    }
+                };
+        InternalTimeServiceManager<Integer> timeServiceManager =
+                createInternalTimeServiceManager(
+                        IntSerializer.INSTANCE,
+                        1,
+                        new KeyGroupRange(0, 0),
+                        processingTimeService,
+                        metricGroup);
+        InternalTimerService<Integer> timeService =
+                timeServiceManager.getInternalTimerService(
+                        timeServiceName,
+                        IntSerializer.INSTANCE,
+                        IntSerializer.INSTANCE,
+                        mock(Triggerable.class));
+
+        // Make sure to adjust this test if metrics are added/removed
+        assertEquals(1, registeredGauges.size());
+
+        // Check initial values
+        Gauge<Integer> timeServiceNumTimer = (Gauge<Integer>) registeredGauges.get(timeServiceName);
+
+        assertEquals(Integer.valueOf(0), timeServiceNumTimer.getValue());
+
+        timeService.registerEventTimeTimer(1, 10);
+        timeService.registerProcessingTimeTimer(
+                1, processingTimeService.getCurrentProcessingTime() + 1);
+
+        // Check counts
+        assertEquals(Integer.valueOf(2), timeServiceNumTimer.getValue());
+
+        // Verify triggered event-time timer is not counted
+        timeServiceManager.advanceWatermark(new Watermark(100));
+        assertEquals(Integer.valueOf(1), timeServiceNumTimer.getValue());
+
+        // Verify triggered processing-time timer is not counted
+        processingTimeService.advance(processingTimeService.getCurrentProcessingTime() + 2);
+        assertEquals(Integer.valueOf(0), timeServiceNumTimer.getValue());
+    }
+
+    private static <K> InternalTimeServiceManager<K> createInternalTimeServiceManager(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            ProcessingTimeService processingTimeService,
+            MetricGroup metricGroup)
+            throws Exception {
+        StateBackend stateBackend = new MemoryStateBackend();
+        Environment env = new DummyEnvironment();
+        CheckpointableKeyedStateBackend<K> keyedStateBackend =
+                stateBackend.createKeyedStateBackend(
+                        env,
+                        new JobID(),
+                        "test_op",
+                        keySerializer,
+                        numberOfKeyGroups,
+                        keyGroupRange,
+                        env.getTaskKvStateRegistry(),
+                        TtlTimeProvider.DEFAULT,
+                        new UnregisteredMetricsGroup(),
+                        Collections.emptyList(),
+                        new CloseableRegistry());
+        KeyContext keyContext = new DummyKeyContext();
+
+        return InternalTimeServiceManagerImpl.create(
+                keyedStateBackend,
+                ClassLoader.getSystemClassLoader(),
+                keyContext,
+                processingTimeService,
+                Collections.emptyList(),
+                mock(StreamTaskCancellationContext.class),
+                metricGroup);
+    }
+
+    private static class DummyKeyContext implements KeyContext {
+        @Override
+        public void setCurrentKey(Object key) {}
+
+        @Override
+        public Object getCurrentKey() {
+            return 0;
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -193,7 +194,8 @@ public class StateInitializationContextImplTest {
                                     KeyContext keyContext,
                                     ProcessingTimeService processingTimeService,
                                     Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-                                    StreamTaskCancellationContext cancellationContext)
+                                    StreamTaskCancellationContext cancellationContext,
+                                    MetricGroup metricGroup)
                                     throws Exception {
                                 // We do not initialize a timer service manager here, because it
                                 // would already consume the raw keyed

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -319,7 +319,8 @@ public class StreamTaskStateInitializerImplTest {
                                 KeyContext keyContext,
                                 ProcessingTimeService processingTimeService,
                                 Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-                                StreamTaskCancellationContext cancellationContext)
+                                StreamTaskCancellationContext cancellationContext,
+                                MetricGroup metricGroup)
                                 throws Exception {
                             return null;
                         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -92,7 +92,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                 new DummyKeyContext(),
                 new TestProcessingTimeService(),
                 Collections.emptyList(),
-                StreamTaskCancellationContext.alwaysRunning());
+                StreamTaskCancellationContext.alwaysRunning(),
+                new UnregisteredMetricsGroup());
     }
 
     @Test
@@ -137,7 +138,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -173,7 +175,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -202,7 +205,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> eventTimeTrigger =
@@ -249,7 +253,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         processingTimeService,
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -284,7 +289,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         processingTimeService,
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =
@@ -324,7 +330,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         new DummyKeyContext(),
                         processingTimeService,
                         Collections.emptyList(),
-                        StreamTaskCancellationContext.alwaysRunning());
+                        StreamTaskCancellationContext.alwaysRunning(),
+                        new UnregisteredMetricsGroup());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorStateRepartitioner;
@@ -151,7 +152,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                         KeyContext keyContext,
                         ProcessingTimeService processingTimeService,
                         Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-                        StreamTaskCancellationContext cancellationContext)
+                        StreamTaskCancellationContext cancellationContext,
+                        MetricGroup metricGroup)
                         throws Exception {
                     InternalTimeServiceManagerImpl<K> typedTimeServiceManager =
                             InternalTimeServiceManagerImpl.create(
@@ -160,7 +162,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                                     keyContext,
                                     processingTimeService,
                                     rawKeyedStates,
-                                    cancellationContext);
+                                    cancellationContext,
+                                    metricGroup);
                     timeServiceManager = typedTimeServiceManager;
                     return typedTimeServiceManager;
                 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -238,7 +239,8 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
                             KeyContext keyContext,
                             ProcessingTimeService processingTimeService,
                             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
-                            StreamTaskCancellationContext cancellationContext)
+                            StreamTaskCancellationContext cancellationContext,
+                            MetricGroup metricGroup)
                             throws IOException {
                         return null;
                     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Expose the number of heap timers to metrics reporter.


## Brief change log

  - Introduce a new API `InternalPriorityQueue#peekSize`. The API attempts to get the size of a priority queue in a lightweight way. The API only works in *heap* priority queue (RocksDB is not supported).
  - Transfer task-level `MetricGroup` to `InternalTimeServiceManager`. `InternalTimeServiceManager` adds a metric group under the task-level `MetricGroup` with name **numberOfTimers**. 
  - The **numberOfTimers** metric group is organized per-`InternalTimeService`. When getting a `InternalTimerService`, register a gauge to **numberOfTimers** metric group with the `InternalTimerService`'s name. 


## Verifying this change

  - Add `InternalTimerServiceImplTest#testPeekNumTimer` to verify the function of `InternalPriorityQueuepeekSize()`.
  - Add `InternalTimeServiceManagerImplTest#testMetricsRegistration` to verify that the **numberOfTimers** metric group and per-`InternalTimeService` gauges are correctly registered.
  - Add `InternalTimeServiceManagerImplTest#testMetricsAreUpdated` to verify that the per-`InternalTimeService` gauges are correctly updated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

