### PR TITLE
[FLINK-33060] Fix the javadoc of ListState interfaces about not allowing null value

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -59,6 +59,7 @@ public interface AppendingState<IN, OUT> extends State {
      * state will represent the updated list.
      *
      * <p>If null is passed in, the behaviour is undefined (implementation related).
+     * TODO: An unified behaviour across all sub-classes.
      *
      * @param value The new value for the state.
      * @throws Exception Thrown if the system cannot access the state.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -58,7 +58,7 @@ public interface AppendingState<IN, OUT> extends State {
      * of values. The next time {@link #get()} is called (for the same state partition) the returned
      * state will represent the updated list.
      *
-     * <p>If null is passed in, the state value will remain unchanged.
+     * <p>If null is passed in, the behaviour is undefined (implementation related).
      *
      * @param value The new value for the state.
      * @throws Exception Thrown if the system cannot access the state.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -48,10 +48,13 @@ public interface ListState<T> extends MergingState<T, Iterable<T>> {
      * given list of values. The next time {@link #get()} is called (for the same state partition)
      * the returned state will represent the updated list.
      *
-     * <p>If null or an empty list is passed in, the state value will be null.
+     * <p>If an empty list is passed in, the state value will be null.
+     *
+     * <p>Null value passed in or any null value in list is not allowed.
      *
      * @param values The new values for the state.
-     * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+     * @throws Exception The method may forward exception thrown internally (by I/O or functions, or
+     *     sanity check for null value).
      */
     void update(List<T> values) throws Exception;
 
@@ -60,10 +63,13 @@ public interface ListState<T> extends MergingState<T, Iterable<T>> {
      * existing list of values. The next time {@link #get()} is called (for the same state
      * partition) the returned state will represent the updated list.
      *
-     * <p>If null or an empty list is passed in, the state value remains unchanged.
+     * <p>If an empty list is passed in, the state value remains unchanged.
+     *
+     * <p>Null value passed in or any null value in list is not allowed.
      *
      * @param values The new values to be added to the state.
-     * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+     * @throws Exception The method may forward exception thrown internally (by I/O or functions, or
+     *     sanity check for null value).
      */
     void addAll(List<T> values) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PartitionableListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PartitionableListState.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Implementation of operator list state.
  *
@@ -129,8 +131,12 @@ public final class PartitionableListState<S> implements ListState<S> {
 
     @Override
     public void addAll(List<S> values) {
-        if (values != null && !values.isEmpty()) {
-            internalList.addAll(values);
+        Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+        if (!values.isEmpty()) {
+            for (S value : values) {
+                checkNotNull(value, "Any value to add to a list cannot be null.");
+                add(value);
+            }
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalListState.java
@@ -39,10 +39,13 @@ public interface InternalListState<K, N, T>
      * given list of values. The next time {@link #get()} is called (for the same state partition)
      * the returned state will represent the updated list.
      *
-     * <p>If `null` or an empty list is passed in, the state value will be null
+     * <p>If an empty list is passed in, the state value will be null
+     *
+     * <p>Null value passed in or any null value in list is not allowed.
      *
      * @param values The new values for the state.
-     * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+     * @throws Exception The method may forward exception thrown internally (by I/O or functions, or
+     *     sanity check for null value).
      */
     void update(List<T> values) throws Exception;
 
@@ -51,10 +54,13 @@ public interface InternalListState<K, N, T>
      * existing list of values. The next time {@link #get()} is called (for the same state
      * partition) the returned state will represent the updated list.
      *
-     * <p>If `null` or an empty list is passed in, the state value remains unchanged
+     * <p>If an empty list is passed in, the state value remains unchanged
+     *
+     * <p>Null value passed in or any null value in list is not allowed.
      *
      * @param values The new values to be added to the state.
-     * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+     * @throws Exception The method may forward exception thrown internally (by I/O or functions, or
+     *     sanity check for null value).
      */
     void addAll(List<T> values) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyListState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyListState.java
@@ -47,6 +47,7 @@ class BatchExecutionKeyListState<K, N, T>
         checkNotNull(values);
         clear();
         for (T value : values) {
+            checkNotNull(value);
             add(value);
         }
     }
@@ -57,6 +58,7 @@ class BatchExecutionKeyListState<K, N, T>
             return;
         }
         for (T value : values) {
+            checkNotNull(value);
             add(value);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-8411, the ListState.update/add/addAll do not allow a null value passed in, while the javadoc says "If null is passed in, the state value will remain unchanged". This should be fixed.

## Brief change log

The javadoc of ListState#update/addAll, InternalListState#update/addAll and AppendingState#add.


## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
