### PR TITLE
[FLINK-32817] Harnessing Jackson for Secure Serialization of YarnLocalResourceDescriptor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/jackson/JacksonMapperFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/util/jackson/JacksonMapperFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.util.jackson;
 
 import org.apache.flink.annotation.Experimental;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
@@ -31,6 +32,12 @@ public final class JacksonMapperFactory {
 
     public static ObjectMapper createObjectMapper() {
         final ObjectMapper objectMapper = new ObjectMapper();
+        registerModules(objectMapper);
+        return objectMapper;
+    }
+
+    public static ObjectMapper createObjectMapper(JsonFactory jsonFactory) {
+        final ObjectMapper objectMapper = new ObjectMapper(jsonFactory);
         registerModules(objectMapper);
         return objectMapper;
     }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
@@ -19,16 +19,22 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -38,14 +44,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link Utils#createTaskExecutorContext}.
  */
 class YarnLocalResourceDescriptor {
+    private static final Logger LOG = LoggerFactory.getLogger(YarnLocalResourceDescriptor.class);
 
-    private static final String STRING_FORMAT =
-            "YarnLocalResourceDescriptor{"
-                    + "key=%s, path=%s, size=%d, modificationTime=%d, visibility=%s, type=%s}";
-    private static final Pattern LOCAL_RESOURCE_DESC_FORMAT =
-            Pattern.compile(
-                    "YarnLocalResourceDescriptor\\{"
-                            + "key=(\\S+), path=(\\S+), size=([\\d]+), modificationTime=([\\d]+), visibility=(\\S+), type=(\\S+)}");
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
     private final String resourceKey;
     private final Path path;
@@ -98,19 +99,31 @@ class YarnLocalResourceDescriptor {
     }
 
     static YarnLocalResourceDescriptor fromString(String desc) throws Exception {
-        Matcher m = LOCAL_RESOURCE_DESC_FORMAT.matcher(desc);
-        boolean mat = m.find();
-        if (mat) {
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(desc);
+            if (!validate(node)) {
+                throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc);
+            }
             return new YarnLocalResourceDescriptor(
-                    m.group(1),
-                    new Path(m.group(2)),
-                    Long.parseLong(m.group(3)),
-                    Long.parseLong(m.group(4)),
-                    LocalResourceVisibility.valueOf(m.group(5)),
-                    LocalResourceType.valueOf(m.group(6)));
-        } else {
-            throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc);
+                    node.get("resourceKey").asText(),
+                    new Path(node.get("path").asText()),
+                    node.get("size").asLong(),
+                    node.get("modificationTime").asLong(),
+                    LocalResourceVisibility.valueOf(node.get("visibility").asText()),
+                    LocalResourceType.valueOf(node.get("resourceType").asText()));
+        } catch (JsonProcessingException e) {
+            throw new FlinkException("Error to parse YarnLocalResourceDescriptor from " + desc, e);
         }
