### PR TITLE
[FLINK-32749][gateway] Support config default catalog for catalog store in gateway

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -22,6 +22,9 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.catalog.CatalogDescriptor;
+import org.apache.flink.table.catalog.CatalogStore;
+import org.apache.flink.table.catalog.FileCatalogStore;
 import org.apache.flink.table.catalog.listener.CatalogFactory1;
 import org.apache.flink.table.catalog.listener.CatalogFactory2;
 import org.apache.flink.table.catalog.listener.CatalogListener1;
@@ -35,7 +38,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +50,9 @@ import static org.apache.flink.configuration.PipelineOptions.MAX_PARALLELISM;
 import static org.apache.flink.configuration.PipelineOptions.NAME;
 import static org.apache.flink.configuration.PipelineOptions.OBJECT_REUSE;
 import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_CATALOG_MODIFICATION_LISTENERS;
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_CATALOG_NAME;
 import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_SQL_DIALECT;
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test {@link SessionContext}. */
@@ -200,12 +207,41 @@ class SessionContextTest {
                                 CatalogListener2.class.getName()));
     }
 
+    @Test
+    void testCreateDefaultCatalogFromStore(@TempDir Path catalogFilePath) {
+        CatalogStore catalogStore = new FileCatalogStore(catalogFilePath.toString());
+        catalogStore.open();
+        catalogStore.storeCatalog(
+                "cat1",
+                CatalogDescriptor.of(
+                        "cat1",
+                        Configuration.fromMap(
+                                Collections.singletonMap("type", "generic_in_memory"))));
+        catalogStore.storeCatalog(
+                "cat2",
+                CatalogDescriptor.of(
+                        "cat2",
+                        Configuration.fromMap(
+                                Collections.singletonMap("type", "generic_in_memory"))));
+        catalogStore.close();
+
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.set(TABLE_CATALOG_STORE_KIND, "file");
+        flinkConfig.setString("table.catalog-store.file.path", catalogFilePath.toString());
+        SessionContext context1 = createSessionContext(flinkConfig);
+        assertThat(context1.getSessionState().catalogManager.getCurrentCatalog())
+                .isEqualTo("default_catalog");
+        context1.close();
+
+        flinkConfig.set(TABLE_CATALOG_NAME, "cat1");
+        SessionContext context2 = createSessionContext(flinkConfig);
+        assertThat(context2.getSessionState().catalogManager.getCurrentCatalog()).isEqualTo("cat1");
+        context2.close();
+    }
+
     // --------------------------------------------------------------------------------------------
 
-    private SessionContext createSessionContext() {
-        Configuration flinkConfig = new Configuration();
-        flinkConfig.set(OBJECT_REUSE, true);
-        flinkConfig.set(MAX_PARALLELISM, 16);
+    private SessionContext createSessionContext(Configuration flinkConfig) {
         DefaultContext defaultContext = new DefaultContext(flinkConfig, Collections.emptyList());
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
@@ -214,5 +250,12 @@ class SessionContextTest {
                         .build();
         return SessionContext.create(
                 defaultContext, SessionHandle.create(), environment, EXECUTOR_SERVICE);
+    }
+
+    private SessionContext createSessionContext() {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.set(OBJECT_REUSE, true);
+        flinkConfig.set(MAX_PARALLELISM, 16);
+        return createSessionContext(flinkConfig);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -201,18 +201,15 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             checkNotNull(classLoader, "Class loader cannot be null");
             checkNotNull(config, "Config cannot be null");
             checkNotNull(catalogStoreHolder, "CatalogStoreHolder cannot be null");
-            catalogStoreHolder.open();
-            CatalogManager catalogManager =
-                    new CatalogManager(
-                            defaultCatalogName,
-                            defaultCatalog,
-                            dataTypeFactory != null
-                                    ? dataTypeFactory
-                                    : new DataTypeFactoryImpl(classLoader, config, executionConfig),
-                            new ManagedTableListener(classLoader, config),
-                            catalogModificationListeners,
-                            catalogStoreHolder);
-            return catalogManager;
+            return new CatalogManager(
+                    defaultCatalogName,
+                    defaultCatalog,
+                    dataTypeFactory != null
+                            ? dataTypeFactory
+                            : new DataTypeFactoryImpl(classLoader, config, executionConfig),
+                    new ManagedTableListener(classLoader, config),
+                    catalogModificationListeners,
+                    catalogStoreHolder);
         }
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogStoreHolder.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogStoreHolder.java
@@ -101,7 +101,10 @@ public class CatalogStoreHolder implements AutoCloseable {
             checkNotNull(catalogStore, "CatalogStore cannot be null");
             checkNotNull(config, "Config cannot be null");
             checkNotNull(classLoader, "Class loader cannot be null");
-            return new CatalogStoreHolder(catalogStore, factory, config, classLoader);
+            CatalogStoreHolder catalogStoreHolder =
+                    new CatalogStoreHolder(catalogStore, factory, config, classLoader);
+            catalogStoreHolder.open();
+            return catalogStoreHolder;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to support default catalog which is loaded by catalog store in sql-gateway

## Brief change log
  - Get default catalog from catalog store if it exists in sql-gateway
  - If there's no default catalog in catalog store, create default memory catalog for sql-gateway

## Verifying this change

This change added tests and can be verified as follows:

  - Added SessionContextTest.testCreateDefaultCatalogFromStore for default catalog loaded by catalog store

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
