### PR TITLE
[FLINK-32994][runtime] Adds human-readable toString implementations to the LeaderElectionDriver classes

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -263,4 +263,9 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
                             throwable));
         }
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s{configMapName='%s'}", getClass().getSimpleName(), configMapName);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -273,4 +273,18 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
             }
         };
     }
+
+    @Test
+    void testToStringContainingConfigMap() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () ->
+                                assertThat(leaderElectionDriver.toString())
+                                        .as(
+                                                "toString() should contain the ConfigMap name for a human-readable representation of the driver instance.")
+                                        .contains(LEADER_CONFIGMAP_NAME));
+            }
+        };
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -48,6 +48,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     private final LeaderElectionDriver.Listener leaderElectionListener;
 
+    private final String leaderLatchPath;
     private final LeaderLatch leaderLatch;
 
     private final TreeCache treeCache;
@@ -63,6 +64,8 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
         this.curatorFramework = Preconditions.checkNotNull(curatorFramework);
         this.leaderElectionListener = Preconditions.checkNotNull(leaderElectionListener);
 
+        this.leaderLatchPath =
+                ZooKeeperUtils.generateLeaderLatchPath(curatorFramework.getNamespace());
         this.leaderLatch = new LeaderLatch(curatorFramework, ZooKeeperUtils.getLeaderLatchPath());
         this.treeCache =
                 ZooKeeperUtils.createTreeCache(
@@ -269,6 +272,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     @Override
     public String toString() {
-        return "ZooKeeperLeaderElectionDriver";
+        return String.format(
+                "%s{leaderLatchPath='%s'}", getClass().getSimpleName(), leaderLatchPath);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
@@ -163,6 +163,24 @@ class ZooKeeperLeaderElectionDriverTest {
     }
 
     @Test
+    void testToStringContainingLeaderLatchPath() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () ->
+                                assertThat(leaderElectionDriver.toString())
+                                        .as(
+                                                "toString() should contain the leader latch path for human-readable representation of the driver instance.")
+                                        .contains(
+                                                ZooKeeperUtils.generateLeaderLatchPath(
+                                                        curatorFramework
+                                                                .asCuratorFramework()
+                                                                .getNamespace())));
+            }
+        };
+    }
+
+    @Test
     void testNonLeaderCannotPublishLeaderInformation() throws Exception {
         new Context() {
             {


### PR DESCRIPTION
## What is the purpose of the change

FLINK-26522 replaced `LeaderElectionDriver` by `MultipleComponentLeaderElectionDriver`. The legacy classes had a proper (human-readable) `toString` implementation. The `MultipleComponentLeaderElectionDriver` didn't have that which is causing odd log messages. This PR brings the human-readable `toString` implementations back.

## Brief change log

* Adds `toString` implementation to `KubernetesLeaderElectionDriver` and `ZooKeeperLeaderElectionDriver`

## Verifying this change

* Adds tests for the `toString` implementations

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable