### PR TITLE
[FLINK-5865][state] Unwrapping exceptions and throw the original ones in state interfaces

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
-
 /**
  * Heap-backed partitioned {@link AggregatingState} that is snapshotted into files.
  *
@@ -93,20 +91,14 @@ class HeapAggregatingState<K, N, IN, ACC, OUT> extends AbstractHeapMergingState<
     }
 
     @Override
-    public void add(IN value) throws IOException {
+    public void add(IN value) throws Exception {
         final N namespace = currentNamespace;
 
         if (value == null) {
             clear();
             return;
         }
-
-        try {
-            stateTable.transform(namespace, value, aggregateTransformation);
-        } catch (Exception e) {
-            throw new IOException(
-                    "Exception while applying AggregateFunction in aggregating state", e);
-        }
+        stateTable.transform(namespace, value, aggregateTransformation);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -106,7 +107,7 @@ class HeapListState<K, N, V> extends AbstractHeapMergingState<K, N, V, List<V>, 
             final TypeSerializer<K> safeKeySerializer,
             final TypeSerializer<N> safeNamespaceSerializer,
             final TypeSerializer<List<V>> safeValueSerializer)
-            throws Exception {
+            throws IOException {
 
         Preconditions.checkNotNull(serializedKeyAndNamespace);
         Preconditions.checkNotNull(safeKeySerializer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
-
 /**
  * Heap-backed partitioned {@link ReducingState} that is snapshotted into files.
  *
@@ -89,18 +87,14 @@ class HeapReducingState<K, N, V> extends AbstractHeapMergingState<K, N, V, V, V>
     }
 
     @Override
-    public void add(V value) throws IOException {
+    public void add(V value) throws Exception {
 
         if (value == null) {
             clear();
             return;
         }
 
-        try {
-            stateTable.transform(currentNamespace, value, reduceTransformation);
-        } catch (Exception e) {
-            throw new IOException("Exception while applying ReduceFunction in reducing state", e);
-        }
+        stateTable.transform(currentNamespace, value, reduceTransformation);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -50,21 +49,17 @@ abstract class AbstractRocksDBAppendingState<K, N, IN, SV, OUT>
     }
 
     @Override
-    public SV getInternal() {
+    public SV getInternal() throws IOException, RocksDBException {
         return getInternal(getKeyBytes());
     }
 
-    SV getInternal(byte[] key) {
-        try {
-            byte[] valueBytes = backend.db.get(columnFamily, key);
-            if (valueBytes == null) {
-                return null;
-            }
-            dataInputView.setBuffer(valueBytes);
-            return valueSerializer.deserialize(dataInputView);
-        } catch (IOException | RocksDBException e) {
-            throw new FlinkRuntimeException("Error while retrieving data from RocksDB", e);
+    SV getInternal(byte[] key) throws IOException, RocksDBException {
+        byte[] valueBytes = backend.db.get(columnFamily, key);
+        if (valueBytes == null) {
+            return null;
         }
+        dataInputView.setBuffer(valueBytes);
+        return valueSerializer.deserialize(dataInputView);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -68,16 +68,12 @@ abstract class AbstractRocksDBAppendingState<K, N, IN, SV, OUT>
     }
 
     @Override
-    public void updateInternal(SV valueToStore) {
+    public void updateInternal(SV valueToStore) throws RocksDBException {
         updateInternal(getKeyBytes(), valueToStore);
     }
 
-    void updateInternal(byte[] key, SV valueToStore) {
-        try {
-            // write the new value to RocksDB
-            backend.db.put(columnFamily, writeOptions, key, getValueBytes(valueToStore));
-        } catch (RocksDBException e) {
-            throw new FlinkRuntimeException("Error while adding value to RocksDB", e);
-        }
+    void updateInternal(byte[] key, SV valueToStore) throws RocksDBException {
+        // write the new value to RocksDB
+        backend.db.put(columnFamily, writeOptions, key, getValueBytes(valueToStore));
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -27,10 +27,11 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -96,7 +97,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
     }
 
     @Override
-    public void add(T value) {
+    public void add(T value) throws RocksDBException {
         byte[] key = getKeyBytes();
         ACC accumulator = getInternal(key);
         accumulator = accumulator == null ? aggFunction.createAccumulator() : accumulator;
@@ -104,60 +105,56 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
     }
 
     @Override
-    public void mergeNamespaces(N target, Collection<N> sources) {
+    public void mergeNamespaces(N target, Collection<N> sources)
+            throws IOException, RocksDBException {
         if (sources == null || sources.isEmpty()) {
             return;
         }
 
-        try {
-            ACC current = null;
+        ACC current = null;
 
-            // merge the sources to the target
-            for (N source : sources) {
-                if (source != null) {
-                    setCurrentNamespace(source);
-                    final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
-                    final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
+        // merge the sources to the target
+        for (N source : sources) {
+            if (source != null) {
+                setCurrentNamespace(source);
+                final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
+                final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 
-                    if (valueBytes != null) {
-                        backend.db.delete(columnFamily, writeOptions, sourceKey);
-                        dataInputView.setBuffer(valueBytes);
-                        ACC value = valueSerializer.deserialize(dataInputView);
+                if (valueBytes != null) {
+                    backend.db.delete(columnFamily, writeOptions, sourceKey);
+                    dataInputView.setBuffer(valueBytes);
+                    ACC value = valueSerializer.deserialize(dataInputView);
 
-                        if (current != null) {
-                            current = aggFunction.merge(current, value);
-                        } else {
-                            current = value;
-                        }
+                    if (current != null) {
+                        current = aggFunction.merge(current, value);
+                    } else {
+                        current = value;
                     }
                 }
             }
+        }
 
-            // if something came out of merging the sources, merge it or write it to the target
-            if (current != null) {
-                setCurrentNamespace(target);
-                // create the target full-binary-key
-                final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
-                final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
+        // if something came out of merging the sources, merge it or write it to the target
+        if (current != null) {
+            setCurrentNamespace(target);
+            // create the target full-binary-key
+            final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
+            final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
-                if (targetValueBytes != null) {
-                    // target also had a value, merge
-                    dataInputView.setBuffer(targetValueBytes);
-                    ACC value = valueSerializer.deserialize(dataInputView);
+            if (targetValueBytes != null) {
+                // target also had a value, merge
+                dataInputView.setBuffer(targetValueBytes);
+                ACC value = valueSerializer.deserialize(dataInputView);
 
-                    current = aggFunction.merge(current, value);
-                }
-
-                // serialize the resulting value
-                dataOutputView.clear();
-                valueSerializer.serialize(current, dataOutputView);
-
-                // write the resulting value
-                backend.db.put(
-                        columnFamily, writeOptions, targetKey, dataOutputView.getCopyOfBuffer());
+                current = aggFunction.merge(current, value);
             }
-        } catch (Exception e) {
-            throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+
+            // serialize the resulting value
+            dataOutputView.clear();
+            valueSerializer.serialize(current, dataOutputView);
+
+            // write the resulting value
+            backend.db.put(columnFamily, writeOptions, targetKey, dataOutputView.getCopyOfBuffer());
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -88,7 +88,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
     }
 
     @Override
-    public R get() {
+    public R get() throws IOException, RocksDBException {
         ACC accumulator = getInternal();
         if (accumulator == null) {
             return null;
@@ -97,7 +97,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
     }
 
     @Override
-    public void add(T value) throws RocksDBException {
+    public void add(T value) throws IOException, RocksDBException {
         byte[] key = getKeyBytes();
         ACC accumulator = getInternal(key);
         accumulator = accumulator == null ? aggFunction.createAccumulator() : accumulator;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -108,34 +108,26 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
     }
 
     @Override
-    public Iterable<V> get() {
+    public Iterable<V> get() throws RocksDBException {
         return getInternal();
     }
 
     @Override
-    public List<V> getInternal() {
-        try {
-            byte[] key = serializeCurrentKeyWithGroupAndNamespace();
-            byte[] valueBytes = backend.db.get(columnFamily, key);
-            return listSerializer.deserializeList(valueBytes, elementSerializer);
-        } catch (RocksDBException e) {
-            throw new FlinkRuntimeException("Error while retrieving data from RocksDB", e);
-        }
+    public List<V> getInternal() throws RocksDBException {
+        byte[] key = serializeCurrentKeyWithGroupAndNamespace();
+        byte[] valueBytes = backend.db.get(columnFamily, key);
+        return listSerializer.deserializeList(valueBytes, elementSerializer);
     }
 
     @Override
-    public void add(V value) {
+    public void add(V value) throws IOException, RocksDBException {
         Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 
-        try {
-            backend.db.merge(
-                    columnFamily,
-                    writeOptions,
-                    serializeCurrentKeyWithGroupAndNamespace(),
-                    serializeValue(value, elementSerializer));
-        } catch (Exception e) {
-            throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
-        }
+        backend.db.merge(
+                columnFamily,
+                writeOptions,
+                serializeCurrentKeyWithGroupAndNamespace(),
+                serializeValue(value, elementSerializer));
     }
 
     @Override
@@ -169,43 +161,35 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
     }
 
     @Override
-    public void update(List<V> valueToStore) {
+    public void update(List<V> valueToStore) throws IOException, RocksDBException {
         updateInternal(valueToStore);
     }
 
     @Override
-    public void updateInternal(List<V> values) {
+    public void updateInternal(List<V> values) throws IOException, RocksDBException {
         Preconditions.checkNotNull(values, "List of values to add cannot be null.");
 
         if (!values.isEmpty()) {
-            try {
-                backend.db.put(
-                        columnFamily,
-                        writeOptions,
-                        serializeCurrentKeyWithGroupAndNamespace(),
-                        listSerializer.serializeList(values, elementSerializer));
-            } catch (IOException | RocksDBException e) {
-                throw new FlinkRuntimeException("Error while updating data to RocksDB", e);
-            }
+            backend.db.put(
+                    columnFamily,
+                    writeOptions,
+                    serializeCurrentKeyWithGroupAndNamespace(),
+                    listSerializer.serializeList(values, elementSerializer));
         } else {
             clear();
         }
     }
 
     @Override
-    public void addAll(List<V> values) {
+    public void addAll(List<V> values) throws IOException, RocksDBException {
         Preconditions.checkNotNull(values, "List of values to add cannot be null.");
 
         if (!values.isEmpty()) {
-            try {
-                backend.db.merge(
-                        columnFamily,
-                        writeOptions,
-                        serializeCurrentKeyWithGroupAndNamespace(),
-                        listSerializer.serializeList(values, elementSerializer));
-            } catch (IOException | RocksDBException e) {
-                throw new FlinkRuntimeException("Error while updating data to RocksDB", e);
-            }
+            backend.db.merge(
+                    columnFamily,
+                    writeOptions,
+                    serializeCurrentKeyWithGroupAndNamespace(),
+                    listSerializer.serializeList(values, elementSerializer));
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -29,7 +29,9 @@ import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -83,7 +85,7 @@ class RocksDBReducingState<K, N, V> extends AbstractRocksDBAppendingState<K, N, 
     }
 
     @Override
-    public V get() {
+    public V get() throws IOException, RocksDBException {
         return getInternal();
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
 
@@ -97,60 +96,55 @@ class RocksDBReducingState<K, N, V> extends AbstractRocksDBAppendingState<K, N, 
     }
 
     @Override
-    public void mergeNamespaces(N target, Collection<N> sources) {
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
         if (sources == null || sources.isEmpty()) {
             return;
         }
 
-        try {
-            V current = null;
+        V current = null;
 
-            // merge the sources to the target
-            for (N source : sources) {
-                if (source != null) {
-                    setCurrentNamespace(source);
-                    final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
-                    final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
+        // merge the sources to the target
+        for (N source : sources) {
+            if (source != null) {
+                setCurrentNamespace(source);
+                final byte[] sourceKey = serializeCurrentKeyWithGroupAndNamespace();
+                final byte[] valueBytes = backend.db.get(columnFamily, sourceKey);
 
-                    if (valueBytes != null) {
-                        backend.db.delete(columnFamily, writeOptions, sourceKey);
-                        dataInputView.setBuffer(valueBytes);
-                        V value = valueSerializer.deserialize(dataInputView);
+                if (valueBytes != null) {
+                    backend.db.delete(columnFamily, writeOptions, sourceKey);
+                    dataInputView.setBuffer(valueBytes);
+                    V value = valueSerializer.deserialize(dataInputView);
 
-                        if (current != null) {
-                            current = reduceFunction.reduce(current, value);
-                        } else {
-                            current = value;
-                        }
+                    if (current != null) {
+                        current = reduceFunction.reduce(current, value);
+                    } else {
+                        current = value;
                     }
                 }
             }
+        }
 
-            // if something came out of merging the sources, merge it or write it to the target
-            if (current != null) {
-                // create the target full-binary-key
-                setCurrentNamespace(target);
-                final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
-                final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
+        // if something came out of merging the sources, merge it or write it to the target
+        if (current != null) {
+            // create the target full-binary-key
+            setCurrentNamespace(target);
+            final byte[] targetKey = serializeCurrentKeyWithGroupAndNamespace();
+            final byte[] targetValueBytes = backend.db.get(columnFamily, targetKey);
 
-                if (targetValueBytes != null) {
-                    dataInputView.setBuffer(targetValueBytes);
-                    // target also had a value, merge
-                    V value = valueSerializer.deserialize(dataInputView);
+            if (targetValueBytes != null) {
+                dataInputView.setBuffer(targetValueBytes);
+                // target also had a value, merge
+                V value = valueSerializer.deserialize(dataInputView);
 
-                    current = reduceFunction.reduce(current, value);
-                }
-
-                // serialize the resulting value
-                dataOutputView.clear();
-                valueSerializer.serialize(current, dataOutputView);
-
-                // write the resulting value
-                backend.db.put(
-                        columnFamily, writeOptions, targetKey, dataOutputView.getCopyOfBuffer());
+                current = reduceFunction.reduce(current, value);
             }
-        } catch (Exception e) {
-            throw new FlinkRuntimeException("Error while merging state in RocksDB", e);
+
+            // serialize the resulting value
+            dataOutputView.clear();
+            valueSerializer.serialize(current, dataOutputView);
+
+            // write the resulting value
+            backend.db.put(columnFamily, writeOptions, targetKey, dataOutputView.getCopyOfBuffer());
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.contrib.streaming.state;
 
-import org.apache.flink.util.FlinkRuntimeException;
-
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksIteratorInterface;
@@ -103,12 +101,8 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
     }
 
     @Override
-    public void status() {
-        try {
-            iterator.status();
-        } catch (RocksDBException ex) {
-            throw new FlinkRuntimeException("Internal exception found in RocksDB", ex);
-        }
+    public void status() throws RocksDBException {
+        iterator.status();
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.util.FlinkRuntimeException;
+
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksIteratorInterface;
@@ -101,8 +103,12 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
     }
 
     @Override
-    public void status() throws RocksDBException {
-        iterator.status();
+    public void status() {
+        try {
+            iterator.status();
+        } catch (RocksDBException ex) {
+            throw new FlinkRuntimeException("Internal exception found in RocksDB", ex);
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 
-import java.io.IOException;
-
 /** An {@link AggregatingState} which keeps value for a single key at a time. */
 class BatchExecutionKeyAggregatingState<K, N, IN, ACC, OUT>
         extends MergingAbstractBatchExecutionKeyState<K, N, ACC, IN, OUT>
