### PR TITLE
[FLINK-32981][PYTHON] Add python dynamic Flink home detection

### DIFF
--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -99,8 +99,12 @@ try:
                   file=sys.stderr)
             sys.exit(-1)
         flink_version = re.sub("[.]dev.*", "-SNAPSHOT", VERSION)
-        FLINK_HOME = os.path.abspath(
-            "../../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
+        flink_homes = glob.glob('../../flink-dist/target/flink-*-bin/flink-*')
+        if len(flink_homes) != 1:
+            print("Exactly one Flink home directory must exist, but found: {0}".format(flink_homes),
+                  file=sys.stderr)
+            sys.exit(-1)
+        FLINK_HOME = os.path.abspath(flink_homes[0])
 
         incorrect_invocation_message = """
 If you are installing pyflink from flink source, you must first build Flink and

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -17,6 +17,7 @@
 ################################################################################
 from __future__ import print_function
 
+import glob
 import io
 import os
 import platform
@@ -208,8 +209,12 @@ try:
                   file=sys.stderr)
             sys.exit(-1)
         flink_version = re.sub("[.]dev.*", "-SNAPSHOT", VERSION)
-        FLINK_HOME = os.path.abspath(
-            "../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
+        flink_homes = glob.glob('../flink-dist/target/flink-*-bin/flink-*')
+        if len(flink_homes) != 1:
+            print("Exactly one Flink home directory must exist, but found: {0}".format(flink_homes),
+                  file=sys.stderr)
+            sys.exit(-1)
+        FLINK_HOME = os.path.abspath(flink_homes[0])
         FLINK_ROOT = os.path.abspath("..")
         FLINK_DIST = os.path.join(FLINK_ROOT, "flink-dist")
         FLINK_BIN = os.path.join(FLINK_DIST, "src/main/flink-bin")


### PR DESCRIPTION
## What is the purpose of the change

During `pyflink` library compilation Flink home is calculated from the provided `pyflink` version which is normally something like: `1.19.dev0`.  Such case `.dev0` is replaced to `-SNAPSHOT` which ends-up in hardcoded home directory: `../../flink-dist/target/flink-1.19-SNAPSHOT-bin/flink-1.19-SNAPSHOT`. This is fine as long as one uses the basic version types described [here](https://peps.python.org/pep-0440/#developmental-releases). In order to support any kind of `pyflink` version one can dynamically find out the Flink home directory through globbing. In this PR I've added this dynamic Flink home detection.

## Brief change log

Dynamic Flink home detection through globbing.

## Verifying this change

Manually:
```
# Change pyflink version to: 1.19.post0.dev0
# OR
# Change Flink version to: 1.19-foo-SNAPSHOT

cd flink

mvn clean install -DskipTests

conda env remove -n venv
conda create -y -n venv python=3.10
conda activate venv
pip3 install -r flink-python/dev/dev-requirements.txt

cd flink-python
python3 setup.py sdist bdist_wheel

cd apache-flink-libraries
python3 setup.py sdist
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
