### PR TITLE
[FLINK-30906][task] TwoInputStreamTask and MultipleInputStreamTask passes wrong configuration when create input processor

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -170,7 +170,7 @@ public class MultipleInputStreamTask<OUT>
                         mainOperator,
                         inputWatermarkGauges,
                         getConfiguration(),
-                        getEnvironment().getTaskConfiguration(),
+                        getEnvironment().getTaskManagerInfo().getConfiguration(),
                         getJobConfiguration(),
                         getExecutionConfig(),
                         getUserCodeClassLoader(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -95,7 +95,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
                         input2WatermarkGauge,
                         operatorChain,
                         getConfiguration(),
-                        getEnvironment().getTaskConfiguration(),
+                        getEnvironment().getTaskManagerInfo().getConfiguration(),
                         getJobConfiguration(),
                         getExecutionConfig(),
                         getUserCodeClassLoader(),


### PR DESCRIPTION
## What is the purpose of the change

*Correct configuration option of `TwoInputStreamTask` and `MultipleInputStreamTask` when create input processor.*


## Brief change log

  - *Modify task configuration to taskManagerConfiguration.* 


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
