### PR TITLE
[FLINK-32796][table] Try to create catalog store path if not exists

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
@@ -80,10 +80,7 @@ public class FileCatalogStore extends AbstractCatalogStore {
         try {
             FileSystem fs = catalogStorePath.getFileSystem();
             if (!fs.exists(catalogStorePath)) {
-                throw new CatalogException(
-                        String.format(
-                                "Failed to open catalog store. The catalog store directory %s does not exist.",
-                                catalogStorePath));
+                fs.mkdirs(catalogStorePath);
             }
 
             if (!fs.getFileStatus(catalogStorePath).isDir()) {


### PR DESCRIPTION
## What is the purpose of the change

Try to create dirs that does not exists when opening file catalog store. If an error is thrown in case the given path not exists, SQL client will fail to start, also SQL gateway won't operate, cause even basic API calls will fail.

It makes sense to at least try creating any missing folders, which can probably help allow some annoying errors and restart rounds.

## Brief change log

Add `FileSystem.mkdirs(...)` to `FileCatalogstore.open()` to try creating dirs the given path does not exist.

## Verifying this change

Added unit test to verify a failing scenario. Every other existing unit test will now create the store root folder.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable