### PR TITLE
[docs] Update Vendor Solutions

### DIFF
--- a/docs/content/docs/deployment/overview.md
+++ b/docs/content/docs/deployment/overview.md
@@ -274,6 +274,14 @@ Please refer to vendor maintained documentation on how to use these products.
 Please keep this list in alphabetical order
 -->
 
+#### Aiven
+
+[Website](https://aiven.io/flink)
+
+{{< label AWS >}}
+{{< label Azure >}}
+{{< label Google Cloud >}}
+
 #### AliCloud Realtime Compute
 
 [Website](https://www.alibabacloud.com/products/realtime-compute)
@@ -304,6 +312,13 @@ Supported Environment:
 {{< label Azure >}}
 {{< label Google Cloud >}}
 {{< label On-Premise >}}
+
+#### Decodable
+
+[Website](https://decodable.co/)
+
+Supported Environment:
+{{< label AWS >}}
 
 #### Huawei Cloud Stream Service
 


### PR DESCRIPTION
- Add Decodable and Aiven
- Update the name of AWS's offering (it's now called Amazon Managed Service for Apache Flink)


## What is the purpose of the change

There are more vendors offering Flink as a managed service, so adding them to the list. 
At the same time, reflect the change in name to AWS' offering. 

EDIT: 
disclaimer: I work for Decodable :)


