### PR TITLE
[FLINK-33026][doc] Fix the title of sql 'Performance Tuning' in the chinese index page

### DIFF
--- a/docs/content.zh/docs/dev/table/tuning.md
+++ b/docs/content.zh/docs/dev/table/tuning.md
@@ -1,6 +1,6 @@
 ---
 title: "Performance Tuning"
-title: "流式聚合"
+title: "性能调优"
 weight: 11
 type: docs
 aliases:


### PR DESCRIPTION
This is a minor fix for the page title, after fix, the preview page will be:
![image](https://github.com/apache/flink/assets/3712895/6d95c767-ab27-4c7f-a33d-c43379d2312b)

