### PR TITLE
[FLINK-33029][python] Drop python 3.7 support

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -367,11 +367,11 @@ Currently, users are able to submit a PyFlink job via the CLI. It does not requi
 JAR file path or the entry main class, which is different from the Java job submission.
 
 {{< hint info >}}
-When submitting Python job via `flink run`, Flink will run the command "python". Please run the following command to confirm that the python executable in current environment points to a supported Python version of 3.7+.
+When submitting Python job via `flink run`, Flink will run the command "python". Please run the following command to confirm that the python executable in current environment points to a supported Python version of 3.8+.
 {{< /hint >}}
 ```bash
 $ python --version
-# the version printed here must be 3.7+
+# the version printed here must be 3.8+
 ```
 
 The following commands show different PyFlink job submission use-cases:
@@ -522,7 +522,7 @@ related options. Here's an overview of all the Python related options for the ac
             <td>
                 Specify the path of the python interpreter used to execute the python UDF worker
                 (e.g.: --pyExecutable /usr/local/bin/python3).
-                The python UDF worker depends on Python 3.7+, Apache Beam (version == 2.43.0),
+                The python UDF worker depends on Python 3.8+, Apache Beam (version == 2.43.0),
                 Pip (version >= 20.3) and SetupTools (version >= 37.0.0).
                 Please ensure that the specified environment meets the above requirements.
             </td>

--- a/docs/content.zh/docs/dev/python/datastream_tutorial.md
+++ b/docs/content.zh/docs/dev/python/datastream_tutorial.md
@@ -48,7 +48,7 @@ Apache Flink 提供了 DataStream API，用于构建健壮的、有状态的流�
 首先，你需要在你的电脑上准备以下环境：
 
 * Java 11
