### PR TITLE
[FLINK-32958][table-planner] Support view as source table of the LIKE clause in the CREATE TABLE statement

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
@@ -194,11 +195,13 @@ class SqlCreateTableConverter {
                                                         sqlTableLike
                                                                 .getSourceTable()
                                                                 .getParserPosition())));
-        if (!(lookupResult.getResolvedTable() instanceof CatalogTable)) {
-            throw new ValidationException(
-                    String.format(
-                            "Source table '%s' of the LIKE clause can not be a VIEW, at %s",
-                            identifier, sqlTableLike.getSourceTable().getParserPosition()));
+        if (lookupResult.getResolvedTable() instanceof CatalogView) {
+            CatalogView view = lookupResult.getResolvedTable();
+            return CatalogTable.of(
+                    view.getUnresolvedSchema(),
+                    view.getComment(),
+                    Collections.emptyList(),
+                    Collections.emptyMap());
         }
         return lookupResult.getResolvedTable();
     }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We can't create a table from a view through CREATE TABLE LIKE statement.
This pr is to resolve it.

case 1:
```sql
create view source_view as select id,val from source;
create table sink with ('connector' = 'print') like source_view (excluding all);
insert into sink select * from source_view;
```
case 2
```java
DataStreamSource<Entity> source = ...;
tEnv.createTemporaryView("source", source);
tEnv.executeSql("create table sink with ('connector' = 'print') like source (excluding all)");
tEnv.executeSql("insert into sink select * from source");
```
The above cases will throw an exception:
```
Source table '`default_catalog`.`default_database`.`source`' of the LIKE clause can not be a VIEW
```

## Brief change log

* Support view as source table of the LIKE clause in the CREATE TABLE statement

## Verifying this change

This change added tests and can be verified as follows:

* Added test that pass cases above

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
