### PR TITLE
[FLINK-33000][sql-gateway][release-1.16] SqlGatewayServiceITCase should utilize TestExecutorExtension instead of using a ThreadFactory 

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.gateway.api.results.FetchOrientation;
 import org.apache.flink.table.gateway.api.results.ResultSet;
 import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.TestLogger;
@@ -38,6 +39,7 @@ import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.commons.collections.iterators.IteratorChain;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -51,7 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -68,8 +71,14 @@ public class ResultFetcherTest extends TestLogger {
     private static ResolvedSchema schema;
     private static List<RowData> data;
 
-    private final ThreadFactory threadFactory =
-            new ExecutorThreadFactory("Result Fetcher Test Pool", IgnoreExceptionHandler.INSTANCE);
+    @RegisterExtension
+    private static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(
+                    () ->
+                            Executors.newCachedThreadPool(
+                                    new ExecutorThreadFactory(
+                                            "Result Fetcher Test Pool",
+                                            IgnoreExceptionHandler.INSTANCE)));
 
     @BeforeAll
     public static void setUp() {
@@ -243,8 +252,9 @@ public class ResultFetcherTest extends TestLogger {
 
         AtomicReference<Boolean> payloadHasData = new AtomicReference<>(true);
         for (int i = 0; i < fetchThreadNum; i++) {
-            threadFactory
-                    .newThread(
+            EXECUTOR_EXTENSION
+                    .getExecutor()
+                    .submit(
                             () -> {
                                 ResultSet resultSet =
                                         fetcher.fetchResults(FetchOrientation.FETCH_NEXT, 1);
@@ -253,10 +263,19 @@ public class ResultFetcherTest extends TestLogger {
                                     payloadHasData.set(false);
                                 }
 
-                                rows.put(Thread.currentThread().getId(), resultSet.getData());
+                                rows.compute(
+                                        Thread.currentThread().getId(),
+                                        (k, v) -> {
+                                            if (v == null) {
+                                                return resultSet.getData();
+                                            } else {
+                                                v.addAll(resultSet.getData());
+                                                return v;
+                                            }
+                                        });
+
                                 latch.countDown();
-                            })
-                    .start();
+                            });
         }
 
         latch.await();
@@ -289,8 +308,9 @@ public class ResultFetcherTest extends TestLogger {
 
         long testToken = token;
         AtomicReference<Boolean> meetEnd = new AtomicReference<>(false);
-        threadFactory
-                .newThread(
+        EXECUTOR_EXTENSION
+                .getExecutor()
+                .submit(
                         () -> {
                             // Should meet EOS in the end.
                             long nextToken = testToken;
@@ -303,8 +323,7 @@ public class ResultFetcherTest extends TestLogger {
                                 nextToken = checkNotNull(resultSet.getNextToken());
                             }
                             meetEnd.set(true);
-                        })
-                .start();
+                        });
 
         CommonTestUtils.waitUtil(
                 meetEnd::get,
@@ -431,8 +450,9 @@ public class ResultFetcherTest extends TestLogger {
 
         List<RowData> firstFetch = fetcher.fetchResults(0, Integer.MAX_VALUE).getData();
         for (int i = 0; i < fetchThreadNum; i++) {
-            threadFactory
-                    .newThread(
+            EXECUTOR_EXTENSION
+                    .getExecutor()
+                    .submit(
                             () -> {
                                 ResultSet resultSet = fetcher.fetchResults(0, Integer.MAX_VALUE);
 
@@ -440,8 +460,7 @@ public class ResultFetcherTest extends TestLogger {
                                     isEqual.set(false);
                                 }
                                 latch.countDown();
-                            })
-                    .start();
+                            });
         }
 
         latch.await();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33000][sql-gateway][release-1.16] SqlGatewayServiceITCase and OperationManagerTest should utilize TestExecutorExtension instead of using a ThreadFactory

## Brief change log

SqlGatewayServiceITCase and OperationManagerTest should utilize TestExecutorExtension instead of using a ThreadFactory


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