-* Python 3.7, 3.8, 3.9 or 3.10
+* Python 3.8, 3.9 or 3.10
 
 使用 Python DataStream API 需要安装 PyFlink，PyFlink 发布在 [PyPI](https://pypi.org/project/apache-flink/)上，可以通过 `pip` 快速安装。 
 

--- a/docs/content.zh/docs/dev/python/installation.md
+++ b/docs/content.zh/docs/dev/python/installation.md
@@ -29,11 +29,11 @@ under the License.
 
 
 ## 环境要求
-<span class="label label-info">注意</span> PyFlink 需要 Python 3.7 以上版本（3.7, 3.8, 3.9 或 3.10）。请运行以下命令，以确保 Python 版本满足要求。
+<span class="label label-info">注意</span> PyFlink 需要 Python 3.7 以上版本（3.8, 3.9 或 3.10）。请运行以下命令，以确保 Python 版本满足要求。
 
 ```bash
 $ python --version
-# the version printed here must be 3.7, 3.8, 3.9 or 3.10
+# the version printed here must be 3.8, 3.9 or 3.10
 ```
 
 ## 环境设置

--- a/docs/content.zh/docs/dev/python/python_execution_mode.md
+++ b/docs/content.zh/docs/dev/python/python_execution_mode.md
@@ -122,7 +122,7 @@ It will fall back to `PROCESS` execution mode in these cases. So it may happen t
 to execute in `THREAD` execution mode, however, it's actually executed in `PROCESS` execution mode.
 {{< /hint >}}
 {{< hint info >}}
-`THREAD` execution mode is only supported in Python 3.7+.
+`THREAD` execution mode is only supported in Python 3.8+.
 {{< /hint >}}
 
 ## Execution Behavior

--- a/docs/content.zh/docs/dev/python/table_api_tutorial.md
+++ b/docs/content.zh/docs/dev/python/table_api_tutorial.md
@@ -50,7 +50,7 @@ Apache Flink 提供 Table API 关系型 API 来统一处理流和批，即查询
 如果要继续我们的旅程，你需要一台具有以下功能的计算机：
 
 * Java 11
-* Python 3.7, 3.8, 3.9 or 3.10
+* Python 3.8, 3.9 or 3.10
 
 使用 Python Table API 需要安装 PyFlink，它已经被发布到 [PyPi](https://pypi.org/project/apache-flink/)，你可以通过如下方式安装 PyFlink：
 

--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -321,7 +321,7 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 --pyExecutable
                                                 /usr/local/bin/python3). The
                                                 python UDF worker depends on
-                                                Python 3.7+, Apache Beam
+                                                Python 3.8+, Apache Beam
                                                 (version == 2.43.0), Pip
                                                 (version >= 20.3) and SetupTools
                                                 (version >= 37.0.0). Please

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -73,11 +73,11 @@ mvn clean install -DskipTests -Dfast -Pskip-webui-build -T 1C
 
     如果想构建一个可用于 pip 安装的 PyFlink 包，需要先构建 Flink 工程，如 [构建 Flink](#build-flink) 中所述。
 
-2. Python 的版本为 3.7, 3.8, 3.9 或者 3.10.
+2. Python 的版本为 3.8, 3.9 或者 3.10.
 
     ```shell
     $ python --version
-    # the version printed here must be 3.7, 3.8, 3.9 or 3.10
+    # the version printed here must be 3.8, 3.9 or 3.10
     ```
 
 3. 构建 PyFlink 的 Cython 扩展模块（可选的）

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -365,11 +365,11 @@ Currently, users are able to submit a PyFlink job via the CLI. It does not requi
 JAR file path or the entry main class, which is different from the Java job submission.
 
 {{< hint info >}}
-When submitting Python job via `flink run`, Flink will run the command "python". Please run the following command to confirm that the python executable in current environment points to a supported Python version of 3.7+.
+When submitting Python job via `flink run`, Flink will run the command "python". Please run the following command to confirm that the python executable in current environment points to a supported Python version of 3.8+.
 {{< /hint >}}
 ```bash
 $ python --version
-# the version printed here must be 3.7+
+# the version printed here must be 3.8+
 ```
 
 The following commands show different PyFlink job submission use-cases:
@@ -520,7 +520,7 @@ related options. Here's an overview of all the Python related options for the ac
             <td>
                 Specify the path of the python interpreter used to execute the python UDF worker
                 (e.g.: --pyExecutable /usr/local/bin/python3).
-                The python UDF worker depends on Python 3.7+, Apache Beam (version == 2.43.0),
+                The python UDF worker depends on Python 3.8+, Apache Beam (version == 2.43.0),
                 Pip (version >= 20.3) and SetupTools (version >= 37.0.0).
                 Please ensure that the specified environment meets the above requirements.
             </td>

--- a/docs/content/docs/dev/python/datastream_tutorial.md
+++ b/docs/content/docs/dev/python/datastream_tutorial.md
@@ -47,7 +47,7 @@ In particular, Apache Flink's [user mailing list](https://flink.apache.org/commu
 If you want to follow along, you will require a computer with: 
 
 * Java 11
-* Python 3.7, 3.8, 3.9 or 3.10
+* Python 3.8, 3.9 or 3.10
 
 Using Python DataStream API requires installing PyFlink, which is available on [PyPI](https://pypi.org/project/apache-flink/) and can be easily installed using `pip`. 
 

--- a/docs/content/docs/dev/python/installation.md
+++ b/docs/content/docs/dev/python/installation.md
@@ -29,12 +29,12 @@ under the License.
 ## Environment Requirements
 
 {{< hint info >}}
-Python version (3.7, 3.8, 3.9 or 3.10) is required for PyFlink. Please run the following command to make sure that it meets the requirements:
+Python version (3.8, 3.9 or 3.10) is required for PyFlink. Please run the following command to make sure that it meets the requirements:
 {{< /hint >}}
 
 ```bash
 $ python --version
-# the version printed here must be 3.7, 3.8, 3.9 or 3.10
+# the version printed here must be 3.8, 3.9 or 3.10
 ```
 
 ## Environment Setup

--- a/docs/content/docs/dev/python/python_execution_mode.md
+++ b/docs/content/docs/dev/python/python_execution_mode.md
@@ -122,7 +122,7 @@ It will fall back to `PROCESS` execution mode in these cases. So it may happen t
 to execute in `THREAD` execution mode, however, it's actually executed in `PROCESS` execution mode.
 {{< /hint >}}
 {{< hint info >}}
-`THREAD` execution mode is only supported in Python 3.7+.
+`THREAD` execution mode is only supported in Python 3.8+.
 {{< /hint >}}
 
 ## Execution Behavior

--- a/docs/content/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/python_udfs.md
@@ -28,7 +28,7 @@ under the License.
 
 User-defined functions are important features, because they significantly extend the expressiveness of Python Table API programs.
 
-**NOTE:** Python UDF execution requires Python version (3.7, 3.8, 3.9 or 3.10) with PyFlink installed. It's required on both the client side and the cluster side. 
+**NOTE:** Python UDF execution requires Python version (3.8, 3.9 or 3.10) with PyFlink installed. It's required on both the client side and the cluster side. 
 
 ## Scalar Functions
 

--- a/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -33,7 +33,7 @@ These Python libraries are highly optimized and provide high-performance data st
 [non-vectorized user-defined functions]({{< ref "docs/dev/python/table/udfs/python_udfs" >}}) on how to define vectorized user-defined functions.
 Users only need to add an extra parameter `func_type="pandas"` in the decorator `udf` or `udaf` to mark it as a vectorized user-defined function.
 
-**NOTE:** Python UDF execution requires Python version (3.7, 3.8, 3.9 or 3.10) with PyFlink installed. It's required on both the client side and the cluster side. 
+**NOTE:** Python UDF execution requires Python version (3.8, 3.9 or 3.10) with PyFlink installed. It's required on both the client side and the cluster side. 
 
 ## Vectorized Scalar Functions
 

--- a/docs/content/docs/dev/python/table_api_tutorial.md
+++ b/docs/content/docs/dev/python/table_api_tutorial.md
@@ -51,7 +51,7 @@ In particular, Apache Flink's [user mailing list](https://flink.apache.org/commu
 If you want to follow along, you will require a computer with: 
 
 * Java 11
-* Python 3.7, 3.8, 3.9 or 3.10
+* Python 3.8, 3.9 or 3.10
 
 Using Python Table API requires installing PyFlink, which is available on [PyPI](https://pypi.org/project/apache-flink/) and can be easily installed using `pip`. 
 

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -259,7 +259,7 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 --pyExecutable
                                                 /usr/local/bin/python3). The
                                                 python UDF worker depends on
-                                                Python 3.7+, Apache Beam
+                                                Python 3.8+, Apache Beam
                                                 (version == 2.43.0), Pip
                                                 (version >= 20.3) and SetupTools
                                                 (version >= 37.0.0). Please

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -72,11 +72,11 @@ The `fast` and `skip-webui-build` profiles have a significant impact on the buil
 
     If you want to build a PyFlink package that can be used for pip installation, you need to build the Flink project first, as described in [Build Flink](#build-flink).
 
-2. Python version(3.7, 3.8, 3.9 or 3.10) is required
+2. Python version(3.8, 3.9 or 3.10) is required
 
     ```shell
     $ python --version
-    # the version printed here must be 3.7, 3.8, 3.9 or 3.10
+    # the version printed here must be 3.8, 3.9 or 3.10
     ```
 
 3. Build PyFlink with Cython extension support (optional)

--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>python.executable</h5></td>
             <td style="word-wrap: break-word;">"python"</td>
             <td>String</td>
-            <td>Specify the path of the python interpreter used to execute the python UDF worker. The python UDF worker depends on Python 3.7+, Apache Beam (version == 2.43.0), Pip (version &gt;= 20.3) and SetupTools (version &gt;= 37.0.0). Please ensure that the specified environment meets the above requirements. The option is equivalent to the command line option "-pyexec".</td>
+            <td>Specify the path of the python interpreter used to execute the python UDF worker. The python UDF worker depends on Python 3.8+, Apache Beam (version == 2.43.0), Pip (version &gt;= 20.3) and SetupTools (version &gt;= 37.0.0). Please ensure that the specified environment meets the above requirements. The option is equivalent to the command line option "-pyexec".</td>
         </tr>
         <tr>
             <td><h5>python.execution-mode</h5></td>

--- a/docs/static/downloads/setup-pyflink-virtual-env.sh
+++ b/docs/static/downloads/setup-pyflink-virtual-env.sh
@@ -15,14 +15,18 @@
 # limitations under the License.
 set -e
 # download miniconda.sh
-if [[ `uname -s` == "Darwin" ]]; then
-    if [[ `uname -m` == "arm64" ]]; then
-        wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-arm64.sh" -O "miniconda.sh"
-    else
-        wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-x86_64.sh" -O "miniconda.sh"
-    fi
+sys_os=$(uname -s)
+echo "Detected OS: ${sys_os}"
+sys_machine=$(uname -m)
+echo "Detected machine: ${sys_machine}"
+
+if [[ ${sys_os} == "Darwin" ]]; then
+    wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-MacOSX-${sys_machine}.sh" -O "miniconda.sh"
+elif [[ ${sys_os} == "Linux" ]]; then
+    wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-${sys_machine}.sh" -O "miniconda.sh"
 else
-    wget "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh" -O "miniconda.sh"
+    echo "Unsupported OS: ${sys_os}"
+    exit 1
 fi
 
 # add the execution permission

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -265,7 +265,7 @@ public class CliFrontendParser {
                     true,
                     "Specify the path of the python interpreter used to execute the python UDF worker "
                             + "(e.g.: --pyExecutable /usr/local/bin/python3). "
-                            + "The python UDF worker depends on Python 3.7+, Apache Beam (version == 2.43.0), "
+                            + "The python UDF worker depends on Python 3.8+, Apache Beam (version == 2.43.0), "
                             + "Pip (version >= 20.3) and SetupTools (version >= 37.0.0). "
                             + "Please ensure that the specified environment meets the above requirements.");
 

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/entrypoint.sh
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/entrypoint.sh
@@ -19,6 +19,7 @@
 
 : ${HADOOP_PREFIX:=/usr/local/hadoop}
 
+export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
 $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 
 MAX_RETRY_SECONDS=800

--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -225,17 +225,16 @@ run sdist.
         license='https://www.apache.org/licenses/LICENSE-2.0',
         author='Apache Software Foundation',
         author_email='dev@flink.apache.org',
-        python_requires='>=3.6',
+        python_requires='>=3.8',
         description='Apache Flink Libraries',
         long_description=long_description,
         long_description_content_type='text/markdown',
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9'],
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10'],
     )
 finally:
     if in_flink_source:

--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -19,14 +19,16 @@ set -e -x
 dev/lint-python.sh -s py_env
 
 PY_ENV_DIR=`pwd`/dev/.conda/envs
-py_env=("3.7" "3.8" "3.9" "3.10")
+py_env=("3.8" "3.9" "3.10")
 ## 2. install dependency
 for ((i=0;i<${#py_env[@]};i++)) do
+    echo "Installing dependencies for environment: ${py_env[i]}"
     ${PY_ENV_DIR}/${py_env[i]}/bin/pip install -r dev/dev-requirements.txt
 done
 
 ## 3. build wheels
 for ((i=0;i<${#py_env[@]};i++)) do
+    echo "Building wheel for environment: ${py_env[i]}"
     if [[ "$(uname)" != "Darwin" ]]; then
         # force the linker to use the older glibc version in Linux
         export CFLAGS="-I. -include dev/glibc_version_fix.h"
@@ -36,6 +38,7 @@ done
 
 ## 4. convert linux_x86_64 wheel to manylinux1 wheel in Linux
 if [[ "$(uname)" != "Darwin" ]]; then
+    echo "Converting linux_x86_64 wheel to manylinux1"
     source `pwd`/dev/.conda/bin/activate
     # 4.1 install patchelf
     conda install -c conda-forge patchelf=0.11 -y

--- a/flink-python/dev/install_command.sh
+++ b/flink-python/dev/install_command.sh
@@ -24,6 +24,13 @@ if [[ "$@" =~ 'apache-flink-libraries' ]]; then
     popd
     popd
 fi
+
+if [[ `uname -s` == "Darwin" && `uname -m` == "arm64" ]]; then
+  echo "Adding MacOS arm64 GRPC pip install fix"
+  export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+  export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+fi
+
 retry_times=3
 install_command="python -m pip install $@"
 ${install_command}

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -1524,7 +1524,7 @@ class KeyedBroadcastProcessFunction(BaseBroadcastProcessFunction, Generic[KEY, I
             pass
 
         @abstractmethod
-        def get_current_key(self) -> KEY:
+        def get_current_key(self) -> KEY:  # type: ignore[type-var]
             """
             Get key of the element being processed.
             """
@@ -1544,7 +1544,7 @@ class KeyedBroadcastProcessFunction(BaseBroadcastProcessFunction, Generic[KEY, I
             pass
 
         @abstractmethod
-        def get_current_key(self) -> KEY:
+        def get_current_key(self) -> KEY:  # type: ignore[type-var]
             """
             Get the key of the firing timer.
             """

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -220,7 +220,7 @@ class AggregateFunction(ImperativeAggregateFunction):
     """
 
     @abc.abstractmethod
-    def get_value(self, accumulator: ACC) -> T:
+    def get_value(self, accumulator: ACC) -> T:  # type: ignore[type-var]
         """
         Called every time when an aggregation result should be materialized. The returned value
         could be either an early and incomplete result (periodically emitted as data arrives) or

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -28,8 +28,8 @@ from shutil import copytree, copy, rmtree
 from setuptools import setup, Extension
 from xml.etree import ElementTree as ET
 
-if sys.version_info < (3, 7):
-    print("Python versions prior to 3.7 are not supported for PyFlink.",
+if sys.version_info < (3, 8):
+    print("Python versions prior to 3.8 are not supported for PyFlink.",
           file=sys.stderr)
     sys.exit(-1)
 
@@ -339,7 +339,7 @@ try:
         license='https://www.apache.org/licenses/LICENSE-2.0',
         author='Apache Software Foundation',
         author_email='dev@flink.apache.org',
-        python_requires='>=3.7',
+        python_requires='>=3.8',
         install_requires=install_requires,
         cmdclass={'build_ext': build_ext},
         description='Apache Flink Python API',
@@ -349,7 +349,6 @@ try:
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10'],

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -159,7 +159,7 @@ public class PythonOptions {
                     .defaultValue("python")
                     .withDescription(
                             "Specify the path of the python interpreter used to execute the python "
-                                    + "UDF worker. The python UDF worker depends on Python 3.7+, Apache Beam "
+                                    + "UDF worker. The python UDF worker depends on Python 3.8+, Apache Beam "
                                     + "(version == 2.43.0), Pip (version >= 20.3) and SetupTools (version >= 37.0.0). "
                                     + "Please ensure that the specified environment meets the above requirements. The "
                                     + "option is equivalent to the command line option \"-pyexec\".");

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -21,7 +21,7 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions.
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = {py37, py38, py39, py310}-cython
+envlist = {py38, py39, py310}-cython
 
 [testenv]
 whitelist_externals=

--- a/flink-table/flink-sql-client/src/test/resources/cli/all-mode-help.out
+++ b/flink-table/flink-sql-client/src/test/resources/cli/all-mode-help.out
@@ -84,7 +84,7 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 --pyExecutable
                                                 /usr/local/bin/python3). The
                                                 python UDF worker depends on
-                                                Python 3.7+, Apache Beam
+                                                Python 3.8+, Apache Beam
                                                 (version == 2.43.0), Pip
                                                 (version >= 20.3) and SetupTools
                                                 (version >= 37.0.0). Please

--- a/flink-table/flink-sql-client/src/test/resources/cli/embedded-mode-help.out
+++ b/flink-table/flink-sql-client/src/test/resources/cli/embedded-mode-help.out
@@ -81,7 +81,7 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
                                                 --pyExecutable
                                                 /usr/local/bin/python3). The
                                                 python UDF worker depends on
-                                                Python 3.7+, Apache Beam
+                                                Python 3.8+, Apache Beam
                                                 (version == 2.43.0), Pip
                                                 (version >= 20.3) and SetupTools
                                                 (version >= 37.0.0). Please

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -129,8 +129,8 @@ make_python_release() {
   cp ${pyflink_actual_name} "${PYTHON_RELEASE_DIR}/${pyflink_release_name}"
 
   wheel_packages_num=0
-  # py37,py38,py39,py310 for mac and linux (11 wheel packages)
-  EXPECTED_WHEEL_PACKAGES_NUM=11
+  # py38,py39,py310 for mac 10.9, 11.0 and linux (9 wheel packages)
+  EXPECTED_WHEEL_PACKAGES_NUM=9
   # Need to move the downloaded wheel packages from Azure CI to the directory flink-python/dist manually.
   for wheel_file in *.whl; do
     if [[ ! ${wheel_file} =~ ^apache_flink-$PYFLINK_VERSION- ]]; then


### PR DESCRIPTION
## What is the purpose of the change

* Python 3.7.17 is the latest security patch of the 3.7 line. This version is end-of-life and is no longer supported: https://www.python.org/downloads/release/python-3717/
* Miniconda 4.7.10 is released on 2019-07-29 which is 4 years old already and not supporting too many architectures (x86_64 and ppc64le)
* The latest miniconda which has real multi-arch feature set supports the following python versions: 3.8, 3.9, 3.10, 3.11 and no 3.7 support

In this PR  python 3.7 support dropped and upgrade miniconda to the latest version which opens the door to other platforms + python 3.11 support

## Brief change log

* Python 3.7 support dropped
* Upgrade miniconda to the latest version
* Add arm support
* Upgrade `mypy==1.5.1` (latest)
* `flink-python/apache-flink-libraries/setup.py` python versions fix (still 3.6 was there which is dropped long time ago)

## Verifying this change

* Existing python tests.
* Manually
```
dev/build-wheels.sh
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
