### PR TITLE
[FLINK-33159] [build] use variables in pom file for Java and Maven versions

### DIFF
--- a/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/src/main/resources/archetype-resources/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>@project.version@</flink.version>
-		<target.java.version>1.8</target.java.version>
+		<target.java.version>@target.java.version@</target.java.version>
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
 		<log4j.version>@log4j.version@</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@ under the License.
 		<flink.shaded.jackson.version>2.14.2</flink.shaded.jackson.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<target.java.version>1.8</target.java.version>
+		<target.java.version.upperbound>1.8.1</target.java.version.upperbound>
+		<!-- build release with this version of mvn -->
+		<release.maven.version>3.8.6</release.maven.version>
+		<!-- enforce at least mvn version 3.1.1 (see FLINK-12447) -->
+		<minimum.maven.version>3.1.1</minimum.maven.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.17.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
@@ -1365,7 +1370,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<target.java.version>1.8</target.java.version>
+				<target.java.version>${target.java.version}</target.java.version>
 			</properties>
 			<build>
 				<plugins>
@@ -1397,10 +1402,10 @@ under the License.
 										<!-- versions for certain build tools are enforced to match the CI setup -->
 										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireMavenVersion>
-											<version>[3.8.6]</version>
+											<version>[${release.maven.version}]</version>
 										</requireMavenVersion>
 										<requireJavaVersion>
-											<version>[1.8.0,1.8.1)</version>
+											<version>[${target.java.version},${target.java.version.upperbound})</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>
@@ -1799,7 +1804,7 @@ under the License.
 							<rules>
 								<requireMavenVersion>
 									<!-- enforce at least mvn version 3.1.1 (see FLINK-12447) -->
-									<version>[3.1.1,)</version>
+									<version>[${minimum.maven.version},)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>${target.java.version}</version>


### PR DESCRIPTION
## What is the purpose of the change

Use Maven variables for all cases when referring to Java and Maven versions in the pom file 


## Brief change log

I have introduced 2 Maven variables for the 2 versions that are referenced in the build.
I have ensured all references to Java 1.8 use the java variable 


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  -no

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
