### PR TITLE
[FLINK-33095] Job jar issue should be reported as BAD_REQUEST instead of INTERNAL_SERVER_ERROR.

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -189,7 +189,11 @@ public class JarHandlerUtils {
                         .setArguments(programArgs.toArray(new String[0]))
                         .build();
             } catch (final ProgramInvocationException e) {
-                throw new CompletionException(e);
+                throw new CompletionException(
+                        new RestHandlerException(
+                                "Could not execute application.",
+                                HttpResponseStatus.BAD_REQUEST,
+                                e));
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -242,8 +242,14 @@ public abstract class AbstractHandler<
             return CompletableFuture.completedFuture(null);
         }
         int maxLength = flinkHttpObjectAggregator.maxContentLength() - OTHER_RESP_PAYLOAD_OVERHEAD;
-        if (throwable instanceof RestHandlerException) {
-            RestHandlerException rhe = (RestHandlerException) throwable;
+        if (throwable instanceof RestHandlerException
+                || throwable.getCause() instanceof RestHandlerException) {
+            RestHandlerException rhe = null;
+            if (throwable.getCause() instanceof RestHandlerException) {
+                rhe = (RestHandlerException) throwable.getCause();
+            } else {
+                rhe = (RestHandlerException) throwable;
+            }
             String stackTrace = ExceptionUtils.stringifyException(rhe);
             String truncatedStackTrace = Ascii.truncate(stackTrace, maxLength, "...");
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
When submitting a job with incorrect parameters, such as an invalid entry class, the current response is an internal server error.

To enhance the user experience and consistency, it is recommended to throw a Rest exception and return a BAD_REQUEST response code in such cases.