### PR TITLE
[FLINK-33058][formats] Add encoding option to Avro format

### DIFF
--- a/docs/content/docs/connectors/table/formats/avro.md
+++ b/docs/content/docs/connectors/table/formats/avro.md
@@ -81,6 +81,16 @@ Format Options
       <td>Specify what format to use, here should be <code>'avro'</code>.</td>
     </tr>
     <tr>
+      <td><h5>avro.encoding</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td>binary</td>
+      <td>String</td>
+      <td>Serialization encoding to use. The valid enumerations are: <code>binary</code>, <code>json</code>. <a href="https://avro.apache.org/docs/current/specification/#encodings">(reference)</a><br>
+      Most applications will use the binary encoding, as it results in smaller and more efficient messages, reducing the usage of disk and network resources, and improving performance for high throughput data. <br>
+      JSON encoding results in human-readable messages which can be useful during development and debugging, and is useful for compatibility when interacting with systems that cannot process binary encoded data.</td>
+    </tr>
+    <tr>
       <td><h5>avro.codec</h5></td>
       <td>optional</td>
       <td>yes</td>

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
@@ -21,8 +21,11 @@ package org.apache.flink.formats.avro;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
 
 import static org.apache.avro.file.DataFileConstants.SNAPPY_CODEC;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /** Options for the avro format. */
 @PublicEvolving
