### PR TITLE
[FLINK-32885 ] [flink-clients] Refactoring: Moving UrlPrefixDecorator into flink-clients so it can be used by RestClusterClient for PyFlink remote execution

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/UrlPrefixDecorator.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/UrlPrefixDecorator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.gateway.rest.header.util;
+package org.apache.flink.client.program.rest;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.RestClient;
@@ -24,9 +24,11 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
 
 import static org.apache.flink.shaded.guava31.com.google.common.base.Preconditions.checkNotNull;
 
@@ -41,7 +43,7 @@ import static org.apache.flink.shaded.guava31.com.google.common.base.Preconditio
  */
 public class UrlPrefixDecorator<
                 R extends RequestBody, P extends ResponseBody, M extends MessageParameters>
-        implements SqlGatewayMessageHeaders<R, P, M> {
+        implements MessageHeaders<R, P, M> {
 
     private final String prefixedUrl;
     private final MessageHeaders<R, P, M> decorated;
@@ -99,5 +101,10 @@ public class UrlPrefixDecorator<
     @Override
     public M getUnresolvedMessageParameters() {
         return decorated.getUnresolvedMessageParameters();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return decorated.getSupportedAPIVersions();
     }
 }


### PR DESCRIPTION
[FLINK-32885](https://issues.apache.org/jira/browse/FLINK-32885) Refactoring: Moving UrlPrefixDecorator into flink-clients so it can be used by RestClusterClient for PyFlink remote execution

## What is the purpose of the change

UrlPrefixDecorator is introduced in `flink-sql-gateway` module, which has a dependency on `flink-clients` module. RestClusterClient will also need to use UrlPrefixDecorator for supporting PyFlink remote execution. Will refactor related classes to achieve this.

This PR will be used in [FLINK-32884 PyFlink remote execution should support URLs with paths and https scheme](https://issues.apache.org/jira/browse/FLINK-32884)

## Brief change log

- Moved UrlPrefixDecorator class from `flink-sql-gateway` module into  `flink-clients` module

## Verifying this change

This change is already covered by existing tests, such as :
- https://github.com/apache/flink/blob/master/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
- https://github.com/apache/flink/blob/master/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/java/org/apache/flink/runtime/rest/RestClientITCase.java 
- https://github.com/apache/flink/blob/master/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/ExecutorImplITCase.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
