### PR TITLE
[FLINK-33028][table] Make expanding behavior of virtual metadata columns configurable

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/systemFunctions.md
+++ b/docs/content.zh/docs/dev/table/functions/systemFunctions.md
@@ -175,6 +175,7 @@ Known Limitations:
 | :----------------------- | :--------------------------- |
 | withColumns(...)         | 选择指定的列                   |
 | withoutColumns(...)      | 选择除指定列以外的列            |
+| withAllColumns()    | select all columns (like `SELECT *` in SQL) |
 
 详细语法如下：
 
@@ -182,6 +183,7 @@ Known Limitations:
 列函数:
     withColumns(columnExprs)
     withoutColumns(columnExprs)
+    withAllColumns()
 
 多列表达式:
     columnExpr [, columnExpr]*

--- a/docs/content/docs/dev/table/functions/systemFunctions.md
+++ b/docs/content/docs/dev/table/functions/systemFunctions.md
@@ -175,6 +175,7 @@ Column functions are only used in Table API.
 | :--------------------- | :-------------------------- |
 | withColumns(...)         | select the specified columns                  |
 | withoutColumns(...)        | deselect the columns specified                  |
+| withAllColumns()    | select all columns (like `SELECT *` in SQL) |
 
 The detailed syntax is as follows:
 
@@ -182,6 +183,7 @@ The detailed syntax is as follows:
 columnFunction:
     withColumns(columnExprs)
     withoutColumns(columnExprs)
+    withAllColumns()
 
 columnExprs:
     columnExpr [, columnExpr]*

--- a/docs/layouts/shortcodes/generated/table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/table_config_configuration.html
@@ -27,6 +27,12 @@
             <td>A (semicolon-separated) list of factories that creates listener for catalog modification which will be notified in catalog manager after it performs database and table ddl operations successfully.</td>
         </tr>
         <tr>
+            <td><h5>table.column-expansion-strategy</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;"></td>
+            <td><p>List&lt;Enum&gt;</p></td>
+            <td>Configures the default expansion behavior of 'SELECT *'. By default, all top-level columns of the table's schema are selected and nested fields are retained.<br /><br />Possible values:<ul><li>"EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS": Excludes virtual metadata columns that reference a metadata key via an alias. For example, a column declared as 'c METADATA VIRTUAL FROM k' is not selected by default if the strategy is applied.</li><li>"EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS": Excludes virtual metadata columns that directly reference a metadata key. For example, a column declared as 'k METADATA VIRTUAL' is not selected by default if the strategy is applied.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.display.max-column-width</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">30</td>
             <td>Integer</td>

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -94,6 +94,8 @@ def col(name: str) -> Expression:
         >>> tab.select(col("key"), col("value"))
 
     :param name: the field name to refer to
