### PR TITLE
[FLINK-32622][table-planner] Optimize mini-batch assignment

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -35,7 +35,8 @@ import org.apache.flink.table.planner.utils.TableConfigUtils
 import org.apache.flink.util.Preconditions
 
 import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.core.TableScan
+import org.apache.calcite.rel.core.{Calc, Filter, Project, TableScan, Values}
+import org.apache.calcite.rel.logical.{LogicalProject, LogicalUnion}
 
 import java.util
 import java.util.Collections
@@ -46,62 +47,98 @@ import scala.collection.JavaConversions._
 class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
   extends CommonSubGraphBasedOptimizer {
 
+  private def shouldSkipMiniBatch(blocks: Seq[RelNodeBlock]): Boolean = {
+
+    val noMiniBatchRequired = {
+      (node: RelNode) =>
+        node match {
+          case _: Filter | _: Project | _: TableScan | _: Calc | _: Values | _: Sink |
+              _: LegacySink =>
+            true
+          case unionNode: LogicalUnion => unionNode.all
+          case _ => false
+        }
+    }
+
+    def nodeTraverser(node: RelNode): Boolean = {
+      noMiniBatchRequired(node) && node.getInputs
+        .map(n => nodeTraverser(n))
+        .forall(r => r)
+    }
+
+    blocks.map(b => nodeTraverser(b.outputNode)).forall(r => r)
+  }
+
   override protected def doOptimize(roots: Seq[RelNode]): Seq[RelNodeBlock] = {
     val tableConfig = planner.getTableConfig
     // build RelNodeBlock plan
     val sinkBlocks = RelNodeBlockPlanBuilder.buildRelNodeBlockPlan(roots, tableConfig)
     // infer trait properties for sink block
-    sinkBlocks.foreach {
-      sinkBlock =>
-        // don't require update before by default
-        sinkBlock.setUpdateBeforeRequired(false)
 
-        val miniBatchInterval: MiniBatchInterval =
-          if (tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)) {
-            val miniBatchLatency =
-              tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY).toMillis
-            Preconditions.checkArgument(
-              miniBatchLatency > 0,
-              "MiniBatch Latency must be greater than 0 ms.",
-              null)
-            new MiniBatchInterval(miniBatchLatency, MiniBatchMode.ProcTime)
-          } else {
-            MiniBatchIntervalTrait.NONE.getMiniBatchInterval
-          }
-        sinkBlock.setMiniBatchInterval(miniBatchInterval)
-    }
+    val origMiniBatchEnabled = tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)
 
-    if (sinkBlocks.size == 1) {
-      // If there is only one sink block, the given relational expressions are a simple tree
-      // (only one root), not a dag. So many operations (e.g. infer and propagate
-      // requireUpdateBefore) can be omitted to save optimization time.
-      val block = sinkBlocks.head
-      val optimizedTree = optimizeTree(
-        block.getPlan,
-        block.isUpdateBeforeRequired,
-        block.getMiniBatchInterval,
-        isSinkBlock = true)
-      block.setOptimizedPlan(optimizedTree)
-      return sinkBlocks
-    }
+    try {
+      if (origMiniBatchEnabled)
+        tableConfig.set(
+          ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED,
+          Boolean.box(!shouldSkipMiniBatch(sinkBlocks)))
+      sinkBlocks.foreach {
+        sinkBlock =>
+          // don't require update before by default
+          sinkBlock.setUpdateBeforeRequired(false)
+          val miniBatchInterval: MiniBatchInterval =
+            if (tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED)) {
+              val miniBatchLatency =
+                tableConfig.get(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY).toMillis
+              Preconditions.checkArgument(
+                miniBatchLatency > 0,
+                "MiniBatch Latency must be greater than 0 ms.",
+                null)
+              new MiniBatchInterval(miniBatchLatency, MiniBatchMode.ProcTime)
+            } else {
+              MiniBatchIntervalTrait.NONE.getMiniBatchInterval
+            }
+          sinkBlock.setMiniBatchInterval(miniBatchInterval)
+      }
 
