### PR TITLE
[FLINK-33065][client] Add possible root cause to the exception message when the program plan could not be fetched

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -183,7 +183,8 @@ public enum PackagedProgramUtils {
 
         throw generateException(
                 program,
-                "The program plan could not be fetched - the program aborted pre-maturely.",
+                "The program plan could not be fetched - the program aborted pre-maturely. "
+                        + "The root cause may be that the main method doesn't call env.execute().",
                 null,
                 stdOutBuffer,
                 stdErrBuffer);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -184,7 +184,7 @@ public enum PackagedProgramUtils {
         throw generateException(
                 program,
                 "The program plan could not be fetched - the program aborted pre-maturely. "
-                        + "The root cause may be that the main method doesn't call env.execute().",
+                        + "The root cause may be that the main method doesn't call `env.execute()` or `env.executeAsync()`.",
                 null,
                 stdOutBuffer,
                 stdErrBuffer);


### PR DESCRIPTION
## What is the purpose of the change

When the program plan could not be fetched, the root cause may be: the main method doesn't call the `env.execute()`. We can optimize the message to help user find this root cause.



## Brief change log

[FLINK-33065][client] Add possible root cause to the exception message when the program plan could not be fetched


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
