### PR TITLE
[FLINK-14032][state]Make the cache size of RocksDBPriorityQueueSetFactory configurable

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -69,6 +69,12 @@
             <td>The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. Current supported candidate predefined-options are DEFAULT, SPINNING_DISK_OPTIMIZED, SPINNING_DISK_OPTIMIZED_HIGH_MEM or FLASH_SSD_OPTIMIZED. Note that user customized options and options from the RocksDBOptionsFactory are applied on top of these predefined ones.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.timer-service.cache-size</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The cache size for rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -72,7 +72,7 @@
             <td><h5>state.backend.rocksdb.timer-service.cache-size</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
-            <td>The cache size for rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'</td>
+            <td>The cache size per keyGroup of rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'. Increasing this value can improve the performance of rocksdb timer service, but consumes more heap memory at the same time.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>

--- a/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
@@ -48,7 +48,7 @@
             <td><h5>state.backend.rocksdb.timer-service.cache-size</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>
-            <td>The cache size for rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'</td>
+            <td>The cache size per keyGroup of rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'. Increasing this value can improve the performance of rocksdb timer service, but consumes more heap memory at the same time.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>

--- a/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
@@ -45,6 +45,12 @@
             <td>The maximum amount of memory that write buffers may take, as a fraction of the total shared memory. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.timer-service.cache-size</h5></td>
