### PR TITLE
[FLINK-33029][python] fix drop python 3.7 wheel building

### DIFF
--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -27,7 +27,7 @@ requires = [
 ]
 
 [tool.cibuildwheel]
-build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+build = ["cp38-*", "cp39-*", "cp310-*"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
## What is the purpose of the change

Nightly wheel building job fails because it tries to build 3.7 still.

## Brief change log

Fixed wheel build job.

## Verifying this change

Checked manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
