### PR TITLE
[FLINK-31650][metrics][rest] Remove transient metrics for subtasks in terminal state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
@@ -194,7 +194,8 @@ public class JobDetails implements Serializable {
                                 taskVertex.getCurrentExecutionAttempt().getAttemptNumber(),
                                 taskVertex.getCurrentExecutions().stream()
                                         .map(AccessExecution::getAttemptNumber)
-                                        .collect(Collectors.toSet())));
+                                        .collect(Collectors.toSet()),
+                                state.isTerminal()));
             }
 
             if (!vertexAttempts.isEmpty()) {
@@ -355,16 +356,21 @@ public class JobDetails implements Serializable {
 
     /**
      * The CurrentAttempts holds the attempt number of the current representative execution attempt,
-     * and the attempt numbers of all the running attempts.
+     * the attempt numbers of all the running attempts, and whether the current execution has
+     * reached terminal state.
      */
     public static final class CurrentAttempts implements Serializable {
         private final int representativeAttempt;
 
         private final Set<Integer> currentAttempts;
 
-        public CurrentAttempts(int representativeAttempt, Set<Integer> currentAttempts) {
+        private final boolean isTerminalState;
+
+        public CurrentAttempts(
+                int representativeAttempt, Set<Integer> currentAttempts, boolean isTerminalState) {
             this.representativeAttempt = representativeAttempt;
             this.currentAttempts = Collections.unmodifiableSet(currentAttempts);
+            this.isTerminalState = isTerminalState;
         }
 
         public int getRepresentativeAttempt() {
@@ -373,6 +379,10 @@ public class JobDetails implements Serializable {
 
         public Set<Integer> getCurrentAttempts() {
             return currentAttempts;
+        }
+
+        public boolean isTerminalState() {
+            return isTerminalState;
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request cleanups transient metrics (idle/busy/backpressured time) for terminal subtasks to avoid confusion caused by outdated metrics. For example, a FINISHED task may have its last updated 100 % busy time metrics retained in the metric store and shown on the UI, which is obviously unreasonable.

## Brief change log

Removes transient metrics (idle/busy/backpressured time) for terminal subtasks in `MetricStore`.

## Verifying this change

- Added UT to test that the busy time metric is removed for terminal subtasks.
- Tested with a real job with a bounded source and verified on UI that the metrics were unavailable after the bounded source finished:
![888709fa-4eca-4e83-9374-9383e4e44b95](https://github.com/apache/flink/assets/22020529/1565c78a-be5b-44b1-9ea8-c2ce54957e0c)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