+            <td style="word-wrap: break-word;">128</td>
+            <td>Integer</td>
+            <td>The cache size for rocksdb timer service factory. This option only has an effect when 'state.backend.rocksdb.timer-service.factory' is configured to 'ROCKSDB'</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
             <td><p>Enum</p></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -486,6 +486,9 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                 latencyTrackingConfigBuilder.setMetricGroup(metricGroup).build();
         RocksDBKeyedStateBackendBuilder<K> builder =
                 new RocksDBKeyedStateBackendBuilder<>(
+                                (configurableOptions != null
+                                        ? configurableOptions
+                                        : new Configuration()),
                                 operatorIdentifier,
                                 env.getUserCodeClassLoader().asClassLoader(),
                                 instanceBasePath,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -82,7 +82,6 @@ import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM;
-import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TIMER_SERVICE_FACTORY;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -146,8 +145,10 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     /** The configuration for memory settings (pool sizes, etc.). */
     private final RocksDBMemoryConfiguration memoryConfiguration;
 
-    /** This determines the type of priority queue state. */
-    @Nullable private PriorityQueueStateType priorityQueueStateType;
+    /**
+     * The configuration for rocksdb priorityQueue state settings (priorityQueue state type, etc.).
+     */
+    private final RocksDBPriorityQueueConfig priorityQueueConfig;
 
     /** The default rocksdb property-based metrics options. */
     private final RocksDBNativeMetricOptions nativeMetricOptions;
@@ -209,6 +210,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
         this.writeBatchSize = UNDEFINED_WRITE_BATCH_SIZE;
         this.overlapFractionThreshold = UNDEFINED_OVERLAP_FRACTION_THRESHOLD;
         this.rocksDBMemoryFactory = RocksDBMemoryFactory.DEFAULT;
+        this.priorityQueueConfig = new RocksDBPriorityQueueConfig();
     }
 
     /**
@@ -242,11 +244,9 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                         original.memoryConfiguration, config);
         this.memoryConfiguration.validate();
 
-        if (null == original.priorityQueueStateType) {
-            this.priorityQueueStateType = config.get(TIMER_SERVICE_FACTORY);
-        } else {
-            this.priorityQueueStateType = original.priorityQueueStateType;
-        }
+        this.priorityQueueConfig =
+                RocksDBPriorityQueueConfig.fromOtherAndConfiguration(
+                        original.priorityQueueConfig, config);
 
         // configure local directories
         if (original.localRocksDbDirectories != null) {
@@ -486,9 +486,6 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                 latencyTrackingConfigBuilder.setMetricGroup(metricGroup).build();
         RocksDBKeyedStateBackendBuilder<K> builder =
                 new RocksDBKeyedStateBackendBuilder<>(
-                                (configurableOptions != null
-                                        ? configurableOptions
-                                        : new Configuration()),
                                 operatorIdentifier,
                                 env.getUserCodeClassLoader().asClassLoader(),
                                 instanceBasePath,
@@ -500,7 +497,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                                 keyGroupRange,
                                 executionConfig,
                                 localRecoveryConfig,
-                                getPriorityQueueStateType(),
+                                priorityQueueConfig,
                                 ttlTimeProvider,
                                 latencyTrackingStateConfig,
                                 metricGroup,
@@ -730,9 +727,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
      * @return The type of the priority queue state.
      */
     public PriorityQueueStateType getPriorityQueueStateType() {
-        return priorityQueueStateType == null
-                ? TIMER_SERVICE_FACTORY.defaultValue()
-                : priorityQueueStateType;
+        return priorityQueueConfig.getPriorityQueueStateType();
     }
 
     /**
@@ -740,7 +735,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
      * not explicitly set.
      */
     public void setPriorityQueueStateType(PriorityQueueStateType priorityQueueStateType) {
-        this.priorityQueueStateType = checkNotNull(priorityQueueStateType);
+        this.priorityQueueConfig.setPriorityQueueStateType(priorityQueueStateType);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -31,7 +31,6 @@ import static org.apache.flink.contrib.streaming.state.PredefinedOptions.DEFAULT
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.FLASH_SSD_OPTIMIZED;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNING_DISK_OPTIMIZED;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM;
-import static org.apache.flink.contrib.streaming.state.RocksDBPriorityQueueSetFactory.DEFAULT_CACHES_SIZE;
 
 /** Configuration options for the RocksDB backend. */
 public class RocksDBOptions {
@@ -63,14 +62,17 @@ public class RocksDBOptions {
                             .withDescription(
                                     "This determines the factory for timer service state implementation.");
 
+    /** The cache size per key-group for ROCKSDB timer service factory implementation. */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
     public static final ConfigOption<Integer> ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE =
             ConfigOptions.key("state.backend.rocksdb.timer-service.cache-size")
                     .intType()
-                    .defaultValue(DEFAULT_CACHES_SIZE)
+                    .defaultValue(128)
                     .withDescription(
                             String.format(
-                                    "The cache size for rocksdb timer service factory. This option only has an effect when '%s' is configured to '%s'",
+                                    "The cache size per keyGroup of rocksdb timer service factory. This option only has an effect "
+                                            + "when '%s' is configured to '%s'. Increasing this value can improve the performance "
+                                            + "of rocksdb timer service, but consumes more heap memory at the same time.",
                                     TIMER_SERVICE_FACTORY.key(), ROCKSDB.name()));
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -31,6 +31,7 @@ import static org.apache.flink.contrib.streaming.state.PredefinedOptions.DEFAULT
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.FLASH_SSD_OPTIMIZED;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNING_DISK_OPTIMIZED;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM;
+import static org.apache.flink.contrib.streaming.state.RocksDBPriorityQueueSetFactory.DEFAULT_CACHES_SIZE;
 
 /** Configuration options for the RocksDB backend. */
 public class RocksDBOptions {
@@ -61,6 +62,16 @@ public class RocksDBOptions {
                             .defaultValue(ROCKSDB)
                             .withDescription(
                                     "This determines the factory for timer service state implementation.");
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
+    public static final ConfigOption<Integer> ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE =
+            ConfigOptions.key("state.backend.rocksdb.timer-service.cache-size")
+                    .intType()
+                    .defaultValue(DEFAULT_CACHES_SIZE)
+                    .withDescription(
+                            String.format(
+                                    "The cache size for rocksdb timer service factory. This option only has an effect when '%s' is configured to '%s'",
+                                    TIMER_SERVICE_FACTORY.key(), ROCKSDB.name()));
 
     /**
      * The number of threads used to transfer (download and upload) files in RocksDBStateBackend.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueConfig.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueConfig.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.contrib.streaming.state.RocksDBOptions.ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE;
+import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TIMER_SERVICE_FACTORY;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The configuration of rocksDB priority queue state implementation. */
+public class RocksDBPriorityQueueConfig {
+
+    private static final int UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE = -1;
+
+    /** This determines the type of priority queue state. */
+    private @Nullable PriorityQueueStateType priorityQueueStateType;
+
+    /** cache size per keyGroup for rocksDB priority queue state. */
+    private int rocksDBPriorityQueueSetCacheSize;
+
+    public RocksDBPriorityQueueConfig() {
+        this.priorityQueueStateType = null;
+        this.rocksDBPriorityQueueSetCacheSize = UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE;
+    }
+
+    public RocksDBPriorityQueueConfig(
+            PriorityQueueStateType priorityQueueStateType, int rocksDBPriorityQueueSetCacheSize) {
+        this.priorityQueueStateType = priorityQueueStateType;
+        this.rocksDBPriorityQueueSetCacheSize = rocksDBPriorityQueueSetCacheSize;
+    }
+
+    /**
+     * Gets the type of the priority queue state. It will fall back to the default value if it is
+     * not explicitly set.
+     */
+    public PriorityQueueStateType getPriorityQueueStateType() {
+        return priorityQueueStateType == null
+                ? TIMER_SERVICE_FACTORY.defaultValue()
+                : priorityQueueStateType;
+    }
+
+    public void setPriorityQueueStateType(PriorityQueueStateType type) {
+        this.priorityQueueStateType = checkNotNull(type);
+    }
+
+    /**
+     * Gets the cache size of rocksDB priority queue set. It will fall back to the default value if
+     * it is not explicitly set.
+     */
+    public int getRocksDBPriorityQueueSetCacheSize() {
+        return rocksDBPriorityQueueSetCacheSize == UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE
+                ? ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE.defaultValue()
+                : rocksDBPriorityQueueSetCacheSize;
+    }
+
+    public void setRocksDBPriorityQueueSetCacheSize(int cacheSize) {
+        this.rocksDBPriorityQueueSetCacheSize = cacheSize;
+    }
+
+    public static RocksDBPriorityQueueConfig fromOtherAndConfiguration(
+            RocksDBPriorityQueueConfig other, ReadableConfig config) {
+        PriorityQueueStateType priorityQueueType =
+                (null == other.priorityQueueStateType)
+                        ? config.get(TIMER_SERVICE_FACTORY)
+                        : other.priorityQueueStateType;
+        int cacheSize =
+                (other.rocksDBPriorityQueueSetCacheSize
+                                == UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE)
+                        ? config.get(ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE)
+                        : other.rocksDBPriorityQueueSetCacheSize;
+        return new RocksDBPriorityQueueConfig(priorityQueueType, cacheSize);
+    }
+
+    public static RocksDBPriorityQueueConfig buildWithPriorityQueueType(
+            PriorityQueueStateType type) {
+        return new RocksDBPriorityQueueConfig(
+                type, ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE.defaultValue());
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueConfig.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueConfig.java
@@ -22,12 +22,16 @@ import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.Prio
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
+
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.TIMER_SERVICE_FACTORY;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The configuration of rocksDB priority queue state implementation. */
-public class RocksDBPriorityQueueConfig {
+public class RocksDBPriorityQueueConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private static final int UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE = -1;
 
@@ -38,8 +42,7 @@ public class RocksDBPriorityQueueConfig {
     private int rocksDBPriorityQueueSetCacheSize;
 
     public RocksDBPriorityQueueConfig() {
-        this.priorityQueueStateType = null;
-        this.rocksDBPriorityQueueSetCacheSize = UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE;
+        this(null, UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE);
     }
 
     public RocksDBPriorityQueueConfig(
@@ -70,10 +73,6 @@ public class RocksDBPriorityQueueConfig {
         return rocksDBPriorityQueueSetCacheSize == UNDEFINED_ROCKSDB_PRIORITY_QUEUE_SET_CACHE_SIZE
                 ? ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE.defaultValue()
                 : rocksDBPriorityQueueSetCacheSize;
-    }
-
-    public void setRocksDBPriorityQueueSetCacheSize(int cacheSize) {
-        this.rocksDBPriorityQueueSetCacheSize = cacheSize;
     }
 
     public static RocksDBPriorityQueueConfig fromOtherAndConfiguration(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInf
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.KeyGroupPartitionedPriorityQueue;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -95,6 +96,7 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
         this.sharedElementOutView = new DataOutputSerializer(128);
         this.sharedElementInView = new DataInputDeserializer();
         this.writeBufferManagerCapacity = writeBufferManagerCapacity;
+        Preconditions.checkArgument(cacheSize > 0);
         this.cacheSize = cacheSize;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
@@ -52,7 +52,9 @@ import java.util.function.Function;
 public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
     /** Default cache size per key-group. */
-    @VisibleForTesting static final int DEFAULT_CACHES_SIZE = 128; // TODO make this configurable
+    @VisibleForTesting static final int DEFAULT_CACHES_SIZE = 128;
+
+    private final int cacheSize;
 
     /** A shared buffer to serialize elements for the priority queue. */
     @Nonnull private final DataOutputSerializer sharedElementOutView;
@@ -81,7 +83,8 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
             RocksDBWriteBatchWrapper writeBatchWrapper,
             RocksDBNativeMetricMonitor nativeMetricMonitor,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            int cacheSize) {
         this.keyGroupRange = keyGroupRange;
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
         this.numberOfKeyGroups = numberOfKeyGroups;
@@ -94,6 +97,7 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
         this.sharedElementOutView = new DataOutputSerializer(128);
         this.sharedElementInView = new DataInputDeserializer();
         this.writeBufferManagerCapacity = writeBufferManagerCapacity;
+        this.cacheSize = cacheSize;
     }
 
     @Nonnull
@@ -131,8 +135,7 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
                             int numKeyGroups,
                             @Nonnull KeyExtractorFunction<T> keyExtractor,
                             @Nonnull PriorityComparator<T> elementPriorityComparator) {
-                        TreeOrderedSetCache orderedSetCache =
-                                new TreeOrderedSetCache(DEFAULT_CACHES_SIZE);
+                        TreeOrderedSetCache orderedSetCache = new TreeOrderedSetCache(cacheSize);
                         return new RocksDBCachingPriorityQueueSet<>(
                                 keyGroupId,
                                 keyGroupPrefixBytes,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
@@ -51,9 +51,7 @@ import java.util.function.Function;
  */
 public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
 
-    /** Default cache size per key-group. */
-    @VisibleForTesting static final int DEFAULT_CACHES_SIZE = 128;
-
+    /** The priorityQueue cache size per key-group. */
     private final int cacheSize;
 
     /** A shared buffer to serialize elements for the priority queue. */
@@ -227,5 +225,10 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
         }
 
         return stateInfo;
+    }
+
+    @VisibleForTesting
+    public int getCacheSize() {
+        return cacheSize;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -213,6 +213,34 @@ public class RocksDBStateBackendConfigTest {
         env.close();
     }
 
+    @Test
+    public void testConfigureRocksDBPriorityQueueFactoryCacheSize() throws Exception {
+        final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
+        EmbeddedRocksDBStateBackend rocksDbBackend = new EmbeddedRocksDBStateBackend();
+        int cacheSize = 512;
+        Configuration conf = new Configuration();
+        conf.set(
+                RocksDBOptions.TIMER_SERVICE_FACTORY,
+                EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
+        conf.set(RocksDBOptions.ROCKSDB_TIMER_SERVICE_FACTORY_CACHE_SIZE, cacheSize);
+
+        rocksDbBackend =
+                rocksDbBackend.configure(conf, Thread.currentThread().getContextClassLoader());
+
+        RocksDBKeyedStateBackend<Integer> keyedBackend =
+                createKeyedStateBackend(rocksDbBackend, env, IntSerializer.INSTANCE);
+
+        Assert.assertEquals(
+                RocksDBPriorityQueueSetFactory.class,
+                keyedBackend.getPriorityQueueFactory().getClass());
+        Assert.assertEquals(
+                cacheSize,
+                ((RocksDBPriorityQueueSetFactory) keyedBackend.getPriorityQueueFactory())
+                        .getCacheSize());
+        keyedBackend.dispose();
+        env.close();
+    }
+
     /** Validates that user custom configuration from code should override the flink-conf.yaml. */
     @Test
     public void testConfigureTimerServiceLoadingFromApplication() throws Exception {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateOptionTest.java
@@ -131,7 +131,13 @@ public class RocksDBStateOptionTest {
             PriorityQueue<TimerHeapInternalTimer<Integer, VoidNamespace>> expectedPriorityQueue =
                     new PriorityQueue<>((o1, o2) -> (int) (o1.getTimestamp() - o2.getTimestamp()));
             // ensure we insert timers more than cache capacity.
-            int queueSize = RocksDBPriorityQueueSetFactory.DEFAULT_CACHES_SIZE + 42;
+            assertTrue(
+                    keyedStateBackend.getPriorityQueueFactory()
+                            instanceof RocksDBPriorityQueueSetFactory);
+            int queueSize =
+                    ((RocksDBPriorityQueueSetFactory) keyedStateBackend.getPriorityQueueFactory())
+                                    .getCacheSize()
+                            + 42;
             List<Integer> timeStamps =
                     IntStream.range(0, queueSize).boxed().collect(Collectors.toList());
             Collections.shuffle(timeStamps);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -21,7 +21,6 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -61,7 +60,6 @@ public final class RocksDBTestUtils {
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
         return new RocksDBKeyedStateBackendBuilder<>(
-                new Configuration(),
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
                 instanceBasePath,
@@ -73,7 +71,7 @@ public final class RocksDBTestUtils {
                 new KeyGroupRange(0, 1),
                 new ExecutionConfig(),
                 TestLocalRecoveryConfig.disabled(),
-                queueStateType,
+                RocksDBPriorityQueueConfig.buildWithPriorityQueueType(queueStateType),
                 TtlTimeProvider.DEFAULT,
                 LatencyTrackingStateConfig.disabled(),
                 new UnregisteredMetricsGroup(),
@@ -92,7 +90,6 @@ public final class RocksDBTestUtils {
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
         return new RocksDBKeyedStateBackendBuilder<>(
-                new Configuration(),
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
                 instanceBasePath,
@@ -104,7 +101,8 @@ public final class RocksDBTestUtils {
                 new KeyGroupRange(0, 1),
                 new ExecutionConfig(),
                 TestLocalRecoveryConfig.disabled(),
-                EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP,
+                RocksDBPriorityQueueConfig.buildWithPriorityQueueType(
+                        EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP),
                 TtlTimeProvider.DEFAULT,
                 LatencyTrackingStateConfig.disabled(),
                 new UnregisteredMetricsGroup(),

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -60,6 +61,7 @@ public final class RocksDBTestUtils {
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
         return new RocksDBKeyedStateBackendBuilder<>(
+                new Configuration(),
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
                 instanceBasePath,
@@ -90,6 +92,7 @@ public final class RocksDBTestUtils {
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
         return new RocksDBKeyedStateBackendBuilder<>(
+                new Configuration(),
                 "no-op",
                 ClassLoader.getSystemClassLoader(),
                 instanceBasePath,

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
@@ -35,6 +35,7 @@ import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
+import org.apache.flink.contrib.streaming.state.RocksDBPriorityQueueConfig;
 import org.apache.flink.contrib.streaming.state.RocksDBResourceContainer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
@@ -161,7 +162,6 @@ public class StateBackendBenchmarkUtils {
         RocksDBResourceContainer resourceContainer = new RocksDBResourceContainer();
         RocksDBKeyedStateBackendBuilder<Long> builder =
                 new RocksDBKeyedStateBackendBuilder<>(
-                        new Configuration(),
                         "Test",
                         Thread.currentThread().getContextClassLoader(),
                         dbPathFile,
@@ -173,7 +173,8 @@ public class StateBackendBenchmarkUtils {
                         new KeyGroupRange(0, 1),
                         executionConfig,
                         new LocalRecoveryConfig(null),
-                        EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB,
+                        RocksDBPriorityQueueConfig.buildWithPriorityQueueType(
+                                EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB),
                         TtlTimeProvider.DEFAULT,
                         LatencyTrackingStateConfig.disabled(),
                         new UnregisteredMetricsGroup(),

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
@@ -161,6 +161,7 @@ public class StateBackendBenchmarkUtils {
         RocksDBResourceContainer resourceContainer = new RocksDBResourceContainer();
         RocksDBKeyedStateBackendBuilder<Long> builder =
                 new RocksDBKeyedStateBackendBuilder<>(
+                        new Configuration(),
                         "Test",
                         Thread.currentThread().getContextClassLoader(),
                         dbPathFile,

--- a/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
@@ -96,7 +96,7 @@ public final class BackendSwitchSpecs {
 
             temporaryFolder.create();
             return new RocksDBKeyedStateBackendBuilder<>(
-                             new Configuration(),
+                            new Configuration(),
                             "no-op",
                             ClassLoader.getSystemClassLoader(),
                             temporaryFolder.newFolder(),

--- a/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
@@ -95,6 +96,7 @@ public final class BackendSwitchSpecs {
 
             temporaryFolder.create();
             return new RocksDBKeyedStateBackendBuilder<>(
+                             new Configuration(),
                             "no-op",
                             ClassLoader.getSystemClassLoader(),
                             temporaryFolder.newFolder(),

--- a/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
@@ -21,11 +21,11 @@ package org.apache.flink.test.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
+import org.apache.flink.contrib.streaming.state.RocksDBPriorityQueueConfig;
 import org.apache.flink.contrib.streaming.state.RocksDBResourceContainer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -96,7 +96,6 @@ public final class BackendSwitchSpecs {
 
             temporaryFolder.create();
             return new RocksDBKeyedStateBackendBuilder<>(
-                            new Configuration(),
                             "no-op",
                             ClassLoader.getSystemClassLoader(),
                             temporaryFolder.newFolder(),
@@ -109,7 +108,7 @@ public final class BackendSwitchSpecs {
                             keyGroupRange,
                             new ExecutionConfig(),
                             TestLocalRecoveryConfig.disabled(),
-                            queueStateType,
+                            RocksDBPriorityQueueConfig.buildWithPriorityQueueType(queueStateType),
                             TtlTimeProvider.DEFAULT,
                             LatencyTrackingStateConfig.disabled(),
                             new UnregisteredMetricsGroup(),


### PR DESCRIPTION
## What is the purpose of the change

This pull request make the cache size of RocksDBPriorityQueueSetFactory configurable.

## Brief change log
- Pass the configurableOptions of EmbeddedRocksDBStateBackend into RocksDBKeyedStateBackendBuilder,  then create RocksDBPriorityQueueSetFactory using the configured cache size


## Verifying this change

This change is a trivial work without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
