### PR TITLE
[FLINK-28513][Backport][release-1.18] Fix Flink Table API CSV streaming sink throws

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
@@ -254,6 +254,16 @@ public class S3RecoverableFsDataOutputStreamTest {
         streamUnderTest.closeForCommit().commit();
     }
 
+    @Test(expected = Exception.class)
+    public void testSync() throws IOException {
+        streamUnderTest.write(bytesOf("hello"));
+        streamUnderTest.write(bytesOf(" world"));
+        streamUnderTest.sync();
+        assertThat(multipartUploadUnderTest, hasContent(bytesOf("hello world")));
+        streamUnderTest.write(randomBuffer(RefCountedBufferingFileStream.BUFFER_SIZE + 1));
+        assertThat(multipartUploadUnderTest, hasContent(bytesOf("hello world")));
+    }
+
     // ------------------------------------------------------------------------------------------------------------
     // Utils
     // ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change
Backport https://github.com/apache/flink/pull/21458 for 1.18 branch