-    // TODO FLINK-24048: Move changeLog inference out of optimizing phase
-    // infer modifyKind property for each blocks independently
-    sinkBlocks.foreach(b => optimizeBlock(b, isSinkBlock = true))
-    // infer and propagate updateKind and miniBatchInterval property for each blocks
-    sinkBlocks.foreach {
-      b =>
-        propagateUpdateKindAndMiniBatchInterval(
-          b,
-          b.isUpdateBeforeRequired,
-          b.getMiniBatchInterval,
+      if (sinkBlocks.size == 1) {
+        // If there is only one sink block, the given relational expressions are a simple tree
+        // (only one root), not a dag. So many operations (e.g. infer and propagate
+        // requireUpdateBefore) can be omitted to save optimization time.
+        val block = sinkBlocks.head
+        val optimizedTree = optimizeTree(
+          block.getPlan,
+          block.isUpdateBeforeRequired,
+          block.getMiniBatchInterval,
           isSinkBlock = true)
+        block.setOptimizedPlan(optimizedTree)
+        sinkBlocks
+      } else {
+        // TODO FLINK-24048: Move changeLog inference out of optimizing phase
+        // infer modifyKind property for each blocks independently
+        sinkBlocks.foreach(b => optimizeBlock(b, isSinkBlock = true))
+        // infer and propagate updateKind and miniBatchInterval property for each blocks
+        sinkBlocks.foreach {
+          b =>
+            propagateUpdateKindAndMiniBatchInterval(
+              b,
+              b.isUpdateBeforeRequired,
+              b.getMiniBatchInterval,
+              isSinkBlock = true)
+        }
+        // clear the intermediate result
+        sinkBlocks.foreach(resetIntermediateResult)
+        // optimize recursively RelNodeBlock
+        sinkBlocks.foreach(b => optimizeBlock(b, isSinkBlock = true))
+        sinkBlocks
+      }
+
+    } finally {
+      tableConfig.getConfiguration.set(
+        ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED,
+        origMiniBatchEnabled)
     }
-    // clear the intermediate result
-    sinkBlocks.foreach(resetIntermediateResult)
-    // optimize recursively RelNodeBlock
-    sinkBlocks.foreach(b => optimizeBlock(b, isSinkBlock = true))
-    sinkBlocks
+
   }
 
   private def optimizeBlock(block: RelNodeBlock, isSinkBlock: Boolean): Unit = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -21,6 +21,8 @@ import org.apache.flink.annotation.Experimental
 import org.apache.flink.configuration.ConfigOption
 import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.functions.sql.SqlTryCastFunction
+import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
+import org.apache.flink.table.planner.plan.optimize.RelNodeBlock
 import org.apache.flink.table.planner.plan.utils.ExpressionDetail.ExpressionDetail
 import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
 import org.apache.flink.table.planner.utils.{ShortcutUtils, TableConfigUtils}
@@ -31,6 +33,8 @@ import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{Calc, Filter, Project, TableScan, Values}
+import org.apache.calcite.rel.logical.LogicalUnion
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.{SqlAsOperator, SqlKind, SqlOperator}
@@ -88,6 +92,32 @@ object FlinkRexUtil {
       maxCnfNodeCount
     }
     new CnfHelper(rexBuilder, maxCnfNodeCnt).toCnf(rex)
