### PR TITLE
[FLINK-25015][Table SQL] Use SQL string as jobName for DQL jobs submitted by sql-gateway

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.operations.CollectModifyOperation;
+import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.test.program.SqlTestStep;
 import org.apache.flink.table.test.program.TableApiTestStep;
 import org.apache.flink.table.test.program.TableTestProgram;
@@ -29,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -76,6 +82,39 @@ public class QueryOperationSqlSerializationTest implements TableTestProgramRunne
                                 .get();
         final Table table = tableApiStep.toTable(env);
         assertThat(table.getQueryOperation().asSerializableString()).isEqualTo(sqlStep.sql);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedPrograms")
+    void testSqlAsJobNameForQueryOperation(TableTestProgram program) {
+        final TableEnvironmentImpl env = (TableEnvironmentImpl) setupEnv(program);
+
+        final TableApiTestStep tableApiStep =
+                (TableApiTestStep)
+                        program.runSteps.stream()
+                                .filter(s -> s instanceof TableApiTestStep)
+                                .findFirst()
+                                .get();
+
+        final SqlTestStep sqlStep =
+                (SqlTestStep)
+                        program.runSteps.stream()
+                                .filter(s -> s instanceof SqlTestStep)
+                                .findFirst()
+                                .get();
+
+        final Table table = tableApiStep.toTable(env);
+
+        QueryOperation queryOperation = table.getQueryOperation();
+        CollectModifyOperation sinkOperation = new CollectModifyOperation(queryOperation);
+        List<Transformation<?>> transformations =
+                env.getPlanner().translate(Collections.singletonList(sinkOperation));
+
+        StreamGraph streamGraph =
+                (StreamGraph)
+                        env.generatePipelineFromQueryOperation(queryOperation, transformations);
+
+        assertThat(sqlStep.sql).isEqualTo(streamGraph.getJobName());
     }
 
     private static TableEnvironment setupEnv(TableTestProgram program) {


### PR DESCRIPTION
## What is the purpose of the change
when submitting DQL jobs, the job name should not always be 'collect'. Using sql as the job name will improve the usability.

## Brief change log

- use 'QueryOperation#asSerializableString()' as the JobName for DQL jobs submitted by sql-gateway

## Verifying this change

- Added unit test 'QueryOperationSqlSerializationTest#testSqlAsJobNameForQueryOperation' to verify the logic using sql as job name

- Test manually by submitting queries SQL Client, the jobName changes to sql
![20240218155700](https://github.com/apache/flink/assets/3021821/e963d44a-807c-4060-a133-f1261484ebdd)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