+    }
+
+    private static boolean validate(JsonNode node) {
+        return !node.isNull()
+                && node.hasNonNull("resourceKey")
+                && node.hasNonNull("path")
+                && node.hasNonNull("size")
+                && node.hasNonNull("modificationTime")
+                && node.hasNonNull("visibility")
+                && node.hasNonNull("resourceType");
     }
 
     static YarnLocalResourceDescriptor fromFileStatus(
@@ -132,14 +145,20 @@ class YarnLocalResourceDescriptor {
 
     @Override
     public String toString() {
-        return String.format(
-                STRING_FORMAT,
-                resourceKey,
-                path.toString(),
-                size,
-                modificationTime,
-                visibility,
-                resourceType);
+        try {
+            ObjectNode node = OBJECT_MAPPER.createObjectNode();
+            node.put("resourceKey", resourceKey);
+            node.put("path", path.toString());
+            node.put("size", size);
+            node.put("modificationTime", modificationTime);
+            node.put("visibility", visibility.toString());
+            node.put("resourceType", resourceType.toString());
+            return OBJECT_MAPPER.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not serialize YarnLocalResourceDescriptor to String.", e);
+            throw new RuntimeException(
+                    "Could not serialize YarnLocalResourceDescriptor[%s] to String.", e);
+        }
     }
 
     @Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnLocalResourceDescriptor.java
@@ -21,6 +21,8 @@ package org.apache.flink.yarn;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactoryBuilder;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,7 +48,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 class YarnLocalResourceDescriptor {
     private static final Logger LOG = LoggerFactory.getLogger(YarnLocalResourceDescriptor.class);
 
-    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER =
+            JacksonMapperFactory.createObjectMapper(
+                            new JsonFactoryBuilder().quoteChar('\'').build())
+                    .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
 
     private final String resourceKey;
     private final Path path;

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
@@ -31,8 +31,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for the {@link YarnLocalResourceDescriptor}. */
 class YarnLocalResourceDescriptionTest {
 
-    private final String key = "flink.jar";
-    private final Path path = new Path("hdfs://nn/tmp/flink.jar");
+    private final String key = "flink 2.jar";
+    private final Path path = new Path("hdfs://nn/tmp/flink 2.jar");
     private final long size = 100 * 1024 * 1024;
     private final long ts = System.currentTimeMillis();
 
@@ -62,8 +62,14 @@ class YarnLocalResourceDescriptionTest {
     void testFromStringMalformed() {
         final String desc =
                 String.format(
-                        "YarnLocalResourceDescriptor{key=%s path=%s size=%d modTime=%d visibility=%s}",
+                        "{\"resourceKey\":\"%s\",\"path\":\"%s\",\"size\":%s,\"modificationTime\":%s,\"visibility\":\"%s\"}",
                         key, path, size, ts, LocalResourceVisibility.PUBLIC);
+        assertThrows(desc);
+        assertThrows("{}");
+        assertThrows("{");
+    }
+
+    private void assertThrows(final String desc) {
         assertThatThrownBy(() -> YarnLocalResourceDescriptor.fromString(desc))
                 .isInstanceOf(FlinkException.class)
                 .hasMessageContaining("Error to parse YarnLocalResourceDescriptor from " + desc);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnLocalResourceDescriptionTest.java
@@ -31,8 +31,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for the {@link YarnLocalResourceDescriptor}. */
 class YarnLocalResourceDescriptionTest {
 
-    private final String key = "flink 2.jar";
-    private final Path path = new Path("hdfs://nn/tmp/flink 2.jar");
+    private final String key = "fli'nk 2.jar";
+    private final Path path = new Path("hdfs://nn/tmp/fli'nk 2.jar");
     private final long size = 100 * 1024 * 1024;
     private final long ts = System.currentTimeMillis();
 
@@ -62,7 +62,7 @@ class YarnLocalResourceDescriptionTest {
     void testFromStringMalformed() {
         final String desc =
                 String.format(
-                        "{\"resourceKey\":\"%s\",\"path\":\"%s\",\"size\":%s,\"modificationTime\":%s,\"visibility\":\"%s\"}",
+                        "{'resourceKey':'%s','path':'%s','size':%s,'modificationTime':%s,'visibility':'%s'}",
                         key, path, size, ts, LocalResourceVisibility.PUBLIC);
         assertThrows(desc);
         assertThrows("{}");


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If you try to submit a flink jar to a yarn cluster with a filename that contains spaces, the task won't be able to parse the file path in `YarnLocalResourceDescriptor`. This will result in warning logs being printed by TaskExecutor repeatedly. 
To avoid this issue, I plan to use Jackson for serializing and deserializing the `YarnLocalResourceDescriptor` instance, which will make the process safer.


## Brief change log

  - *Using the JscksonMapperFactory to create an ObjectMapper in the `YarnLocalResourceDescriptor`*
  - *To convert the `YarnLocalResourceDescriptor` into a JSON string, and utilize the ObjectMapper for serialization and deserialization.*
  - *Add some UTs*


## Verifying this change
This change added tests and can be verified as follows:

  - *Modified the `YarnLocalResourceDescriptionTest` about the file name containing a space*
  - *Added more malformed string tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: Yarn
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
