### PR TITLE
[FLINK-32824] Port Calcite's fix for the sql like operator.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/SqlLikeUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/SqlLikeUtils.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  * <p>Note: THIS IS COPIED FROM CALCITE to EXPOSE SOME PRIVATE METHOD
  */
 public class SqlLikeUtils {
-    private static final String JAVA_REGEX_SPECIALS = "[]()|^-+*?{}$\\";
+    private static final String JAVA_REGEX_SPECIALS = "[]()|^-+*?{}$\\.";
     private static final String SQL_SIMILAR_SPECIALS = "[]()|^-+*_%?{}";
     private static final String[] REG_CHAR_CLASSES = {
         "[:ALPHA:]", "\\p{Alpha}",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkSqlLikeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkSqlLikeUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.calcite;
+
+import org.apache.flink.table.functions.SqlLikeUtils;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for the SqlLikeUtils. */
+public class FlinkSqlLikeUtilsTest {
+    @Test
+    public void testSqlLike() {
+        assertThat(SqlLikeUtils.like("abc", "a.c", "\\")).isEqualTo(false);
+        assertThat(SqlLikeUtils.like("a.c", "a.c", "\\")).isEqualTo(true);
+        assertThat(SqlLikeUtils.like("abcd", "a.*d", "\\")).isEqualTo(false);
+        assertThat(SqlLikeUtils.like("abcde", "%c.e", "\\")).isEqualTo(false);
+
+        assertThat(SqlLikeUtils.similar("abc", "a.c", "\\")).isEqualTo(true);
+        assertThat(SqlLikeUtils.similar("a.c", "a.c", "\\")).isEqualTo(true);
+        assertThat(SqlLikeUtils.similar("abcd", "a.*d", "\\")).isEqualTo(true);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2859,6 +2859,36 @@ class TableEnvironmentTest {
     checkData(expectedResult.iterator(), tableResult.collect())
   }
 
+  @Test
+  def testShowColumnsWithLike(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE TestTb1 (
+        |  abc bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+    """.stripMargin
+    tableEnv.executeSql(createTableStmt)
+
+    var sql = "SHOW COLUMNS from TestTb1 LIKE 'abc'"
+    var tableResult = tableEnv.executeSql(sql)
+
+    val expectedResult = util.Arrays.asList(
+      Row.of("abc", "BIGINT", Boolean.box(true), null, null, null)
+    )
+
+    checkData(expectedResult.iterator(), tableResult.collect())
+
+    sql = "SHOW COLUMNS from TestTb1 LIKE 'a.c'"
+    tableResult = tableEnv.executeSql(sql)
+
+    checkData(Collections.emptyList().iterator(), tableResult.collect());
+  }
+
   private def checkData(expected: util.Iterator[Row], actual: util.Iterator[Row]): Unit = {
     while (expected.hasNext && actual.hasNext) {
       assertEquals(expected.next(), actual.next())


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request aims to port Calcite's fix for the sql like operator and relates to FLINK-32824.


## Brief change log

 Modified the JAVA_REGEX_SPECIALS in SqlLikeUtils class.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *testSqlLike in ParserImplTest for validatation.*
  - *testShowColumnsWithLike in TableEnvironmentTest in table layer for validation.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
