### PR TITLE
[FLINK-20886] Support printing the thread dump when checkpoint expired

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -63,10 +63,16 @@
             <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
         </tr>
         <tr>
+            <td><h5>cluster.thread-dump.log-level</h5></td>
+            <td style="word-wrap: break-word;">DEBUG</td>
+            <td><p>Enum</p></td>
+            <td>When a checkpoint is notified expired, the task manager could produce a thread dump to log for debugging purpose. This flag defines the log level of the thread dump. Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' and 'OFF' are supported.<br />The stack length of thread dump can be configured by <code class="highlighter-rouge">cluster.thread-dump.stacktrace-max-depth</code>.<br /><br />Possible values:<ul><li>"ERROR"</li><li>"WARN"</li><li>"INFO"</li><li>"DEBUG"</li><li>"TRACE"</li><li>"OFF"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
             <td style="word-wrap: break-word;">50</td>
             <td>Integer</td>
-            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
+            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed or logged.</td>
         </tr>
         <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>

--- a/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
@@ -63,6 +63,12 @@
             <td>Checkpoint id for which in-flight data should be ignored in case of the recovery from this checkpoint.<br /><br />It is better to keep this value empty until there is explicit needs to restore from the specific checkpoint without in-flight data.<br /></td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.thread-dump-log-level-when-checkpoint-timeout</h5></td>
+            <td style="word-wrap: break-word;">DEBUG</td>
+            <td><p>Enum</p></td>
+            <td>When a checkpoint is notified expired, the task manager could produce a thread dump to log for debugging purpose. This flag defines the log level of this thread dump. Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' and 'OFF' are supported. The logger name of the dumper is '<code class="highlighter-rouge">org.apache.flink.runtime.state.CheckpointExpiredThreadDumper</code>', user could specify logger configuration of it.<br />The stack length of thread dump can be configured by <code class="highlighter-rouge">cluster.thread-dump.stacktrace-max-depth</code>.<br /><br />Possible values:<ul><li>"ERROR"</li><li>"WARN"</li><li>"INFO"</li><li>"DEBUG"</li><li>"TRACE"</li><li>"OFF"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.timeout</h5></td>
             <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
@@ -63,10 +63,10 @@
             <td>Checkpoint id for which in-flight data should be ignored in case of the recovery from this checkpoint.<br /><br />It is better to keep this value empty until there is explicit needs to restore from the specific checkpoint without in-flight data.<br /></td>
         </tr>
         <tr>
-            <td><h5>execution.checkpointing.thread-dump-log-level-when-checkpoint-timeout</h5></td>
-            <td style="word-wrap: break-word;">DEBUG</td>
-            <td><p>Enum</p></td>
-            <td>When a checkpoint is notified expired, the task manager could produce a thread dump to log for debugging purpose. This flag defines the log level of this thread dump. Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' and 'OFF' are supported. The logger name of the dumper is '<code class="highlighter-rouge">org.apache.flink.runtime.state.CheckpointExpiredThreadDumper</code>', user could specify logger configuration of it.<br />The stack length of thread dump can be configured by <code class="highlighter-rouge">cluster.thread-dump.stacktrace-max-depth</code>.<br /><br />Possible values:<ul><li>"ERROR"</li><li>"WARN"</li><li>"INFO"</li><li>"DEBUG"</li><li>"TRACE"</li><li>"OFF"</li></ul></td>
+            <td><h5>execution.checkpointing.thread-dump-when-checkpoint-expired.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When a checkpoint is notified expired, the task manager could produce a thread dump to log for debugging purpose. This flag enables this thread dump.<br />The log level of this thread dump can be specified by <code class="highlighter-rouge">cluster.thread-dump.log-level</code>, and the stack length of thread dump can be configured by <code class="highlighter-rouge">cluster.thread-dump.stacktrace-max-depth</code>.</td>
         </tr>
         <tr>
             <td><h5>execution.checkpointing.timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -21,10 +21,16 @@
             <td>Whether processes should halt on fatal errors instead of performing a graceful shutdown. In some environments (e.g. Java 8 with the G1 garbage collector), a regular graceful shutdown can lead to a JVM deadlock. See <a href="https://issues.apache.org/jira/browse/FLINK-16510">FLINK-16510</a> for details.</td>
         </tr>
         <tr>
+            <td><h5>cluster.thread-dump.log-level</h5></td>
+            <td style="word-wrap: break-word;">DEBUG</td>
+            <td><p>Enum</p></td>
+            <td>When a checkpoint is notified expired, the task manager could produce a thread dump to log for debugging purpose. This flag defines the log level of the thread dump. Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' and 'OFF' are supported.<br />The stack length of thread dump can be configured by <code class="highlighter-rouge">cluster.thread-dump.stacktrace-max-depth</code>.<br /><br />Possible values:<ul><li>"ERROR"</li><li>"WARN"</li><li>"INFO"</li><li>"DEBUG"</li><li>"TRACE"</li><li>"OFF"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
             <td style="word-wrap: break-word;">50</td>
             <td>Integer</td>
-            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
+            <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed or logged.</td>
         </tr>
         <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -134,7 +134,27 @@ public class ClusterOptions {
                     .intType()
                     .defaultValue(50)
                     .withDescription(
-                            "The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.");
+                            "The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed or logged.");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<ThreadDumpLogLevel> THREAD_DUMP_LOG_LEVEL =
+            key("cluster.thread-dump.log-level")
+                    .enumType(ThreadDumpLogLevel.class)
+                    .defaultValue(ThreadDumpLogLevel.DEBUG)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "When a checkpoint is notified expired, the task manager could "
+                                                    + "produce a thread dump to log for debugging purpose. "
+                                                    + "This flag defines the log level of the thread dump. "
+                                                    + "Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' "
+                                                    + "and 'OFF' are supported.")
+                                    .linebreak()
+                                    .text(
+                                            "The stack length of thread dump can be configured by %s.",
+                                            TextElement.code(
+                                                    THREAD_DUMP_STACKTRACE_MAX_DEPTH.key()))
+                                    .build());
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
     @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
