### PR TITLE
[FLINK-23860]Fix the conversion to relational algebra failed to preserve datatypes when use Row function

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -111,7 +111,7 @@ class FlinkTypeFactory(
           rowType.getFieldNames,
           rowType.getChildren,
           // fields are not expanded in "SELECT *"
-          StructKind.PEEK_FIELDS_NO_EXPAND)
+          StructKind.FULLY_QUALIFIED)
 
       case LogicalTypeRoot.STRUCTURED_TYPE =>
         t match {


### PR DESCRIPTION

## What is the purpose of the change

```sql
tableenv.executesql(" CREATE TABLE source1 (
bigint1 BIGINT NOT NULL ,
boolean1 BOOLEAN NOT NULL ,
char1 CHAR NOT NULL ,
date1 DATE NOT NULL ,
decimal1 DECIMAL NOT NULL ,
double1 DOUBLE NOT NULL ,
float1 FLOAT NOT NULL ,
int1 INT NOT NULL ,
string1 STRING NOT NULL ,
smallint1 SMALLINT NOT NULL ,
tinyint1 TINYINT NOT NULL ,
time1 TIME NOT NULL ,
timestamp1 TIMESTAMP NOT NULL ,
timestamp2 TIMESTAMP_LTZ NOT NULL
 )  WITH (  'connector' = 'datagen',
'rows-per-second' = '1' )");


Table t1 = tableenv.sqlQuery("select * from  source1");


Table t2 = tableenv.sqlQuery("select  bigint1 , boolean1 , char1 , date1 , decimal1 , double1 , float1 , int1 , string1 , smallint1 , tinyint1 , time1 , timestamp1 , timestamp2 , ROW(string1,tinyint1)  from " + t1);


tableenv.sqlQuery("select * from " +  t2);


```

```java
	... 8 more
Caused by: java.lang.AssertionError: Conversion to relational algebra failed to preserve datatypes:
validated type:
RecordType(BIGINT NOT NULL bigint1, BOOLEAN NOT NULL boolean1, CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL char1, DATE NOT NULL date1, DECIMAL(10, 0) NOT NULL decimal1, DOUBLE NOT NULL double1, FLOAT NOT NULL float1, INTEGER NOT NULL int1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL string1, SMALLINT NOT NULL smallint1, TINYINT NOT NULL tinyint1, TIME(0) NOT NULL time1, TIMESTAMP(6) NOT NULL timestamp1, TIMESTAMP_WITH_LOCAL_TIME_ZONE(6) NOT NULL timestamp2, RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL EXPR$0, TINYINT NOT NULL EXPR$1) NOT NULL EXPR$14) NOT NULL
converted type:
RecordType(BIGINT NOT NULL bigint1, BOOLEAN NOT NULL boolean1, CHAR(1) CHARACTER SET "UTF-16LE" NOT NULL char1, DATE NOT NULL date1, DECIMAL(10, 0) NOT NULL decimal1, DOUBLE NOT NULL double1, FLOAT NOT NULL float1, INTEGER NOT NULL int1, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL string1, SMALLINT NOT NULL smallint1, TINYINT NOT NULL tinyint1, TIME(0) NOT NULL time1, TIMESTAMP(6) NOT NULL timestamp1, TIMESTAMP_WITH_LOCAL_TIME_ZONE(6) NOT NULL timestamp2, RecordType(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL EXPR$0, TINYINT NOT NULL EXPR$1) NOT NULL EXPR$14) NOT NULL
rel:
LogicalProject(bigint1=[$0], boolean1=[$1], char1=[$2], date1=[$3], decimal1=[$4], double1=[$5], float1=[$6], int1=[$7], string1=[$8], smallint1=[$9], tinyint1=[$10], time1=[$11], timestamp1=[$12], timestamp2=[$13], EXPR$14=[ROW($8, $10)])
  LogicalTableScan(table=[[default_catalog, default_database, source1]])

	at org.apache.calcite.sql2rel.SqlToRelConverter.checkConvertedType(SqlToRelConverter.java:467)
	at org.apache.calcite.sql2rel.SqlToRelConverter.convertQuery(SqlToRelConverter.java:582)
	at org.apache.flink.table.planner.calcite.FlinkPlannerImpl.org$apache$flink$table$planner$calcite$FlinkPlannerImpl$$rel(FlinkPlannerImpl.scala:177)
	at org.apache.flink.table.planner.calcite.FlinkPlannerImpl.rel(FlinkPlannerImpl.scala:169)
	at org.apache.flink.table.planner.operations.SqlToOperationConverter.toQueryOperation(SqlToOperationConverter.java:1057)
	at org.apache.flink.table.planner.operations.SqlToOperationConverter.convertSqlQuery(SqlToOperationConverter.java:1026)
	at org.apache.flink.table.planner.operations.SqlToOperationConverter.convert(SqlToOperationConverter.java:301)
	at org.apache.flink.table.planner.delegation.ParserImpl.parse(ParserImpl.java:108)
	at org.apache.flink.table.api.internal.TableEnvironmentImpl.sqlQuery(TableEnvironmentImpl.java:716)
```


## Brief change log

convert  PEEK_FIELDS_NO_EXPAND t StructKind o  FULLY_QUALIFIED  StructKind when type is row




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
