### PR TITLE
[FLINK-32884] [flink-clients] PyFlink remote execution should support URLs with paths and https scheme

### DIFF
--- a/docs/layouts/shortcodes/generated/common_host_port_section.html
+++ b/docs/layouts/shortcodes/generated/common_host_port_section.html
@@ -45,6 +45,12 @@
             <td>The port that the server binds itself. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple Rest servers are running on the same machine.</td>
         </tr>
         <tr>
+            <td><h5>rest.path</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The path that should be used by clients to interact to the server which is accessible via URL.</td>
+        </tr>
+        <tr>
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/rest_configuration.html
+++ b/docs/layouts/shortcodes/generated/rest_configuration.html
@@ -105,6 +105,12 @@
             <td>The maximum time in ms for a connection to stay idle before failing.</td>
         </tr>
         <tr>
+            <td><h5>rest.path</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The path that should be used by clients to interact to the server which is accessible via URL.</td>
+        </tr>
+        <tr>
             <td><h5>rest.port</h5></td>
             <td style="word-wrap: break-word;">8081</td>
             <td>Integer</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -25,10 +25,15 @@ import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.rest.retry.ExponentialWaitStrategy;
 import org.apache.flink.client.program.rest.retry.WaitStrategy;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -48,11 +53,13 @@ import org.apache.flink.runtime.messages.webmonitor.JobStatusInfo;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.rest.FileUpload;
+import org.apache.flink.runtime.rest.HttpHeader;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
 import org.apache.flink.runtime.rest.handler.async.TriggerResponse;
 import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterOverviewWithVersion;
 import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
+import org.apache.flink.runtime.rest.messages.CustomHeadersDecorator;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
@@ -193,6 +200,10 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                     ExceptionUtils.findThrowable(exception, JobStateUnknownException.class)
                             .isPresent();
 
+    private final URL jobmanagerUrl;
+
+    private final Collection<HttpHeader> customHttpHeaders;
+
     public RestClusterClient(Configuration config, T clusterId) throws Exception {
         this(config, clusterId, DefaultClientHighAvailabilityServicesFactory.INSTANCE);
     }
@@ -255,10 +266,20 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                 RestClusterClientConfiguration.fromConfiguration(configuration);
         this.tempDir = tempDir;
 
+        this.customHttpHeaders =
+                ClientUtils.readHeadersFromEnvironmentVariable(
+                        ConfigConstants.FLINK_REST_CLIENT_HEADERS);
+        jobmanagerUrl =
+                new URL(
+                        SecurityOptions.isRestSSLEnabled(configuration) ? "https" : "http",
+                        configuration.getString(JobManagerOptions.ADDRESS),
+                        configuration.getInteger(JobManagerOptions.PORT),
+                        configuration.getString(RestOptions.PATH));
+
         if (restClient != null) {
             this.restClient = restClient;
         } else {
-            this.restClient = new RestClient(configuration, executorService);
+            this.restClient = RestClient.forUrl(configuration, executorService, jobmanagerUrl);
         }
 
         this.waitStrategy = checkNotNull(waitStrategy);
@@ -853,6 +874,16 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                 .thenApply(ignored -> Acknowledge.get());
     }
 
+    @VisibleForTesting
+    URL getJobmanagerUrl() {
+        return jobmanagerUrl;
+    }
+
+    @VisibleForTesting
+    Collection<HttpHeader> getCustomHttpHeaders() {
+        return customHttpHeaders;
+    }
+
     /**
      * Get an overview of the Flink cluster.
      *
@@ -1005,6 +1036,12 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                                 .thenCompose(
                                         webMonitorBaseUrl -> {
                                             try {
+                                                CustomHeadersDecorator<R, P, U> headers =
+                                                        new CustomHeadersDecorator<>(
+                                                                new UrlPrefixDecorator<>(
+                                                                        messageHeaders,
+                                                                        jobmanagerUrl.getPath()));
+                                                headers.setCustomHeaders(customHttpHeaders);
                                                 final CompletableFuture<P> future =
                                                         restClient.sendRequest(
                                                                 webMonitorBaseUrl.getHost(),

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -80,6 +80,15 @@ public class RestOptions {
                     .withDescription(
                             "The address that should be used by clients to connect to the server. Attention: This option is respected only if the high-availability configuration is NONE.");
 
+    /** The path that should be used by clients to interact with the server. */
+    @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
+    public static final ConfigOption<String> PATH =
+            key("rest.path")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "The path that should be used by clients to interact to the server which is accessible via URL.");
+
     /**
      * The port that the REST client connects to and the REST server binds to if {@link #BIND_PORT}
      * has not been specified.

--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -103,8 +103,15 @@ public class NetUtils {
      * @return URL object for accessing host and port
      */
     private static URL validateHostPortString(String hostPort) {
+        if (StringUtils.isNullOrWhitespaceOnly(hostPort)) {
+            throw new IllegalArgumentException("hostPort should not be null or empty");
+        }
         try {
-            URL u = new URL("http://" + hostPort);
+            URL u =
+                    (hostPort.toLowerCase().startsWith("http://")
+                                    || hostPort.toLowerCase().startsWith("https://"))
+                            ? new URL(hostPort)
+                            : new URL("http://" + hostPort);
             if (u.getHost() == null) {
                 throw new IllegalArgumentException(
                         "The given host:port ('" + hostPort + "') doesn't contain a valid host");

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -52,6 +52,14 @@ public class NetUtilsTest extends TestLogger {
     }
 
     @Test
+    public void testCorrectHostnamePortWithHttpsScheme() throws Exception {
+        final URL url = new URL("https", "foo.com", 8080, "/some/other/path/index.html");
+        assertEquals(
+                url,
+                NetUtils.getCorrectHostnamePort("https://foo.com:8080/some/other/path/index.html"));
+    }
+
+    @Test
     public void testParseHostPortAddress() {
         final InetSocketAddress socketAddress = new InetSocketAddress("foo.com", 8080);
         assertEquals(socketAddress, NetUtils.parseHostPortAddress("foo.com:8080"));


### PR DESCRIPTION
[FLINK-32884](https://issues.apache.org/jira/browse/FLINK-32884) PyFlink remote execution should support URLs with paths and https scheme

## What is the purpose of the change

Currently, the `SUBMIT_ARGS=remote -m http://<hostname>:<port>` format. For local execution it works fine `SUBMIT_ARGS=remote -m http://localhost:8081/`, but it does not support the placement of the JobManager behind a proxy or using an Ingress for routing to a specific Flink cluster based on the URL path. In the current scenario, it expects JobManager to access PyFlink jobs at `http://<hostname>:<port>/v1/jobs` endpoint. Mapping to a non-root location, `https://<hostname>:<port>/flink-clusters/namespace/flink_job_deployment/v1/jobs` is not supported.

This will use changes from [FLINK-32885](https://issues.apache.org/jira/browse/FLINK-32885)(https://issues.apache.org/jira/browse/FLINK-32885)

Since RestClusterClient talks to the JobManager via its REST endpoint, the right format for `SUBMIT_ARGS` is a URL with a path (also support for https scheme).


## Brief change log

- Added 2 new options into RestOptions: RestOptions.PATH and RestOptions.PROTOCOL
- Added `https` schema support and jobManagerUrl with path support to RestClusterClient
- Added customHttpHeaders support to RestClusterClient (for example setting auth token from env variable)
- Updated `NetUtils.validateHostPortString()` to handle both `http` and `https` schema for hostPort


## Verifying this change

This change added tests and can be verified as follows:
- Extended flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java to cover `http` and `https` schemes
- Added unit test flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java to check `https` scheme and URL with path

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
