### PR TITLE
[FLINK-33085][table-planner] Improve the error message when the invalidated lookupTableSource without primary key is used as temporal join table

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/TemporalTableJoinUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/TemporalTableJoinUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.utils;
 
 import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexFieldAccess;
@@ -78,6 +79,16 @@ public class TemporalTableJoinUtil {
             return rexFieldAccess.getType() instanceof TimeIndicatorRelDataType
                     && rexFieldAccess.getReferenceExpr() instanceof RexCorrelVariable;
         }
+        return false;
+    }
+
+    public static boolean isProcessingTime(RexNode period) {
+        RelDataType type = period.getType();
+        if (type instanceof TimeIndicatorRelDataType) {
+            TimeIndicatorRelDataType timeIndicator = (TimeIndicatorRelDataType) type;
+            return !timeIndicator.isEventTime();
+        }
+
         return false;
     }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CommonLookupJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/common/CommonLookupJoinRule.scala
@@ -22,8 +22,7 @@ import org.apache.flink.table.connector.source.LookupTableSource
 import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.common.{CommonPhysicalLegacyTableSourceScan, CommonPhysicalLookupJoin, CommonPhysicalTableSourceScan}
 import org.apache.flink.table.planner.plan.rules.common.CommonTemporalTableJoinRule
-import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType
-import org.apache.flink.table.planner.plan.utils.JoinUtil
+import org.apache.flink.table.planner.plan.utils.{JoinUtil, TemporalTableJoinUtil}
 import org.apache.flink.table.sources.LookupableTableSource
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptTable}
@@ -60,11 +59,7 @@ trait CommonLookupJoinRule extends CommonTemporalTableJoinRule {
 
     // Temporal table join implemented by lookup join only supports processing-time join
     // Other temporal table join will be matched by CommonTemporalTableJoinRule
-    val isProcessingTime = snapshot.getPeriod.getType match {
-      case t: TimeIndicatorRelDataType if !t.isEventTime => true
-      case _ => false
-    }
-    isProcessingTime
+    TemporalTableJoinUtil.isProcessingTime(snapshot.getPeriod)
   }
 
   protected def isTableSourceScan(relNode: RelNode): Boolean = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -263,6 +263,33 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
   }
 
   @Test
+  def testLookupJoinInvalidateLookupTable(): Unit = {
+    util.addTable("""
+                    |CREATE TABLE InvalidateLookupTable (
+                    |  `id` INT,
+                    |  `name` STRING,
+                    |  `age` INT
+                    |) WITH (
+                    |  'connector' = 'values'
+                    |  ,'disable-lookup' = 'true'
+                    |)
+                    |""".stripMargin)
+    val sql = "SELECT * FROM MyTable AS T JOIN InvalidateLookupTable " +
+      "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id"
+
+    expectExceptionThrown(
+      sql,
+      "The specified table source `default_catalog`.`default_database`.`InvalidateLookupTable`" +
+        " is used as a dim table in temporal join or lookup join, but it doesn't contains primary key " +
+        "in this versioned table and doesn't extend LookupTableSource\n" +
+        "Hint: If you want use lookup join, you need to extend LookupTableSource, on the contrary, if " +
+        "you want to use temporal join, you need add primary key for this versioned table. The difference " +
+        "between temporal join and lookup join please refer to Flink docs.",
+      classOf[ValidationException]
+    )
+  }
+
+  @Test
   def testJoinOnDifferentKeyTypes(): Unit = {
     // Will do implicit type coercion.
     thrown.expect(classOf[TableException])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -443,11 +443,11 @@ class TemporalJoinTest extends TableTestBase {
       "ON o.currency = r.currency"
     expectExceptionThrown(
       sqlQuery3,
-      "Temporal Table Join requires primary key in versioned table, " +
-        "but no primary key can be found. The physical plan is:\n" +
-        "FlinkLogicalJoin(condition=[AND(=($1, $4), " +
-        "__INITIAL_TEMPORAL_JOIN_CONDITION($2, $6, __TEMPORAL_JOIN_LEFT_KEY($1), " +
-        "__TEMPORAL_JOIN_RIGHT_KEY($4)))], joinType=[inner])",
+      "The specified table source `default_catalog`.`default_database`.`versionedTableWithoutPk` " +
+        "is used as a dim table in temporal join or lookup join, but it doesn't contains primary key " +
+        "in this versioned table and the row time attribute is not processing time\n" +
+        "Hint: If you want use lookup join, you need change the row time attribute to processing time, " +
+        "and if you want use temporal join, you need add primary key for this versioned table.",
       classOf[ValidationException]
     )
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Improve the error message when the invalidate `lookupTableSource` without primary key is used as temporal join table.  This pr can check the legality of temporary table join syntax in `sqlToRel` phase and make the thrown error clearer.


## Brief change log

- Adding the check logical in `SqlToRelConverter`.
- Adding test in `LookupJoinTest` and `TemporalJoinTest`

## Verifying this change

- Adding test in `LookupJoinTest` and `TemporalJoinTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs
