### PR TITLE
[hotfix][network] Fix the notification of inaccurate data availability in Hybrid Shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriter.java
@@ -33,7 +33,7 @@ public interface NettyConnectionWriter {
      *
      * @param nettyPayload the payload send to netty connection.
      */
-    void writeBuffer(NettyPayload nettyPayload);
+    void writeNettyPayload(NettyPayload nettyPayload);
 
     /**
      * Get the id of connection in the writer.
@@ -46,11 +46,18 @@ public interface NettyConnectionWriter {
     void notifyAvailable();
 
     /**
-     * Get the number of written but unsent buffers.
+     * Get the number of written but unsent netty payloads.
      *
      * @return the buffer number.
      */
-    int numQueuedBuffers();
+    int numQueuedPayloads();
+
+    /**
+     * Get the number of written but unsent buffer netty payloads.
+     *
+     * @return the buffer number.
+     */
+    int numQueuedBufferPayloads();
 
     /**
      * If error is null, remove and recycle all buffers in the writer. If error is not null, the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterImpl.java
@@ -51,12 +51,17 @@ public class NettyConnectionWriterImpl implements NettyConnectionWriter {
     }
 
     @Override
-    public int numQueuedBuffers() {
+    public int numQueuedPayloads() {
         return nettyPayloadManager.getSize();
     }
 
     @Override
-    public void writeBuffer(NettyPayload nettyPayload) {
+    public int numQueuedBufferPayloads() {
+        return nettyPayloadManager.getBacklog();
+    }
+
+    @Override
+    public void writeNettyPayload(NettyPayload nettyPayload) {
         nettyPayloadManager.add(nettyPayload);
     }
 
@@ -67,7 +72,7 @@ public class NettyConnectionWriterImpl implements NettyConnectionWriter {
             nettyPayload.getBuffer().ifPresent(Buffer::recycleBuffer);
         }
         if (error != null) {
-            writeBuffer(NettyPayload.newError(error));
+            writeNettyPayload(NettyPayload.newError(error));
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TieredStorageResultSubpartitionView.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.END_OF_SEGMENT;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * The {@link TieredStorageResultSubpartitionView} is the implementation of {@link
@@ -187,9 +188,7 @@ public class TieredStorageResultSubpartitionView implements ResultSubpartitionVi
         if (nettyPayload == null) {
             return Optional.empty();
         } else {
-            if (nettyPayload.getSegmentId() != -1) {
-                return readNettyPayload(nettyPayloadManager);
-            }
+            checkState(nettyPayload.getSegmentId() == -1);
             Optional<Throwable> error = nettyPayload.getError();
             if (error.isPresent()) {
                 releaseAllResources();
@@ -246,6 +245,9 @@ public class TieredStorageResultSubpartitionView implements ResultSubpartitionVi
                 continue;
             }
             managerIndexContainsCurrentSegment = managerIndex;
+            NettyPayload segmentId =
+                    nettyPayloadManagers.get(managerIndexContainsCurrentSegment).poll();
+            checkState(segmentId.getSegmentId() != -1);
             return true;
         }
         return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskIOScheduler.java
@@ -355,7 +355,7 @@ public class DiskIOScheduler implements Runnable, BufferRecycler, NettyServicePr
                                 + " has already been failed.");
             }
             while (!buffers.isEmpty()
-                    && nettyConnectionWriter.numQueuedBuffers() < maxBufferReadAhead
+                    && nettyConnectionWriter.numQueuedBufferPayloads() < maxBufferReadAhead
                     && nextSegmentId >= 0) {
                 MemorySegment memorySegment = buffers.poll();
                 Buffer buffer;
@@ -404,8 +404,9 @@ public class DiskIOScheduler implements Runnable, BufferRecycler, NettyServicePr
         }
 
         private void writeToNettyConnectionWriter(NettyPayload nettyPayload) {
-            nettyConnectionWriter.writeBuffer(nettyPayload);
-            if (nettyConnectionWriter.numQueuedBuffers() <= 1) {
+            nettyConnectionWriter.writeNettyPayload(nettyPayload);
+            if (nettyConnectionWriter.numQueuedPayloads() <= 1
+                    || nettyConnectionWriter.numQueuedBufferPayloads() <= 1) {
                 notifyAvailable();
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierSubpartitionProducerAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierSubpartitionProducerAgent.java
@@ -66,7 +66,7 @@ class MemoryTierSubpartitionProducerAgent {
     int numQueuedBuffers() {
         return nettyConnectionWriter == null
                 ? 0
-                : checkNotNull(nettyConnectionWriter).numQueuedBuffers();
+                : checkNotNull(nettyConnectionWriter).numQueuedBufferPayloads();
     }
 
     void release() {
@@ -81,8 +81,9 @@ class MemoryTierSubpartitionProducerAgent {
 
     private void addFinishedBuffer(NettyPayload nettyPayload) {
         finishedBufferIndex++;
-        checkNotNull(nettyConnectionWriter).writeBuffer(nettyPayload);
-        if (checkNotNull(nettyConnectionWriter).numQueuedBuffers() <= 1) {
+        checkNotNull(nettyConnectionWriter).writeNettyPayload(nettyPayload);
+        if (checkNotNull(nettyConnectionWriter).numQueuedPayloads() <= 1
+                || checkNotNull(nettyConnectionWriter).numQueuedBufferPayloads() <= 1) {
             checkNotNull(nettyConnectionWriter).notifyAvailable();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/NettyConnectionWriterTest.java
@@ -40,7 +40,8 @@ public class NettyConnectionWriterTest {
                 new NettyConnectionWriterImpl(nettyPayloadManager, () -> {});
         writeBufferToWriter(bufferNumber, nettyConnectionWriter);
         assertThat(nettyPayloadManager.getBacklog()).isEqualTo(bufferNumber);
-        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(bufferNumber);
+        assertThat(nettyConnectionWriter.numQueuedPayloads()).isEqualTo(bufferNumber);
+        assertThat(nettyConnectionWriter.numQueuedBufferPayloads()).isEqualTo(bufferNumber);
     }
 
     @Test
@@ -70,16 +71,18 @@ public class NettyConnectionWriterTest {
                 new NettyConnectionWriterImpl(new NettyPayloadManager(), () -> {});
         writeBufferToWriter(bufferNumber, nettyConnectionWriter);
         nettyConnectionWriter.close(null);
-        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(0);
+        assertThat(nettyConnectionWriter.numQueuedPayloads()).isZero();
+        assertThat(nettyConnectionWriter.numQueuedBufferPayloads()).isZero();
         writeBufferToWriter(bufferNumber, nettyConnectionWriter);
         nettyConnectionWriter.close(new IOException());
-        assertThat(nettyConnectionWriter.numQueuedBuffers()).isEqualTo(1);
+        assertThat(nettyConnectionWriter.numQueuedPayloads()).isOne();
+        assertThat(nettyConnectionWriter.numQueuedBufferPayloads()).isZero();
     }
 
     private static void writeBufferToWriter(
             int bufferNumber, NettyConnectionWriter nettyConnectionWriter) {
         for (int index = 0; index < bufferNumber; ++index) {
-            nettyConnectionWriter.writeBuffer(
+            nettyConnectionWriter.writeNettyPayload(
                     NettyPayload.newBuffer(
                             BufferBuilderTestUtils.buildSomeBuffer(0), index, SUBPARTITION_ID));
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierProducerAgentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierProducerAgentTest.java
@@ -74,7 +74,7 @@ class MemoryTierProducerAgentTest {
                         new TieredStorageResourceRegistry())) {
             TestingNettyConnectionWriter connectionWriter =
                     new TestingNettyConnectionWriter.Builder()
-                            .setNumQueuedBuffersSupplier(() -> numQueuedBuffers)
+                            .setNumQueuedBufferPayloadsSupplier(() -> numQueuedBuffers)
                             .build();
             memoryTierProducerAgent.connectionEstablished(SUBPARTITION_ID, connectionWriter);
             assertThat(memoryTierProducerAgent.tryStartNewSegment(SUBPARTITION_ID, 0)).isTrue();
@@ -92,7 +92,7 @@ class MemoryTierProducerAgentTest {
                         new TieredStorageResourceRegistry())) {
             TestingNettyConnectionWriter connectionWriter =
                     new TestingNettyConnectionWriter.Builder()
-                            .setNumQueuedBuffersSupplier(() -> numQueuedBuffers)
+                            .setNumQueuedBufferPayloadsSupplier(() -> numQueuedBuffers)
                             .build();
             memoryTierProducerAgent.connectionEstablished(SUBPARTITION_ID, connectionWriter);
             assertThat(memoryTierProducerAgent.tryStartNewSegment(SUBPARTITION_ID, 0)).isFalse();


### PR DESCRIPTION
## What is the purpose of the change

*Fix the notification of inaccurate data availability in Hybrid Shuffle.*


## Brief change log

  - *Fix the notification of inaccurate data availability in Hybrid Shuffle.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
