### PR TITLE
[FLINK-33038][table-planner] remove getMinRetentionTime in StreamExec…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -255,10 +255,6 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
             return config.get(TABLE_EXEC_DEDUPLICATE_MINIBATCH_COMPACT_CHANGES_ENABLED);
         }
 
-        protected long getMinRetentionTime() {
-            return config.get(ExecutionConfigOptions.IDLE_STATE_RETENTION).toMillis();
-        }
-
         protected long getMiniBatchSize() {
             if (isMiniBatchEnabled()) {
                 long size = config.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE);


### PR DESCRIPTION


## What is the purpose of the change

remove code no longer needed


## Brief change log


  - *remove the getMinRetentionTime*


## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
