### PR TITLE
[FLINK-33126] Fix EventTimeAllWindowCheckpointingITCase jobName typo

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -298,7 +298,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
                                             numKeys, numElementsPerKey, windowSize)))
                     .setParallelism(1);
 
-            env.execute("Tumbling Window Test");
+            env.execute("PreAggregated Tumbling Window Test");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -378,7 +378,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
                                             numKeys, numElementsPerKey, windowSlide)))
                     .setParallelism(1);
 
-            env.execute("Tumbling Window Test");
+            env.execute("PreAggregated Sliding Window Test");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

 Fix EventTimeAllWindowCheckpointingITCase jobName typo

## Brief change log

Adjust the jobName of test in EventTimeAllWindowCheckpointingITCase

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework

