### PR TITLE
[FLINK-33128] Add converter.open() method call on TestValuesRuntimeFunctions

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.data.GenericRowData;
@@ -631,11 +632,11 @@ final class TestValuesRuntimeFunctions {
         public void open(FunctionContext context) throws Exception {
             RESOURCE_COUNTER.incrementAndGet();
             isOpenCalled = true;
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             if (projectable) {
-                projection =
-                        generatedProjection.newInstance(
-                                Thread.currentThread().getContextClassLoader());
+                projection = generatedProjection.newInstance(classLoader);
             }
+            converter.open(RuntimeConverter.Context.create(classLoader));
             rowSerializer = InternalSerializers.create(producedRowType);
             indexDataByKey();
         }
@@ -725,11 +726,11 @@ final class TestValuesRuntimeFunctions {
         @Override
         public void open(FunctionContext context) throws Exception {
             RESOURCE_COUNTER.incrementAndGet();
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             if (projectable) {
-                projection =
-                        generatedProjection.newInstance(
-                                Thread.currentThread().getContextClassLoader());
+                projection = generatedProjection.newInstance(classLoader);
             }
+            converter.open(RuntimeConverter.Context.create(classLoader));
             rowSerializer = InternalSerializers.create(producedRowType);
             isOpenCalled = true;
             // generate unordered result for async lookup

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -203,7 +203,8 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                          |CREATE TABLE $tableName (
                          |  `age` INT,
                          |  `id` BIGINT,
-                         |  `name` STRING
+                         |  `name` STRING,
+                         |  `attributes` ARRAY<ROW<`id` INT, `name` STRING>>
                          |) WITH (
                          |  $cacheOptions
                          |  'connector' = 'values',

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -75,12 +75,6 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
     rowOf(33, 3L, "Fabian"),
     rowOf(44, null, "Hello world"))
 
-  val userDataWithComplexType = List(
-    rowOf(11, 1L, "Julian", Array(rowOf(1, "a"))),
-    rowOf(22, 2L, "Jark", Array(rowOf(2, "b"), rowOf(3, "c"))),
-    rowOf(33, 3L, "Fabian", Array[Row]())
-  )
-
   @Before
   override def before(): Unit = {
     super.before()
@@ -99,7 +93,6 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
     // lookup will start from the 3rd time, first lookup will always get null result
     createLookupTable("user_table_with_lookup_threshold3", userData, 3)
     createLookupTableWithComputedColumn("userTableWithComputedColumn", userData)
-    createLookupTableWithComplex("user_table_with_complex_type", userDataWithComplexType)
   }
 
   @After
@@ -157,56 +150,6 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                          |) WITH (
                          |  $cacheOptions
                          |  $lookupThresholdOption
-                         |  'connector' = 'values',
-                         |  'data-id' = '$dataId'
-                         |)
-                         |""".stripMargin)
-    }
-  }
-
-  private def createLookupTableWithComplex(
-      tableName: String,
-      data: List[Row]
-  ): Unit = {
-
-    if (legacyTableSource) {
-      val userSchema = TableSchema
-        .builder()
-        .field("age", Types.INT)
-        .field("id", Types.LONG)
-        .field("name", Types.STRING)
-        .field("attributes", Types.OBJECT_ARRAY(Types.ROW(Types.INT(), Types.STRING())))
-        .build()
-      InMemoryLookupableTableSource.createTemporaryTable(
-        tEnv,
-        isAsync = false,
-        data,
-        userSchema,
-        tableName)
-    } else {
-      val dataId = TestValuesTableFactory.registerData(data)
-      val cacheOptions =
-        if (cacheType == LookupCacheType.PARTIAL)
-          s"""
-             |  '${LookupOptions.CACHE_TYPE.key()}' = '${LookupCacheType.PARTIAL}',
-             |  '${LookupOptions.PARTIAL_CACHE_MAX_ROWS.key()}' = '${Long.MaxValue}',
-             |""".stripMargin
-        else if (cacheType == LookupCacheType.FULL)
-          s"""
-             |  '${LookupOptions.CACHE_TYPE.key()}' = '${LookupCacheType.FULL}',
-             |  '${LookupOptions.FULL_CACHE_RELOAD_STRATEGY.key()}' = '${ReloadStrategy.PERIODIC}',
-             |  '${LookupOptions.FULL_CACHE_PERIODIC_RELOAD_INTERVAL.key()}' = '${Long.MaxValue}',
-             |""".stripMargin
-        else ""
-
-      tEnv.executeSql(s"""
-                         |CREATE TABLE $tableName (
-                         |  `age` INT,
-                         |  `id` BIGINT,
-                         |  `name` STRING,
-                         |  `attributes` ARRAY<ROW<`id` INT, `name` STRING>>
-                         |) WITH (
-                         |  $cacheOptions
                          |  'connector' = 'values',
                          |  'data-id' = '$dataId'
                          |)
@@ -581,20 +524,6 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
     env.execute()
 
     assertTrue(sink.getAppendResults.isEmpty)
-  }
-
-  @Test
-  def testJoinTemporalTableOnComplexData(): Unit = {
-    val sql =
-      "SELECT T.id, T.len, D.name, D.attributes FROM src AS T JOIN user_table_with_complex_type " +
-        "for system_time as of T.proctime AS D ON T.id = D.id"
-
-    val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
-    env.execute()
-
-    val expected = Seq("1,12,Julian,[+I[1, a]]", "2,15,Jark,[+I[2, b], +I[3, c]]", "3,15,Fabian,[]")
-    assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Make sure complex type such as `Array<Row<>>` get converted property in TestValues connector when doing lookup joins.

## Brief change log

- Added a call to concerter.open() on TestValuesRuntimeFunctions (sync and sync)

## Verifying this change

This change added tests and can be verified as follows:

- Added integration tests for lookup join with Array<Row<>> on lookup table.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
