### PR TITLE
[FLINK-33199][tests] Use fully qualified class names instead of Class objects in ArchitectureTests

### DIFF
--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
@@ -183,11 +183,10 @@ public class Predicates {
         if (fqClassName.trim().isEmpty()) {
             throw new IllegalArgumentException("Fully qualified class name cannot be empty");
         }
-        String[] classNameComponents = fqClassName.split("\\.");
-        if (classNameComponents.length == 0) {
-            throw new IllegalArgumentException("Failed to extract class name from: " + fqClassName);
-        }
-        String className = classNameComponents[classNameComponents.length - 1];
+        int lastDotIndex = fqClassName.lastIndexOf('.');
+        int lastDollarIndex = fqClassName.lastIndexOf('$');
+        int startIndex = Math.max(lastDotIndex, lastDollarIndex) + 1;
+        String className = fqClassName.substring(startIndex);
         if (className.trim().isEmpty()) {
             throw new IllegalArgumentException(
                     "Extracted class name is empty from: " + fqClassName);

--- a/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/main/java/org/apache/flink/architecture/common/Predicates.java
@@ -39,7 +39,13 @@ import static org.apache.flink.architecture.common.JavaFieldPredicates.isPublic;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.isStatic;
 import static org.apache.flink.architecture.common.JavaFieldPredicates.ofType;
 
-/** Common predicates for architecture tests. */
+/**
+ * Common predicates for architecture tests.
+ *
+ * <p>NOTE: it is recommended to use methods that accept fully qualified class names instead of
+ * {@code Class} objects to reduce the risks of introducing circular dependencies between the
+ * project submodules.
+ */
 public class Predicates {
 
     @SafeVarargs
@@ -62,21 +68,23 @@ public class Predicates {
     }
 
     /**
-     * Tests that the given field is {@code public static} and of the given type {@code clazz} .
+     * Tests that the given field is {@code public static} and has the fully qualified type name of
+     * {@code fqClassName}.
      *
      * <p>Attention: changing the description will add a rule into the stored.rules.
      */
-    public static DescribedPredicate<JavaField> arePublicStaticOfType(Class<?> clazz) {
-        return areFieldOfType(clazz, JavaModifier.PUBLIC, JavaModifier.STATIC);
+    public static DescribedPredicate<JavaField> arePublicStaticOfType(String fqClassName) {
+        return areFieldOfType(fqClassName, JavaModifier.PUBLIC, JavaModifier.STATIC);
     }
 
     /**
-     * Tests that the given field is of the given type {@code clazz} and has given modifiers.
+     * Tests that the field has the fully qualified type of {@code fqClassName} with the given
+     * modifiers.
      *
      * <p>Attention: changing the description will add a rule into the stored.rules.
      */
     public static DescribedPredicate<JavaField> areFieldOfType(
-            Class<?> clazz, JavaModifier... modifiers) {
+            String fqClassName, JavaModifier... modifiers) {
         return DescribedPredicate.describe(
                 String.format(
                         "are %s, and of type %s",
@@ -84,18 +92,18 @@ public class Predicates {
                                 .map(JavaModifier::toString)
                                 .map(String::toLowerCase)
                                 .collect(Collectors.joining(", ")),
-                        clazz.getSimpleName()),
+                        getClassSimpleNameFromFqName(fqClassName)),
                 field ->
                         field.getModifiers().containsAll(Arrays.asList(modifiers))
-                                && field.getRawType().isEquivalentTo(clazz));
+                                && field.getRawType().getName().equals(fqClassName));
     }
 
     /**
-     * Tests that the given field is {@code public final} and not {@code static} and of the given
-     * type {@code clazz} .
+     * Tests that the given field is {@code public final}, not {@code static} and has the given
+     * fully qualified type name of {@code fqClassName}.
      */
-    public static DescribedPredicate<JavaField> arePublicFinalOfType(Class<?> clazz) {
-        return is(ofType(clazz)).and(isPublic()).and(isFinal()).and(isNotStatic());
+    public static DescribedPredicate<JavaField> arePublicFinalOfType(String fqClassName) {
+        return is(ofType(fqClassName)).and(isPublic()).and(isFinal()).and(isNotStatic());
     }
 
     /**
@@ -107,38 +115,39 @@ public class Predicates {
     }
 
     /**
-     * Tests that the given field is {@code public static final} and of the given type {@code clazz}
-     * .
+     * Tests that the field is {@code public static final} and has the fully qualified type name of
+     * {@code fqClassName}.
      */
-    public static DescribedPredicate<JavaField> arePublicStaticFinalOfType(Class<?> clazz) {
-        return arePublicStaticOfType(clazz).and(isFinal());
+    public static DescribedPredicate<JavaField> arePublicStaticFinalOfType(String fqClassName) {
+        return arePublicStaticOfType(fqClassName).and(isFinal());
     }
 
     /**
-     * Tests that the given field is {@code public final} and of the given type {@code clazz} with
-     * exactly the given {@code annotationType}.
+     * Tests that the field is {@code public final}, has the fully qualified type name of {@code
+     * fqClassName} and is annotated with the {@code annotationType}.
      */
     public static DescribedPredicate<JavaField> arePublicFinalOfTypeWithAnnotation(
-            Class<?> clazz, Class<? extends Annotation> annotationType) {
-        return arePublicFinalOfType(clazz).and(annotatedWith(annotationType));
+            String fqClassName, Class<? extends Annotation> annotationType) {
+        return arePublicFinalOfType(fqClassName).and(annotatedWith(annotationType));
     }
 
     /**
-     * Tests that the given field is {@code public static final} and of the given type {@code clazz}
-     * with exactly the given {@code annotationType}.
+     * Tests that the field is {@code public static final}, has the fully qualified type name of
+     * {@code fqClassName} and is annotated with the {@code annotationType}.
      */
     public static DescribedPredicate<JavaField> arePublicStaticFinalOfTypeWithAnnotation(
-            Class<?> clazz, Class<? extends Annotation> annotationType) {
-        return arePublicStaticFinalOfType(clazz).and(annotatedWith(annotationType));
+            String fqClassName, Class<? extends Annotation> annotationType) {
+        return arePublicStaticFinalOfType(fqClassName).and(annotatedWith(annotationType));
     }
 
     /**
-     * Tests that the given field is {@code static final} and of the given type {@code clazz} with
-     * exactly the given {@code annotationType}. It doesn't matter if public, private or protected.
+     * Tests that the field is {@code static final}, has the fully qualified type name of {@code
+     * fqClassName} and is annotated with the {@code annotationType}. It doesn't matter if public,
+     * private or protected.
      */
     public static DescribedPredicate<JavaField> areStaticFinalOfTypeWithAnnotation(
-            Class<?> clazz, Class<? extends Annotation> annotationType) {
-        return areFieldOfType(clazz, JavaModifier.STATIC, JavaModifier.FINAL)
+            String fqClassName, Class<? extends Annotation> annotationType) {
+        return areFieldOfType(fqClassName, JavaModifier.STATIC, JavaModifier.FINAL)
                 .and(annotatedWith(annotationType));
     }
 
@@ -155,6 +164,35 @@ public class Predicates {
                                 .map(dp -> "* " + dp + "\n")
                                 .collect(Collectors.joining()),
                 t -> Arrays.stream(other).map(dp -> dp.test(t)).reduce(false, Boolean::logicalXor));
+    }
+
+    /**
+     * Extracts the class name from the given fully qualified class name.
+     *
+     * <p>Example:
+     *
+     * <pre>
+     *     getClassFromFqName("com.example.MyClass");  // Returns: "MyClass"
+     * </pre>
+     */
+    public static String getClassSimpleNameFromFqName(String fqClassName) {
+        // Not using Preconditions to avoid adding non-test flink-core dependency
+        if (fqClassName == null) {
+            throw new NullPointerException("Fully qualified class name cannot be null");
+        }
+        if (fqClassName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Fully qualified class name cannot be empty");
+        }
+        String[] classNameComponents = fqClassName.split("\\.");
+        if (classNameComponents.length == 0) {
+            throw new IllegalArgumentException("Failed to extract class name from: " + fqClassName);
+        }
+        String className = classNameComponents[classNameComponents.length - 1];
+        if (className.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Extracted class name is empty from: " + fqClassName);
+        }
+        return className;
     }
 
     private Predicates() {}

--- a/flink-architecture-tests/flink-architecture-tests-base/src/test/java/PredicatesTest.java
+++ b/flink-architecture-tests/flink-architecture-tests-base/src/test/java/PredicatesTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.architecture.common.Predicates.getClassSimpleNameFromFqName;
+import static org.assertj.core.api.Assertions.*;
+
+/** Tests for {@link org.apache.flink.architecture.common.Predicates}. */
+class PredicatesTest {
+
+    @Test
+    void testGetClassSimpleNameFromFqName() {
+        assertThat(getClassSimpleNameFromFqName("com.example.OuterClass")).isEqualTo("OuterClass");
+        assertThat(getClassSimpleNameFromFqName("com.example.OuterClass.InnerClass"))
+                .isEqualTo("InnerClass");
+        assertThat(getClassSimpleNameFromFqName("com.example.OuterClass$InnerClass"))
+                .isEqualTo("InnerClass");
+    }
+
+    @Test
+    void testInvalidInput() {
+        assertThatThrownBy(() -> getClassSimpleNameFromFqName(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Fully qualified class name cannot be null");
+        assertThatThrownBy(() -> getClassSimpleNameFromFqName(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Fully qualified class name cannot be empty");
+        assertThatThrownBy(() -> getClassSimpleNameFromFqName("  "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Fully qualified class name cannot be empty");
+    }
+}

--- a/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/TableApiRules.java
+++ b/flink-architecture-tests/flink-architecture-tests-production/src/main/java/org/apache/flink/architecture/rules/TableApiRules.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
@@ -52,9 +51,12 @@ public class TableApiRules {
     private static final Pattern TABLE_API_MODULES =
             Pattern.compile(".*/flink-table-(api-(bridge-base|java(|-bridge))|common)/.*");
 
+    public static final String CONFIG_OPTIONS_FQ_NAME =
+            "org.apache.flink.configuration.ConfigOption";
+
     @ArchTest
     public static final ArchRule CONFIG_OPTIONS_IN_OPTIONS_CLASSES =
-            fields().that(arePublicStaticOfType(ConfigOption.class))
+            fields().that(arePublicStaticOfType(CONFIG_OPTIONS_FQ_NAME))
                     .and()
                     .areDeclaredInClassesThat(
                             areJavaClasses().and(resideInAPackage("org.apache.flink.table..")))
@@ -67,7 +69,7 @@ public class TableApiRules {
     @ArchTest
     public static final ArchRule TABLE_FACTORIES_CONTAIN_NO_CONFIG_OPTIONS =
             noFields()
-                    .that(arePublicStaticOfType(ConfigOption.class))
+                    .that(arePublicStaticOfType(CONFIG_OPTIONS_FQ_NAME))
                     .and()
                     .areDeclaredInClassesThat(
                             areJavaClasses().and(resideInAPackage("org.apache.flink.table..")))

--- a/flink-architecture-tests/flink-architecture-tests-test/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-test/pom.xml
@@ -65,24 +65,6 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- Test Utils -->
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils-junit</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-test-utils</artifactId>
-			<version>${project.version}</version>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-architecture-tests/flink-architecture-tests-test/src/main/java/org/apache/flink/architecture/rules/ITCaseRules.java
+++ b/flink-architecture-tests/flink-architecture-tests-test/src/main/java/org/apache/flink/architecture/rules/ITCaseRules.java
@@ -19,12 +19,6 @@
 package org.apache.flink.architecture.rules;
 
 import org.apache.flink.architecture.common.Predicates;
-import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
-import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
-import org.apache.flink.runtime.testutils.InternalMiniClusterExtension;
-import org.apache.flink.test.junit5.MiniClusterExtension;
-import org.apache.flink.test.util.AbstractTestBase;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -33,7 +27,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Arrays;
@@ -48,15 +41,33 @@ import static org.apache.flink.architecture.common.Predicates.arePublicFinalOfTy
 import static org.apache.flink.architecture.common.Predicates.arePublicStaticFinalOfTypeWithAnnotation;
 import static org.apache.flink.architecture.common.Predicates.areStaticFinalOfTypeWithAnnotation;
 import static org.apache.flink.architecture.common.Predicates.containAnyFieldsInClassHierarchyThat;
+import static org.apache.flink.architecture.common.Predicates.getClassSimpleNameFromFqName;
 
 /** Rules for Integration Tests. */
 public class ITCaseRules {
+
+    private static final String ABSTRACT_TEST_BASE_FQ =
+            "org.apache.flink.test.util.AbstractTestBase";
+    private static final String INTERNAL_MINI_CLUSTER_EXTENSION_FQ_NAME =
+            "org.apache.flink.runtime.testutils.InternalMiniClusterExtension";
+    private static final String MINI_CLUSTER_EXTENSION_FQ_NAME =
+            "org.apache.flink.test.junit5.MiniClusterExtension";
+    private static final String MINI_CLUSTER_TEST_ENVIRONMENT_FQ_NAME =
+            "org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment";
+    private static final String TEST_ENV_FQ_NAME =
+            "org.apache.flink.connector.testframe.junit.annotations.TestEnv";
 
     @ArchTest
     public static final ArchRule INTEGRATION_TEST_ENDING_WITH_ITCASE =
             freeze(
                             javaClassesThat()
-                                    .areAssignableTo(AbstractTestBase.class)
+                                    .areAssignableTo(
+                                            DescribedPredicate.describe(
+                                                    "is assignable to " + ABSTRACT_TEST_BASE_FQ,
+                                                    javaClass ->
+                                                            javaClass
+                                                                    .getName()
+                                                                    .equals(ABSTRACT_TEST_BASE_FQ)))
                                     .and()
                                     .doNotHaveModifier(ABSTRACT)
                                     .should()
@@ -142,13 +153,14 @@ public class ITCaseRules {
     private static DescribedPredicate<JavaClass> miniClusterWithClientResourceClassRule() {
         return containAnyFieldsInClassHierarchyThat(
                 arePublicStaticFinalOfTypeWithAnnotation(
-                        MiniClusterWithClientResource.class, ClassRule.class));
+                        "org.apache.flink.test.util.MiniClusterWithClientResource",
+                        ClassRule.class));
     }
 
     private static DescribedPredicate<JavaClass> miniClusterWithClientResourceRule() {
         return containAnyFieldsInClassHierarchyThat(
                 arePublicFinalOfTypeWithAnnotation(
-                        MiniClusterWithClientResource.class, Rule.class));
+                        "org.apache.flink.test.util.MiniClusterWithClientResource", Rule.class));
     }
 
     private static DescribedPredicate<JavaClass> inFlinkRuntimePackages() {
@@ -167,37 +179,40 @@ public class ITCaseRules {
                         .and(
                                 containAnyFieldsInClassHierarchyThat(
                                         areStaticFinalOfTypeWithAnnotation(
-                                                InternalMiniClusterExtension.class,
+                                                INTERNAL_MINI_CLUSTER_EXTENSION_FQ_NAME,
                                                 RegisterExtension.class))),
                 outsideFlinkRuntimePackages()
                         .and(
                                 containAnyFieldsInClassHierarchyThat(
                                         areStaticFinalOfTypeWithAnnotation(
-                                                        MiniClusterExtension.class,
+                                                        MINI_CLUSTER_EXTENSION_FQ_NAME,
                                                         RegisterExtension.class)
                                                 .or(
                                                         areFieldOfType(
-                                                                        MiniClusterTestEnvironment
-                                                                                .class)
+                                                                        MINI_CLUSTER_TEST_ENVIRONMENT_FQ_NAME)
                                                                 .and(
                                                                         annotatedWith(
-                                                                                TestEnv.class))))),
+                                                                                TEST_ENV_FQ_NAME))))),
                 inFlinkRuntimePackages()
                         .and(
                                 isAnnotatedWithExtendWithUsingExtension(
-                                        InternalMiniClusterExtension.class)),
+                                        INTERNAL_MINI_CLUSTER_EXTENSION_FQ_NAME)),
                 outsideFlinkRuntimePackages()
-                        .and(isAnnotatedWithExtendWithUsingExtension(MiniClusterExtension.class)));
+                        .and(
+                                isAnnotatedWithExtendWithUsingExtension(
+                                        MINI_CLUSTER_EXTENSION_FQ_NAME)));
     }
 
     private static DescribedPredicate<JavaClass> isAnnotatedWithExtendWithUsingExtension(
-            Class<? extends Extension> extensionClass) {
+            String extensionClassFqName) {
         return DescribedPredicate.describe(
-                "is annotated with @ExtendWith with class " + extensionClass.getSimpleName(),
+                "is annotated with @ExtendWith with class "
+                        + getClassSimpleNameFromFqName(extensionClassFqName),
                 clazz ->
                         clazz.isAnnotatedWith(ExtendWith.class)
-                                && Arrays.asList(
+                                && Arrays.stream(
                                                 clazz.getAnnotationOfType(ExtendWith.class).value())
-                                        .contains(extensionClass));
+                                        .map(Class::getCanonicalName)
+                                        .anyMatch(s -> s.equals(extensionClassFqName)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently architecture tests rely on importing such classes as `MiniClusterExtension`. This introduces a production scope dependency on `flink-test-utils` which in turn depends on `flink-streaming-java`. This is problematic because adding architecture tests to any direct or transitive dependency of `flink-streaming-java` creates a dependency cycle.
Example: https://github.com/apache/flink/pull/22850#discussion_r1243343382
In general, since architecture tests are supposed to be used freely in any submodule, it is desirable to reduce its dependency surface as much as possible to prevent such cycles. 

## Brief change log
  - Modifies methods to using  fully qualified type names checks instead of Class objects
  - Removes production maven dependencies on `flink-test-utils`,  `flink-test-utils-junit` and `flink-connector-test-utils`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation
  - Does this pull request introduce a new feature? (yes / **no**)
