### PR TITLE
[FLINK-5279] Print state name and type in error message when trying to access keyed state in non-keyed operator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -237,7 +237,9 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         checkNotNull(stateDescriptor, "The state properties must not be null");
         checkNotNull(
                 keyedStateStore,
-                "Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.");
+                String.format(
+                        "Keyed state '%s' with type %s can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.",
+                        stateDescriptor.getName(), stateDescriptor.getType()));
         return keyedStateStore;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
@@ -458,14 +458,13 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 
         boolean exceptionThrown = false;
 
+        final ValueStateDescriptor<String> valueState =
+                new ValueStateDescriptor<>("any", BasicTypeInfo.STRING_TYPE_INFO);
+
         try (TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness =
                 getInitializedTestHarness(
                         new BroadcastProcessFunction<String, Integer, String>() {
                             private static final long serialVersionUID = -1725365436500098384L;
-
-                            private final ValueStateDescriptor<String> valueState =
-                                    new ValueStateDescriptor<>(
-                                            "any", BasicTypeInfo.STRING_TYPE_INFO);
 
                             @Override
                             public void processBroadcastElement(
@@ -488,7 +487,9 @@ public class CoBroadcastWithNonKeyedOperatorTest {
             testHarness.processElement2(new StreamRecord<>(5, 12L));
         } catch (NullPointerException e) {
             Assert.assertEquals(
-                    "Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.",
+                    String.format(
+                            "Keyed state '%s' with type %s can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.",
+                            valueState.getName(), valueState.getType()),
                     e.getMessage());
             exceptionThrown = true;
         }
@@ -503,14 +504,13 @@ public class CoBroadcastWithNonKeyedOperatorTest {
 
         boolean exceptionThrown = false;
 
+        final ValueStateDescriptor<String> valueState =
+                new ValueStateDescriptor<>("any", BasicTypeInfo.STRING_TYPE_INFO);
+
         try (TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness =
                 getInitializedTestHarness(
                         new BroadcastProcessFunction<String, Integer, String>() {
                             private static final long serialVersionUID = -1725365436500098384L;
-
-                            private final ValueStateDescriptor<String> valueState =
-                                    new ValueStateDescriptor<>(
-                                            "any", BasicTypeInfo.STRING_TYPE_INFO);
 
                             @Override
                             public void processBroadcastElement(
@@ -533,7 +533,9 @@ public class CoBroadcastWithNonKeyedOperatorTest {
             testHarness.processElement1(new StreamRecord<>("5", 12L));
         } catch (NullPointerException e) {
             Assert.assertEquals(
-                    "Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.",
+                    String.format(
+                            "Keyed state '%s' with type %s can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.",
+                            valueState.getName(), valueState.getType()),
                     e.getMessage());
             exceptionThrown = true;
         }


### PR DESCRIPTION
## What is the purpose of the change

Improve the error message when trying to access keyed state in non-keyed operator, printing the state name and state type. It is more convenient for user to identify the problem.

## Brief change log

Modify the error message and insert the state name and state type.


## Verifying this change

This change is a trivial rework, and the new error message can be validated by ```CoBroadcastWithNonKeyedOperatorTest```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
