### PR TITLE
[FLINK-32884] [flink-clients] Sending messageHeaders with decorated customHeaders for PyFlink client

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -1021,7 +1021,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                                                         restClient.sendRequest(
                                                                 webMonitorBaseUrl.getHost(),
                                                                 webMonitorBaseUrl.getPort(),
-                                                                messageHeaders,
+                                                                headers,
                                                                 messageParameters,
                                                                 request,
                                                                 filesToUpload);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/UrlPrefixDecorator.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/UrlPrefixDecorator.java
@@ -107,4 +107,13 @@ public class UrlPrefixDecorator<
     public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
         return decorated.getSupportedAPIVersions();
     }
+
+    @Override
+    public Collection<Class<?>> getResponseTypeParameters() {
+        return decorated.getResponseTypeParameters();
+    }
+
+    public MessageHeaders<R, P, M> getDecorated() {
+        return decorated;
+    }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -61,6 +61,7 @@ import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
 import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationResult;
 import org.apache.flink.runtime.rest.handler.async.TriggerResponse;
 import org.apache.flink.runtime.rest.messages.AccumulatorsIncludeSerializedValueQueryParameter;
+import org.apache.flink.runtime.rest.messages.CustomHeadersDecorator;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
@@ -909,6 +910,11 @@ class RestClusterClientTest {
         final AtomicBoolean firstSubmitRequestFailed = new AtomicBoolean(false);
         failHttpRequest =
                 (messageHeaders, messageParameters, requestBody) -> {
+                    messageHeaders =
+                            ((UrlPrefixDecorator)
+                                            ((CustomHeadersDecorator) messageHeaders)
+                                                    .getDecorated())
+                                    .getDecorated();
                     if (messageHeaders instanceof JobExecutionResultHeaders) {
                         return !firstExecutionResultPollFailed.getAndSet(true);
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/CustomHeadersDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/CustomHeadersDecorator.java
@@ -96,6 +96,11 @@ public class CustomHeadersDecorator<
         return customHeaders;
     }
 
+    @Override
+    public Collection<Class<?>> getResponseTypeParameters() {
+        return decorated.getResponseTypeParameters();
+    }
+
     /**
      * Sets the custom headers for the message.
      *
@@ -116,5 +121,9 @@ public class CustomHeadersDecorator<
             customHeaders = new ArrayList<>();
         }
         customHeaders.add(httpHeader);
+    }
+
+    public MessageHeaders<R, P, M> getDecorated() {
+        return decorated;
     }
 }


### PR DESCRIPTION
[FLINK-32884](https://issues.apache.org/jira/browse/FLINK-32884) PyFlink remote execution should support URLs with paths and https scheme

## What is the purpose of the change

This PR handles including customHeaders in messageHeaders when a Python client is sending requests. This will allow sending auth tokens with the request.

## Brief change log

- send messageHeaders which are decorated with customHeaders

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change is already covered by existing tests, such as `flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java#testRESTManualConfigurationOverride`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
