### PR TITLE
[hotfix][docs] Misprints in security-ssl.md

### DIFF
--- a/docs/content.zh/docs/deployment/security/security-ssl.md
+++ b/docs/content.zh/docs/deployment/security/security-ssl.md
@@ -113,7 +113,7 @@ need to be set up such that the truststore trusts the keystore's certificate.
 
 Because internal communication is mutually authenticated between server and client side, keystore and truststore typically refer to a dedicated
 certificate that acts as a shared secret. In such a setup, the certificate can use wild card hostnames or addresses.
-WHen using self-signed certificates, it is even possible to use the same file as keystore and truststore.
+When using self-signed certificates, it is even possible to use the same file as keystore and truststore.
 
 ```yaml
 security.ssl.internal.keystore: /path/to/file.keystore
@@ -171,7 +171,7 @@ If these cipher suites are not supported on your setup, you will see that Flink 
 
 ## Creating and Deploying Keystores and Truststores
 
-Keys, Certificates, and the Keystores and Truststores can be generatedd using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html).
+Keys, Certificates, and the Keystores and Truststores can be generated using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html).
 You need to have an appropriate Java Keystore and Truststore accessible from each node in the Flink cluster.
 
   - For standalone setups, this means copying the files to each node, or adding them to a shared mounted directory.

--- a/docs/content/docs/deployment/security/security-ssl.md
+++ b/docs/content/docs/deployment/security/security-ssl.md
@@ -113,7 +113,7 @@ need to be set up such that the truststore trusts the keystore's certificate.
 
 Because internal communication is mutually authenticated between server and client side, keystore and truststore typically refer to a dedicated
 certificate that acts as a shared secret. In such a setup, the certificate can use wild card hostnames or addresses.
-WHen using self-signed certificates, it is even possible to use the same file as keystore and truststore.
+When using self-signed certificates, it is even possible to use the same file as keystore and truststore.
 
 ```yaml
 security.ssl.internal.keystore: /path/to/file.keystore
@@ -171,7 +171,7 @@ If these cipher suites are not supported on your setup, you will see that Flink 
 
 ## Creating and Deploying Keystores and Truststores
 
-Keys, Certificates, and the Keystores and Truststores can be generatedd using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html).
+Keys, Certificates, and the Keystores and Truststores can be generated using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html).
 You need to have an appropriate Java Keystore and Truststore accessible from each node in the Flink cluster.
 
   - For standalone setups, this means copying the files to each node, or adding them to a shared mounted directory.


### PR DESCRIPTION
## What is the purpose of the change
There are a couple of misprints in `security-ssl.md` (both englich and chinese versions)
`WHen` => `When`
`generatedd` => `generated`

## Brief change log

`security-ssl.md`


## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