@@ -251,5 +271,18 @@ public class ClusterOptions {
     public enum UncaughtExceptionHandleMode {
         LOG,
         FAIL
+    }
+
+    /**
+     * Defines the log level of the thread dump of executors. @see
+     * ClusterOptions#THREAD_DUMP_LOG_LEVEL.
+     */
+    public enum ThreadDumpLogLevel {
+        ERROR,
+        WARN,
+        INFO,
+        DEBUG,
+        TRACE,
+        OFF
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -112,6 +112,8 @@ public class SavepointEnvironment implements Environment {
 
     private final ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory;
 
+    private final CheckpointExpiredThreadDumper threadDumper;
+
     private SavepointEnvironment(
             RuntimeContext ctx,
             Configuration configuration,
@@ -319,7 +321,7 @@ public class SavepointEnvironment implements Environment {
 
     @Override
     public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
-        throw new UnsupportedOperationException(ERROR_MSG);
+        return threadDumper;
     }
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
@@ -314,6 +315,11 @@ public class SavepointEnvironment implements Environment {
     @Override
     public ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory() {
         return channelStateExecutorFactory;
+    }
+
+    @Override
+    public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
+        return null;
     }
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -319,7 +319,7 @@ public class SavepointEnvironment implements Environment {
 
     @Override
     public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
-        return null;
+        throw new UnsupportedOperationException(ERROR_MSG);
     }
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -141,6 +141,7 @@ public class SavepointEnvironment implements Environment {
 
         this.userCodeClassLoader = UserCodeClassLoaderRuntimeContextAdapter.from(ctx);
         this.channelStateExecutorFactory = new ChannelStateWriteRequestExecutorFactory(jobID);
+        this.threadDumper = new CheckpointExpiredThreadDumper();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.internal.InternalKvState;
@@ -267,4 +268,6 @@ public interface Environment {
     }
 
     ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory();
+
+    CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -818,12 +819,16 @@ public class Execution
     /**
      * Notify the task of this execution about a aborted checkpoint.
      *
-     * @param abortCheckpointId of the subsumed checkpoint
+     * @param abortCheckpointId of the aborted checkpoint
      * @param latestCompletedCheckpointId of the latest completed checkpoint
-     * @param timestamp of the subsumed checkpoint
+     * @param timestamp of the aborted checkpoint
+     * @param failureReason the reason why abort this checkpoint
      */
     public void notifyCheckpointAborted(
-            long abortCheckpointId, long latestCompletedCheckpointId, long timestamp) {
+            long abortCheckpointId,
+            long latestCompletedCheckpointId,
+            long timestamp,
+            CheckpointFailureReason failureReason) {
         final LogicalSlot slot = assignedResource;
 
         if (slot != null) {
@@ -834,7 +839,8 @@ public class Execution
                     getVertex().getJobId(),
                     abortCheckpointId,
                     latestCompletedCheckpointId,
-                    timestamp);
+                    timestamp,
+                    failureReason);
         } else {
             LOG.debug(
                     "The execution has no slot assigned. This indicates that the execution is "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -215,6 +215,14 @@ public abstract class AbstractInvokable
                         this.getClass().getName()));
     }
 
+    @Override
+    public Future<Void> threadDumpOnCheckpointTimeout(long checkpointId) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "threadDumpOnCheckpointTimeout not supported by %s",
+                        this.getClass().getName()));
+    }
+
     public void dispatchOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> event)
             throws FlinkException {
         throw new UnsupportedOperationException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
@@ -107,4 +107,12 @@ public interface CheckpointableTask {
      * @param cause The reason why the checkpoint was aborted during alignment
      */
     void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) throws IOException;
+
+    /**
+     * Request to do a thread dump when checkpoint timeout.
+     *
+     * @param checkpointId the id of the checkpoint that timeout.
+     * @return future that completes when the thread dump has been processed by the task.
+     */
+    Future<Void> threadDumpOnCheckpointTimeout(long checkpointId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmanager.slots;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -110,13 +111,15 @@ public interface TaskManagerGateway extends TaskExecutorOperatorEventGateway {
      * @param checkpointId of the subsumed checkpoint
      * @param latestCompletedCheckpointId of the latest completed checkpoint
      * @param timestamp of the subsumed checkpoint
+     * @param failureReason the reason of this abortion
      */
     void notifyCheckpointAborted(
             ExecutionAttemptID executionAttemptID,
             JobID jobId,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long timestamp);
+            long timestamp,
+            CheckpointFailureReason failureReason);
 
     /**
      * Trigger for the given task a checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -98,9 +99,14 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
             JobID jobId,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long timestamp) {
+            long timestamp,
+            CheckpointFailureReason failureReason) {
         taskExecutorGateway.abortCheckpoint(
-                executionAttemptID, checkpointId, latestCompletedCheckpointId, timestamp);
+                executionAttemptID,
+                checkpointId,
+                latestCompletedCheckpointId,
+                timestamp,
+                failureReason);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ThreadDumpInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ThreadDumpInfo.java
@@ -18,15 +18,12 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.util.JvmUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
-import java.lang.management.LockInfo;
-import java.lang.management.MonitorInfo;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -61,91 +58,9 @@ public final class ThreadDumpInfo implements ResponseBody, Serializable {
                                 threadInfo ->
                                         ThreadDumpInfo.ThreadInfo.create(
                                                 threadInfo.getThreadName(),
-                                                stringifyThreadInfo(
+                                                JvmUtils.stringifyThreadInfo(
                                                         threadInfo, stacktraceMaxDepth)))
                         .collect(Collectors.toList()));
-    }
-
-    /**
-     * Custom stringify format of JVM thread info to bypass the MAX_FRAMES = 8 limitation.
-     *
-     * <p>This method is based on
-     * https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/java/lang/management/ThreadInfo.java#L597
-     */
-    @VisibleForTesting
-    protected static String stringifyThreadInfo(
-            java.lang.management.ThreadInfo threadInfo, int maxDepth) {
-        StringBuilder sb =
-                new StringBuilder(
-                        "\""
-                                + threadInfo.getThreadName()
-                                + "\""
-                                + " Id="
-                                + threadInfo.getThreadId()
-                                + " "
-                                + threadInfo.getThreadState());
-        if (threadInfo.getLockName() != null) {
-            sb.append(" on " + threadInfo.getLockName());
-        }
-        if (threadInfo.getLockOwnerName() != null) {
-            sb.append(
-                    " owned by \""
-                            + threadInfo.getLockOwnerName()
-                            + "\" Id="
-                            + threadInfo.getLockOwnerId());
-        }
-        if (threadInfo.isSuspended()) {
-            sb.append(" (suspended)");
-        }
-        if (threadInfo.isInNative()) {
-            sb.append(" (in native)");
-        }
-        sb.append('\n');
-        int i = 0;
-        StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
-        for (; i < stackTraceElements.length && i < maxDepth; i++) {
-            StackTraceElement ste = stackTraceElements[i];
-            sb.append("\tat " + ste.toString());
-            sb.append('\n');
-            if (i == 0 && threadInfo.getLockInfo() != null) {
-                Thread.State ts = threadInfo.getThreadState();
-                switch (ts) {
-                    case BLOCKED:
-                        sb.append("\t-  blocked on " + threadInfo.getLockInfo());
-                        sb.append('\n');
-                        break;
-                    case WAITING:
-                    case TIMED_WAITING:
-                        sb.append("\t-  waiting on " + threadInfo.getLockInfo());
-                        sb.append('\n');
-                        break;
-                    default:
-                }
-            }
-
-            for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
-                if (mi.getLockedStackDepth() == i) {
-                    sb.append("\t-  locked " + mi);
-                    sb.append('\n');
-                }
-            }
-        }
-        if (i < threadInfo.getStackTrace().length) {
-            sb.append("\t...");
-            sb.append('\n');
-        }
-
-        LockInfo[] locks = threadInfo.getLockedSynchronizers();
-        if (locks.length > 0) {
-            sb.append("\n\tNumber of locked synchronizers = " + locks.length);
-            sb.append('\n');
-            for (LockInfo li : locks) {
-                sb.append("\t- " + li);
-                sb.append('\n');
-            }
-        }
-        sb.append('\n');
-        return sb.toString();
     }
 
     /** Class containing information about a thread. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumper.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static org.apache.flink.configuration.ClusterOptions.ThreadDumpLogLevel;
+
 /**
  * A worker that can print thread dump to log when checkpoint aborted. There is a throttling
  * strategy that it can only output once for each job and each checkpoint abortion.
@@ -38,19 +40,6 @@ import java.util.function.Consumer;
 public class CheckpointExpiredThreadDumper {
 
     private static final Logger LOG = LoggerFactory.getLogger(CheckpointExpiredThreadDumper.class);
-
-    /**
-     * When a checkpoint is notified timeout, the task manager could produce a thread dump to log
-     * for debugging purpose. This enum defines the log level of this thread dump.
-     */
-    public enum ThreadDumpLogLevel {
-        ERROR,
-        WARN,
-        INFO,
-        DEBUG,
-        TRACE,
-        OFF
-    }
 
     /** A map records the last dumped checkpoint for each job. */
     private final ConcurrentHashMap<JobID, Long> jobIdLastDumpCheckpointIdMap;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumper.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.util.JvmUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * A worker that can print thread dump to log when checkpoint aborted. There is a throttling
+ * strategy that it can only output once for each job and each checkpoint abortion.
+ */
+public class CheckpointExpiredThreadDumper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CheckpointExpiredThreadDumper.class);
+
+    /**
+     * When a checkpoint is notified timeout, the task manager could produce a thread dump to log
+     * for debugging purpose. This enum defines the log level of this thread dump.
+     */
+    public enum ThreadDumpLogLevel {
+        ERROR,
+        WARN,
+        INFO,
+        DEBUG,
+        TRACE,
+        OFF
+    }
+
+    /** A map records the last dumped checkpoint for each job. */
+    private final Map<JobID, Long> jobIdLastDumpCheckpointIdMap;
+
+    public CheckpointExpiredThreadDumper() {
+        this.jobIdLastDumpCheckpointIdMap = new HashMap<>();
+    }
+
+    /**
+     * Print the thread dump to log if needed. A thread dump is captured and print only when:
+     *
+     * <p>1. It is the first time to request a thread dump for this checkpoint within current job.
+     *
+     * <p>2. The configured log level is enabled.
+     *
+     * @param jobId id of the current job.
+     * @param checkpointId id of the aborted checkpoint.
+     * @param threadDumpLogLevelWhenAbort the configured log level for thread dump.
+     * @param maxDepthOfThreadDump the max stack depth for thread dump.
+     * @return true if really print the log.
+     */
+    public boolean threadDumpIfNeeded(
+            JobID jobId,
+            long checkpointId,
+            ThreadDumpLogLevel threadDumpLogLevelWhenAbort,
+            int maxDepthOfThreadDump) {
+        synchronized (this) {
+            long lastCheckpointId = jobIdLastDumpCheckpointIdMap.computeIfAbsent(jobId, (k) -> -1L);
+            if (lastCheckpointId >= checkpointId) {
+                return false;
+            }
+            jobIdLastDumpCheckpointIdMap.put(jobId, checkpointId);
+        }
+        Consumer<String> logger = null;
+        switch (threadDumpLogLevelWhenAbort) {
+            case TRACE:
+                if (LOG.isTraceEnabled()) {
+                    logger = LOG::trace;
+                }
+                break;
+            case DEBUG:
+                if (LOG.isDebugEnabled()) {
+                    logger = LOG::debug;
+                }
+                break;
+            case INFO:
+                if (LOG.isInfoEnabled()) {
+                    logger = LOG::info;
+                }
+                break;
+            case WARN:
+                if (LOG.isWarnEnabled()) {
+                    logger = LOG::warn;
+                }
+                break;
+            case ERROR:
+                if (LOG.isErrorEnabled()) {
+                    logger = LOG::error;
+                }
+                break;
+            default:
+                break;
+        }
+        if (logger != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Checkpoint ")
+                    .append(checkpointId)
+                    .append(" of job ")
+                    .append(jobId.toString())
+                    .append(" is notified expired, producing the thread dump for debugging:\n");
+            JvmUtils.createThreadDump()
+                    .forEach(
+                            threadInfo ->
+                                    sb.append(
+                                            JvmUtils.stringifyThreadInfo(
+                                                    threadInfo, maxDepthOfThreadDump)));
+            logger.accept(sb.toString());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Remove the thread dump history for one job.
+     *
+     * @param jobId the specified job to remove history.
+     */
+    public void removeCheckpointExpiredThreadDumpRecordForJob(JobID jobId) {
+        synchronized (this) {
+            jobIdLastDumpCheckpointIdMap.remove(jobId);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.management.jmx.JMXService;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.JobPermanentBlobService;
@@ -98,6 +97,7 @@ import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TaskExecutorChannelStateExecutorFactoryManager;
 import org.apache.flink.runtime.state.TaskExecutorFileMergingManager;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -180,6 +180,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.configuration.ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -299,6 +300,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private final ShuffleDescriptorsCache shuffleDescriptorsCache;
 
+    private final CheckpointExpiredThreadDumper checkpointExpiredThreadDumper;
+
     public TaskExecutor(
             RpcService rpcService,
             TaskManagerConfiguration taskManagerConfiguration,
@@ -375,6 +378,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
         this.sharedResources = taskExecutorServices.getSharedResources();
         this.shuffleDescriptorsCache = taskExecutorServices.getShuffleDescriptorCache();
+        this.checkpointExpiredThreadDumper = new CheckpointExpiredThreadDumper();
     }
 
     private HeartbeatManager<Void, TaskExecutorHeartbeatPayload>
@@ -803,7 +807,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             taskMetricGroup,
                             partitionStateChecker,
                             getRpcService().getScheduledExecutor(),
-                            channelStateExecutorFactoryManager.getOrCreateExecutorFactory(jobId));
+                            channelStateExecutorFactoryManager.getOrCreateExecutorFactory(jobId),
+                            checkpointExpiredThreadDumper);
 
             taskMetricGroup.gauge(MetricNames.IS_BACK_PRESSURED, task::isBackPressured);
 
@@ -1088,7 +1093,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long checkpointTimestamp) {
+            long checkpointTimestamp,
+            CheckpointFailureReason failureReason) {
         log.debug(
                 "Abort checkpoint {}@{} for {}.",
                 checkpointId,
@@ -1098,6 +1104,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         final Task task = taskSlotTable.getTask(executionAttemptID);
 
         if (task != null) {
+            if (failureReason == CheckpointFailureReason.CHECKPOINT_EXPIRED) {
+                task.threadDumpWhenCheckpointTimeout(checkpointId);
+            }
             task.notifyCheckpointAborted(checkpointId, latestCompletedCheckpointId);
 
             return CompletableFuture.completedFuture(Acknowledge.get());
@@ -1357,9 +1366,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     @Override
     public CompletableFuture<ThreadDumpInfo> requestThreadDump(Time timeout) {
         int stacktraceMaxDepth =
-                taskManagerConfiguration
-                        .getConfiguration()
-                        .get(ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH);
+                taskManagerConfiguration.getConfiguration().get(THREAD_DUMP_STACKTRACE_MAX_DEPTH);
         return CompletableFuture.completedFuture(ThreadDumpInfo.dumpAndCreate(stacktraceMaxDepth));
     }
 
@@ -1905,6 +1912,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         channelStateExecutorFactoryManager.releaseResourcesForJob(jobId);
         shuffleDescriptorsCache.clearCacheForJob(jobId);
         fileMergingManager.releaseMergingSnapshotManagerForJob(jobId);
+        checkpointExpiredThreadDumper.removeCheckpointExpiredThreadDumpRecordForJob(jobId);
     }
 
     private void scheduleResultPartitionCleanup(JobID jobId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -174,7 +175,8 @@ public interface TaskExecutorGateway
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long checkpointTimestamp);
+            long checkpointTimestamp,
+            CheckpointFailureReason failureReason);
 
     /**
      * Cancel the given task.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -150,9 +151,14 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long checkpointTimestamp) {
+            long checkpointTimestamp,
+            CheckpointFailureReason failureReason) {
         return originalGateway.abortCheckpoint(
-                executionAttemptID, checkpointId, latestCompletedCheckpointId, checkpointTimestamp);
+                executionAttemptID,
+                checkpointId,
+                latestCompletedCheckpointId,
+                checkpointTimestamp,
+                failureReason);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -111,6 +112,8 @@ public class RuntimeEnvironment implements Environment {
 
     ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory;
 
+    @Nullable private final CheckpointExpiredThreadDumper checkpointExpiredThreadDumper;
+
     // ------------------------------------------------------------------------
 
     public RuntimeEnvironment(
@@ -142,7 +145,8 @@ public class RuntimeEnvironment implements Environment {
             Task containingTask,
             ExternalResourceInfoProvider externalResourceInfoProvider,
             ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory,
-            TaskManagerActions taskManagerActions) {
+            TaskManagerActions taskManagerActions,
+            @Nullable CheckpointExpiredThreadDumper checkpointExpiredThreadDumper) {
 
         this.jobId = checkNotNull(jobId);
         this.jobVertexId = checkNotNull(jobVertexId);
@@ -173,6 +177,7 @@ public class RuntimeEnvironment implements Environment {
         this.externalResourceInfoProvider = checkNotNull(externalResourceInfoProvider);
         this.channelStateExecutorFactory = checkNotNull(channelStateExecutorFactory);
         this.taskManagerActions = checkNotNull(taskManagerActions);
+        this.checkpointExpiredThreadDumper = checkpointExpiredThreadDumper;
     }
 
     // ------------------------------------------------------------------------
@@ -386,5 +391,10 @@ public class RuntimeEnvironment implements Environment {
     @Override
     public ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory() {
         return channelStateExecutorFactory;
+    }
+
+    @Override
+    public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
+        return checkpointExpiredThreadDumper;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
@@ -23,7 +23,9 @@ import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
@@ -97,6 +99,87 @@ public final class JvmUtils {
                         .collect(Collectors.toList());
 
         return ThreadInfoSample.from(threadInfoNoNulls);
+    }
+
+    /**
+     * Custom stringify format of JVM thread info to bypass the MAX_FRAMES = 8 limitation.
+     *
+     * <p>This method is based on
+     * https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/java/lang/management/ThreadInfo.java#L597
+     */
+    public static String stringifyThreadInfo(
+            java.lang.management.ThreadInfo threadInfo, int maxDepth) {
+        StringBuilder sb =
+                new StringBuilder(
+                        "\""
+                                + threadInfo.getThreadName()
+                                + "\""
+                                + " Id="
+                                + threadInfo.getThreadId()
+                                + " "
+                                + threadInfo.getThreadState());
+        if (threadInfo.getLockName() != null) {
+            sb.append(" on " + threadInfo.getLockName());
+        }
+        if (threadInfo.getLockOwnerName() != null) {
+            sb.append(
+                    " owned by \""
+                            + threadInfo.getLockOwnerName()
+                            + "\" Id="
+                            + threadInfo.getLockOwnerId());
+        }
+        if (threadInfo.isSuspended()) {
+            sb.append(" (suspended)");
+        }
+        if (threadInfo.isInNative()) {
+            sb.append(" (in native)");
+        }
+        sb.append('\n');
+        int i = 0;
+        StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+        for (; i < stackTraceElements.length && i < maxDepth; i++) {
+            StackTraceElement ste = stackTraceElements[i];
+            sb.append("\tat " + ste.toString());
+            sb.append('\n');
+            if (i == 0 && threadInfo.getLockInfo() != null) {
+                Thread.State ts = threadInfo.getThreadState();
+                switch (ts) {
+                    case BLOCKED:
+                        sb.append("\t-  blocked on " + threadInfo.getLockInfo());
+                        sb.append('\n');
+                        break;
+                    case WAITING:
+                    case TIMED_WAITING:
+                        sb.append("\t-  waiting on " + threadInfo.getLockInfo());
+                        sb.append('\n');
+                        break;
+                    default:
+                }
+            }
+
+            for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
+                if (mi.getLockedStackDepth() == i) {
+                    sb.append("\t-  locked " + mi);
+                    sb.append('\n');
+                }
+            }
+        }
+        if (i < threadInfo.getStackTrace().length) {
+            sb.append("\t...");
+            sb.append('\n');
+        }
+
+        LockInfo[] locks = threadInfo.getLockedSynchronizers();
+        if (locks.length > 0) {
+            sb.append("\n\tNumber of locked synchronizers = " + locks.length);
+            sb.append('\n');
+            for (LockInfo li : locks) {
+                sb.append("\t- " + li);
+                sb.append('\n');
+            }
+        }
+        sb.append('\n');
+        return sb.toString();
     }
 
     /** Private default constructor to avoid instantiation. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -587,7 +587,8 @@ class CheckpointCoordinatorTest {
                                             JobID jobId,
                                             long checkpointId,
                                             long latestCompletedCheckpointId,
-                                            long timestamp) {
+                                            long timestamp,
+                                            CheckpointFailureReason failureReason) {
                                         checkpointAborted.set(true);
                                     }
                                 })
@@ -3913,7 +3914,8 @@ class CheckpointCoordinatorTest {
                                             JobID jobId,
                                             long checkpointId,
                                             long latestCompletedCheckpointId,
-                                            long timestamp) {
+                                            long timestamp,
+                                            CheckpointFailureReason failureReason) {
                                         reportedCheckpointId.set(latestCompletedCheckpointId);
                                     }
                                 })

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -519,7 +519,8 @@ public class CheckpointCoordinatorTestingUtils {
                 JobID jobId,
                 long checkpointId,
                 long latestCompletedCheckpointId,
-                long timestamp) {
+                long timestamp,
+                CheckpointFailureReason failureReason) {
             notifiedAbortCheckpoints
                     .computeIfAbsent(attemptId, k -> new ArrayList<>())
                     .add(new NotifiedCheckpoint(jobId, checkpointId, timestamp));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -139,7 +140,8 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
             JobID jobId,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long timestamp) {}
+            long timestamp,
+            CheckpointFailureReason failureReason) {}
 
     @Override
     public CompletableFuture<Acknowledge> triggerCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -281,5 +282,10 @@ public class DummyEnvironment implements Environment {
     @Override
     public ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory() {
         return channelStateExecutorFactory;
+    }
+
+    @Override
+    public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
+        return null;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -79,6 +79,9 @@ public class DummyEnvironment implements Environment {
     private final ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory =
             new ChannelStateWriteRequestExecutorFactory(jobId);
 
+    private final CheckpointExpiredThreadDumper checkpointExpiredThreadDumper =
+            new CheckpointExpiredThreadDumper();
+
     public DummyEnvironment() {
         this("Test Job", 1, 0, 1);
     }
@@ -286,6 +289,6 @@ public class DummyEnvironment implements Environment {
 
     @Override
     public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
-        return null;
+        return checkpointExpiredThreadDumper;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -141,6 +141,8 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
     private final ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory;
 
+    private final CheckpointExpiredThreadDumper checkpointExpiredThreadDumper;
+
     public static MockEnvironmentBuilder builder() {
         return new MockEnvironmentBuilder();
     }
@@ -203,6 +205,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
         this.asyncOperationsThreadPool = Executors.newDirectExecutorService();
         this.channelStateExecutorFactory = channelStateExecutorFactory;
+        this.checkpointExpiredThreadDumper = new CheckpointExpiredThreadDumper();
     }
 
     public IteratorWrappingTestSingleInputGate<Record> addInput(
@@ -461,7 +464,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
     @Override
     public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
-        return null;
+        return checkpointExpiredThreadDumper;
     }
 
     public void setExpectedExternalFailureCause(Class<? extends Throwable> expectedThrowableClass) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -456,6 +457,11 @@ public class MockEnvironment implements Environment, AutoCloseable {
     @Override
     public ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory() {
         return channelStateExecutorFactory;
+    }
+
+    @Override
+    public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
+        return null;
     }
 
     public void setExpectedExternalFailureCause(Class<? extends Throwable> expectedThrowableClass) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/ThreadDumpInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/ThreadDumpInfoTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.runtime.util.JvmUtils;
 import org.apache.flink.testutils.junit.extensions.parameterized.NoOpTestExtension;
 
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,7 @@ class ThreadDumpInfoTest extends RestResponseMarshallingTestBase<ThreadDumpInfo>
         String[] threadInfoLines = threadInfo.toString().split("\n");
         String[] expected = Arrays.copyOfRange(threadInfoLines, 1, threadInfoLines.length);
 
-        String stringifyThreadInfo = ThreadDumpInfo.stringifyThreadInfo(threadInfo, 8);
+        String stringifyThreadInfo = JvmUtils.stringifyThreadInfo(threadInfo, 8);
         String[] stringifyThreadInfoLines = stringifyThreadInfo.split("\n");
         String[] stringified =
                 Arrays.copyOfRange(stringifyThreadInfoLines, 1, stringifyThreadInfoLines.length);
@@ -84,11 +85,11 @@ class ThreadDumpInfoTest extends RestResponseMarshallingTestBase<ThreadDumpInfo>
 
         int expectedStacktraceDepth = threadInfo.getStackTrace().length;
 
-        String stringifiedInfo = ThreadDumpInfo.stringifyThreadInfo(threadInfo, Integer.MAX_VALUE);
+        String stringifiedInfo = JvmUtils.stringifyThreadInfo(threadInfo, Integer.MAX_VALUE);
         assertThat(getOutputDepth(stringifiedInfo)).isEqualTo(expectedStacktraceDepth);
 
         String stringifiedInfoExceedMaxDepth =
-                ThreadDumpInfo.stringifyThreadInfo(threadInfo, expectedStacktraceDepth - 1);
+                JvmUtils.stringifyThreadInfo(threadInfo, expectedStacktraceDepth - 1);
         assertThat(getOutputDepth(stringifiedInfoExceedMaxDepth))
                 .isEqualTo(expectedStacktraceDepth - 1);
         assertThat(stringifiedInfoExceedMaxDepth.contains("\t...")).isTrue();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.Test;
+
+import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CheckpointExpiredThreadDumper}. */
+public class CheckpointExpiredThreadDumperTest {
+
+    @Test
+    public void testRepeatedlyAbortOneCheckpoint() {
+        CheckpointExpiredThreadDumper dumper = new CheckpointExpiredThreadDumper();
+        JobID id1 = new JobID(1L, 1L);
+        JobID id2 = new JobID(2L, 2L);
+
+        String original = setLoggerLevel(CheckpointExpiredThreadDumper.class.getName(), "INFO");
+
+        // If set logger level valid, do the test.
+        if (!"".equals(original)) {
+            assertThat(dumper.threadDumpIfNeeded(id1, 1L, ThreadDumpLogLevel.DEBUG, 100)).isFalse();
+            assertThat(dumper.threadDumpIfNeeded(id1, 2L, ThreadDumpLogLevel.INFO, 100)).isTrue();
+            assertThat(dumper.threadDumpIfNeeded(id1, 2L, ThreadDumpLogLevel.INFO, 100)).isFalse();
+            assertThat(dumper.threadDumpIfNeeded(id2, 2L, ThreadDumpLogLevel.INFO, 100)).isTrue();
+            dumper.removeCheckpointExpiredThreadDumpRecordForJob(id1);
+            assertThat(dumper.threadDumpIfNeeded(id1, 2L, ThreadDumpLogLevel.INFO, 100)).isTrue();
+            setLoggerLevel(CheckpointExpiredThreadDumper.class.getName(), original);
+        }
+    }
+
+    /**
+     * Dynamically set the logger level to a specified logger name. Set to root if not exist.
+     *
+     * @param loggerName the logger name to set to.
+     * @param newLogLevel the new logger level.
+     * @return the original logger level name. Empty string if apply failed.
+     */
+    private String setLoggerLevel(String loggerName, String newLogLevel) {
+        final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = context.getConfiguration();
+
+        final LoggerConfig loggerConfig = config.getLoggerConfig(loggerName);
+        String original = "";
+
+        if (loggerConfig != null) {
+            original = loggerConfig.getLevel().name();
+            loggerConfig.setLevel(org.apache.logging.log4j.Level.valueOf(newLogLevel));
+            context.updateLoggers();
+        }
+        return original;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointExpiredThreadDumperTest.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.Test;
 
-import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
+import static org.apache.flink.configuration.ClusterOptions.ThreadDumpLogLevel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link CheckpointExpiredThreadDumper}. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple6;
 import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -263,7 +264,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             long latestCompletedCheckpointId,
-            long checkpointTimestamp) {
+            long checkpointTimestamp,
+            CheckpointFailureReason failureReason) {
         return CompletableFuture.completedFuture(Acknowledge.get());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
@@ -220,7 +221,8 @@ public class TaskAsyncCallTest extends TestLogger {
                 taskMetricGroup,
                 partitionProducerStateChecker,
                 executor,
-                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                new CheckpointExpiredThreadDumper());
     }
 
     /** Invokable for testing checkpoints. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.NoOpPartitionProducerStateChecker;
@@ -227,7 +228,8 @@ public final class TestTaskBuilder {
                 taskMetricGroup,
                 partitionProducerStateChecker,
                 executor,
-                new ChannelStateWriteRequestExecutorFactory(jobId));
+                new ChannelStateWriteRequestExecutorFactory(jobId),
+                new CheckpointExpiredThreadDumper());
     }
 
     public static void setTaskState(Task task, ExecutionState state) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
@@ -255,7 +256,8 @@ class JvmExitOnFatalErrorTest {
                                 new NoOpPartitionProducerStateChecker(),
                                 executor,
                                 new ChannelStateWriteRequestExecutorFactory(
-                                        jobInformation.getJobId()));
+                                        jobInformation.getJobId()),
+                                new CheckpointExpiredThreadDumper());
 
                 System.err.println("starting task thread");
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -26,15 +26,14 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
-import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import java.time.Duration;
 
+import static org.apache.flink.configuration.ClusterOptions.THREAD_DUMP_LOG_LEVEL;
 import static org.apache.flink.configuration.ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH;
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
-import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
 
 /**
  * Execution {@link ConfigOption} for configuring checkpointing related parameters.
@@ -318,27 +317,22 @@ public class ExecutionCheckpointingOptions {
                                     + "It can reduce the number of small files when enable unaligned checkpoint. "
                                     + "Each subtask will create a new channel state file when this is configured to 1.");
 
-    public static final ConfigOption<ThreadDumpLogLevel>
-            THREAD_DUMP_LOG_LEVEL_WHEN_CHECKPOINT_TIMEOUT =
-                    key("execution.checkpointing.thread-dump-log-level-when-checkpoint-timeout")
-                            .enumType(ThreadDumpLogLevel.class)
-                            .defaultValue(ThreadDumpLogLevel.DEBUG)
-                            .withDescription(
-                                    Description.builder()
-                                            .text(
-                                                    "When a checkpoint is notified expired, the task manager could "
-                                                            + "produce a thread dump to log for debugging purpose. "
-                                                            + "This flag defines the log level of this thread dump. "
-                                                            + "Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' "
-                                                            + "and 'OFF' are supported. The logger name of the dumper "
-                                                            + "is '%s', user could specify logger configuration of it.",
-                                                    TextElement.code(
-                                                            CheckpointExpiredThreadDumper.class
-                                                                    .getName()))
-                                            .linebreak()
-                                            .text(
-                                                    "The stack length of thread dump can be configured by %s.",
-                                                    TextElement.code(
-                                                            THREAD_DUMP_STACKTRACE_MAX_DEPTH.key()))
-                                            .build());
+    public static final ConfigOption<Boolean> ENABLE_THREAD_DUMP_WHEN_CHECKPOINT_TIMEOUT =
+            key("execution.checkpointing.thread-dump-when-checkpoint-expired.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "When a checkpoint is notified expired, the task manager could "
+                                                    + "produce a thread dump to log for debugging purpose. "
+                                                    + "This flag enables this thread dump.")
+                                    .linebreak()
+                                    .text(
+                                            "The log level of this thread dump can be specified by %s, "
+                                                    + "and the stack length of thread dump can be configured by %s.",
+                                            TextElement.code(THREAD_DUMP_LOG_LEVEL.key()),
+                                            TextElement.code(
+                                                    THREAD_DUMP_STACKTRACE_MAX_DEPTH.key()))
+                                    .build());
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -26,12 +26,15 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import java.time.Duration;
 
+import static org.apache.flink.configuration.ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH;
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
+import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
 
 /**
  * Execution {@link ConfigOption} for configuring checkpointing related parameters.
@@ -314,4 +317,28 @@ public class ExecutionCheckpointingOptions {
                             "Defines the maximum number of subtasks that share the same channel state file. "
                                     + "It can reduce the number of small files when enable unaligned checkpoint. "
                                     + "Each subtask will create a new channel state file when this is configured to 1.");
+
+    public static final ConfigOption<ThreadDumpLogLevel>
+            THREAD_DUMP_LOG_LEVEL_WHEN_CHECKPOINT_TIMEOUT =
+                    key("execution.checkpointing.thread-dump-log-level-when-checkpoint-timeout")
+                            .enumType(ThreadDumpLogLevel.class)
+                            .defaultValue(ThreadDumpLogLevel.DEBUG)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "When a checkpoint is notified expired, the task manager could "
+                                                            + "produce a thread dump to log for debugging purpose. "
+                                                            + "This flag defines the log level of this thread dump. "
+                                                            + "Only 'ERROR', 'WARN', 'INFO', 'DEBUG'(default), 'TRACE' "
+                                                            + "and 'OFF' are supported. The logger name of the dumper "
+                                                            + "is '%s', user could specify logger configuration of it.",
+                                                    TextElement.code(
+                                                            CheckpointExpiredThreadDumper.class
+                                                                    .getName()))
+                                            .linebreak()
+                                            .text(
+                                                    "The stack length of thread dump can be configured by %s.",
+                                                    TextElement.code(
+                                                            THREAD_DUMP_STACKTRACE_MAX_DEPTH.key()))
+                                            .build());
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExpiredThreadDumperWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExpiredThreadDumperWrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
+
+import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
+
+/**
+ * A wrapper that encapsulates the dumper worker and some job-related data and configuration,
+ * convenient to request a thread dump for subtask.
+ */
+public class CheckpointExpiredThreadDumperWrapper {
+
+    private final CheckpointExpiredThreadDumper dumper;
+
+    private final JobID jobID;
+
+    private final ThreadDumpLogLevel dumpLogLevel;
+
+    private final int maxDepthOfThreadDump;
+
+    CheckpointExpiredThreadDumperWrapper(
+            CheckpointExpiredThreadDumper dumper,
+            JobID jobID,
+            ThreadDumpLogLevel dumpLogLevel,
+            int maxDepthOfThreadDump) {
+        this.dumper = dumper;
+        this.jobID = jobID;
+        this.dumpLogLevel = dumpLogLevel;
+        this.maxDepthOfThreadDump = maxDepthOfThreadDump;
+    }
+
+    /**
+     * Print the thread dump to log for a checkpoint. This can be ignored. See {@link
+     * CheckpointExpiredThreadDumper#threadDumpIfNeeded}.
+     *
+     * @param checkpointId the id of aborted checkpoint.
+     */
+    public void threadDumpIfNeeded(long checkpointId) {
+        dumper.threadDumpIfNeeded(jobID, checkpointId, dumpLogLevel, maxDepthOfThreadDump);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExpiredThreadDumperWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExpiredThreadDumperWrapper.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 
-import static org.apache.flink.runtime.state.CheckpointExpiredThreadDumper.ThreadDumpLogLevel;
+import static org.apache.flink.configuration.ClusterOptions.ThreadDumpLogLevel;
 
 /**
  * A wrapper that encapsulates the dumper worker and some job-related data and configuration,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1340,16 +1340,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
             return notifyCheckpointOperation(
                     () -> {
                         if (isRunning()
-                                && subtaskCheckpointCoordinator.checkCheckpointRegistered(
+                                && subtaskCheckpointCoordinator.isCheckpointRegistered(
                                         checkpointId)) {
                             checkpointExpiredThreadDumper.threadDumpIfNeeded(checkpointId);
                         }
                     },
                     "Request thread dump when checkpoint timeout");
         }
-        CompletableFuture<Void> result = new CompletableFuture<>();
-        result.complete(null);
-        return result;
+        return FutureUtils.completedVoidFuture();
     }
 
     private boolean performCheckpoint(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -477,15 +477,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
             this.checkpointExpiredThreadDumper =
                     environment.getCheckpointExpiredThreadDumper() == null
+                                    || configuration
+                                            .getConfiguration()
+                                            .get(
+                                                    ExecutionCheckpointingOptions
+                                                            .ENABLE_THREAD_DUMP_WHEN_CHECKPOINT_TIMEOUT)
                             ? null
                             : new CheckpointExpiredThreadDumperWrapper(
                                     environment.getCheckpointExpiredThreadDumper(),
                                     environment.getJobID(),
                                     configuration
                                             .getConfiguration()
-                                            .get(
-                                                    ExecutionCheckpointingOptions
-                                                            .THREAD_DUMP_LOG_LEVEL_WHEN_CHECKPOINT_TIMEOUT),
+                                            .get(ClusterOptions.THREAD_DUMP_LOG_LEVEL),
                                     configuration
                                             .getConfiguration()
                                             .get(ClusterOptions.THREAD_DUMP_STACKTRACE_MAX_DEPTH));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -101,6 +101,14 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
     /** Waits for all the pending checkpoints to finish their asynchronous step. */
     void waitForPendingCheckpoints() throws Exception;
 
+    /**
+     * Check whether a checkpoint is registered (running) in this coordinator.
+     *
+     * @param checkpointId of the target checkpoint
+     * @return true if the checkpoint is running.
+     */
+    boolean checkCheckpointRegistered(long checkpointId);
+
     /** Cancel all resources. */
     void cancel() throws IOException;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -107,7 +107,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
      * @param checkpointId of the target checkpoint
      * @return true if the checkpoint is running.
      */
-    boolean checkCheckpointRegistered(long checkpointId);
+    boolean isCheckpointRegistered(long checkpointId);
 
     /** Cancel all resources. */
     void cancel() throws IOException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -531,6 +531,13 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
     }
 
     @Override
+    public boolean checkCheckpointRegistered(long checkpointId) {
+        synchronized (lock) {
+            return !closed && checkpoints.containsKey(checkpointId);
+        }
+    }
+
+    @Override
     public void close() throws IOException {
         cancelAlignmentTimer();
         cancel();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -531,7 +531,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
     }
 
     @Override
-    public boolean checkCheckpointRegistered(long checkpointId) {
+    public boolean isCheckpointRegistered(long checkpointId) {
         synchronized (lock) {
             return !closed && checkpoints.containsKey(checkpointId);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -295,7 +296,8 @@ public class InterruptSensitiveRestoreTest {
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup(),
                 mock(PartitionProducerStateChecker.class),
                 mock(Executor.class),
-                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                new CheckpointExpiredThreadDumper());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -137,6 +137,9 @@ public class StreamMockEnvironment implements Environment {
 
     private CheckpointResponder checkpointResponder = NoOpCheckpointResponder.INSTANCE;
 
+    private CheckpointExpiredThreadDumper checkpointExpiredThreadDumper =
+            new CheckpointExpiredThreadDumper();
+
     public StreamMockEnvironment(
             Configuration jobConfig,
             Configuration taskConfig,
@@ -435,6 +438,6 @@ public class StreamMockEnvironment implements Environment {
 
     @Override
     public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
-        return null;
+        return checkpointExpiredThreadDumper;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
@@ -430,5 +431,10 @@ public class StreamMockEnvironment implements Environment {
     @Override
     public ChannelStateWriteRequestExecutorFactory getChannelStateExecutorFactory() {
         return channelStateExecutorFactory;
+    }
+
+    @Override
+    public CheckpointExpiredThreadDumper getCheckpointExpiredThreadDumper() {
+        return null;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
@@ -207,7 +208,8 @@ public class StreamTaskSystemExitTest extends TestLogger {
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup(),
                 mock(PartitionProducerStateChecker.class),
                 Executors.directExecutor(),
-                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                new CheckpointExpiredThreadDumper());
     }
 
     /** StreamTask emulating system exit behavior from different callback functions. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -191,7 +192,8 @@ public class StreamTaskTerminationTest extends TestLogger {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup(),
                         mock(PartitionProducerStateChecker.class),
                         Executors.directExecutor(),
-                        new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                        new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                        new CheckpointExpiredThreadDumper());
 
         CompletableFuture<Void> taskRun =
                 CompletableFuture.runAsync(() -> task.run(), EXECUTOR_RESOURCE.getExecutor());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
@@ -277,7 +278,8 @@ public class SynchronousCheckpointITCase {
                 taskMetricGroup,
                 partitionProducerStateChecker,
                 executor,
-                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                new CheckpointExpiredThreadDumper());
     }
 
     private static class TaskCleaner implements AutoCloseable {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.memory.SharedResources;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
+import org.apache.flink.runtime.state.CheckpointExpiredThreadDumper;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
@@ -246,7 +247,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup(),
                 mock(PartitionProducerStateChecker.class),
                 Executors.directExecutor(),
-                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()));
+                new ChannelStateWriteRequestExecutorFactory(jobInformation.getJobId()),
+                new CheckpointExpiredThreadDumper());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -98,6 +98,11 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
     public void waitForPendingCheckpoints() throws Exception {}
 
     @Override
+    public boolean checkCheckpointRegistered(long checkpointId) {
+        return false;
+    }
+
+    @Override
     public void close() {}
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -98,7 +98,7 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
     public void waitForPendingCheckpoints() throws Exception {}
 
     @Override
-    public boolean checkCheckpointRegistered(long checkpointId) {
+    public boolean isCheckpointRegistered(long checkpointId) {
         return false;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The thread dump of TM is very useful to investigate the reason why checkpoint happens to timeout. This PR make it possible  for TM to print thread dump to log when checkpoint expired.

## Brief change log

* Introduce a ```CheckpointExpiredThreadDumper``` to do the dump.
* Move a common thread dump stringifying util to ```org.apache.flink.runtime.util.JvmUtils```
* Construct an instance of ```CheckpointExpiredThreadDumper``` in ```TaskExecutor``` and pass it all the way to the ```StreamTask```
* Pass ```CheckpointFailureReason``` from ```CheckpointCoordinator``` to ```StreamTask``` via checkpoint notification when checkpoint aborted.
* When ```StreamTask``` receive the checkpoint expired notification, it will use the ```CheckpointExpiredThreadDumper``` to print the thread dump.

## Verifying this change

This change added tests and can be verified as follows:
 - Run ```CheckpointExpiredThreadDumperTest``` to verify the functionality of ```CheckpointExpiredThreadDumper```
 - Manually run a stateful test job with checkpoint timeout set to 1s (destined to time out), check the print thread dump.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), **Checkpointing**, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
