### PR TITLE
[FLINK-32108][test] KubernetesExtension calls assumeThat in @BeforeAll callback which doesn't print the actual failure message

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -45,7 +45,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public KubernetesExtension(){
+    public KubernetesExtension() {
         checkEnv();
         configuration = new Configuration();
         configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -50,7 +50,6 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         assumeThat(kubeConfigEnv)
                 .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
                 .isNotBlank();
-        
         kubeConfigFile = kubeConfigEnv;
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -50,20 +50,12 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         assumeThat(kubeConfigEnv)
                 .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
                 .isNotBlank();
+        
         kubeConfigFile = kubeConfigEnv;
     }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
-        checkEnv();
-        configuration = new Configuration();
-        configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
-        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
-        configuration.set(
-                KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
-                KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
-        final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
-        flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
     }
 
     @Override
@@ -73,11 +65,29 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         }
     }
 
+    public  void createConfiguration() {
+        if(configuration == null) {
+            checkEnv();
+            configuration = new Configuration();
+            configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
+            configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+            configuration.set(
+                    KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
+                    KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
+        }
+    }
+
     public Configuration getConfiguration() {
+        createConfiguration();
         return configuration;
     }
 
     public FlinkKubeClient getFlinkKubeClient() {
+        if(flinkKubeClient == null) {
+            createConfiguration();
+            final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
+            flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
+        }
         return flinkKubeClient;
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -23,12 +23,13 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 
+import org.junit.Assume;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * {@link ExternalResource} which has a configured real Kubernetes cluster and client. We assume
@@ -47,7 +48,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
 
     public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        assertThat(kubeConfigEnv)
+        assumeThat(kubeConfigEnv)
                 .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
                 .isNotBlank();
         kubeConfigFile = kubeConfigEnv;

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -54,8 +54,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     }
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
-    }
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {}
 
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
@@ -64,8 +63,8 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         }
     }
 
-    public  void createConfiguration() {
-        if(configuration == null) {
+    public void createConfiguration() {
+        if (configuration == null) {
             checkEnv();
             configuration = new Configuration();
             configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
@@ -82,7 +81,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     }
 
     public FlinkKubeClient getFlinkKubeClient() {
-        if(flinkKubeClient == null) {
+        if (flinkKubeClient == null) {
             createConfiguration();
             final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
             flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -46,6 +46,10 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
+    public KubernetesExtension() {
+        checkEnv();
+    }
+
     public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
         assumeThat(kubeConfigEnv)

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
-
 /**
  * {@link ExternalResource} which has a configured real Kubernetes cluster and client. We assume
  * that one already has a running Kubernetes cluster. And all the ITCases assume that the
@@ -46,11 +43,11 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public static void checkEnv() {
+    public static void checkEnv() throws Exception {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        assertThat(kubeConfigEnv)
-                .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
-                .isNotBlank();
+        if (kubeConfigEnv.isEmpty()) {
+            throw new Exception("ITCASE_KUBECONFIG environment is not set.");
+        }
         kubeConfigFile = kubeConfigEnv;
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -45,7 +45,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
 
     public static void checkEnv() throws Exception {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        if (kubeConfigEnv.isEmpty()) {
+        if (kubeConfigEnv == null) {
             throw new Exception("ITCASE_KUBECONFIG environment is not set.");
         }
         kubeConfigFile = kubeConfigEnv;

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
@@ -47,14 +48,6 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
 
     public KubernetesExtension() {
         checkEnv();
-        configuration = new Configuration();
-        configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
-        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
-        configuration.set(
-                KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
-                KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
-        final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
-        flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
     }
 
     public static void checkEnv() {
@@ -66,7 +59,16 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     }
 
     @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {}
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        configuration = new Configuration();
+        configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
+        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        configuration.set(
+                KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
+                KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
+        final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
+        flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
+    }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -46,13 +46,9 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public KubernetesExtension() {
-        checkEnv();
-    }
-
     public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        assumeThat(kubeConfigEnv)
+        assertThat(kubeConfigEnv)
                 .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
                 .isNotBlank();
         kubeConfigFile = kubeConfigEnv;
@@ -60,6 +56,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        checkEnv();
         configuration = new Configuration();
         configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
         configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -45,6 +45,18 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
+    public KubernetesExtension(){
+        checkEnv();
+        configuration = new Configuration();
+        configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
+        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        configuration.set(
+                KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
+                KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
+        final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
+        flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
+    }
+
     public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
         assumeThat(kubeConfigEnv)
@@ -63,29 +75,11 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         }
     }
 
-    public void createConfiguration() {
-        if (configuration == null) {
-            checkEnv();
-            configuration = new Configuration();
-            configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
-            configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
-            configuration.set(
-                    KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
-                    KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
-        }
-    }
-
     public Configuration getConfiguration() {
-        createConfiguration();
         return configuration;
     }
 
     public FlinkKubeClient getFlinkKubeClient() {
-        if (flinkKubeClient == null) {
-            createConfiguration();
-            final FlinkKubeClientFactory kubeClientFactory = new FlinkKubeClientFactory();
-            flinkKubeClient = kubeClientFactory.fromConfiguration(configuration, "testing");
-        }
         return flinkKubeClient;
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * {@link ExternalResource} which has a configured real Kubernetes cluster and client. We assume
  * that one already has a running Kubernetes cluster. And all the ITCases assume that the
@@ -43,11 +45,11 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public static void checkEnv() throws Exception {
+    public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        if (kubeConfigEnv.isEmpty()) {
-            throw new Exception("ITCASE_KUBECONFIG environment is not set.");
-        }
+        assertThat(kubeConfigEnv)
+                .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
+                .isNotBlank();
         kubeConfigFile = kubeConfigEnv;
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * {@link ExternalResource} which has a configured real Kubernetes cluster and client. We assume
  * that one already has a running Kubernetes cluster. And all the ITCases assume that the
@@ -43,11 +45,11 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public static void checkEnv() throws Exception {
+    public static void checkEnv() {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        if (kubeConfigEnv == null) {
-            throw new Exception("ITCASE_KUBECONFIG environment is not set.");
-        }
+        assertThat(kubeConfigEnv)
+                .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
+                .isNotBlank();
         kubeConfigFile = kubeConfigEnv;
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * {@link ExternalResource} which has a configured real Kubernetes cluster and client. We assume
  * that one already has a running Kubernetes cluster. And all the ITCases assume that the
@@ -45,11 +43,11 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
     private Configuration configuration;
     private FlinkKubeClient flinkKubeClient;
 
-    public static void checkEnv() {
+    public static void checkEnv() throws Exception {
         final String kubeConfigEnv = System.getenv("ITCASE_KUBECONFIG");
-        assertThat(kubeConfigEnv)
-                .withFailMessage("ITCASE_KUBECONFIG environment is not set.")
-                .isNotBlank();
+        if (kubeConfigEnv.isEmpty()) {
+            throw new Exception("ITCASE_KUBECONFIG environment is not set.");
+        }
         kubeConfigFile = kubeConfigEnv;
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

 *KubernetesExtension implements BeforeAllCallback which calls the assumeThat in the @BeforeAll context. assumeThat doesn't work properly in the @BeforeAll context, though: The error message is not printed and the test fails with exit code -1.*


## Brief change log

  - *Migrate content in  `beforeAll ` to  `getConfiguration ` and  `getFlinkKubeClient `*



## Verifying this change

 *This change is already covered by existing test.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)