### PR TITLE
[FLINK-33054][datastream] Align the execution result fetching timeout…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -51,6 +51,7 @@ import org.apache.flink.api.java.io.TextOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
@@ -1421,12 +1422,15 @@ public class DataStream<T> {
         CollectSinkOperatorFactory<T> factory =
                 new CollectSinkOperatorFactory<>(serializer, accumulatorName);
         CollectSinkOperator<T> operator = (CollectSinkOperator<T>) factory.getOperator();
+        long resultFetchTimeout =
+                env.getConfiguration().get(AkkaOptions.ASK_TIMEOUT_DURATION).toMillis();
         CollectResultIterator<T> iterator =
                 new CollectResultIterator<>(
                         operator.getOperatorIdFuture(),
                         serializer,
                         accumulatorName,
-                        env.getCheckpointConfig());
+                        env.getCheckpointConfig(),
+                        resultFetchTimeout);
         CollectStreamSink<T> sink = new CollectStreamSink<>(this, factory);
         sink.name("Data stream collect sink");
         env.addOperator(sink.getTransformation());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcher.java
@@ -48,8 +48,6 @@ import java.util.concurrent.TimeoutException;
 public class CollectResultFetcher<T> {
 
     private static final int DEFAULT_RETRY_MILLIS = 100;
-    private static final long DEFAULT_ACCUMULATOR_GET_MILLIS = 10000;
-
     private static final Logger LOG = LoggerFactory.getLogger(CollectResultFetcher.class);
 
     private final AbstractCollectResultBuffer<T> buffer;
@@ -57,6 +55,7 @@ public class CollectResultFetcher<T> {
     private final CompletableFuture<OperatorID> operatorIdFuture;
     private final String accumulatorName;
     private final int retryMillis;
+    private final long resultFetchTimeout;
 
     @Nullable private JobClient jobClient;
     @Nullable private CoordinationRequestGateway gateway;
@@ -67,20 +66,23 @@ public class CollectResultFetcher<T> {
     public CollectResultFetcher(
             AbstractCollectResultBuffer<T> buffer,
             CompletableFuture<OperatorID> operatorIdFuture,
-            String accumulatorName) {
-        this(buffer, operatorIdFuture, accumulatorName, DEFAULT_RETRY_MILLIS);
+            String accumulatorName,
+            long resultFetchTimeout) {
+        this(buffer, operatorIdFuture, accumulatorName, DEFAULT_RETRY_MILLIS, resultFetchTimeout);
     }
 
     CollectResultFetcher(
             AbstractCollectResultBuffer<T> buffer,
             CompletableFuture<OperatorID> operatorIdFuture,
             String accumulatorName,
-            int retryMillis) {
+            int retryMillis,
+            long resultFetchTimeout) {
         this.buffer = buffer;
 
         this.operatorIdFuture = operatorIdFuture;
         this.accumulatorName = accumulatorName;
         this.retryMillis = retryMillis;
+        this.resultFetchTimeout = resultFetchTimeout;
 
         this.jobTerminated = false;
         this.closed = false;
@@ -180,7 +182,7 @@ public class CollectResultFetcher<T> {
             executionResult =
                     jobClient
                             .getJobExecutionResult()
-                            .get(DEFAULT_ACCUMULATOR_GET_MILLIS, TimeUnit.MILLISECONDS);
+                            .get(resultFetchTimeout, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new IOException("Failed to fetch job execution result", e);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectResultIterator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators.collect;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -55,9 +56,12 @@ public class CollectResultIterator<T> implements CloseableIterator<T> {
             CompletableFuture<OperatorID> operatorIdFuture,
             TypeSerializer<T> serializer,
             String accumulatorName,
-            CheckpointConfig checkpointConfig) {
+            CheckpointConfig checkpointConfig,
+            long resultFetchTimeout) {
         AbstractCollectResultBuffer<T> buffer = createBuffer(serializer, checkpointConfig);
-        this.fetcher = new CollectResultFetcher<>(buffer, operatorIdFuture, accumulatorName);
+        this.fetcher =
+                new CollectResultFetcher<>(
+                        buffer, operatorIdFuture, accumulatorName, resultFetchTimeout);
         this.bufferedResult = null;
     }
 
@@ -68,7 +72,12 @@ public class CollectResultIterator<T> implements CloseableIterator<T> {
             String accumulatorName,
             int retryMillis) {
         this.fetcher =
-                new CollectResultFetcher<>(buffer, operatorIdFuture, accumulatorName, retryMillis);
+                new CollectResultFetcher<>(
+                        buffer,
+                        operatorIdFuture,
+                        accumulatorName,
+                        retryMillis,
+                        AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue().toMillis());
         this.bufferedResult = null;
     }
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.testframe.environment.TestEnvironment;
 import org.apache.flink.connector.testframe.environment.TestEnvironmentSettings;
@@ -611,7 +612,8 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                 operator.getOperatorIdFuture(),
                 serializer,
                 accumulatorName,
-                stream.getExecutionEnvironment().getCheckpointConfig());
+                stream.getExecutionEnvironment().getCheckpointConfig(),
+                AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue().toMillis());
     }
 
     private void waitExpectedSizeData(CollectResultIterator<T> iterator, int targetNum) {

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.testframe.environment.ClusterControllable;
 import org.apache.flink.connector.testframe.environment.TestEnvironment;
@@ -792,7 +793,8 @@ public abstract class SourceTestSuiteBase<T> {
                             operator.getOperatorIdFuture(),
                             serializer,
                             accumulatorName,
-                            checkpointConfig);
+                            checkpointConfig,
+                            AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue().toMillis());
             iterator.setJobClient(jobClient);
             return iterator;
         }


### PR DESCRIPTION
… in CollectResultFetcher with akka ask timeout

## What is the purpose of the change

Currently in CollectResultFetcher, the job execution result will be fetched after job's termination. In [FLINK-17735](https://issues.apache.org/jira/browse/FLINK-17735), we arbitrarily introduce a static timeout for this rpc call. However, in OLAP scenario, the Dispatcher endpoint might be too busy to reply in time. We'd like to set it according to the akka ask timeout, which is commonly used as rpc timeout in Flink.

## Brief change log

Set the execution result fetching timeout to akka ask timeout in CollectResultFetcher.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable 
