### PR TITLE
[FLINK-32971][PYTHON] Add pyflink proper development version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,8 @@ flink-python/dev/.conda/
 flink-python/dev/log/
 flink-python/dev/.stage.txt
 flink-python/.eggs/
-flink-python/apache-flink-*.dev0/
-flink-python/apache-flink-libraries/apache_flink_libraries-*.dev0/
+flink-python/apache-flink-*.dev*/
+flink-python/apache-flink-libraries/apache_flink_libraries-*.dev*/
 flink-python/**/*.c
 flink-python/.idea/
 flink-python/**/*.so

--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -21,6 +21,7 @@ import glob
 import io
 import os
 import platform
+import re
 import subprocess
 import sys
 from shutil import copytree, copy, rmtree
@@ -97,7 +98,7 @@ try:
             print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
                   file=sys.stderr)
             sys.exit(-1)
-        flink_version = VERSION.replace(".dev0", "-SNAPSHOT")
+        flink_version = re.sub("[.]dev.*", "-SNAPSHOT", VERSION)
         FLINK_HOME = os.path.abspath(
             "../../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
 

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import io
 import os
 import platform
+import re
 import sys
 from distutils.command.build_ext import build_ext
 from shutil import copytree, copy, rmtree
@@ -206,7 +207,7 @@ try:
             print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
                   file=sys.stderr)
             sys.exit(-1)
-        flink_version = VERSION.replace(".dev0", "-SNAPSHOT")
+        flink_version = re.sub("[.]dev.*", "-SNAPSHOT", VERSION)
         FLINK_HOME = os.path.abspath(
             "../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
         FLINK_ROOT = os.path.abspath("..")
@@ -252,7 +253,7 @@ try:
                   "is complete, or do this in the flink-python directory of the flink source "
                   "directory.")
             sys.exit(-1)
-    if VERSION.find('dev0') != -1:
+    if re.search('dev.*$', VERSION) is not None:
         apache_flink_libraries_dependency = 'apache-flink-libraries==%s' % VERSION
     else:
         split_versions = VERSION.split('.')


### PR DESCRIPTION
## What is the purpose of the change

The following doc describes the python version specification: https://peps.python.org/pep-0440/#developmental-releases

Extract:
```
Developmental releases are also permitted for pre-releases and post-releases:

X.YaN.devM       # Developmental release of an alpha release
X.YbN.devM       # Developmental release of a beta release
X.YrcN.devM      # Developmental release of a release candidate
X.Y.postN.devM   # Developmental release of a post-release
```

At the moment pyflink supports only `.dev0` development version. In this PR I've added `.devM` support.

## Brief change log

Added `.devM` support.

## Verifying this change

Manually:
```
# Change version to: __version__ = "1.19.dev1"

cd flink

conda env remove -n venv
conda create -y -n venv python=3.10
conda activate venv
pip3 install -r flink-python/dev/dev-requirements.txt

cd flink-python
python3 setup.py sdist bdist_wheel

cd apache-flink-libraries
python3 setup.py sdist
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