+  }
+
+  /**
+   * Returns true if a input blocks only consist of [[Filter]], [[Project]], [[TableScan]],
+   * [[Calc]], [[Values]], and [[Sink]] nodes.
+   */
+  def shouldSkipMiniBatch(blocks: Seq[RelNodeBlock]): Boolean = {
+
+    val noMiniBatchRequired = {
+      (node: RelNode) =>
+        node match {
+          case _: Filter | _: Project | _: TableScan | _: Calc | _: Values | _: Sink |
+              _: LegacySink =>
+            true
+          case unionNode: LogicalUnion => unionNode.all
+          case _ => false
+        }
+    }
+
+    def nodeTraverser(node: RelNode): Boolean = {
+      noMiniBatchRequired(node) && node.getInputs
+        .map(n => nodeTraverser(n))
+        .forall(r => r)
+    }
+
+    blocks.map(b => nodeTraverser(b.outputNode)).forall(r => r)
   }
 
   /** Returns true if the RexNode contains any node in the given expected [[RexInputRef]] nodes. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/MiniBatchOptimizationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/MiniBatchOptimizationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.plan.trait.MiniBatchIntervalTrait;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for enabling/disabling mini-batch assigner operator based on query plan. The optimization is
+ * performed in {@link StreamCommonSubGraphBasedOptimizer}.
+ */
+@ExtendWith(ParameterizedTestExtension.class)
+public class MiniBatchOptimizationTest extends TableTestBase {
+
+    private final StreamTableTestUtil util = streamTestUtil(TableConfig.getDefault());
+    private final StreamTableEnvironment streamTableEnv =
+            StreamTableEnvironment.create(util.getStreamEnv());
+
+    @Parameter public boolean isMiniBatchEnabled;
+
+    @Parameter(1)
+    public long miniBatchLatency;
+
+    @Parameter(2)
+    public long miniBatchSize;
+
+    @BeforeEach
+    public void setup() {
+        streamTableEnv
+                .getConfig()
+                .set(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED, isMiniBatchEnabled)
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY,
+                        Duration.ofSeconds(miniBatchLatency))
+                .set(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE, miniBatchSize);
+        streamTableEnv.executeSql(
+                "CREATE TABLE MyTableA (\n"
+                        + "  a BIGINT,\n"
+                        + "  b INT NOT NULL,\n"
+                        + "  c VARCHAR,\n"
+                        + "  d BIGINT\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')");
+        streamTableEnv.executeSql(
+                "CREATE TABLE MyTableB (\n"
+                        + "  a BIGINT,\n"
+                        + "  b INT NOT NULL,\n"
+                        + "  c VARCHAR,\n"
+                        + "  d BIGINT\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')");
+    }
+
+    private boolean containsMiniBatch(String sql) {
+        final Table result = streamTableEnv.sqlQuery(sql);
+        RelNode relNode = TableTestUtil.toRelNode(result);
+        StreamPlanner planner =
+                (StreamPlanner) ((TableEnvironmentImpl) streamTableEnv).getPlanner();
+        StreamCommonSubGraphBasedOptimizer optimizer =
+                new StreamCommonSubGraphBasedOptimizer(planner);
+        Seq<RelNode> nodeSeq =
+                JavaConverters.asScalaIteratorConverter(Arrays.asList(relNode).iterator())
+                        .asScala()
+                        .toSeq();
+        Seq<RelNodeBlock> blockSeq = optimizer.doOptimize(nodeSeq);
+        List<RelNodeBlock> blockList = scala.collection.JavaConverters.seqAsJavaList(blockSeq);
+        boolean res =
+                blockList.stream()
+                        .map(
+                                b ->
+                                        !b.getMiniBatchInterval()
+                                                .equals(
+                                                        MiniBatchIntervalTrait.NONE()
+                                                                .getMiniBatchInterval()))
+                        .reduce(false, (l, r) -> l || r);
+        return res;
+    }
+
+    @TestTemplate
+    public void testMiniBatchWithAggregation() {
+        final String aggQuery =
+                "SELECT\n"
+                        + "  AVG(a) AS avg_a,\n"
+                        + "  COUNT(*) AS cnt,\n"
+                        + "  count(b) AS cnt_b,\n"
+                        + "  min(b) AS min_b,\n"
+                        + "  MAX(c) FILTER (WHERE a > 1) AS max_c\n"
+                        + "FROM MyTableA";
+
+        boolean containsMiniBatch = containsMiniBatch(aggQuery);
+        if (isMiniBatchEnabled) {
+            assertTrue(containsMiniBatch);
+        } else {
+            assertFalse(containsMiniBatch);
+        }
+    }
+
+    @TestTemplate
+    public void testMiniBatchWithJoin() {
+        final String joinQuery = "SELECT * FROM MyTableA a, MyTableB b WHERE a.a = b.a";
+
+        boolean containsMiniBatch = containsMiniBatch(joinQuery);
+        if (isMiniBatchEnabled) {
+            assertTrue(containsMiniBatch);
+        } else {
+            assertFalse(containsMiniBatch);
+        }
+    }
+
+    @TestTemplate
+    public void testMiniBatchWithProjectFilter() {
+        final String joinQuery = "SELECT b FROM MyTableA a WHERE a.a > 123";
+
+        boolean containsMiniBatch = containsMiniBatch(joinQuery);
+        assertFalse(containsMiniBatch);
+    }
+
+    @Parameters(name = "isMiniBatchEnabled={0}, miniBatchLatency={1}, miniBatchSize={2}")
+    public static Object[][] data() {
+        return new Object[][] {
+            new Object[] {true, 10L, 5L},
+            new Object[] {false, 10L, 5L}
+        };
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -620,6 +620,28 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
    * Verify whether the optimized rel plan for the given SELECT query does not contain the
    * `notExpected` strings.
    */
+  def verifyRelPlanExpected(query: String, notExpected: String*): Unit = {
+    verifyRelPlanExpected(getTableEnv.sqlQuery(query), notExpected: _*)
+  }
+
+  /**
+   * Verify whether the optimized rel plan for the given [[Table]] does not contain the
+   * `notExpected` strings.
+   */
+  def verifyRelPlanExpected(table: Table, expected: String*): Unit = {
+    require(expected.nonEmpty)
+    val relNode = TableTestUtil.toRelNode(table)
+    val optimizedRel = getPlanner.optimize(relNode)
+    val optimizedPlan = getOptimizedRelPlan(Array(optimizedRel), Array.empty, withRowType = false)
+    val result = expected.forall(optimizedPlan.contains(_))
+    val message = s"\nactual plan:\n$optimizedPlan\nexpected:\n${expected.mkString(", ")}"
+    assertTrue(result, message)
+  }
+
+  /**
+   * Verify whether the optimized rel plan for the given SELECT query does not contain the
+   * `notExpected` strings.
+   */
   def verifyRelPlanNotExpected(query: String, notExpected: String*): Unit = {
     verifyRelPlanNotExpected(getTableEnv.sqlQuery(query), notExpected: _*)
   }


### PR DESCRIPTION
## What is the purpose of the change

The pull request detects unnecessary mini-batch assignments and ignores them in the query plan


## Brief change log

  - Search query plan if it contains aggregate or join operators
  - If none of them exists in query plan, then we ignore the mini-batch assignment
  - With that, we avoid generating useless events and causing performance issues


## Verifying this change

This change added tests and can be verified as unit tests that I added as part of this PR

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no 

## Documentation

  - Does this pull request introduce a new feature?  no