### PR TITLE
[FLINK-32989][python] Fix version parsing issue

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -17,7 +17,6 @@
 ################################################################################
 from __future__ import print_function
 
-import glob
 import io
 import os
 import platform
@@ -27,6 +26,7 @@ from distutils.command.build_ext import build_ext
 from shutil import copytree, copy, rmtree
 
 from setuptools import setup, Extension
+from xml.etree import ElementTree as ET
 
 if sys.version_info < (3, 7):
     print("Python versions prior to 3.7 are not supported for PyFlink.",
@@ -208,13 +208,18 @@ try:
             print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
                   file=sys.stderr)
             sys.exit(-1)
-        flink_version = re.sub("[.]dev.*", "-SNAPSHOT", VERSION)
-        flink_homes = glob.glob('../flink-dist/target/flink-*-bin/flink-*')
-        if len(flink_homes) != 1:
-            print("Exactly one Flink home directory must exist, but found: {0}".format(flink_homes),
-                  file=sys.stderr)
+        namespace = "http://maven.apache.org/POM/4.0.0"
+        flink_version = ET.parse("../pom.xml").getroot().find(
+            'POM:version',
+            namespaces={
+                'POM': 'http://maven.apache.org/POM/4.0.0'
+            }).text
+        if not flink_version:
+            print("Not able to get flink version", file=sys.stderr)
             sys.exit(-1)
-        FLINK_HOME = os.path.abspath(flink_homes[0])
+        print("Detected flink version: {0}".format(flink_version))
+        FLINK_HOME = os.path.abspath(
+            "../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
         FLINK_ROOT = os.path.abspath("..")
         FLINK_DIST = os.path.join(FLINK_ROOT, "flink-dist")
         FLINK_BIN = os.path.join(FLINK_DIST, "src/main/flink-bin")


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/flink/pull/23306 introduced a blocker issue because the underneath directories to detect Flink home are not always exist. In this PR I've added better way to find out Flink version and home. Namely the version comes from the root `pom.xml` file which is an existing pattern in the code base.

## Brief change log

The version comes from the root `pom.xml` file which is an existing pattern in the code base.

## Verifying this change

Manually.

Test to cover the original feature:
```
# Change pyflink version to: 1.19.post0.dev0
# OR
# Change Flink version to: 1.19-foo-SNAPSHOT

cd flink

mvn clean install -DskipTests

conda env remove -n venv
conda create -y -n venv python=3.10
conda activate venv
pip3 install -r flink-python/dev/dev-requirements.txt

cd flink-python
python3 setup.py sdist bdist_wheel

cd apache-flink-libraries
python3 setup.py sdist
```

Test which covers the broken feature:
```
cd flink/flink-python
dev/build-wheels.sh
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
