### PR TITLE
[FLINK-33090][checkpointing] CheckpointsCleaner clean individual chec…

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -27,6 +27,12 @@
             <td>The checkpoint storage implementation to be used to checkpoint state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">CheckpointStorageFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">CheckpointStorageFactory#createFromConfig(ReadableConfig, ClassLoader)</code>  method is called.<br />Recognized shortcut names are 'jobmanager' and 'filesystem'.</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoint.cleaner.parallel-mode</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Option whether to discard a checkpoint's states in parallel using the ExecutorService passed into the cleaner</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -45,6 +45,12 @@
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoint.cleaner.parallel-mode</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Option whether to discard a checkpoint's states in parallel using the ExecutorService passed into the cleaner</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.num-retained</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -109,6 +109,19 @@ public class CheckpointingOptions {
                     .defaultValue(1)
                     .withDescription("The maximum number of completed checkpoints to retain.");
 
+    /* Option whether to clean individual checkpoint's operatorstates in parallel. If enabled,
+     * operator states are discarded in parallel using the ExecutorService passed to the cleaner.
+     * This speeds up checkpoints cleaning, but adds load to the IO.
+     */
+    @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
+    public static final ConfigOption<Boolean> CLEANER_PARALLEL_MODE =
+            ConfigOptions.key("state.checkpoint.cleaner.parallel-mode")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Option whether to discard a checkpoint's states in parallel using"
+                                    + " the ExecutorService passed into the cleaner");
+
     /** @deprecated Checkpoints are always asynchronous. */
     @Deprecated
     public static final ConfigOption<Boolean> ASYNC_SNAPSHOTS =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoint.java
