### PR TITLE
[FLINK-33010][table] GREATEST/LEAST should work with other functions as input

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1369,11 +1369,12 @@ object ScalarOperatorGens {
       }
     }
 
-    val elementsCode = elements
+    val elementsCode = elements.zipWithIndex
       .map {
-        element =>
+        case (element, index) =>
           s"""
              | ${element.code}
+             | ${if (index == 0) s"$tmpResult = ${castIfNumeric(elements.head)};" else ""}
              | if (!$nullTerm) {
              |   $boxedResultTypeTerm $cur = ${castIfNumeric(element)};
              |   if (${element.nullTerm}) {
@@ -1391,7 +1392,7 @@ object ScalarOperatorGens {
 
     val code =
       s"""
-         | $boxedResultTypeTerm $tmpResult = ${castIfNumeric(elements.head)};
+         | $boxedResultTypeTerm $tmpResult;
          | $primitiveResultTypeTerm $result = ${primitiveDefaultValue(widerType.get)};
          | boolean $nullTerm = false;
          | $elementsCode

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/GreatestLeastFunctionsITCase.java
@@ -74,6 +74,14 @@ class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "world",
                                 DataTypes.STRING().notNull())
                         .testResult(
+                                call(
+                                        "GREATEST",
+                                        call("IFNULL", $("f4"), $("f5")),
+                                        call("IFNULL", $("f5"), $("f4"))),
+                                "GREATEST(IFNULL(f4, f5), IFNULL(f5, f4))",
+                                "world",
+                                DataTypes.STRING().notNull())
+                        .testResult(
                                 call("GREATEST", $("f6"), $("f7")),
                                 "GREATEST(f6, f7)",
                                 LocalDateTime.parse("1970-01-01T00:00:03.001"),
@@ -157,6 +165,14 @@ class GreatestLeastFunctionsITCase extends BuiltInFunctionTestBase {
                                 "LEAST(f0, f1) = LEAST(f0, f1)",
                                 null,
                                 DataTypes.BOOLEAN())
+                        .testResult(
+                                call(
+                                        "LEAST",
+                                        call("IFNULL", $("f4"), $("f5")),
+                                        call("IFNULL", $("f5"), $("f4"))),
+                                "LEAST(IFNULL(f4, f5), IFNULL(f5, f4))",
+                                "hello",
+                                DataTypes.STRING().notNull())
                         .testSqlValidationError(
                                 "LEAST(f5, f6)",
                                 "SQL validation failed. Invalid function call:\n"


### PR DESCRIPTION
## What is the purpose of the change

The issue is that `tmpResult` could refer to not initialised variable and this fact leads to compiliation issues. 
It could be reproduced with `GREATEST`/`LEAST` queries when input is a result of other functions like
```sql
SELECT GREATEST(IFNULL(1, 2), IFNULL(2, 1));
```

## Brief change log
 _ScalarOperatorGens.scala_ assign value to `tmpResult` after it is already initialised in `${element.code}` block


## Verifying this change
a test to _GreatestLeastFunctionsITCase.java_ was added

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality g
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
