### PR TITLE
[BP-1.18][FLINK-32994][runtime] Adds proper toString() implementations to the LeaderElectionDriver implementations to have human-readable versions of the driver in log messages

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -263,4 +263,9 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
                             throwable));
         }
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s{configMapName='%s'}", getClass().getSimpleName(), configMapName);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -273,4 +273,18 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
             }
         };
     }
+
+    @Test
+    void testToStringContainingConfigMap() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () ->
+                                assertThat(leaderElectionDriver.toString())
+                                        .as(
+                                                "toString() should contain the ConfigMap name for a human-readable representation of the driver instance.")
+                                        .contains(LEADER_CONFIGMAP_NAME));
+            }
+        };
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -48,6 +48,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     private final LeaderElectionDriver.Listener leaderElectionListener;
 
+    private final String leaderLatchPath;
     private final LeaderLatch leaderLatch;
 
     private final TreeCache treeCache;
@@ -63,6 +64,8 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
         this.curatorFramework = Preconditions.checkNotNull(curatorFramework);
         this.leaderElectionListener = Preconditions.checkNotNull(leaderElectionListener);
 
+        this.leaderLatchPath =
+                ZooKeeperUtils.generateLeaderLatchPath(curatorFramework.getNamespace());
         this.leaderLatch = new LeaderLatch(curatorFramework, ZooKeeperUtils.getLeaderLatchPath());
         this.treeCache =
                 ZooKeeperUtils.createTreeCache(
@@ -269,6 +272,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     @Override
     public String toString() {
-        return "ZooKeeperLeaderElectionDriver";
+        return String.format(
+                "%s{leaderLatchPath='%s'}", getClass().getSimpleName(), leaderLatchPath);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverTest.java
@@ -163,6 +163,24 @@ class ZooKeeperLeaderElectionDriverTest {
     }
 
     @Test
+    void testToStringContainingLeaderLatchPath() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () ->
+                                assertThat(leaderElectionDriver.toString())
+                                        .as(
+                                                "toString() should contain the leader latch path for human-readable representation of the driver instance.")
+                                        .contains(
+                                                ZooKeeperUtils.generateLeaderLatchPath(
+                                                        curatorFramework
+                                                                .asCuratorFramework()
+                                                                .getNamespace())));
+            }
+        };
+    }
+
+    @Test
     void testNonLeaderCannotPublishLeaderInformation() throws Exception {
         new Context() {
             {


### PR DESCRIPTION
1.18 backport for parent PR #23327