@@ -17,6 +17,11 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 /** A checkpoint, pending or completed. */
 public interface Checkpoint {
     DiscardObject NOOP_DISCARD_OBJECT = () -> {};
@@ -33,5 +38,9 @@ public interface Checkpoint {
     /** Extra interface for discarding the checkpoint. */
     interface DiscardObject {
         void discard() throws Exception;
+
+        default CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            return FutureUtils.runAsync(this::discard, ioExecutor);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -25,9 +25,12 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.FutureUtils.ConjunctFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -327,7 +333,6 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
     /** Implementation of {@link org.apache.flink.runtime.checkpoint.Checkpoint.DiscardObject}. */
     @NotThreadSafe
     public class CompletedCheckpointDiscardObject implements DiscardObject {
-
         @Override
         public void discard() throws Exception {
             LOG.trace("Executing discard procedure for {}.", this);
@@ -370,6 +375,35 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
 
         private boolean isMarkedAsDiscarded() {
             return completedCheckpointStats == null || completedCheckpointStats.isDiscarded();
+        }
+
+        @Override
+        public CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            checkState(
+                    isMarkedAsDiscarded(),
+                    "Checkpoint should be marked as discarded before discard.");
+
+            List<StateObject> discardables =
+                    operatorStates.values().stream()
+                            .flatMap(op -> op.getDiscardables().stream())
+                            .collect(Collectors.toList());
+            discardables.add(metadataHandle);
+
+            ConjunctFuture<Void> discardStates =
+                    FutureUtils.completeAll(
+                            discardables.stream()
+                                    .map(
+                                            item ->
+                                                    FutureUtils.runAsync(
+                                                            item::discardState, ioExecutor))
+                                    .collect(Collectors.toList()));
+
+            return FutureUtils.runAfterwards(
+                    discardStates,
+                    () -> {
+                        operatorStates.clear();
+                        storageLocation.disposeStorageLocation();
+                    });
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
@@ -29,8 +30,10 @@ import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -163,6 +166,18 @@ public class OperatorState implements CompositeStateHandle {
         }
 
         return newState;
+    }
+
+    public List<StateObject> getDiscardables() {
+        List<StateObject> toDispose =
+                operatorSubtaskStates.values().stream()
+                        .flatMap(op -> op.getDiscardables().stream())
+                        .collect(Collectors.toList());
+
+        if (coordinatorState != null) {
+            toDispose.add(coordinatorState);
+        }
+        return toDispose;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -194,22 +194,27 @@ public class OperatorSubtaskState implements CompositeStateHandle {
         return outputRescalingDescriptor;
     }
 
+    public List<StateObject> getDiscardables() {
+        List<StateObject> toDispose =
+                new ArrayList<>(
+                        managedOperatorState.size()
+                                + rawOperatorState.size()
+                                + managedKeyedState.size()
+                                + rawKeyedState.size()
+                                + inputChannelState.size()
+                                + resultSubpartitionState.size());
+        toDispose.addAll(managedOperatorState);
+        toDispose.addAll(rawOperatorState);
+        toDispose.addAll(managedKeyedState);
+        toDispose.addAll(rawKeyedState);
+        toDispose.addAll(collectUniqueDelegates(inputChannelState, resultSubpartitionState));
+        return toDispose;
+    }
+
     @Override
     public void discardState() {
         try {
-            List<StateObject> toDispose =
-                    new ArrayList<>(
-                            managedOperatorState.size()
-                                    + rawOperatorState.size()
-                                    + managedKeyedState.size()
-                                    + rawKeyedState.size()
-                                    + inputChannelState.size()
-                                    + resultSubpartitionState.size());
-            toDispose.addAll(managedOperatorState);
-            toDispose.addAll(rawOperatorState);
-            toDispose.addAll(managedKeyedState);
-            toDispose.addAll(rawKeyedState);
-            toDispose.addAll(collectUniqueDelegates(inputChannelState, resultSubpartitionState));
+            List<StateObject> toDispose = getDiscardables();
             StateUtil.bestEffortDiscardAllStateObjects(toDispose);
         } catch (Exception e) {
             LOG.warn("Error while discarding operator states.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -29,11 +29,14 @@ import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.FutureUtils.ConjunctFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +56,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -651,6 +655,40 @@ public class PendingCheckpoint implements Checkpoint {
             } finally {
                 operatorStates.clear();
             }
+        }
+
+        @Override
+        public CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            synchronized (lock) {
+                if (discarded) {
+                    Preconditions.checkState(
+                            disposed, "Checkpoint should be disposed before being discarded");
+                } else {
+                    discarded = true;
+                }
+            }
+            List<StateObject> discardables =
+                    operatorStates.values().stream()
+                            .flatMap(op -> op.getDiscardables().stream())
+                            .collect(Collectors.toList());
+
+            ConjunctFuture<Void> discardStates =
+                    FutureUtils.completeAll(
+                            discardables.stream()
+                                    .map(
+                                            item ->
+                                                    FutureUtils.runAsync(
+                                                            item::discardState, ioExecutor))
+                                    .collect(Collectors.toList()));
+
+            return FutureUtils.runAfterwards(
+                    discardStates,
+                    () -> {
+                        operatorStates.clear();
+                        if (targetLocation != null) {
+                            targetLocation.disposeOnFailure();
+                        }
+                    });
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher.cleanup;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -88,7 +89,10 @@ public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
         this.cleanupExecutor = Preconditions.checkNotNull(cleanupExecutor);
         this.initializationTimestamp = initializationTimestamp;
 
-        this.checkpointsCleaner = new CheckpointsCleaner();
+        this.checkpointsCleaner =
+                new CheckpointsCleaner(
+                        jobManagerConfiguration.getBoolean(
+                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
 
         this.resultFuture = new CompletableFuture<>();
         this.cleanupFuture = resultFuture.thenCompose(ignored -> runCleanupAsync());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.failure.FailureEnricher;
@@ -122,6 +123,11 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                         shuffleMaster,
                         partitionTracker);
 
+        final CheckpointsCleaner checkpointsCleaner =
+                new CheckpointsCleaner(
+                        jobMasterConfiguration.getBoolean(
+                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
+
         return new DefaultScheduler(
                 log,
                 jobGraph,
@@ -130,7 +136,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 schedulerComponents.getStartUpAction(),
                 new ScheduledExecutorServiceAdapter(futureExecutor),
                 userCodeLoader,
-                new CheckpointsCleaner(),
+                checkpointsCleaner,
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,
                 schedulerComponents.getSchedulingStrategyFactory(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -170,7 +170,6 @@ class CheckpointCoordinatorFailureTest {
         assertThat(pendingCheckpoint.isDisposed()).isTrue();
 
         // make sure that the subtask state has been discarded after we could not complete it.
-        verify(operatorSubtaskState).discardState();
         verify(operatorSubtaskState.getManagedOperatorState().iterator().next()).discardState();
         verify(operatorSubtaskState.getRawOperatorState().iterator().next()).discardState();
         verify(operatorSubtaskState.getManagedKeyedState().iterator().next()).discardState();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -60,6 +61,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.PhysicalStateHandleID;
 import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryImpl;
@@ -1520,9 +1522,12 @@ class CheckpointCoordinatorTest {
         TaskStateSnapshot taskOperatorSubtaskStates12 = spy(new TaskStateSnapshot());
         TaskStateSnapshot taskOperatorSubtaskStates13 = spy(new TaskStateSnapshot());
 
-        OperatorSubtaskState subtaskState11 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState12 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState13 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskState11mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState12mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState13mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState11 = subtaskState11mock.getSubtaskState();
+        OperatorSubtaskState subtaskState12 = subtaskState12mock.getSubtaskState();
+        OperatorSubtaskState subtaskState13 = subtaskState13mock.getSubtaskState();
         taskOperatorSubtaskStates11.putSubtaskStateByOperatorID(opID1, subtaskState11);
         taskOperatorSubtaskStates12.putSubtaskStateByOperatorID(opID2, subtaskState12);
         taskOperatorSubtaskStates13.putSubtaskStateByOperatorID(opID3, subtaskState13);
@@ -1561,9 +1566,12 @@ class CheckpointCoordinatorTest {
         TaskStateSnapshot taskOperatorSubtaskStates22 = spy(new TaskStateSnapshot());
         TaskStateSnapshot taskOperatorSubtaskStates23 = spy(new TaskStateSnapshot());
 
-        OperatorSubtaskState subtaskState21 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState22 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState23 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskState21mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState22mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState23mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState21 = subtaskState21mock.getSubtaskState();
+        OperatorSubtaskState subtaskState22 = subtaskState22mock.getSubtaskState();
+        OperatorSubtaskState subtaskState23 = subtaskState23mock.getSubtaskState();
 
         taskOperatorSubtaskStates21.putSubtaskStateByOperatorID(opID1, subtaskState21);
         taskOperatorSubtaskStates22.putSubtaskStateByOperatorID(opID2, subtaskState22);
@@ -1625,13 +1633,13 @@ class CheckpointCoordinatorTest {
         assertThat(checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints()).isOne();
 
         // validate that all received subtask states in the first checkpoint have been discarded
-        verify(subtaskState11, times(1)).discardState();
-        verify(subtaskState12, times(1)).discardState();
+        subtaskState11mock.verifyDiscard();
+        subtaskState12mock.verifyDiscard();
 
         // validate that all subtask states in the second checkpoint are not discarded
-        verify(subtaskState21, never()).discardState();
-        verify(subtaskState22, never()).discardState();
-        verify(subtaskState23, never()).discardState();
+        subtaskState21mock.verifyNotDiscard();
+        subtaskState22mock.verifyNotDiscard();
+        subtaskState23mock.verifyNotDiscard();
 
         // validate the committed checkpoints
         List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
@@ -1656,15 +1664,15 @@ class CheckpointCoordinatorTest {
                         new CheckpointMetrics(),
                         taskOperatorSubtaskStates13),
                 TASK_MANAGER_LOCATION_INFO);
-        verify(subtaskState13, times(1)).discardState();
+        subtaskState13mock.verifyDiscard();
 
         checkpointCoordinator.shutdown();
         completedCheckpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
 
         // validate that the states in the second checkpoint have been discarded
-        verify(subtaskState21, times(1)).discardState();
-        verify(subtaskState22, times(1)).discardState();
-        verify(subtaskState23, times(1)).discardState();
+        subtaskState21mock.verifyDiscard();
+        subtaskState22mock.verifyDiscard();
+        subtaskState23mock.verifyDiscard();
     }
 
     @Test
@@ -1708,7 +1716,8 @@ class CheckpointCoordinatorTest {
         OperatorID opID1 = vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
 
         TaskStateSnapshot taskOperatorSubtaskStates1 = spy(new TaskStateSnapshot());
-        OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock operatorSubtaskStateMock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState1 = operatorSubtaskStateMock.getSubtaskState();
         taskOperatorSubtaskStates1.putSubtaskStateByOperatorID(opID1, subtaskState1);
 
         checkpointCoordinator.receiveAcknowledgeMessage(
@@ -1727,9 +1736,7 @@ class CheckpointCoordinatorTest {
                 .isTrue();
         assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
         assertThat(checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints()).isZero();
-
-        // validate that the received states have been discarded
-        verify(subtaskState1, times(1)).discardState();
+        operatorSubtaskStateMock.verifyDiscard();
 
         // no confirm message must have been sent
         for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
@@ -1852,7 +1859,8 @@ class CheckpointCoordinatorTest {
                 vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
 
         TaskStateSnapshot taskOperatorSubtaskStatesTrigger = spy(new TaskStateSnapshot());
-        OperatorSubtaskState subtaskStateTrigger = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskStateMock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskStateTrigger = subtaskStateMock.getSubtaskState();
         taskOperatorSubtaskStatesTrigger.putSubtaskStateByOperatorID(
                 opIDtrigger, subtaskStateTrigger);
 
@@ -1867,7 +1875,7 @@ class CheckpointCoordinatorTest {
                 TASK_MANAGER_LOCATION_INFO);
 
         // verify that the subtask state has not been discarded
-        verify(subtaskStateTrigger, never()).discardState();
+        subtaskStateMock.verifyNotDiscard();
 
         TaskStateSnapshot unknownSubtaskState = mock(TaskStateSnapshot.class);
 
@@ -1914,7 +1922,7 @@ class CheckpointCoordinatorTest {
         verify(triggerSubtaskState, never()).discardState();
 
         // let the checkpoint fail at the first ack vertex
-        reset(subtaskStateTrigger);
+        subtaskStateMock.reset();
         checkpointCoordinator.receiveDeclineMessage(
                 new DeclineCheckpoint(
                         graph.getJobID(),
@@ -1926,7 +1934,7 @@ class CheckpointCoordinatorTest {
         assertThat(pendingCheckpoint.isDisposed()).isTrue();
 
         // check that we've cleaned up the already acknowledged state
-        verify(subtaskStateTrigger, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
 
         TaskStateSnapshot ackSubtaskState = mock(TaskStateSnapshot.class);
 
@@ -4302,5 +4310,89 @@ class CheckpointCoordinatorTest {
                                                                 metaState))
                                                 .build()))),
                 "test");
+    }
+
+    static class OperatorSubtaskStateMock {
+        OperatorSubtaskState subtaskState;
+        TestingOperatorStateHandle managedOpHandle;
+        TestingOperatorStateHandle rawOpHandle;
+
+        OperatorSubtaskStateMock() {
+            this.managedOpHandle = new TestingOperatorStateHandle();
+            this.rawOpHandle = new TestingOperatorStateHandle();
+            this.subtaskState =
+                    OperatorSubtaskState.builder()
+                            .setManagedOperatorState(managedOpHandle)
+                            .setRawOperatorState(rawOpHandle)
+                            .build();
+        }
+
+        public OperatorSubtaskState getSubtaskState() {
+            return this.subtaskState;
+        }
+
+        public void reset() {
+            managedOpHandle.reset();
+            rawOpHandle.reset();
+        }
+
+        public void verifyDiscard() {
+            assert (managedOpHandle.isDiscarded() && rawOpHandle.discarded);
+        }
+
+        public void verifyNotDiscard() {
+            assert (!managedOpHandle.isDiscarded() && !rawOpHandle.isDiscarded());
+        }
+
+        private static class TestingOperatorStateHandle implements OperatorStateHandle {
+
+            private static final long serialVersionUID = 983594934287613083L;
+
+            boolean discarded;
+
+            @Override
+            public Map<String, StateMetaInfo> getStateNameToPartitionOffsets() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public FSDataInputStream openInputStream() throws IOException {
+                throw new IOException("Cannot open input streams in testing implementation.");
+            }
+
+            @Override
+            public PhysicalStateHandleID getStreamStateHandleID() {
+                throw new RuntimeException("Cannot return ID in testing implementation.");
+            }
+
+            @Override
+            public Optional<byte[]> asBytesIfInMemory() {
+                return Optional.empty();
+            }
+
+            @Override
+            public StreamStateHandle getDelegateStateHandle() {
+                return null;
+            }
+
+            @Override
+            public void discardState() throws Exception {
+                assertThat(discarded).isFalse();
+                discarded = true;
+            }
+
+            @Override
+            public long getStateSize() {
+                return 0L;
+            }
+
+            public void reset() {
+                discarded = false;
+            }
+
+            public boolean isDiscarded() {
+                return discarded;
+            }
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
@@ -17,28 +17,26 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
-import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Random;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
-import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.generateKeyGroupState;
-import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.generatePartitionableStateHandle;
-import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
-import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.generateSampleOperatorSubtaskState;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link OperatorSubtaskState} test. */
@@ -65,43 +63,31 @@ class OperatorSubtaskStateTest {
     @Test
     void testToBuilderCorrectness() throws IOException {
         // given: Initialized operator subtask state.
-        JobVertexID jobVertexID = new JobVertexID();
-        int index = 0;
-        Random random = new Random();
-
-        OperatorSubtaskState operatorSubtaskState =
-                OperatorSubtaskState.builder()
-                        .setManagedOperatorState(
-                                generatePartitionableStateHandle(jobVertexID, index, 2, 8, false))
-                        .setRawOperatorState(
-                                generatePartitionableStateHandle(jobVertexID, index, 2, 8, true))
-                        .setManagedKeyedState(
-                                generateKeyGroupState(jobVertexID, new KeyGroupRange(0, 11), false))
-                        .setRawKeyedState(
-                                generateKeyGroupState(jobVertexID, new KeyGroupRange(0, 9), true))
-                        .setInputChannelState(
-                                StateObjectCollection.singleton(
-                                        createNewInputChannelStateHandle(3, random)))
-                        .setResultSubpartitionState(
-                                StateObjectCollection.singleton(
-                                        createNewResultSubpartitionStateHandle(3, random)))
-                        .setInputRescalingDescriptor(
-                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
-                                        new int[1],
-                                        new RescaleMappings[0],
-                                        Collections.singleton(1)))
-                        .setOutputRescalingDescriptor(
-                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
-                                        new int[1],
-                                        new RescaleMappings[0],
-                                        Collections.singleton(2)))
-                        .build();
+        OperatorSubtaskState operatorSubtaskState = generateSampleOperatorSubtaskState().f1;
 
         // when: Copy the operator subtask state.
         OperatorSubtaskState operatorSubtaskStateCopy = operatorSubtaskState.toBuilder().build();
 
         // then: It should be equal to original one.
         assertThat(reflectionEquals(operatorSubtaskState, operatorSubtaskStateCopy)).isTrue();
+    }
+
+    @Test
+    void testGetDiscardables() throws IOException {
+        Tuple2<List<StateObject>, OperatorSubtaskState> opStates =
+                generateSampleOperatorSubtaskState();
+        List<StateObject> states = opStates.f0;
+        OperatorSubtaskState operatorSubtaskState = opStates.f1;
+        List<StateObject> discardables =
+                Arrays.asList(
+                        states.get(0),
+                        states.get(1),
+                        states.get(2),
+                        states.get(3),
+                        ((InputChannelStateHandle) states.get(4)).getDelegate(),
+                        ((ResultSubpartitionStateHandle) states.get(5)).getDelegate());
+        assertThat(new HashSet<>(operatorSubtaskState.getDiscardables()))
+                .isEqualTo(new HashSet<>(discardables));
     }
 
     private ResultSubpartitionStateHandle buildSubpartitionHandle(

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.StateChangelogOptions;
@@ -118,6 +119,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                     Duration.ofSeconds(0),
                     Duration.ofMillis(100),
                     Duration.ofSeconds(2));
+            randomize(conf, CheckpointingOptions.CLEANER_PARALLEL_MODE, true, false);
         }
 
         // randomize ITTests for enabling state change log


### PR DESCRIPTION
## What is the purpose of the change
improve CheckpointsCleaner by parallelize cleaning individual checkpoint's state objects


## Brief change log
add a discardAsync to CheckPoint$DiscardObject for CheckpointCleaner's usage, in which it gathers discardable state objects and clean them up in parallel instead of sequentially.


## Verifying this change
This change added tests and can be verified as follows:
- added test that validates all discardable stateobjects to be cleaned up.
- manually verified the change with clean up 4K state files in blobstorage, it reduces time from ~8 minute to 1 minute on a 8 threads pool

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: Checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?