+
+    .. seealso:: :func:`~pyflink.table.expressions.with_all_columns`
     """
     return _unary_op("col", name)
 
@@ -685,6 +687,22 @@ def coalesce(*args) -> Expression:
     gateway = get_gateway()
     args = to_jarray(gateway.jvm.Object, [_get_java_expression(arg) for arg in args])
     return _unary_op("coalesce", args)
+
+
+def with_all_columns() -> Expression:
+    """
+    Creates an expression that selects all columns. It can be used wherever an array of
+    expression is accepted such as function calls, projections, or groupings.
+
+    This expression is a synonym of col("*"). It is semantically equal to SELECT * in
+    SQL when used in a projection.
+
+    e.g. tab.select(with_all_columns())
+
+    .. seealso:: :func:`~pyflink.table.expressions.with_columns`
+                 :func:`~pyflink.table.expressions.without_columns`
+    """
+    return _leaf_op("withAllColumns")
 
 
 def with_columns(head, *tails) -> Expression:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -83,6 +83,7 @@ public final class Expressions {
      * }</pre>
      *
      * @see #col(String)
+     * @see #withAllColumns()
      */
     // CHECKSTYLE.OFF: MethodName
     public static ApiExpression $(String name) {
@@ -101,6 +102,8 @@ public final class Expressions {
      * <pre>{@code
      * tab.select(col("key"), col("value"))
      * }</pre>
+     *
+     * @see #withAllColumns()
      */
     public static ApiExpression col(String name) {
         return $(name);
@@ -729,13 +732,33 @@ public final class Expressions {
     }
 
     /**
+     * Creates an expression that selects all columns. It can be used wherever an array of
+     * expression is accepted such as function calls, projections, or groupings.
+     *
+     * <p>This expression is a synonym of $("*"). It is semantically equal to {@code SELECT *} in
+     * SQL when used in a projection.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * tab.select(withAllColumns())
+     * }</pre>
+     *
+     * @see #withColumns(Object, Object...)
+     * @see #withoutColumns(Object, Object...)
+     */
+    public static ApiExpression withAllColumns() {
+        return $("*");
+    }
+
+    /**
      * Creates an expression that selects a range of columns. It can be used wherever an array of
      * expression is accepted such as function calls, projections, or groupings.
      *
      * <p>A range can either be index-based or name-based. Indices start at 1 and boundaries are
      * inclusive.
      *
-     * <p>e.g. withColumns(range("b", "c")) or withoutColumns($("*"))
+     * <p>e.g. withColumns(range("b", "c")) or withColumns($("*"))
      */
     public static ApiExpression withColumns(Object head, Object... tail) {
         return apiCallAtLeastOneArgument(BuiltInFunctionDefinitions.WITH_COLUMNS, head, tail);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -125,6 +125,38 @@ public class TableConfigOptions {
                                     + "This only applies to columns with variable-length types (e.g. STRING) in the streaming mode. "
                                     + "Fixed-length types are printed in the batch mode using a deterministic column width.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    @Documentation.OverrideDefault("System.getProperty(\"java.io.tmpdir\")")
+    public static final ConfigOption<String> RESOURCES_DOWNLOAD_DIR =
+            key("table.resources.download-dir")
+                    .stringType()
+                    .defaultValue(System.getProperty("java.io.tmpdir"))
+                    .withDescription(
+                            "Local directory that is used by planner for storing downloaded resources.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<Boolean> TABLE_RTAS_CTAS_ATOMICITY_ENABLED =
+            key("table.rtas-ctas.atomicity-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specifies if the CREATE TABLE/REPLACE TABLE/CREATE OR REPLACE AS SELECT statement is executed atomically. By default, the statement is non-atomic. "
+                                    + "The target table is created/replaced on the client side, and it will not be rolled back even though the job fails or is canceled. "
+                                    + "If set this option to true and the underlying DynamicTableSink implements the SupportsStaging interface, "
+                                    + "the statement is expected to be executed atomically, the behavior of which depends on the actual DynamicTableSink.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<List<ColumnExpansionStrategy>>
+            TABLE_COLUMN_EXPANSION_STRATEGY =
+                    key("table.column-expansion-strategy")
+                            .enumType(ColumnExpansionStrategy.class)
+                            .asList()
+                            .defaultValues()
+                            .withDescription(
+                                    "Configures the default expansion behavior of 'SELECT *'. "
+                                            + "By default, all top-level columns of the table's "
+                                            + "schema are selected and nested fields are retained.");
+
     // ------------------------------------------------------------------------------------------
     // Options for plan handling
     // ------------------------------------------------------------------------------------------
@@ -200,26 +232,6 @@ public class TableConfigOptions {
                     .defaultValue(10000)
                     .withDescription(
                             "Specifies a threshold where class members of generated code will be grouped into arrays by types.");
-
-    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
-    @Documentation.OverrideDefault("System.getProperty(\"java.io.tmpdir\")")
-    public static final ConfigOption<String> RESOURCES_DOWNLOAD_DIR =
-            key("table.resources.download-dir")
-                    .stringType()
-                    .defaultValue(System.getProperty("java.io.tmpdir"))
-                    .withDescription(
-                            "Local directory that is used by planner for storing downloaded resources.");
-
-    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
-    public static final ConfigOption<Boolean> TABLE_RTAS_CTAS_ATOMICITY_ENABLED =
-            key("table.rtas-ctas.atomicity-enabled")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Specifies if the CREATE TABLE/REPLACE TABLE/CREATE OR REPLACE AS SELECT statement is executed atomically. By default, the statement is non-atomic. "
-                                    + "The target table is created/replaced on the client side, and it will not be rolled back even though the job fails or is canceled. "
-                                    + "If set this option to true and the underlying DynamicTableSink implements the SupportsStaging interface, "
-                                    + "the statement is expected to be executed atomically, the behavior of which depends on the actual DynamicTableSink.");
 
     // ------------------------------------------------------------------------------------------
     // Enum option types
@@ -304,6 +316,34 @@ public class TableConfigOptions {
         private final InlineElement description;
 
         CatalogPlanRestore(InlineElement description) {
+            this.description = description;
+        }
+
+        @Internal
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /** Strategy to expand columns in {@code SELECT *} queries. */
+    @PublicEvolving
+    public enum ColumnExpansionStrategy implements DescribedEnum {
+        EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS(
+                text(
+                        "Excludes virtual metadata columns that reference a metadata key via an alias. "
+                                + "For example, a column declared as 'c METADATA VIRTUAL FROM k' "
+                                + "is not selected by default if the strategy is applied.")),
+
+        EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS(
+                text(
+                        "Excludes virtual metadata columns that directly reference a metadata key. "
+                                + "For example, a column declared as 'k METADATA VIRTUAL' "
+                                + "is not selected by default if the strategy is applied."));
+
+        private final InlineElement description;
+
+        ColumnExpansionStrategy(InlineElement description) {
             this.description = description;
         }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/StarReferenceFlatteningRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/StarReferenceFlatteningRule.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.expressions.resolver.rules;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
@@ -38,21 +40,28 @@ final class StarReferenceFlatteningRule implements ResolverRule {
 
     @Override
     public List<Expression> apply(List<Expression> expression, ResolutionContext context) {
+        final List<ColumnExpansionStrategy> strategies =
+                context.configuration().get(TableConfigOptions.TABLE_COLUMN_EXPANSION_STRATEGY);
         return expression.stream()
-                .flatMap(expr -> expr.accept(new FieldFlatteningVisitor(context)).stream())
+                .flatMap(e -> e.accept(new FieldFlatteningVisitor(context, strategies)).stream())
                 .collect(Collectors.toList());
     }
 
     private static class FieldFlatteningVisitor extends RuleExpressionVisitor<List<Expression>> {
 
-        FieldFlatteningVisitor(ResolutionContext resolutionContext) {
+        private final List<ColumnExpansionStrategy> strategies;
+
+        FieldFlatteningVisitor(
+                ResolutionContext resolutionContext, List<ColumnExpansionStrategy> strategies) {
             super(resolutionContext);
+            this.strategies = strategies;
         }
 
         @Override
         public List<Expression> visit(UnresolvedReferenceExpression unresolvedReference) {
             if (unresolvedReference.getName().equals("*")) {
-                return new ArrayList<>(resolutionContext.referenceLookup().getAllInputFields());
+                return new ArrayList<>(
+                        resolutionContext.referenceLookup().getInputFields(strategies));
             } else {
                 return singletonList(unresolvedReference);
             }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
@@ -107,6 +107,10 @@ public final class ShortcutUtils {
         return unwrapContext(relOptRuleCall.getPlanner()).getTableConfig();
     }
 
+    public static TableConfig unwrapTableConfig(RelOptCluster relOptCluster) {
+        return unwrapContext(relOptCluster.getPlanner()).getTableConfig();
+    }
+
     public static ClassLoader unwrapClassLoader(RelNode relNode) {
         return unwrapContext(relNode).getClassLoader();
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ColumnExpansionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ColumnExpansionTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.TableConfigOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy.EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS;
+import static org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy.EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS;
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_COLUMN_EXPANSION_STRATEGY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableConfigOptions#TABLE_COLUMN_EXPANSION_STRATEGY}. */
+public class ColumnExpansionTest {
+
+    private TableEnvironment tableEnv;
+
+    @Before
+    public void before() {
+        tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tableEnv.executeSql(
+                "CREATE TABLE t1 (\n"
+                        + "  t1_i INT,\n"
+                        + "  t1_s STRING,\n"
+                        + "  t1_m_virtual INT METADATA VIRTUAL,\n"
+                        + "  t1_m_aliased_virtual STRING METADATA FROM 'k1' VIRTUAL,\n"
+                        + "  t1_m_default INT METADATA,\n"
+                        + "  t1_m_aliased STRING METADATA FROM 'k2'\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'readable-metadata' = 't1_m_virtual:INT,k1:STRING,t1_m_default:INT,k2:STRING'\n"
+                        + ")");
+
+        tableEnv.executeSql(
+                "CREATE TABLE t2 (\n"
+                        + "  t2_i INT,\n"
+                        + "  t2_s STRING,\n"
+                        + "  t2_m_virtual INT METADATA VIRTUAL,\n"
+                        + "  t2_m_aliased_virtual STRING METADATA FROM 'k1' VIRTUAL,\n"
+                        + "  t2_m_default INT METADATA,\n"
+                        + "  t2_m_aliased STRING METADATA FROM 'k2'\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'readable-metadata' = 't2_m_virtual:INT,k1:STRING,t2_m_default:INT,k2:STRING'\n"
+                        + ")");
+
+        tableEnv.getConfig().set(TABLE_COLUMN_EXPANSION_STRATEGY, Collections.emptyList());
+    }
+
+    @Test
+    public void testExcludeDefaultVirtualMetadataColumns() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Collections.singletonList(EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS));
+
+        // From one table
+        assertColumnNames(
+                "SELECT * FROM t1",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From one table with explicit selection of metadata column
+        assertColumnNames(
+                "SELECT t1_m_virtual, * FROM t1",
+                "t1_m_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From two tables (i.e. implicit join)
+        assertColumnNames(
+                "SELECT * FROM t1, t2",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_aliased_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+
+        // From two tables (i.e. implicit join) with per table expansion
+        assertColumnNames(
+                "SELECT t1.*, t2.* FROM t1, t2",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_aliased_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+
+        // Transitive metadata columns are always selected
+        assertColumnNames(
+                "SELECT * FROM (SELECT t1_m_virtual, t2_m_virtual, * FROM t1, t2)",
+                "t1_m_virtual",
+                "t2_m_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_aliased_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+    }
+
+    @Test
+    public void testExcludeAliasedVirtualMetadataColumns() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Collections.singletonList(EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        // From one table
+        assertColumnNames(
+                "SELECT * FROM t1", "t1_i", "t1_s", "t1_m_virtual", "t1_m_default", "t1_m_aliased");
+
+        // From one table with explicit selection of metadata column
+        assertColumnNames(
+                "SELECT t1_m_aliased_virtual, * FROM t1",
+                "t1_m_aliased_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From two tables (i.e. implicit join)
+        assertColumnNames(
+                "SELECT * FROM t1, t2",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+
+        // From two tables (i.e. implicit join) with per table expansion
+        assertColumnNames(
+                "SELECT t1.*, t2.* FROM t1, t2",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+
+        // Transitive metadata columns are always selected
+        assertColumnNames(
+                "SELECT * FROM (SELECT t1_m_aliased_virtual, t2_m_aliased_virtual, * FROM t1, t2)",
+                "t1_m_aliased_virtual",
+                "t2_m_aliased_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased",
+                "t2_i",
+                "t2_s",
+                "t2_m_virtual",
+                "t2_m_default",
+                "t2_m_aliased");
+    }
+
+    @Test
+    public void testExcludeViaView() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Arrays.asList(
+                                EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS,
+                                EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        tableEnv.executeSql("CREATE VIEW v1 AS SELECT * FROM t1");
+
+        assertColumnNames("SELECT * FROM v1", "t1_i", "t1_s", "t1_m_default", "t1_m_aliased");
+    }
+
+    private void assertColumnNames(String sql, String... columnNames) {
+        assertThat(tableEnv.sqlQuery(sql).getResolvedSchema().getColumnNames())
+                .containsExactly(columnNames);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/table/ColumnExpansionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/table/ColumnExpansionTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.table;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.TableConfigOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.range;
+import static org.apache.flink.table.api.Expressions.withColumns;
+import static org.apache.flink.table.api.Expressions.withoutColumns;
+import static org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy.EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS;
+import static org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy.EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS;
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_COLUMN_EXPANSION_STRATEGY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableConfigOptions#TABLE_COLUMN_EXPANSION_STRATEGY}. */
+public class ColumnExpansionTest {
+
+    private TableEnvironment tableEnv;
+
+    @Before
+    public void before() {
+        tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tableEnv.executeSql(
+                "CREATE TABLE t1 (\n"
+                        + "  t1_i INT,\n"
+                        + "  t1_s STRING,\n"
+                        + "  t1_m_virtual INT METADATA VIRTUAL,\n"
+                        + "  t1_m_aliased_virtual STRING METADATA FROM 'k1' VIRTUAL,\n"
+                        + "  t1_m_default INT METADATA,\n"
+                        + "  t1_m_aliased STRING METADATA FROM 'k2'\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'readable-metadata' = 't1_m_virtual:INT,k1:STRING,t1_m_default:INT,k2:STRING'\n"
+                        + ")");
+
+        tableEnv.executeSql(
+                "CREATE TABLE t2 (\n"
+                        + "  t2_i INT,\n"
+                        + "  t2_s STRING,\n"
+                        + "  t2_m_virtual INT METADATA VIRTUAL,\n"
+                        + "  t2_m_aliased_virtual STRING METADATA FROM 'k1' VIRTUAL,\n"
+                        + "  t2_m_default INT METADATA,\n"
+                        + "  t2_m_aliased STRING METADATA FROM 'k2'\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'readable-metadata' = 't2_m_virtual:INT,k1:STRING,t2_m_default:INT,k2:STRING'\n"
+                        + ")");
+
+        tableEnv.getConfig().set(TABLE_COLUMN_EXPANSION_STRATEGY, Collections.emptyList());
+    }
+
+    @Test
+    public void testExcludeDefaultVirtualMetadataColumns() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Collections.singletonList(EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS));
+
+        // Special case: 'from()' which does not count as an expansion
+        assertColumnNames(
+                tableEnv.from("t1"),
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From one table
+        assertColumnNames(
+                tableEnv.from("t1").select($("*")),
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From one table with explicit selection of metadata column
+        assertColumnNames(
+                tableEnv.from("t1").select($("t1_m_virtual"), $("*")),
+                "t1_m_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // Transitive metadata columns are always selected
+        assertColumnNames(
+                tableEnv.from("t1").select($("t1_m_virtual"), $("*")).select($("*")),
+                "t1_m_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+    }
+
+    @Test
+    public void testExcludeAliasedVirtualMetadataColumns() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Collections.singletonList(EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        // Special case: 'from()' which does not count as an expansion
+        assertColumnNames(
+                tableEnv.from("t1"),
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_aliased_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From one table
+        assertColumnNames(
+                tableEnv.from("t1").select($("*")),
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // From one table with explicit selection of metadata column
+        assertColumnNames(
+                tableEnv.from("t1").select($("t1_m_aliased_virtual"), $("*")),
+                "t1_m_aliased_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+
+        // Transitive metadata columns are always selected
+        assertColumnNames(
+                tableEnv.from("t1").select($("t1_m_aliased_virtual"), $("*")).select($("*")),
+                "t1_m_aliased_virtual",
+                "t1_i",
+                "t1_s",
+                "t1_m_virtual",
+                "t1_m_default",
+                "t1_m_aliased");
+    }
+
+    @Test
+    public void testExcludeViaView() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Arrays.asList(
+                                EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS,
+                                EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        tableEnv.executeSql("CREATE VIEW v1 AS SELECT * FROM t1");
+
+        assertColumnNames(tableEnv.from("v1"), "t1_i", "t1_s", "t1_m_default", "t1_m_aliased");
+    }
+
+    @Test
+    public void testExcludeViaWithColumn() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Arrays.asList(
+                                EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS,
+                                EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        assertColumnNames(
+                tableEnv.from("t1").select(withColumns(range("t1_i", "t1_m_aliased"))),
+                "t1_i",
+                "t1_s",
+                "t1_m_default",
+                "t1_m_aliased");
+    }
+
+    @Test
+    public void testExcludeViaWithoutColumn() {
+        tableEnv.getConfig()
+                .set(
+                        TABLE_COLUMN_EXPANSION_STRATEGY,
+                        Arrays.asList(
+                                EXCLUDE_DEFAULT_VIRTUAL_METADATA_COLUMNS,
+                                EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS));
+
+        assertColumnNames(
+                tableEnv.from("t1").select(withoutColumns($("t1_i"), $("t1_s"))),
+                "t1_m_default",
+                "t1_m_aliased");
+    }
+
+    private void assertColumnNames(Table query, String... columnNames) {
+        assertThat(query.getResolvedSchema().getColumnNames()).containsExactly(columnNames);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/table/ColumnExpansionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/table/ColumnExpansionTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.range;
+import static org.apache.flink.table.api.Expressions.withAllColumns;
 import static org.apache.flink.table.api.Expressions.withColumns;
 import static org.apache.flink.table.api.Expressions.withoutColumns;
 import static org.apache.flink.table.api.config.TableConfigOptions.ColumnExpansionStrategy.EXCLUDE_ALIASED_VIRTUAL_METADATA_COLUMNS;
@@ -95,7 +96,7 @@ public class ColumnExpansionTest {
 
         // From one table
         assertColumnNames(
-                tableEnv.from("t1").select($("*")),
+                tableEnv.from("t1").select(withAllColumns()),
                 "t1_i",
                 "t1_s",
                 "t1_m_aliased_virtual",
@@ -104,7 +105,7 @@ public class ColumnExpansionTest {
 
         // From one table with explicit selection of metadata column
         assertColumnNames(
-                tableEnv.from("t1").select($("t1_m_virtual"), $("*")),
+                tableEnv.from("t1").select($("t1_m_virtual"), withAllColumns()),
                 "t1_m_virtual",
                 "t1_i",
                 "t1_s",
@@ -114,7 +115,9 @@ public class ColumnExpansionTest {
 
         // Transitive metadata columns are always selected
         assertColumnNames(
-                tableEnv.from("t1").select($("t1_m_virtual"), $("*")).select($("*")),
+                tableEnv.from("t1")
+                        .select($("t1_m_virtual"), withAllColumns())
+                        .select(withAllColumns()),
                 "t1_m_virtual",
                 "t1_i",
                 "t1_s",
@@ -142,7 +145,7 @@ public class ColumnExpansionTest {
 
         // From one table
         assertColumnNames(
-                tableEnv.from("t1").select($("*")),
+                tableEnv.from("t1").select(withAllColumns()),
                 "t1_i",
                 "t1_s",
                 "t1_m_virtual",
@@ -151,7 +154,7 @@ public class ColumnExpansionTest {
 
         // From one table with explicit selection of metadata column
         assertColumnNames(
-                tableEnv.from("t1").select($("t1_m_aliased_virtual"), $("*")),
+                tableEnv.from("t1").select($("t1_m_aliased_virtual"), withAllColumns()),
                 "t1_m_aliased_virtual",
                 "t1_i",
                 "t1_s",
@@ -161,7 +164,9 @@ public class ColumnExpansionTest {
 
         // Transitive metadata columns are always selected
         assertColumnNames(
-                tableEnv.from("t1").select($("t1_m_aliased_virtual"), $("*")).select($("*")),
+                tableEnv.from("t1")
+                        .select($("t1_m_aliased_virtual"), withAllColumns())
+                        .select(withAllColumns()),
                 "t1_m_aliased_virtual",
                 "t1_i",
                 "t1_s",


### PR DESCRIPTION
## What is the purpose of the change

This introduces a new `table.column-expansion-strategy` option according to FLIP-348. It updates all code locations in SQL and Table API where column expansion takes place. In other words: where `*` is a valid column selector.

For SQL this includes `SELECT *`. For Table API, includes `$(*)`, `withColumns` and `withoutColumns`.

## Brief change log

Updated the resolution logic in SQL validator and Table API resolution rules.

## Verifying this change

This change added tests and can be verified as follows: `ColumnExpansionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
