### PR TITLE
[FLINK-33000][sql-gateway][release-1.18] SqlGatewayServiceITCase should utilize TestExecutorExtension instead of using a ThreadFactory 

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -66,6 +66,7 @@ import org.apache.flink.table.planner.utils.TableFunc0;
 import org.apache.flink.test.junit5.InjectClusterClient;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.UserClassLoaderJarTestUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
@@ -96,9 +97,10 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -125,7 +127,7 @@ public class SqlGatewayServiceITCase {
 
     @RegisterExtension
     @Order(1)
-    public static final MiniClusterExtension MINI_CLUSTER =
+    static final MiniClusterExtension MINI_CLUSTER =
             new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(2)
@@ -133,8 +135,18 @@ public class SqlGatewayServiceITCase {
 
     @RegisterExtension
     @Order(2)
-    public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+    static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
             new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @RegisterExtension
+    @Order(3)
+    static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(
+                    () ->
+                            Executors.newCachedThreadPool(
+                                    new ExecutorThreadFactory(
+                                            "SqlGatewayService Test Pool",
+                                            IgnoreExceptionHandler.INSTANCE)));
 
     private static SessionManagerImpl sessionManager;
     private static SqlGatewayServiceImpl service;
@@ -143,9 +155,6 @@ public class SqlGatewayServiceITCase {
             SessionEnvironment.newBuilder()
                     .setSessionEndpointVersion(MockedEndpointVersion.V1)
                     .build();
-    private final ThreadFactory threadFactory =
-            new ExecutorThreadFactory(
-                    "SqlGatewayService Test Pool", IgnoreExceptionHandler.INSTANCE);
 
     @BeforeAll
     static void setUp() {
@@ -773,12 +782,10 @@ public class SqlGatewayServiceITCase {
                     service.getSession(sessionHandle)
                             .getOperationManager()
                             .getOperation(operationHandle));
-            threadFactory
-                    .newThread(() -> service.cancelOperation(sessionHandle, operationHandle))
-                    .start();
-            threadFactory
-                    .newThread(() -> service.closeOperation(sessionHandle, operationHandle))
-                    .start();
+
+            ExecutorService executor = EXECUTOR_EXTENSION.getExecutor();
+            executor.submit(() -> service.cancelOperation(sessionHandle, operationHandle));
+            executor.submit(() -> service.closeOperation(sessionHandle, operationHandle));
         }
 
         CommonTestUtils.waitUtil(
@@ -800,16 +807,16 @@ public class SqlGatewayServiceITCase {
         int submitThreadsNum = 100;
         CountDownLatch latch = new CountDownLatch(submitThreadsNum);
         for (int i = 0; i < submitThreadsNum; i++) {
-            threadFactory
-                    .newThread(
+            EXECUTOR_EXTENSION
+                    .getExecutor()
+                    .submit(
                             () -> {
                                 try {
                                     submitDefaultOperation(sessionHandle, () -> {});
                                 } finally {
                                     latch.countDown();
                                 }
-                            })
-                    .start();
+                            });
         }
         manager.close();
         latch.await();
@@ -823,8 +830,9 @@ public class SqlGatewayServiceITCase {
         CountDownLatch terminateRunning = new CountDownLatch(1);
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         for (int i = 0; i < count; i++) {
-            threadFactory
-                    .newThread(
+            EXECUTOR_EXTENSION
+                    .getExecutor()
+                    .submit(
                             () ->
                                     service.submitOperation(
                                             sessionHandle,
@@ -832,8 +840,7 @@ public class SqlGatewayServiceITCase {
                                                 startRunning.countDown();
                                                 terminateRunning.await();
                                                 return getDefaultResultSet();
-                                            }))
-                    .start();
+                                            }));
         }
         startRunning.await();
         service.getSession(sessionHandle).getOperationManager().close();
@@ -1034,7 +1041,8 @@ public class SqlGatewayServiceITCase {
                             schemaFetcherIsRunning.countDown();
                             return service.getOperationResultSchema(sessionHandle, operationHandle);
                         });
-        threadFactory.newThread(task).start();
+
+        EXECUTOR_EXTENSION.getExecutor().submit(task);
 
         schemaFetcherIsRunning.await();
         operationIsRunning.countDown();
@@ -1048,16 +1056,17 @@ public class SqlGatewayServiceITCase {
             Condition<String> condition) {
 
         List<RowData> actual = new ArrayList<>();
-        threadFactory
-                .newThread(
+
+        EXECUTOR_EXTENSION
+                .getExecutor()
+                .submit(
                         () -> {
                             try {
                                 cancelOrClose.run();
                             } catch (Exception e) {
                                 // ignore
                             }
-                        })
-                .start();
+                        });
 
         assertThatThrownBy(
                         () -> {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33000][sql-gateway][release-1.18] SqlGatewayServiceITCase, ResultFetcherTest and OperationManagerTest should utilize TestExecutorExtension instead of using a ThreadFactory

## Brief change log

SqlGatewayServiceITCase, ResultFetcherTest and OperationManagerTest should utilize TestExecutorExtension instead of using a ThreadFactory


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
