### PR TITLE
[FLINK-33033][tests] Add haservice benchmark test for dispatcher

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -62,7 +62,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
 /** {@link Dispatcher} implementation used for testing purposes. */
-class TestingDispatcher extends Dispatcher {
+public class TestingDispatcher extends Dispatcher {
 
     private final CompletableFuture<Void> startFuture;
 
@@ -133,6 +133,10 @@ class TestingDispatcher extends Dispatcher {
         startFuture.complete(null);
     }
 
+    public void cleanupJob(JobID jobId) {
+        runAsync(() -> getJobTerminationFuture(jobId).complete(null));
+    }
+
     void completeJobExecution(ExecutionGraphInfo executionGraphInfo) {
         runAsync(
                 () -> {
@@ -165,6 +169,7 @@ class TestingDispatcher extends Dispatcher {
         return new Builder();
     }
 
+    /** Builder to build {@link TestingDispatcher}. */
     public static class Builder {
         private DispatcherId fencingToken = DispatcherId.generate();
         private Collection<JobGraph> recoveredJobs = Collections.emptyList();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/DispatcherHighAvailabilityServiceBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/DispatcherHighAvailabilityServiceBenchmark.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.benchmark;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.failure.FailureEnricher;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.dispatcher.JobManagerRunnerFactory;
+import org.apache.flink.runtime.dispatcher.NoOpJobGraphListener;
+import org.apache.flink.runtime.dispatcher.TestingDispatcher;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.runtime.dispatcher.benchmark.TestingDispatcherHighAvailabilityService.createAndGetFile;
+
+/** Benchmark for submitting job to dispatcher with {@link HighAvailabilityServices}. */
+public class DispatcherHighAvailabilityServiceBenchmark {
+    private TestingDispatcherHighAvailabilityService highAvailabilityServices;
+    private JobGraphStore jobGraphStore;
+    private TestingDispatcher dispatcher;
+    private DispatcherGateway dispatcherGateway;
+    private RpcService rpcService;
+    private BlobServer blobServer;
+
+    public void setup(Configuration configuration, File highAvailabilityPath) throws Exception {
+        this.highAvailabilityServices =
+                TestingDispatcherHighAvailabilityService.fromConfiguration(
+                        configuration, highAvailabilityPath);
+        this.jobGraphStore = highAvailabilityServices.highAvailabilityService().getJobGraphStore();
+        this.jobGraphStore.start(NoOpJobGraphListener.INSTANCE);
+
+        this.rpcService = new TestingRpcService();
+        this.blobServer =
+                new BlobServer(
+                        configuration,
+                        createAndGetFile(highAvailabilityPath, "blobserver"),
+                        BlobUtils.createBlobStoreFromConfig(configuration));
+        this.dispatcher =
+                TestingDispatcher.builder()
+                        .setJobGraphWriter(jobGraphStore)
+                        .setJobResultStore(
+                                highAvailabilityServices
+                                        .highAvailabilityService()
+                                        .getJobResultStore())
+                        .setBlobServer(blobServer)
+                        .setJobManagerRunnerFactory(new FinishedJobManagerRunnerFactory())
+                        .build(rpcService);
+
+        this.dispatcher.start();
+        this.dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+    }
+
+    public void submitJob() throws Exception {
+        JobGraph job = JobGraphTestUtils.singleNoOpJobGraph();
+        dispatcherGateway.submitJob(job, Time.of(1, TimeUnit.MINUTES)).get();
+        dispatcher.cleanupJob(job.getJobID());
+    }
+
+    public void close() throws Exception {
+        this.dispatcher.shutDownCluster();
+        this.rpcService.close();
+        this.dispatcher.close();
+        this.blobServer.close();
+        this.jobGraphStore.stop();
+        this.highAvailabilityServices.close();
+    }
+
+    /** Finished job manager runner. */
+    private static class FinishedJobManagerRunnerFactory implements JobManagerRunnerFactory {
+
+        @Override
+        public JobManagerRunner createJobManagerRunner(
+                JobGraph jobGraph,
+                Configuration configuration,
+                RpcService rpcService,
+                HighAvailabilityServices highAvailabilityServices,
+                HeartbeatServices heartbeatServices,
+                JobManagerSharedServices jobManagerServices,
+                JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+                FatalErrorHandler fatalErrorHandler,
+                Collection<FailureEnricher> failureEnrichers,
+                long initializationTimestamp) {
+            return TestingJobManagerRunner.newBuilder().setJobId(jobGraph.getJobID()).build();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/DispatcherHighAvailabilityServiceBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/DispatcherHighAvailabilityServiceBenchmarkTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.benchmark;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+/** Test for {@link DispatcherHighAvailabilityServiceBenchmark}. */
+class DispatcherHighAvailabilityServiceBenchmarkTest {
+
+    @Test
+    void testDispatcherZKHaService(@TempDir Path path) throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
+
+        DispatcherHighAvailabilityServiceBenchmark benchmark =
+                new DispatcherHighAvailabilityServiceBenchmark();
+        benchmark.setup(configuration, path.toFile());
+        benchmark.submitJob();
+        benchmark.close();
+    }
+
+    @Test
+    void testDispatcherNoneHaService(@TempDir Path path) throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.NONE.name());
+
+        DispatcherHighAvailabilityServiceBenchmark benchmark =
+                new DispatcherHighAvailabilityServiceBenchmark();
+        benchmark.setup(configuration, path.toFile());
+        benchmark.submitJob();
+        benchmark.close();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/TestingDispatcherHighAvailabilityService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/benchmark/TestingDispatcherHighAvailabilityService.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.benchmark;
+
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.blob.BlobStoreService;
+import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
+import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperLeaderElectionHaServices;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+
+import org.apache.curator.test.TestingServer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Testing util class for {@link DispatcherHighAvailabilityServiceBenchmark}. */
+interface TestingDispatcherHighAvailabilityService {
+
+    HighAvailabilityServices highAvailabilityService();
+
+    void close() throws Exception;
+
+    static TestingDispatcherHighAvailabilityService fromConfiguration(
+            Configuration configuration, File highAvailabilityPath) throws Exception {
+        configuration.set(
+                HighAvailabilityOptions.HA_STORAGE_PATH,
+                createAndGetFile(highAvailabilityPath, "ha").toURI().toString());
+        configuration.set(
+                BlobServerOptions.STORAGE_DIRECTORY,
+                createAndGetFile(highAvailabilityPath, "blob").toURI().toString());
+        configuration.set(
+                JobResultStoreOptions.STORAGE_PATH,
+                createAndGetFile(highAvailabilityPath, "resultstore").toURI().toString());
+
+        HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
+        if (highAvailabilityMode == HighAvailabilityMode.NONE) {
+            return new DispatcherNoneHighAvailabilityService();
+        } else if (highAvailabilityMode == HighAvailabilityMode.ZOOKEEPER) {
+            return new DispatcherZookeeperHighAvailabilityService(configuration);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Only support none or zookeeper high availability service for benchmark.");
+        }
+    }
+
+    static File createAndGetFile(File baseFile, String child) {
+        File file = new File(baseFile, child);
+        checkState(file.mkdir());
+        return file;
+    }
+
+    /** None high availability service. */
+    class DispatcherNoneHighAvailabilityService
+            implements TestingDispatcherHighAvailabilityService {
+        private final HighAvailabilityServices standaloneServices;
+
+        private DispatcherNoneHighAvailabilityService() {
+            String dispatcherAddress = "dispatcher";
+            String resourceManagerAddress = "resourceManager";
+            String webMonitorAddress = "webMonitor";
+            standaloneServices =
+                    new StandaloneHaServices(
+                            resourceManagerAddress, dispatcherAddress, webMonitorAddress);
+        }
+
+        @Override
+        public HighAvailabilityServices highAvailabilityService() {
+            return standaloneServices;
+        }
+
+        @Override
+        public void close() throws Exception {
+            standaloneServices.close();
+        }
+    }
+
+    /** Zookeeper high availability service. */
+    class DispatcherZookeeperHighAvailabilityService
+            implements TestingDispatcherHighAvailabilityService {
+        private final TestingServer zooKeeperServer;
+        private final ExecutorService executorService;
+
+        private final BlobStoreService blobStoreService;
+        private final CuratorFrameworkWithUnhandledErrorListener curatorFrameworkListener;
+        private final HighAvailabilityServices zookeeperService;
+
+        public DispatcherZookeeperHighAvailabilityService(Configuration configuration)
+                throws Exception {
+            this.executorService = Executors.newSingleThreadExecutor();
+            this.zooKeeperServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
+            this.zooKeeperServer.start();
+
+            configuration.setString(
+                    HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
+                    zooKeeperServer.getConnectString());
+
+            blobStoreService = BlobUtils.createBlobStoreFromConfig(configuration);
+            curatorFrameworkListener =
+                    ZooKeeperUtils.startCuratorFramework(
+                            configuration, new TestingFatalErrorHandler());
+            zookeeperService =
+                    new ZooKeeperLeaderElectionHaServices(
+                            curatorFrameworkListener,
+                            configuration,
+                            executorService,
+                            blobStoreService);
+        }
+
+        @Override
+        public HighAvailabilityServices highAvailabilityService() {
+            return zookeeperService;
+        }
+
+        @Override
+        public void close() throws IOException {
+            zooKeeperServer.close();
+            executorService.shutdown();
+
+            blobStoreService.closeAndCleanupAllData();
+            curatorFrameworkListener.close();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add benchmark test classes for high availability service in dispatcher, they will be used in flink-benchmark project


## Brief change log
  - Add `DispatcherHighAvailableServiceBenchmark` for zookeeper and none high availability service 
  - Submit job to dispatcher with different haservices in `DispatcherHighAvailableServiceBenchmark` 

## Verifying this change
This change added tests and can be verified as follows:

  - Added `DispatcherHighAvailabilityServiceBenchmarkTest` to submit jobs in `DispatcherHighAvailabilityServiceBenchmark`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
