### PR TITLE
[FLINK-32965][flink-runtime] Removing the deprecated MutableObjectMode and restore related tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -287,19 +287,14 @@ public class TaskConfig implements Serializable {
             InstantiationUtil.writeObjectToConfig(wrapper, this.config, STUB_OBJECT);
         } catch (IOException e) {
             throw new CorruptConfigurationException(
-                    "Could not write the user code wrapper "
-                            + wrapper.getClass()
-                            + " : "
-                            + e.toString(),
-                    e);
+                    "Could not write the user code wrapper " + wrapper.getClass() + " : " + e, e);
         }
     }
 
     @SuppressWarnings("unchecked")
     public <T> UserCodeWrapper<T> getStubWrapper(ClassLoader cl) {
         try {
-            return (UserCodeWrapper<T>)
-                    InstantiationUtil.readObjectFromConfig(this.config, STUB_OBJECT, cl);
+            return InstantiationUtil.readObjectFromConfig(this.config, STUB_OBJECT, cl);
         } catch (ClassNotFoundException | IOException e) {
             throw new CorruptConfigurationException(
                     "Could not read the user code wrapper: " + e.getMessage(), e);
@@ -671,9 +666,8 @@ public class TaskConfig implements Serializable {
     public Partitioner<?> getOutputPartitioner(int outputNum, final ClassLoader cl)
             throws ClassNotFoundException {
         try {
-            return (Partitioner<?>)
-                    InstantiationUtil.readObjectFromConfig(
-                            config, OUTPUT_PARTITIONER + outputNum, cl);
+            return InstantiationUtil.readObjectFromConfig(
+                    config, OUTPUT_PARTITIONER + outputNum, cl);
         } catch (ClassNotFoundException e) {
             throw e;
         } catch (Throwable t) {
@@ -1035,14 +1029,13 @@ public class TaskConfig implements Serializable {
             return Collections.emptyList();
         }
 
-        List<AggregatorWithName<?>> list = new ArrayList<AggregatorWithName<?>>(numAggs);
+        List<AggregatorWithName<?>> list = new ArrayList<>(numAggs);
         for (int i = 0; i < numAggs; i++) {
             Aggregator<Value> aggObj;
             try {
                 aggObj =
-                        (Aggregator<Value>)
-                                InstantiationUtil.readObjectFromConfig(
-                                        this.config, ITERATION_AGGREGATOR_PREFIX + i, cl);
+                        InstantiationUtil.readObjectFromConfig(
+                                this.config, ITERATION_AGGREGATOR_PREFIX + i, cl);
             } catch (IOException e) {
                 throw new RuntimeException(
                         "Error while reading the aggregator object from the task configuration.");
@@ -1058,7 +1051,7 @@ public class TaskConfig implements Serializable {
             if (name == null) {
                 throw new RuntimeException("Missing config entry for aggregator.");
             }
-            list.add(new AggregatorWithName<Value>(name, aggObj));
+            list.add(new AggregatorWithName<>(name, aggObj));
         }
         return list;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/TaskConfig.java
@@ -74,8 +74,6 @@ public class TaskConfig implements Serializable {
 
     private static final String DRIVER_PAIR_COMPARATOR_FACTORY = "driver.paircomp";
 
-    private static final String DRIVER_MUTABLE_OBJECT_MODE = "diver.mutableobjects";
-
     // -------------------------------------- Inputs ----------------------------------------------
 
     private static final String NUM_INPUTS = "in.num";
@@ -364,14 +362,6 @@ public class TaskConfig implements Serializable {
         } else {
             return DriverStrategy.values()[ls];
         }
-    }
-
-    public void setMutableObjectMode(boolean mode) {
-        this.config.setBoolean(DRIVER_MUTABLE_OBJECT_MODE, mode);
-    }
-
-    public boolean getMutableObjectMode() {
-        return this.config.getBoolean(DRIVER_MUTABLE_OBJECT_MODE, false);
     }
 
     public void setDriverComparator(TypeComparatorFactory<?> factory, int inputNum) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/GroupReduceDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/GroupReduceDriverTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
 @SuppressWarnings("serial")
@@ -226,6 +227,7 @@ class GroupReduceDriverTest {
             context.setComparator1(comparator);
             context.setCollector(result);
             context.setUdf(new ConcatSumMutableAccumulatingReducer());
+            context.getExecutionConfig().enableObjectReuse();
 
             GroupReduceDriver<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>> driver =
                     new GroupReduceDriver<
@@ -237,12 +239,9 @@ class GroupReduceDriverTest {
             Object[] res = result.getList().toArray();
             Object[] expected = DriverTestData.createReduceMutableDataGroupedResult().toArray();
 
-            try {
-                DriverTestData.compareTupleArrays(expected, res);
-                fail("Accumulationg mutable objects is expected to result in incorrect values.");
-            } catch (AssertionError e) {
-                // expected
-            }
+            assertThatExceptionOfType(AssertionError.class)
+                    .as("Accumulationg mutable objects is expected to result in incorrect values.")
+                    .isThrownBy(() -> DriverTestData.compareTupleArrays(expected, res));
         } catch (Exception e) {
             System.err.println(e.getMessage());
             e.printStackTrace();
@@ -284,7 +283,7 @@ class GroupReduceDriverTest {
             context.setComparator1(comparator);
             context.setCollector(result);
             context.setUdf(new ConcatSumMutableAccumulatingReducer());
-            context.setMutableObjectMode(false);
+            context.getExecutionConfig().disableObjectReuse();
 
             GroupReduceDriver<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>> driver =
                     new GroupReduceDriver<

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/GroupReduceDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/GroupReduceDriverTest.java
@@ -52,11 +52,7 @@ class GroupReduceDriverTest {
             TestTaskContext<
                             GroupReduceFunction<Tuple2<String, Integer>, Tuple2<String, Integer>>,
                             Tuple2<String, Integer>>
-                    context =
-                            new TestTaskContext<
-                                    GroupReduceFunction<
-                                            Tuple2<String, Integer>, Tuple2<String, Integer>>,
-                                    Tuple2<String, Integer>>();
+                    context = new TestTaskContext<>();
 
             List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
             TupleTypeInfo<Tuple2<String, Integer>> typeInfo =
@@ -69,15 +65,14 @@ class GroupReduceDriverTest {
             context.setDriverStrategy(DriverStrategy.SORTED_GROUP_REDUCE);
 
             GatheringCollector<Tuple2<String, Integer>> result =
-                    new GatheringCollector<Tuple2<String, Integer>>(
-                            typeInfo.createSerializer(new ExecutionConfig()));
+                    new GatheringCollector<>(typeInfo.createSerializer(new ExecutionConfig()));
 
             context.setInput1(input, typeInfo.createSerializer(new ExecutionConfig()));
             context.setComparator1(comparator);
             context.setCollector(result);
 
             GroupReduceDriver<Tuple2<String, Integer>, Tuple2<String, Integer>> driver =
-                    new GroupReduceDriver<Tuple2<String, Integer>, Tuple2<String, Integer>>();
+                    new GroupReduceDriver<>();
             driver.setup(context);
             driver.prepare();
             driver.run();
@@ -96,26 +91,21 @@ class GroupReduceDriverTest {
             TestTaskContext<
                             GroupReduceFunction<Tuple2<String, Integer>, Tuple2<String, Integer>>,
                             Tuple2<String, Integer>>
-                    context =
-                            new TestTaskContext<
-                                    GroupReduceFunction<
-                                            Tuple2<String, Integer>, Tuple2<String, Integer>>,
-                                    Tuple2<String, Integer>>();
+                    context = new TestTaskContext<>();
 
             List<Tuple2<String, Integer>> data = DriverTestData.createReduceImmutableData();
             TupleTypeInfo<Tuple2<String, Integer>> typeInfo =
                     (TupleTypeInfo<Tuple2<String, Integer>>)
                             TypeExtractor.getForObject(data.get(0));
             MutableObjectIterator<Tuple2<String, Integer>> input =
-                    new RegularToMutableObjectIterator<Tuple2<String, Integer>>(
+                    new RegularToMutableObjectIterator<>(
                             data.iterator(), typeInfo.createSerializer(new ExecutionConfig()));
             TypeComparator<Tuple2<String, Integer>> comparator =
                     typeInfo.createComparator(
                             new int[] {0}, new boolean[] {true}, 0, new ExecutionConfig());
 
             GatheringCollector<Tuple2<String, Integer>> result =
-                    new GatheringCollector<Tuple2<String, Integer>>(
-                            typeInfo.createSerializer(new ExecutionConfig()));
+                    new GatheringCollector<>(typeInfo.createSerializer(new ExecutionConfig()));
 
             context.setDriverStrategy(DriverStrategy.SORTED_GROUP_REDUCE);
             context.setInput1(input, typeInfo.createSerializer(new ExecutionConfig()));
@@ -124,7 +114,7 @@ class GroupReduceDriverTest {
             context.setUdf(new ConcatSumReducer());
 
             GroupReduceDriver<Tuple2<String, Integer>, Tuple2<String, Integer>> driver =
-                    new GroupReduceDriver<Tuple2<String, Integer>, Tuple2<String, Integer>>();
+                    new GroupReduceDriver<>();
             driver.setup(context);
             driver.prepare();
             driver.run();
@@ -147,27 +137,21 @@ class GroupReduceDriverTest {
                             GroupReduceFunction<
                                     Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>,
                             Tuple2<StringValue, IntValue>>
-                    context =
-                            new TestTaskContext<
-                                    GroupReduceFunction<
-                                            Tuple2<StringValue, IntValue>,
-                                            Tuple2<StringValue, IntValue>>,
-                                    Tuple2<StringValue, IntValue>>();
+                    context = new TestTaskContext<>();
 
             List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
             TupleTypeInfo<Tuple2<StringValue, IntValue>> typeInfo =
                     (TupleTypeInfo<Tuple2<StringValue, IntValue>>)
                             TypeExtractor.getForObject(data.get(0));
             MutableObjectIterator<Tuple2<StringValue, IntValue>> input =
-                    new RegularToMutableObjectIterator<Tuple2<StringValue, IntValue>>(
+                    new RegularToMutableObjectIterator<>(
                             data.iterator(), typeInfo.createSerializer(new ExecutionConfig()));
             TypeComparator<Tuple2<StringValue, IntValue>> comparator =
                     typeInfo.createComparator(
                             new int[] {0}, new boolean[] {true}, 0, new ExecutionConfig());
 
             GatheringCollector<Tuple2<StringValue, IntValue>> result =
-                    new GatheringCollector<Tuple2<StringValue, IntValue>>(
-                            typeInfo.createSerializer(new ExecutionConfig()));
+                    new GatheringCollector<>(typeInfo.createSerializer(new ExecutionConfig()));
 
             context.setDriverStrategy(DriverStrategy.SORTED_GROUP_REDUCE);
             context.setInput1(input, typeInfo.createSerializer(new ExecutionConfig()));
@@ -176,8 +160,7 @@ class GroupReduceDriverTest {
             context.setUdf(new ConcatSumMutableReducer());
 
             GroupReduceDriver<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>> driver =
-                    new GroupReduceDriver<
-                            Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>();
+                    new GroupReduceDriver<>();
             driver.setup(context);
             driver.prepare();
             driver.run();
@@ -200,27 +183,21 @@ class GroupReduceDriverTest {
                             GroupReduceFunction<
                                     Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>,
                             Tuple2<StringValue, IntValue>>
-                    context =
-                            new TestTaskContext<
-                                    GroupReduceFunction<
-                                            Tuple2<StringValue, IntValue>,
-                                            Tuple2<StringValue, IntValue>>,
-                                    Tuple2<StringValue, IntValue>>();
+                    context = new TestTaskContext<>();
 
             List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
             TupleTypeInfo<Tuple2<StringValue, IntValue>> typeInfo =
                     (TupleTypeInfo<Tuple2<StringValue, IntValue>>)
                             TypeExtractor.getForObject(data.get(0));
             MutableObjectIterator<Tuple2<StringValue, IntValue>> input =
-                    new RegularToMutableObjectIterator<Tuple2<StringValue, IntValue>>(
+                    new RegularToMutableObjectIterator<>(
                             data.iterator(), typeInfo.createSerializer(new ExecutionConfig()));
             TypeComparator<Tuple2<StringValue, IntValue>> comparator =
                     typeInfo.createComparator(
                             new int[] {0}, new boolean[] {true}, 0, new ExecutionConfig());
 
             GatheringCollector<Tuple2<StringValue, IntValue>> result =
-                    new GatheringCollector<Tuple2<StringValue, IntValue>>(
-                            typeInfo.createSerializer(new ExecutionConfig()));
+                    new GatheringCollector<>(typeInfo.createSerializer(new ExecutionConfig()));
 
             context.setDriverStrategy(DriverStrategy.SORTED_GROUP_REDUCE);
             context.setInput1(input, typeInfo.createSerializer(new ExecutionConfig()));
@@ -230,8 +207,7 @@ class GroupReduceDriverTest {
             context.getExecutionConfig().enableObjectReuse();
 
             GroupReduceDriver<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>> driver =
-                    new GroupReduceDriver<
-                            Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>();
+                    new GroupReduceDriver<>();
             driver.setup(context);
             driver.prepare();
             driver.run();
@@ -256,27 +232,21 @@ class GroupReduceDriverTest {
                             GroupReduceFunction<
                                     Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>,
                             Tuple2<StringValue, IntValue>>
-                    context =
-                            new TestTaskContext<
-                                    GroupReduceFunction<
-                                            Tuple2<StringValue, IntValue>,
-                                            Tuple2<StringValue, IntValue>>,
-                                    Tuple2<StringValue, IntValue>>();
+                    context = new TestTaskContext<>();
 
             List<Tuple2<StringValue, IntValue>> data = DriverTestData.createReduceMutableData();
             TupleTypeInfo<Tuple2<StringValue, IntValue>> typeInfo =
                     (TupleTypeInfo<Tuple2<StringValue, IntValue>>)
                             TypeExtractor.getForObject(data.get(0));
             MutableObjectIterator<Tuple2<StringValue, IntValue>> input =
-                    new RegularToMutableObjectIterator<Tuple2<StringValue, IntValue>>(
+                    new RegularToMutableObjectIterator<>(
                             data.iterator(), typeInfo.createSerializer(new ExecutionConfig()));
             TypeComparator<Tuple2<StringValue, IntValue>> comparator =
                     typeInfo.createComparator(
                             new int[] {0}, new boolean[] {true}, 0, new ExecutionConfig());
 
             GatheringCollector<Tuple2<StringValue, IntValue>> result =
-                    new GatheringCollector<Tuple2<StringValue, IntValue>>(
-                            typeInfo.createSerializer(new ExecutionConfig()));
+                    new GatheringCollector<>(typeInfo.createSerializer(new ExecutionConfig()));
 
             context.setDriverStrategy(DriverStrategy.SORTED_GROUP_REDUCE);
             context.setInput1(input, typeInfo.createSerializer(new ExecutionConfig()));
@@ -286,8 +256,7 @@ class GroupReduceDriverTest {
             context.getExecutionConfig().disableObjectReuse();
 
             GroupReduceDriver<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>> driver =
-                    new GroupReduceDriver<
-                            Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>();
+                    new GroupReduceDriver<>();
             driver.setup(context);
             driver.prepare();
             driver.run();
@@ -313,7 +282,7 @@ class GroupReduceDriverTest {
         @Override
         public void reduce(
                 Iterable<Tuple2<String, Integer>> values, Collector<Tuple2<String, Integer>> out) {
-            Tuple2<String, Integer> current = new Tuple2<String, Integer>("", 0);
+            Tuple2<String, Integer> current = new Tuple2<>("", 0);
 
             for (Tuple2<String, Integer> next : values) {
                 next.f0 = current.f0 + next.f0;
@@ -334,7 +303,7 @@ class GroupReduceDriverTest {
                 Iterable<Tuple2<StringValue, IntValue>> values,
                 Collector<Tuple2<StringValue, IntValue>> out) {
             Tuple2<StringValue, IntValue> current =
-                    new Tuple2<StringValue, IntValue>(new StringValue(""), new IntValue(0));
+                    new Tuple2<>(new StringValue(""), new IntValue(0));
 
             for (Tuple2<StringValue, IntValue> next : values) {
                 next.f0.append(current.f0);
@@ -355,8 +324,7 @@ class GroupReduceDriverTest {
                 Iterable<Tuple2<StringValue, IntValue>> values,
                 Collector<Tuple2<StringValue, IntValue>> out)
                 throws Exception {
-            List<Tuple2<StringValue, IntValue>> all =
-                    new ArrayList<Tuple2<StringValue, IntValue>>();
+            List<Tuple2<StringValue, IntValue>> all = new ArrayList<>();
 
             for (Tuple2<StringValue, IntValue> t : values) {
                 all.add(t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
@@ -63,7 +63,7 @@ public class TestTaskContext<S, T> implements TaskContext<S, T> {
 
     private MemoryManager memoryManager;
 
-    private ExecutionConfig executionConfig = new ExecutionConfig();
+    private final ExecutionConfig executionConfig = new ExecutionConfig();
 
     private TaskManagerRuntimeInfo taskManageInfo;
 
@@ -96,7 +96,7 @@ public class TestTaskContext<S, T> implements TaskContext<S, T> {
     public <X> void setInput1(MutableObjectIterator<X> input, TypeSerializer<X> serializer) {
         this.input1 = input;
         this.serializer1 =
-                new RuntimeSerializerFactory<X>(
+                new RuntimeSerializerFactory<>(
                         serializer, (Class<X>) serializer.createInstance().getClass());
     }
 
@@ -104,7 +104,7 @@ public class TestTaskContext<S, T> implements TaskContext<S, T> {
     public <X> void setInput2(MutableObjectIterator<X> input, TypeSerializer<X> serializer) {
         this.input2 = input;
         this.serializer2 =
-                new RuntimeSerializerFactory<X>(
+                new RuntimeSerializerFactory<>(
                         serializer, (Class<X>) serializer.createInstance().getClass());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/drivers/TestTaskContext.java
@@ -132,10 +132,6 @@ public class TestTaskContext<S, T> implements TaskContext<S, T> {
         this.config.setDriverStrategy(strategy);
     }
 
-    public void setMutableObjectMode(boolean mutableObjectMode) {
-        this.config.setMutableObjectMode(mutableObjectMode);
-    }
-
     // --------------------------------------------------------------------------------------------
     //  Context Methods
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-1285](https://issues.apache.org/jira/browse/FLINK-1285) updated the MutableObjectMode to ObjectReuse. The TaskConfig#getMutableObjectMode() is not used for a long long time, and it's internal class, so it can be removed directly.

Also, we should update the GroupReduceDriverTest:

- Updating the testAllReduceDriverAccumulatingImmutable() from `context.setMutableObjectMode(false);` to `context.getExecutionConfig().disableObjectReuse();`.
- Updating the testAllReduceDriverIncorrectlyAccumulatingMutable() to `context.getExecutionConfig().disableObjectReuse();`, and fix the assert.

 
More details can be get from https://github.com/apache/flink/pull/23233#discussion_r1304595960


## Brief change log

- [FLINK-32965][flink-runtime] Removing the deprecated MutableObjectMode and restore related tests
- [FLINK-32965][flink-runtime][hotfix] Refactor some code with code style warning


## Verifying this change

Improve the old tests:

- GroupReduceDriverTest#testAllReduceDriverIncorrectlyAccumulatingMutable
- GroupReduceDriverTest#testAllReduceDriverAccumulatingImmutable

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
