### PR TITLE
[FLINK-32975][state] Enhance equal() for all MapState's iterator

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -35,6 +35,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Delegated partitioned {@link MapState} that forwards changes to {@link StateChange} upon {@link
@@ -82,6 +83,16 @@ class ChangelogMapState<K, N, UK, UV>
                     ExceptionUtils.rethrow(e);
                 }
                 return oldValue;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (!(o instanceof Map.Entry)) {
+                    return false;
+                }
+                Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+                return Objects.equals(entry.getKey(), e.getKey())
+                        && Objects.equals(entry.getValue(), e.getValue());
             }
         };
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.Test;
 
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -110,6 +111,25 @@ public class ChangelogMapStateTest {
                 singletonMap("x", "y"),
                 ChangelogMapState::clear,
                 logger -> assertTrue(logger.stateCleared));
+    }
+
+    @Test
+    public void testMapEntryEqual() throws Exception {
+        Map.Entry<String, String> expectedEntry = new AbstractMap.SimpleEntry<>("key", "value");
+        Map<String, String> data =
+                new HashMap<String, String>() {
+                    {
+                        put(expectedEntry.getKey(), expectedEntry.getValue());
+                    }
+                };
+        TestChangeLoggerKv logger = TestChangeLoggerKv.forMap(data);
+        ChangelogMapState state1 = createState(data, logger);
+        ChangelogMapState state2 = createState(data, logger);
+
+        assertEquals(expectedEntry, state1.entries().iterator().next());
+        assertEquals(expectedEntry, state2.entries().iterator().next());
+
+        assertEquals(state1.entries().iterator().next(), state2.entries().iterator().next());
     }
 
     private <T> void testIterator(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.Test;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -111,25 +110,6 @@ public class ChangelogMapStateTest {
                 singletonMap("x", "y"),
                 ChangelogMapState::clear,
                 logger -> assertTrue(logger.stateCleared));
-    }
-
-    @Test
-    public void testMapEntryEqual() throws Exception {
-        Map.Entry<String, String> expectedEntry = new AbstractMap.SimpleEntry<>("key", "value");
-        Map<String, String> data =
-                new HashMap<String, String>() {
-                    {
-                        put(expectedEntry.getKey(), expectedEntry.getValue());
-                    }
-                };
-        TestChangeLoggerKv logger = TestChangeLoggerKv.forMap(data);
-        ChangelogMapState state1 = createState(data, logger);
-        ChangelogMapState state2 = createState(data, logger);
-
-        assertEquals(expectedEntry, state1.entries().iterator().next());
-        assertEquals(expectedEntry, state2.entries().iterator().next());
-
-        assertEquals(state1.entries().iterator().next(), state2.entries().iterator().next());
     }
 
     private <T> void testIterator(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -536,6 +537,15 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             }
 
             return oldValue;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+            return Objects.equals(getKey(), e.getKey()) && Objects.equals(getValue(), e.getValue());
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The assertThat() in junit5 uses Object#equals to compare two Map.Entry. The unnamed class Map.Entry<UK, UV> in ChangelogMapState uses the default Object#equals(), which does not compares the contents of two entries.


## Brief change log

  - *Add a basic equal() implementation for the Map.Entry<UK, UV> in ChangelogMapState.*

## Verification
  
  - Existing test `ChangelogMapStateTest#testEntriesIterator` has covered the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

