### PR TITLE
[FLINK-30217] Replace ListState#clear along with following #add/addAll with a ListState#update

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -685,10 +685,7 @@ public class BufferingSink
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        checkpointedState.clear();
-        for (Tuple2<String, Integer> element : bufferedElements) {
-            checkpointedState.add(element);
-        }
+        checkpointedState.update(bufferedElements);
     }
 
     @Override
@@ -731,10 +728,7 @@ class BufferingSink(threshold: Int = 0)
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    checkpointedState.clear()
-    for (element <- bufferedElements) {
-      checkpointedState.add(element)
-    }
+    checkpointedState.update(bufferedElements.asJava)
   }
 
   override def initializeState(context: FunctionInitializationContext): Unit = {
@@ -851,8 +845,7 @@ public static class CounterSource
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        state.clear();
-        state.add(offset);
+        state.update(Collections.singletonList(offset));
     }
 }
 ```
@@ -894,8 +887,7 @@ class CounterSource
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    state.clear()
-    state.add(offset)
+    state.update(java.util.Collections.singletonList(offset))
   }
 }
 ```

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -789,10 +789,7 @@ public class BufferingSink
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        checkpointedState.clear();
-        for (Tuple2<String, Integer> element : bufferedElements) {
-            checkpointedState.add(element);
-        }
+        checkpointedState.update(bufferedElements);
     }
 
     @Override
