### PR TITLE
[FLINK-32953][docs]Add notes about changing state ttl value

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -381,6 +381,8 @@ Heap state backend 会额外存储一个包括用户状态以及时间戳的 Jav
 
 - TTL 的配置并不会保存在 checkpoint/savepoint 中，仅对当前 Job 有效。
 
+- 不建议checkpoint恢复前后将state TTL从短调长，这可能会产生潜在的数据错误。
+
 - 当前开启 TTL 的 map state 仅在用户值序列化器支持 null 的情况下，才支持用户值为 null。如果用户值序列化器不支持 null，
 可以用 `NullableSerializer` 包装一层。
   

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -429,6 +429,9 @@ will lead to compatibility failure and `StateMigrationException`.
 
 - The TTL configuration is not part of check- or savepoints but rather a way of how Flink treats it in the currently running job.
 
+- It is not recommended to restore checkpoint state with adjusting the ttl from a short value to a long value,
+which may cause potential data errors.
+
 - The map state with TTL currently supports null user values only if the user value serializer can handle null values. 
 If the serializer does not support null values, it can be wrapped with `NullableSerializer` at the cost of an extra byte in the serialized form.
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request add notes about changing state TTL value when restore checkpoint.

## Brief change log

- Add a note in "state.md" document.

## Verifying this change

This change is a trivial work about document without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