@@ -33,6 +36,40 @@ public class AvroFormatOptions {
                     .stringType()
                     .defaultValue(SNAPPY_CODEC)
                     .withDescription("The compression codec for avro");
+
+    public static final ConfigOption<AvroEncoding> AVRO_ENCODING =
+            ConfigOptions.key("encoding")
+                    .enumType(AvroEncoding.class)
+                    .defaultValue(AvroEncoding.BINARY)
+                    .withDescription(
+                            "The encoding to use for serialization. "
+                                    + "Binary offers a more compact, space-efficient way "
+                                    + "to represent objects, while JSON offers a more "
+                                    + "human-readable option.");
+
+    /** Serialization types for Avro encoding, see {@link #AVRO_ENCODING}. */
+    public enum AvroEncoding implements DescribedEnum {
+        BINARY("binary", text("Use binary encoding for serialization and deserialization.")),
+        JSON("json", text("Use JSON encoding for serialization and deserialization."));
+
+        private final String value;
+        private final InlineElement description;
+
+        AvroEncoding(String value, InlineElement description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
 
     private AvroFormatOptions() {}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -65,8 +66,22 @@ public class AvroRowDataDeserializationSchema implements DeserializationSchema<R
      *     AvroRowDataDeserializationSchema#getProducedType()}.
      */
     public AvroRowDataDeserializationSchema(RowType rowType, TypeInformation<RowData> typeInfo) {
+        this(rowType, typeInfo, AvroEncoding.BINARY);
+    }
+
+    /**
+     * Creates a Avro deserialization schema for the given logical type.
+     *
+     * @param rowType The logical type used to deserialize the data.
+     * @param typeInfo The TypeInformation to be used by {@link
+     *     AvroRowDataDeserializationSchema#getProducedType()}.
+     * @param encoding The serialization approach used to deserialize the data.
+     */
+    public AvroRowDataDeserializationSchema(
+            RowType rowType, TypeInformation<RowData> typeInfo, AvroEncoding encoding) {
         this(
-                AvroDeserializationSchema.forGeneric(AvroSchemaConverter.convertToSchema(rowType)),
+                AvroDeserializationSchema.forGeneric(
+                        AvroSchemaConverter.convertToSchema(rowType), encoding),
                 AvroToRowDataConverters.createRowConverter(rowType),
                 typeInfo);
     }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -55,9 +56,19 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 
     /** Creates an Avro serialization schema with the given record row type. */
     public AvroRowDataSerializationSchema(RowType rowType) {
+        this(rowType, AvroEncoding.BINARY);
+    }
+
+    /**
+     * Creates an Avro serialization schema with the given record row type.
+     *
+     * @param encoding The serialization approach used to serialize the data.
+     */
+    public AvroRowDataSerializationSchema(RowType rowType, AvroEncoding encoding) {
         this(
                 rowType,
-                AvroSerializationSchema.forGeneric(AvroSchemaConverter.convertToSchema(rowType)),
+                AvroSerializationSchema.forGeneric(
+                        AvroSchemaConverter.convertToSchema(rowType), encoding),
                 RowDataToAvroConverters.createConverter(rowType));
     }
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.avro;
 
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import org.apache.avro.Schema;
@@ -30,7 +31,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * Serialization schema that serializes to Avro binary format.
+ * Serialization schema that serializes to Avro format.
  *
  * @param <T> the type to be serialized
  */
@@ -42,6 +43,7 @@ public class RegistryAvroSerializationSchema<T> extends AvroSerializationSchema<
     private final SchemaCoder.SchemaCoderProvider schemaCoderProvider;
 
     protected SchemaCoder schemaCoder;
+
     /**
      * Creates a Avro serialization schema.
      *
@@ -56,19 +58,52 @@ public class RegistryAvroSerializationSchema<T> extends AvroSerializationSchema<
             Class<T> recordClazz,
             Schema schema,
             SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
-        super(recordClazz, schema);
+        this(recordClazz, schema, schemaCoderProvider, AvroEncoding.BINARY);
+    }
+
+    /**
+     * Creates a Avro serialization schema.
+     *
+     * @param recordClazz class to serialize. Should be either {@link SpecificRecord} or {@link
+     *     GenericRecord}.
+     * @param schema writers's Avro schema. Should be provided if recordClazz is {@link
+     *     GenericRecord}
+     * @param schemaCoderProvider schema provider that allows instantiation of {@link SchemaCoder}
+     *     that will be used for schema writing
+     * @param encoding Avro serialization approach to use.
+     */
+    public RegistryAvroSerializationSchema(
+            Class<T> recordClazz,
+            Schema schema,
+            SchemaCoder.SchemaCoderProvider schemaCoderProvider,
+            AvroEncoding encoding) {
+        super(recordClazz, schema, encoding);
         this.schemaCoderProvider = schemaCoderProvider;
     }
 
     public static <T extends SpecificRecord> RegistryAvroSerializationSchema<T> forSpecific(
             Class<T> tClass, SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
-        return new RegistryAvroSerializationSchema<>(tClass, null, schemaCoderProvider);
+        return forSpecific(tClass, schemaCoderProvider, AvroEncoding.BINARY);
+    }
+
+    public static <T extends SpecificRecord> RegistryAvroSerializationSchema<T> forSpecific(
+            Class<T> tClass,
+            SchemaCoder.SchemaCoderProvider schemaCoderProvider,
+            AvroEncoding encoding) {
+        return new RegistryAvroSerializationSchema<>(tClass, null, schemaCoderProvider, encoding);
     }
 
     public static RegistryAvroSerializationSchema<GenericRecord> forGeneric(
             Schema schema, SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
+        return forGeneric(schema, schemaCoderProvider, AvroEncoding.BINARY);
+    }
+
+    public static RegistryAvroSerializationSchema<GenericRecord> forGeneric(
+            Schema schema,
+            SchemaCoder.SchemaCoderProvider schemaCoderProvider,
+            AvroEncoding encoding) {
         return new RegistryAvroSerializationSchema<>(
-                GenericRecord.class, schema, schemaCoderProvider);
+                GenericRecord.class, schema, schemaCoderProvider, encoding);
     }
 
     @Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -32,7 +33,8 @@ import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContex
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,10 +53,12 @@ class AvroFormatFactoryTest {
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
 
-    @Test
-    void testSeDeSchema() {
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testSeDeSchema(AvroEncoding encoding) {
         final AvroRowDataDeserializationSchema expectedDeser =
-                new AvroRowDataDeserializationSchema(ROW_TYPE, InternalTypeInfo.of(ROW_TYPE));
+                new AvroRowDataDeserializationSchema(
+                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), encoding);
 
         final Map<String, String> options = getAllOptions();
 
@@ -70,7 +74,7 @@ class AvroFormatFactoryTest {
         assertThat(actualDeser).isEqualTo(expectedDeser);
 
         final AvroRowDataSerializationSchema expectedSer =
-                new AvroRowDataSerializationSchema(ROW_TYPE);
+                new AvroRowDataSerializationSchema(ROW_TYPE, encoding);
 
         final DynamicTableSink actualSink = FactoryMocks.createTableSink(SCHEMA, options);
         assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.avro;
 
+import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.SimpleRecord;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
@@ -28,6 +29,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,8 +77,9 @@ class RegistryAvroDeserializationSchemaTest {
         assertThat(genericRecord.get("country")).isNull();
     }
 
-    @Test
-    void testSpecificRecordReadMoreFieldsThanWereWritten() throws IOException {
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testSpecificRecordReadMoreFieldsThanWereWritten(AvroEncoding encoding) throws IOException {
         Schema smallerUserSchema =
                 new Schema.Parser()
                         .parse(
@@ -102,13 +106,14 @@ class RegistryAvroDeserializationSchemaTest {
                                             throws IOException {
                                         // Do nothing
                                     }
-                                });
+                                },
+                        encoding);
 
         GenericData.Record smallUser =
                 new GenericRecordBuilder(smallerUserSchema).set("name", "someName").build();
 
         SimpleRecord simpleRecord =
-                deserializer.deserialize(writeRecord(smallUser, smallerUserSchema));
+                deserializer.deserialize(writeRecord(smallUser, smallerUserSchema, encoding));
 
         assertThat(simpleRecord.getName().toString()).isEqualTo("someName");
         assertThat(simpleRecord.getOptionalField()).isNull();


### PR DESCRIPTION
## What is the purpose of the change

Initially proposed in https://issues.apache.org/jira/browse/FLINK-33058 

Avro supports two serialization encoding methods: binary and JSON (cf. [Avro docs](https://avro.apache.org/docs/1.11.1/specification/#encodings))

flink-avro currently has a hard-coded assumption that Avro data is binary-encoded (and cannot process Avro data that has been JSON-encoded).

This pull request introduces a new optional format option to flink-avro: `avro.encoding`
It supports two options: 'binary' and 'json'. 
It unset, it will default to 'binary' to maintain compatibility/consistency with current behaviour. 


## Brief change log

Flink uses Avro [`Decoder`](https://avro.apache.org/docs/1.8.2/api/java/org/apache/avro/io/Decoder.html) and [`Encoder`](https://avro.apache.org/docs/1.8.2/api/java/org/apache/avro/io/Encoder.html) classes for deserializing/serializing Avro data. 

However it was hard-coding the use of factory classes to only use the binary-encoding implementations of these abstract classes.  (`DecoderFactory.get().binaryDecoder` and `EncoderFactory.get().directBinaryEncoder`)

In this pull request, I'm using the value of the new `avro.encoding` option to create the JSON Decoder/Encoder classes where appropriate. 

## Verifying this change

This change modified existing tests by re-running all of the tests that perform Avro serialization/deserialization to repeat the test using both binary and avro encoding. 

This verifies that the existing binary behaviour is unaffected by the new option, as well as the new JSON support.

I've also manually verified the new support using Flink SQL such as:

```sql
CREATE TABLE JSONAVRO
(
    ... my columns ...
)
WITH (
    'connector' = 'kafka',
    'topic' = 'MY.TOPIC',
    'properties.bootstrap.servers' = 'localhost:9092',
    'properties.group.id' = 'my-group',
    'scan.startup.mode' = 'earliest-offset',
    'format' = 'avro',
    'avro.encoding' = 'json'
);
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? update to the Avro format page to explain the new option