@@ -52,21 +50,15 @@ class BatchExecutionKeyAggregatingState<K, N, IN, ACC, OUT>
     }
 
     @Override
-    public void add(IN value) throws IOException {
+    public void add(IN value) throws Exception {
         if (value == null) {
             clear();
             return;
         }
-
-        try {
-            if (getCurrentNamespaceValue() == null) {
-                setCurrentNamespaceValue(aggFunction.createAccumulator());
-            }
-            setCurrentNamespaceValue(aggFunction.add(value, getCurrentNamespaceValue()));
-        } catch (Exception e) {
-            throw new IOException(
-                    "Exception while applying AggregateFunction in aggregating state", e);
+        if (getCurrentNamespaceValue() == null) {
+            setCurrentNamespaceValue(aggFunction.createAccumulator());
         }
+        setCurrentNamespaceValue(aggFunction.add(value, getCurrentNamespaceValue()));
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyAggregatingState.java
@@ -50,7 +50,7 @@ class BatchExecutionKeyAggregatingState<K, N, IN, ACC, OUT>
     }
 
     @Override
-    public void add(IN value) throws Exception {
+    public void add(IN value) {
         if (value == null) {
             clear();
             return;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyReducingState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyReducingState.java
@@ -26,8 +26,6 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 
-import java.io.IOException;
-
 /** A {@link ReducingState} which keeps value for a single key at a time. */
 class BatchExecutionKeyReducingState<K, N, T>
         extends MergingAbstractBatchExecutionKeyState<K, N, T, T, T>
@@ -50,21 +48,17 @@ class BatchExecutionKeyReducingState<K, N, T>
     }
 
     @Override
-    public void add(T value) throws IOException {
+    public void add(T value) throws Exception {
         if (value == null) {
             clear();
             return;
         }
 
-        try {
-            T currentNamespaceValue = getCurrentNamespaceValue();
-            if (currentNamespaceValue != null) {
-                setCurrentNamespaceValue(reduceFunction.reduce(currentNamespaceValue, value));
-            } else {
-                setCurrentNamespaceValue(value);
-            }
-        } catch (Exception e) {
-            throw new IOException("Exception while applying ReduceFunction in reducing state", e);
+        T currentNamespaceValue = getCurrentNamespaceValue();
+        if (currentNamespaceValue != null) {
+            setCurrentNamespaceValue(reduceFunction.reduce(currentNamespaceValue, value));
+        } else {
+            setCurrentNamespaceValue(value);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Some implementations of state interfaces wrap the original exception and throw as FlinkRuntimeException. Since all the interfaces claim to throw Exception, it is unnecessary to wrap exceptions into FlinkRuntimeException, which is not intuitive to users in log.

## Brief change log

- Go through the implementation of state interfaces and unwrap the try...catch blocks in best effort.

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