@@ -835,10 +832,7 @@ class BufferingSink(threshold: Int = 0)
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    checkpointedState.clear()
-    for (element <- bufferedElements) {
-      checkpointedState.add(element)
-    }
+    checkpointedState.update(bufferedElements.asJava)
   }
 
   override def initializeState(context: FunctionInitializationContext): Unit = {
@@ -966,8 +960,7 @@ public static class CounterSource
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        state.clear();
-        state.add(offset);
+        state.update(Collections.singletonList(offset));
     }
 }
 ```
@@ -1009,8 +1002,7 @@ class CounterSource
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    state.clear()
-    state.add(offset)
+    state.update(java.util.Collections.singletonList(offset))
   }
 }
 ```

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitTrigger.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitTrigger.java
@@ -30,6 +30,7 @@ import org.apache.flink.connector.file.table.stream.PartitionCommitPredicate.Pre
 import org.apache.flink.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -144,12 +145,11 @@ public class PartitionTimeCommitTrigger implements PartitionCommitTrigger {
 
     @Override
     public void snapshotState(long checkpointId, long watermark) throws Exception {
-        pendingPartitionsState.clear();
-        pendingPartitionsState.add(new ArrayList<>(pendingPartitions));
+        pendingPartitionsState.update(
+                Collections.singletonList(new ArrayList<>(pendingPartitions)));
 
         watermarks.put(checkpointId, watermark);
-        watermarksState.clear();
-        watermarksState.add(new HashMap<>(watermarks));
+        watermarksState.update(Collections.singletonList(new HashMap<>(watermarks)));
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/ProcTimeCommitTrigger.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/ProcTimeCommitTrigger.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -120,8 +121,7 @@ public class ProcTimeCommitTrigger implements PartitionCommitTrigger {
 
     @Override
     public void snapshotState(long checkpointId, long watermark) throws Exception {
-        pendingPartitionsState.clear();
-        pendingPartitionsState.add(new HashMap<>(pendingPartitions));
+        pendingPartitionsState.update(Collections.singletonList(new HashMap<>(pendingPartitions)));
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinator.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -197,9 +198,8 @@ public class CompactCoordinator extends AbstractStreamOperator<CoordinatorOutput
     public void snapshotState(StateSnapshotContext context) throws Exception {
         super.snapshotState(context);
 
-        inputFilesState.clear();
         inputFiles.put(context.getCheckpointId(), new HashMap<>(currentInputFiles));
-        inputFilesState.add(inputFiles);
+        inputFilesState.update(Collections.singletonList(inputFiles));
         currentInputFiles.clear();
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactOperator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactOperator.java
@@ -45,6 +45,7 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -168,9 +169,8 @@ public class CompactOperator<T> extends AbstractStreamOperator<PartitionCommitIn
     }
 
     private void snapshotState(long checkpointId) throws Exception {
-        expiredFilesState.clear();
         expiredFiles.put(checkpointId, new ArrayList<>(currentExpiredFiles));
-        expiredFilesState.add(expiredFiles);
+        expiredFilesState.update(Collections.singletonList(expiredFiles));
         currentExpiredFiles.clear();
     }
 

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -37,6 +37,8 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 
+import java.util.Collections;
+
 /**
  * This is a periodic streaming job that runs for CLI testing purposes.
  *
@@ -137,8 +139,7 @@ public class PeriodicStreamingJob {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.add(ms);
+            state.update(Collections.singletonList(ms));
         }
     }
 }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SequenceGeneratorSource.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -192,8 +193,7 @@ public class SequenceGeneratorSource extends RichParallelSourceFunction<Event>
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         snapshotKeyRanges.update(keyRanges);
 
-        lastEventTimes.clear();
-        lastEventTimes.add(monotonousEventTime);
+        lastEventTimes.update(Collections.singletonList(monotonousEventTime));
     }
 
     @Override

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/ArtificalOperatorStateMapper.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/artificialstate/ArtificalOperatorStateMapper.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -176,8 +177,7 @@ public class ArtificalOperatorStateMapper<IN, OUT> extends RichMapFunction<IN, O
         }
 
         // each subtask only stores its own subtask index as a subset of the union set
-        unionElementsState.clear();
-        unionElementsState.add(thisSubtaskIndex);
+        unionElementsState.update(Collections.singletonList(thisSubtaskIndex));
     }
 
     private String getBroadcastStateEntryValue(int thisSubtaskIndex) {

--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 import java.io.PrintStream;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -189,8 +190,7 @@ public enum FileSinkProgram {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.add(numRecordsEmitted);
+            state.update(Collections.singletonList(numRecordsEmitted));
         }
     }
 }

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/src/main/java/org/apache/flink/streaming/tests/StickyAllocationAndLocalRecoveryTestJob.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -199,8 +200,7 @@ public class StickyAllocationAndLocalRecoveryTestJob {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            sourceCurrentKeyState.clear();
-            sourceCurrentKeyState.add(currentKey);
+            sourceCurrentKeyState.update(Collections.singletonList(currentKey));
         }
 
         @Override
@@ -366,8 +366,8 @@ public class StickyAllocationAndLocalRecoveryTestJob {
                             taskNameWithSubtasks,
                             allocationID);
 
-            schedulingAndFailureState.clear();
-            schedulingAndFailureState.add(currentSchedulingAndFailureInfo);
+            schedulingAndFailureState.update(
+                    Collections.singletonList(currentSchedulingAndFailureInfo));
         }
 
         @Override

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -314,8 +314,7 @@ public class StreamSQLTestProgram {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.add(ms);
+            state.update(Collections.singletonList(ms));
         }
     }
 
@@ -367,8 +366,7 @@ public class StreamSQLTestProgram {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.add(saveRecordCnt);
+            state.update(Collections.singletonList(saveRecordCnt));
         }
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -245,9 +246,9 @@ class KubernetesHighAvailabilityRecoverFromSavepointITCase {
                 running = false;
             }
 
-            stateFromSavepoint.clear();
             // mark this subtask as executed before
-            stateFromSavepoint.add(getRuntimeContext().getIndexOfThisSubtask());
+            stateFromSavepoint.update(
+                    Collections.singletonList(getRuntimeContext().getIndexOfThisSubtask()));
         }
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/DataSetSavepointReaderITTestBase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/DataSetSavepointReaderITTestBase.java
@@ -294,13 +294,9 @@ public abstract class DataSetSavepointReaderITTestBase extends AbstractTestBase 
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            listState.clear();
+            listState.update(elements);
 
-            listState.addAll(elements);
-
-            unionState.clear();
-
-            unionState.addAll(elements);
+            unionState.update(elements);
         }
 
         @Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderITTestBase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderITTestBase.java
@@ -295,7 +295,7 @@ public abstract class SavepointReaderITTestBase extends AbstractTestBase {
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
             listState.update(elements);
 
-            unionState.addAll(elements);
+            unionState.update(elements);
         }
 
         @Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderITTestBase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderITTestBase.java
@@ -293,11 +293,7 @@ public abstract class SavepointReaderITTestBase extends AbstractTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            listState.clear();
-
-            listState.addAll(elements);
-
-            unionState.clear();
+            listState.update(elements);
 
             unionState.addAll(elements);
         }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -357,8 +357,7 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.addAll(numbers);
+            state.update(numbers);
         }
 
         @Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -332,8 +332,7 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.addAll(numbers);
+            state.update(numbers);
         }
 
         @Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/WritableSavepointITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/WritableSavepointITCase.java
@@ -329,8 +329,7 @@ public class WritableSavepointITCase extends AbstractTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.addAll(numbers);
+            state.update(numbers);
         }
 
         @Override
@@ -355,8 +354,7 @@ public class WritableSavepointITCase extends AbstractTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            state.clear();
-            state.addAll(numbers);
+            state.update(numbers);
         }
 
         @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
@@ -54,6 +54,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 
 /**
@@ -183,10 +184,7 @@ public class ArrowSourceFunction extends RichParallelSourceFunction<RowData>
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " state has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        for (Tuple2<Integer, Integer> v : indexesToEmit) {
-            this.checkpointedState.add(v);
-        }
+        this.checkpointedState.update(new ArrayList<>(indexesToEmit));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -45,6 +45,7 @@ import java.time.Clock;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -350,12 +351,12 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT> extends RichS
         }
         LOG.debug("{} - started new transaction '{}'", name(), currentTransactionHolder);
 
-        state.clear();
-        state.add(
-                new State<>(
-                        this.currentTransactionHolder,
-                        new ArrayList<>(pendingCommitTransactions.values()),
-                        userContext));
+        state.update(
+                Collections.singletonList(
+                        new State<>(
+                                this.currentTransactionHolder,
+                                new ArrayList<>(pendingCommitTransactions.values()),
+                                userContext)));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -256,10 +257,9 @@ public class Buckets<IN, BucketID> {
                 maxPartCounter);
 
         bucketStatesContainer.clear();
-        partCounterStateContainer.clear();
 
         snapshotActiveBuckets(checkpointId, bucketStatesContainer);
-        partCounterStateContainer.add(maxPartCounter);
+        partCounterStateContainer.update(Collections.singletonList(maxPartCounter));
     }
 
     private void snapshotActiveBuckets(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -412,8 +412,7 @@ public class ContinuousFileMonitoringFunction<OUT>
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " state has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        this.checkpointedState.add(this.globalModificationTime);
+        this.checkpointedState.update(Collections.singletonList(this.globalModificationTime));
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("{} checkpointed {}.", getClass().getSimpleName(), globalModificationTime);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -527,14 +527,10 @@ public class ContinuousFileReaderOperator<OUT, T extends TimestampedInputSplit>
 
         int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
 
-        checkpointedState.clear();
-
         List<T> readerState = getReaderState();
 
         try {
-            for (T split : readerState) {
-                checkpointedState.add(split);
-            }
+            checkpointedState.update(readerState);
         } catch (Exception e) {
             checkpointedState.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -44,6 +44,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -271,8 +272,7 @@ public class FromElementsFunction<T>
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        this.checkpointedState.add(this.numElementsEmitted);
+        this.checkpointedState.update(Collections.singletonList(this.numElementsEmitted));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MessageAcknowledgingSourceBase.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -242,9 +243,9 @@ public abstract class MessageAcknowledgingSourceBase<Type, UId> extends RichSour
                 new Tuple2<>(context.getCheckpointId(), idsForCurrentCheckpoint));
         idsForCurrentCheckpoint = CollectionUtil.newHashSetWithExpectedSize(64);
 
-        this.checkpointedState.clear();
-        this.checkpointedState.add(
-                SerializedCheckpointData.fromDeque(pendingCheckpoints, idSerializer));
+        this.checkpointedState.update(
+                Collections.singletonList(
+                        SerializedCheckpointData.fromDeque(pendingCheckpoints, idSerializer)));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 
 /**
@@ -130,10 +131,7 @@ public class StatefulSequenceSource extends RichParallelSourceFunction<Long>
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " state has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        for (Long v : this.valuesToEmit) {
-            this.checkpointedState.add(v);
-        }
+        this.checkpointedState.update(new ArrayList<>(valuesToEmit));
     }
 
     private static int safeDivide(long left, long right) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 
 /**
@@ -100,10 +101,7 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " state has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        for (Long v : this.valuesToEmit) {
-            this.checkpointedState.add(v);
-        }
+        this.checkpointedState.update(new ArrayList<>(this.valuesToEmit));
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -293,10 +293,9 @@ public class AsyncWaitOperator<IN, OUT>
                 getOperatorStateBackend()
                         .getListState(
                                 new ListStateDescriptor<>(STATE_NAME, inStreamElementSerializer));
-        partitionableState.clear();
 
         try {
-            partitionableState.addAll(queue.values());
+            partitionableState.update(queue.values());
         } catch (Exception e) {
             partitionableState.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -216,11 +216,9 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         bufferLock.lock();
         try {
-            bufferState.clear();
-            bufferState.addAll(buffer);
+            bufferState.update(buffer);
 
-            offsetState.clear();
-            offsetState.add(offset);
+            offsetState.update(Collections.singletonList(offset));
 
             uncompletedCheckpointMap.put(context.getCheckpointId(), offset);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -179,13 +180,9 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 
         saveHandleInState(context.getCheckpointId(), context.getCheckpointTimestamp());
 
-        this.checkpointedState.clear();
-
         try {
-            for (PendingCheckpoint pendingCheckpoint : pendingCheckpoints) {
-                // create a new partition for each entry.
-                this.checkpointedState.add(pendingCheckpoint);
-            }
+            // create a new partition for each entry.
+            this.checkpointedState.update(new ArrayList<>(pendingCheckpoints));
         } catch (Exception e) {
             checkpointedState.clear();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -43,6 +43,7 @@ import org.apache.flink.shaded.guava31.com.google.common.collect.FluentIterable;
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -407,10 +408,10 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
         // work around to fix FLINK-4369, remove the evicted elements from the windowState.
         // this is inefficient, but there is no other way to remove elements from ListState, which
         // is an AppendingState.
-        windowState.clear();
-        for (TimestampedValue<IN> record : recordsWithTimestamp) {
-            windowState.add(record.getStreamRecord());
-        }
+        windowState.update(
+                recordsWithTimestamp.stream()
+                        .map(TimestampedValue::getStreamRecord)
+                        .collect(Collectors.toList()));
     }
 
     private void clearAllState(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Utility for keeping track of merging {@link Window Windows} when using a {@link
@@ -97,10 +98,10 @@ public class MergingWindowSet<W extends Window> {
      */
     public void persist() throws Exception {
         if (!mapping.equals(initialMapping)) {
-            state.clear();
-            for (Map.Entry<W, W> window : mapping.entrySet()) {
-                state.add(new Tuple2<>(window.getKey(), window.getValue()));
-            }
+            state.update(
+                    mapping.entrySet().stream()
+                            .map((w) -> new Tuple2<>(w.getKey(), w.getValue()))
+                            .collect(Collectors.toList()));
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/functions/StreamingFunctionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/functions/StreamingFunctionUtils.java
@@ -139,13 +139,9 @@ public final class StreamingFunctionUtils {
                             new JavaSerializer<>());
             ListState<Serializable> listState = backend.getListState(listStateDescriptor);
 
-            listState.clear();
-
             if (null != partitionableState) {
                 try {
-                    for (Serializable statePartition : partitionableState) {
-                        listState.add(statePartition);
-                    }
+                    listState.update(partitionableState);
                 } catch (Exception e) {
                     listState.clear();
 
@@ -153,6 +149,8 @@ public final class StreamingFunctionUtils {
                             "Could not write partitionable state to operator " + "state backend.",
                             e);
                 }
+            } else {
+                listState.clear();
             }
 
             return true;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -460,10 +461,18 @@ public class MergingWindowSetTest {
 
         windowSet.persist();
 
-        verify(mockState).add(eq(new Tuple2<>(new TimeWindow(1, 2), new TimeWindow(1, 2))));
-        verify(mockState).add(eq(new Tuple2<>(new TimeWindow(17, 42), new TimeWindow(17, 42))));
+        verify(mockState)
+                .update(
+                        eq(
+                                new ArrayList<>(
+                                        Arrays.asList(
+                                                new Tuple2<>(
+                                                        new TimeWindow(1, 2), new TimeWindow(1, 2)),
+                                                new Tuple2<>(
+                                                        new TimeWindow(17, 42),
+                                                        new TimeWindow(17, 42))))));
 
-        verify(mockState, times(2)).add(Matchers.<Tuple2<TimeWindow, TimeWindow>>anyObject());
+        verify(mockState, times(1)).update(Matchers.anyObject());
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -312,9 +312,8 @@ final class TestValuesRuntimeFunctions {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            rawResultState.clear();
             synchronized (LOCK) {
-                rawResultState.addAll(localRawResult);
+                rawResultState.update(localRawResult);
             }
         }
     }
@@ -512,9 +511,8 @@ final class TestValuesRuntimeFunctions {
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
             super.snapshotState(context);
-            retractResultState.clear();
             synchronized (LOCK) {
-                retractResultState.addAll(localRetractResult);
+                retractResultState.update(localRetractResult);
             }
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/FailingCollectionSource.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/FailingCollectionSource.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -230,8 +231,7 @@ public class FailingCollectionSource<T>
                 this.checkpointedState != null,
                 "The " + getClass().getSimpleName() + " has not been properly initialized.");
 
-        this.checkpointedState.clear();
-        this.checkpointedState.add(this.numElementsEmitted);
+        this.checkpointedState.update(Collections.singletonList(this.numElementsEmitted));
         long checkpointId = context.getCheckpointId();
         checkpointedEmittedNums.put(checkpointId, numElementsEmitted);
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -105,10 +105,7 @@ abstract class AbstractExactlyOnceSink[T] extends RichSinkFunction[T] with Check
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    resultsState.clear()
-    for (value <- localResults) {
-      resultsState.add(value)
-    }
+    resultsState.update(localResults.asJava)
   }
 
   protected def clearAndStashGlobalResults(): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TimeTestUtil.scala
@@ -69,8 +69,7 @@ object TimeTestUtil {
 
     override def snapshotState(context: StateSnapshotContext): Unit = {
       super.snapshotState(context)
-      watermarkState.clear()
-      watermarkState.add(currentWatermark)
+      watermarkState.update(java.util.Collections.singletonList(currentWatermark))
     }
 
     override def initializeState(context: StateInitializationContext): Unit = {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
@@ -123,14 +123,12 @@ public class StreamSortOperator extends TableStreamOperator<RowData>
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
         super.snapshotState(context);
-        // clear state first
-        bufferState.clear();
 
         List<Tuple2<RowData, Long>> dataToFlush = new ArrayList<>(inputBuffer.size());
         inputBuffer.forEach((key, value) -> dataToFlush.add(Tuple2.of(key, value)));
 
         // batch put
-        bufferState.addAll(dataToFlush);
+        bufferState.update(dataToFlush);
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
@@ -127,7 +127,7 @@ public class StreamSortOperator extends TableStreamOperator<RowData>
         List<Tuple2<RowData, Long>> dataToFlush = new ArrayList<>(inputBuffer.size());
         inputBuffer.forEach((key, value) -> dataToFlush.add(Tuple2.of(key, value)));
 
-        // batch put
+        // batch update
         bufferState.update(dataToFlush);
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
@@ -46,6 +46,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
 
+import java.util.Collections;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -203,8 +205,7 @@ public final class SlicingWindowOperator<K, W> extends TableStreamOperator<RowDa
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
         super.snapshotState(context);
-        this.watermarkState.clear();
-        this.watermarkState.add(currentWatermark);
+        this.watermarkState.update(Collections.singletonList(currentWatermark));
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -68,6 +68,7 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -147,8 +148,7 @@ public class CheckpointFailureManagerITCase extends TestLogger {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            listState.clear();
-            listState.add(emitted);
+            listState.update(Collections.singletonList(emitted));
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -285,15 +285,13 @@ public class RegionFailoverITCase extends TestLogger {
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
             int indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
             if (indexOfThisSubtask != 0) {
-                listState.clear();
-                listState.add(index);
+                listState.update(Collections.singletonList(index));
                 if (indexOfThisSubtask == NUM_OF_REGIONS - 1) {
                     lastRegionIndex = index;
                     snapshotIndicesOfSubTask.put(context.getCheckpointId(), lastRegionIndex);
                 }
             }
-            unionListState.clear();
-            unionListState.add(indexOfThisSubtask);
+            unionListState.update(Collections.singletonList(indexOfThisSubtask));
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -49,6 +49,7 @@ import org.junit.runners.Parameterized;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
@@ -469,8 +470,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            stateList.clear();
-            stateList.add(state);
+            stateList.update(Collections.singletonList(state));
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointStressITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointStressITCase.java
@@ -75,6 +75,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -430,8 +431,7 @@ class UnalignedCheckpointStressITCase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            nextState.clear();
-            nextState.add(nextValue);
+            nextState.update(Collections.singletonList(nextValue));
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -88,6 +88,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -1018,8 +1019,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            stateList.clear();
-            stateList.add(state);
+            stateList.update(Collections.singletonList(state));
             if (recovered) {
                 backpressureUntil = Deadline.fromNow(backpressureInterval);
             }
@@ -1070,8 +1070,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            stateList.clear();
-            stateList.add(state);
+            stateList.update(Collections.singletonList(state));
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
@@ -330,8 +330,8 @@ class LocalRecoveryITCase {
                 running = false;
             }
 
-            previousAllocations.clear();
-            previousAllocations.add(new TaskNameAllocationID(myName, allocationId));
+            previousAllocations.update(
+                    Collections.singletonList(new TaskNameAllocationID(myName, allocationId)));
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveSchedulerITCase.java
@@ -420,8 +420,7 @@ public class AdaptiveSchedulerITCase extends TestLogger {
                 hasFailedBefore |= previousState;
             }
 
-            unionListState.clear();
-            unionListState.add(true);
+            unionListState.update(Collections.singletonList(true));
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
@@ -58,6 +58,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -278,8 +279,7 @@ public class ReinterpretDataStreamAsKeyedStreamITCase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            positionState.clear();
-            positionState.add(position);
+            positionState.update(Collections.singletonList(position));
         }
 
         @Override
@@ -331,8 +331,7 @@ public class ReinterpretDataStreamAsKeyedStreamITCase {
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            sumState.clear();
-            sumState.add(runningSum);
+            sumState.update(Collections.singletonList(runningSum));
         }
 
         @Override

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -274,8 +274,7 @@ class StatefulJobSavepointMigrationITCase(snapshotSpec: SnapshotSpec)
     }
 
     override def snapshotState(context: FunctionSnapshotContext): Unit = {
-      state.clear()
-      state.add(CustomCaseClass("Here be dragons!", 123))
+      state.update(java.util.Collections.singletonList(CustomCaseClass("Here be dragons!", 123)))
     }
   }
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobWBroadcastStateMigrationITCase.scala
@@ -349,8 +349,7 @@ private class CheckpointedSource(val numElements: Int)
   }
 
   override def snapshotState(context: FunctionSnapshotContext): Unit = {
-    state.clear()
-    state.add(CustomCaseClass("Here be dragons!", 123))
+    state.update(java.util.Collections.singletonList(CustomCaseClass("Here be dragons!", 123)))
   }
 }
 


### PR DESCRIPTION

## What is the purpose of the change

This PR replace ListState#clear along with following ListState#add with a ListState#update, which reduces the state access overhead for KeyedState and normalize the function calls for updating a ListState.

## Brief change log

Found the ListState#clear along with following ListState#add everywhere and did an equivalent replacement for these function calls. I tried my best to do the replacement and there may be omissions.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
