### PR TITLE
[FLINK-33034][Backport][runtime] Correct ValueState creating for StateBackendTestBase#testGetKeysAndNamespaces

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -492,7 +492,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                                     keysByNamespace.computeIfAbsent(entry.f1, k -> new HashSet<>());
                             assertTrue("Duplicate key for namespace", keys.add(entry.f0));
                         });
-                assertThat(keysByNamespace.size(), is(namespaces.length));
+                assertThat(
+                        "Unexpected namespaces count",
+                        keysByNamespace.size(),
+                        is(namespaces.length));
             }
         } finally {
             IOUtils.closeQuietly(backend);


### PR DESCRIPTION
## What is the purpose of the change

Backport for [FLINK-33034](https://issues.apache.org/jira/browse/FLINK-33034) to release 1.15 branch

## Verifying this change

StateBackendTestBase#testGetKeysAndNamespaces

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
