### PR TITLE
[FLINK-33218] Replace glob with version parameter

### DIFF
--- a/docs/content/docs/try-flink/local_installation.md
+++ b/docs/content/docs/try-flink/local_installation.md
@@ -50,7 +50,7 @@ Next, [download the latest binary release]({{< downloads >}}) of Flink,
 then extract the archive: 
 
 ```bash
-$ tar -xzf flink-*.tgz
+$ tar -xzf flink-{{< param Version >}}-bin-scala{{< param ScalaVersion >}}.tgz
 ```
 
 ## Browsing the project directory
@@ -58,7 +58,7 @@ $ tar -xzf flink-*.tgz
 Navigate to the extracted directory and list the contents by issuing:
 
 ```bash
-$ cd flink-* && ls -l
+$ cd flink-{{< param Version >}} && ls -l
 ```
 
 You should see something like:


### PR DESCRIPTION
## What is the purpose of the change

Fix a nit in the docs that will currently trip up zsh users

See https://issues.apache.org/jira/browse/FLINK-33218

## Brief change log

* Use Hugo parameters to insert the versions in the generated text

### Example generated docs

#### master branch

![CleanShot 2023-10-09 at 12 07 03](https://github.com/apache/flink/assets/3671582/00bb3645-2f09-4329-927d-48111e9db195)

#### 1.17.1 branch

![CleanShot 2023-10-09 at 12 08 36](https://github.com/apache/flink/assets/3671582/ea8cd45e-16af-426c-9516-81457daf3c62)
