### PR TITLE
[FLINK-33172][python] Bump numpy version

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -24,7 +24,7 @@ avro-python3>=1.8.1,!=1.9.2
 pandas>=1.3.0
 pyarrow>=5.0.0
 pytz>=2018.3
-numpy>=1.21.4
+numpy>=1.22.4
 fastavro>=1.1.0,!=1.8.0
 grpcio>=1.29.0,<=1.48.2
 grpcio-tools>=1.29.0,<=1.48.2

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -321,7 +321,7 @@ try:
                         'cloudpickle>=2.2.0', 'avro-python3>=1.8.1,!=1.9.2',
                         'pytz>=2018.3', 'fastavro>=1.1.0,!=1.8.0', 'requests>=2.26.0',
                         'protobuf>=3.19.0',
-                        'numpy>=1.21.4',
+                        'numpy>=1.22.4',
                         'pandas>=1.3.0',
                         'pyarrow>=5.0.0',
                         'pemja==0.3.0;platform_system != "Windows"',


### PR DESCRIPTION
## What is the purpose of the change

`Numpy 1.21.4` was released on Nov 5, 2021 which is quite old. In this PR I've bumped it to `1.22.4`.

## Brief change log

Bumped numpy version.

## Verifying this change

Built wheels with the following command:
`dev/build-wheels.sh`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
