### PR TITLE
[FLINK-33053][zookeeper] Manually remove the leader watcher after ret…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -101,7 +101,8 @@ public class ZooKeeperUtils {
     /** The prefix of the completed checkpoint file. */
     public static final String HA_STORAGE_COMPLETED_CHECKPOINT = "completedCheckpoint";
 
-    private static final String RESOURCE_MANAGER_NODE = "resource_manager";
+    /** The prefix of the resource manager node. */
+    public static final String RESOURCE_MANAGER_NODE = "resource_manager";
 
     private static final String DISPATCHER_NODE = "dispatcher";
 


### PR DESCRIPTION
…riever closed to avoid the watcher leak at zookeeper server side

## What is the purpose of the change

Currently, there will be watcher leak at zookeeper server side after a batch job finished. This PR proposes to add a manually watcher removal after the leader retriever closed as a safetynet.

## Verifying this change

I have not found a ZK api to fetch the current watcher. But the HA functionality should be covered by the existing UT/IT Case/E2E. The watcher leak disappear after this change in my local standalone test.
<img width="608" alt="截屏2023-09-14 15 15 32" src="https://github.com/apache/flink/assets/8684799/4faaa255-f4fc-4356-881a-dd3566eac643">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
