### PR TITLE
[FLINK-33064][table-planner] Improve the error message when the lookup source is used as the scan source

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/TemporalTableJoinUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/TemporalTableJoinUtil.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.table.planner.plan.utils;
 
+import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType;
+
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexVisitor;
 import org.apache.calcite.rex.RexVisitorImpl;
@@ -65,5 +69,15 @@ public class TemporalTableJoinUtil {
         // (LEFT_TIME_ATTRIBUTE, RIGHT_TIME_ATTRIBUTE, LEFT_KEY, RIGHT_KEY, PRIMARY_KEY)
         return call.getOperator() == TemporalJoinUtil.TEMPORAL_JOIN_CONDITION()
                 && call.operands.size() == 5;
+    }
+
+    public static boolean isTemporalJoinSupportPeriod(RexNode period) {
+        // it should be left table's field and is a time attribute
+        if (period instanceof RexFieldAccess) {
+            RexFieldAccess rexFieldAccess = (RexFieldAccess) period;
+            return rexFieldAccess.getType() instanceof TimeIndicatorRelDataType
+                    && rexFieldAccess.getReferenceExpr() instanceof RexCorrelVariable;
+        }
+        return false;
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
@@ -22,13 +22,13 @@ import org.apache.flink.table.connector.source.LookupTableSource
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalRel, FlinkLogicalSnapshot, FlinkLogicalTableSourceScan}
 import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalLookupJoin, StreamPhysicalTemporalJoin}
 import org.apache.flink.table.planner.plan.schema.{LegacyTableSourceTable, TableSourceTable, TimeIndicatorRelDataType}
+import org.apache.flink.table.planner.plan.utils.TemporalTableJoinUtil
 import org.apache.flink.table.sources.LookupableTableSource
 
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.TableScan
 import org.apache.calcite.rel.logical.{LogicalProject, LogicalTableScan}
-import org.apache.calcite.rex.{RexCorrelVariable, RexFieldAccess}
 
 /**
  * Base implementation that matches temporal join node.
@@ -42,15 +42,12 @@ trait CommonTemporalTableJoinRule {
   protected def matches(snapshot: FlinkLogicalSnapshot): Boolean = {
 
     // period specification check
-    snapshot.getPeriod match {
-      // it should be left table's field and is a time attribute
-      case r: RexFieldAccess
-          if r.getType.isInstanceOf[TimeIndicatorRelDataType] &&
-            r.getReferenceExpr.isInstanceOf[RexCorrelVariable] => // pass
-      case _ =>
-        throw new TableException(
-          "Temporal table join currently only supports " +
-            "'FOR SYSTEM_TIME AS OF' left table's time attribute field.")
+    val isTemporalJoinSnapshot =
+      TemporalTableJoinUtil.isTemporalJoinSupportPeriod(snapshot.getPeriod)
+    if (!isTemporalJoinSnapshot) {
+      throw new TableException(
+        "Temporal table join currently only supports " +
+          "'FOR SYSTEM_TIME AS OF' left table's time attribute field.")
     }
 
     true

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -1117,15 +1117,17 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
 
   @Test
   def testCreateViewAndShowCreateTable(): Unit = {
+    val isBounded = !isStreamingMode
     val createTableDDL =
-      """ |create table `source` (
-        |  `id` bigint not null,
-        | `group` string not null,
-        | `score` double
-        |) with (
-        |  'connector' = 'source-only'
-        |)
-        |""".stripMargin
+      s""" |create table `source` (
+         |  `id` bigint not null,
+         | `group` string not null,
+         | `score` double
+         |) with (
+         |  'connector' = 'source-only',
+         |  'bounded' = '$isBounded'
+         |)
+         |""".stripMargin
     val createViewDDL =
       """ |create view `tmp` as
         |select `group`, avg(`score`) as avg_score
@@ -1144,13 +1146,15 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
 
   @Test
   def testAlterViewRename(): Unit = {
-    tableEnv.executeSql("""
-                          | CREATE TABLE T (
-                          |   id INT
-                          | ) WITH (
-                          |   'connector' = 'source-only'
-                          | )
-                          |""".stripMargin)
+    val isBounded = !isStreamingMode
+    tableEnv.executeSql(s"""
+                           | CREATE TABLE T (
+                           |   id INT
+                           | ) WITH (
+                           |   'connector' = 'source-only',
+                           |   'bounded' = '$isBounded'
+                           | )
+                           |""".stripMargin)
     tableEnv.executeSql("CREATE VIEW V AS SELECT * FROM T")
 
     tableEnv.executeSql("ALTER VIEW V RENAME TO V2")
@@ -1159,14 +1163,16 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
 
   @Test
   def testAlterViewAs(): Unit = {
-    tableEnv.executeSql("""
-                          | CREATE TABLE T (
-                          |   a INT,
-                          |   b INT
-                          | ) WITH (
-                          |   'connector' = 'source-only'
-                          | )
-                          |""".stripMargin)
+    val isBounded = !isStreamingMode
+    tableEnv.executeSql(s"""
+                           | CREATE TABLE T (
+                           |   a INT,
+                           |   b INT
+                           | ) WITH (
+                           |   'connector' = 'source-only',
+                           |   'bounded' = '$isBounded'
+                           | )
+                           |""".stripMargin)
     tableEnv.executeSql("CREATE VIEW V AS SELECT a FROM T")
 
     tableEnv.executeSql("ALTER VIEW V AS SELECT b FROM T")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -731,8 +731,12 @@ class TableScanTest extends TableTestBase {
                      |  'table-source-class' = '${classOf[MockedLookupTableSource].getName}'
                      |)
       """.stripMargin)
-    thrown.expect(classOf[TableException])
-    thrown.expectMessage("Cannot generate a valid execution plan for the given query")
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage(
+      "The specified table source `default_catalog`.`default_database`.`src` " +
+        "doesn't extend ScanTableSource and can not be used as the scan source.\nHint: You can read the data " +
+        "from the source as a dim table with the look up join syntax. Otherwise, please refer to the document " +
+        "and change the type of the connector to a source table that supports direct reads.")
     util.verifyRelPlan("SELECT * FROM src", ExplainDetail.CHANGELOG_MODE)
   }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Improve the error message when the lookup source is used as the scan source. Currently, if we use a source which only implement `LookupTableSource` but not implement `ScanTableSource` as a scan source, it cannot get a property plan and give a `Cannot generate a valid execution plan for the given query` which can be improved.


## Brief change log
- optimize the erro message.
- adding test to cover it 


## Verifying this change
- adding test to cover it 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? no docs
