### PR TITLE
[FLINK-33226][table] Forbid to drop current database

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
@@ -44,7 +44,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -94,7 +93,7 @@ public class HiveRunnerITCase {
     private static HiveCatalog hiveCatalog;
 
     @BeforeClass
-    public static void createCatalog() throws IOException {
+    public static void createCatalog() {
         HiveConf hiveConf = hiveShell.getHiveConf();
         hiveCatalog = HiveTestUtils.createHiveCatalog(hiveConf);
         hiveCatalog.open();
@@ -212,32 +211,32 @@ public class HiveRunnerITCase {
         TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
-        tableEnv.executeSql("create database db1");
-        try {
-            // 17 data types
-            tableEnv.executeSql(
-                    "create table db1.src"
-                            + "(t tinyint,s smallint,i int,b bigint,f float,d double,de decimal(10,5),ts timestamp,dt date,"
-                            + "str string,ch char(5),vch varchar(8),bl boolean,bin binary,arr array<int>,mp map<int,string>,strt struct<f1:int,f2:string>)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(
-                            new Object[] {
-                                null, null, null, null, null, null, null, null, null, null, null,
-                                null, null, null, null, null, null
-                            })
-                    .commit();
-            hiveShell.execute("create table db1.dest like db1.src");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    // 17 data types
+                    tableEnv.executeSql(
+                            "create table db1.src"
+                                    + "(t tinyint,s smallint,i int,b bigint,f float,d double,de decimal(10,5),ts timestamp,dt date,"
+                                    + "str string,ch char(5),vch varchar(8),bl boolean,bin binary,arr array<int>,mp map<int,string>,strt struct<f1:int,f2:string>)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(
+                                    new Object[] {
+                                        null, null, null, null, null, null, null, null, null, null,
+                                        null, null, null, null, null, null, null
+                                    })
+                            .commit();
+                    hiveShell.execute("create table db1.dest like db1.src");
 
-            tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
-            List<String> results = hiveShell.executeQuery("select * from db1.dest");
-            assertThat(results).hasSize(1);
-            String[] cols = results.get(0).split("\t");
-            assertThat(cols).hasSize(17);
-            assertThat(cols[0]).isEqualTo("NULL");
-            assertThat(new HashSet<>(Arrays.asList(cols))).hasSize(1);
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
+                    List<String> results = hiveShell.executeQuery("select * from db1.dest");
+                    assertThat(results).hasSize(1);
+                    String[] cols = results.get(0).split("\t");
+                    assertThat(cols).hasSize(17);
+                    assertThat(cols[0]).isEqualTo("NULL");
+                    assertThat(new HashSet<>(Arrays.asList(cols))).hasSize(1);
+                });
     }
 
     @Test
@@ -255,140 +254,156 @@ public class HiveRunnerITCase {
     @Test
     public void testDecimal() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src1 (x decimal(12,2))");
-            tableEnv.executeSql("create table db1.src2 (x decimal(12,2))");
-            tableEnv.executeSql("create table db1.dest (x decimal(12,2))");
-            // populate src1 from Hive
-            // TABLE keyword in INSERT INTO is mandatory prior to 1.1.0
-            hiveShell.execute(
-                    "insert into table db1.src1 values (1.0),(2.12),(5.123),(5.456),(123456789.12)");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src1 (x decimal(12,2))");
+                    tableEnv.executeSql("create table db1.src2 (x decimal(12,2))");
+                    tableEnv.executeSql("create table db1.dest (x decimal(12,2))");
+                    // populate src1 from Hive
+                    // TABLE keyword in INSERT INTO is mandatory prior to 1.1.0
+                    hiveShell.execute(
+                            "insert into table db1.src1 values (1.0),(2.12),(5.123),(5.456),(123456789.12)");
 
-            // populate src2 with same data from Flink
-            tableEnv.executeSql(
-                            "insert into db1.src2 values (1.0),(2.12),(5.123),(5.456),(123456789.12)")
-                    .await();
-            // verify src1 and src2 contain same data
-            verifyHiveQueryResult(
-                    "select * from db1.src2", hiveShell.executeQuery("select * from db1.src1"));
+                    // populate src2 with same data from Flink
+                    tableEnv.executeSql(
+                                    "insert into db1.src2 values (1.0),(2.12),(5.123),(5.456),(123456789.12)")
+                            .await();
+                    // verify src1 and src2 contain same data
+                    verifyHiveQueryResult(
+                            "select * from db1.src2",
+                            hiveShell.executeQuery("select * from db1.src1"));
 
-            // populate dest with src1 from Flink -- to test reading decimal type from Hive
-            tableEnv.executeSql("insert into db1.dest select * from db1.src1").await();
-            verifyHiveQueryResult(
-                    "select * from db1.dest", hiveShell.executeQuery("select * from db1.src1"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    // populate dest with src1 from Flink -- to test reading decimal type from Hive
+                    tableEnv.executeSql("insert into db1.dest select * from db1.src1").await();
+                    verifyHiveQueryResult(
+                            "select * from db1.dest",
+                            hiveShell.executeQuery("select * from db1.src1"));
+                });
     }
 
     @Test
     public void testInsertOverwrite() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            // non-partitioned
-            tableEnv.executeSql("create table db1.dest (x int, y string)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "dest")
-                    .addRow(new Object[] {1, "a"})
-                    .addRow(new Object[] {2, "b"})
-                    .commit();
-            verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\ta", "2\tb"));
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    TableEnvironment tableEnvIn = getTableEnvWithHiveCatalog();
+                    // non-partitioned
+                    tableEnvIn.executeSql("create table db1.dest (x int, y string)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "dest")
+                            .addRow(new Object[] {1, "a"})
+                            .addRow(new Object[] {2, "b"})
+                            .commit();
+                    verifyHiveQueryResult("select * from db1.dest", Arrays.asList("1\ta", "2\tb"));
 
-            tableEnv.executeSql("insert overwrite table db1.dest values (3, 'c')").await();
-            verifyHiveQueryResult("select * from db1.dest", Collections.singletonList("3\tc"));
+                    tableEnvIn
+                            .executeSql("insert overwrite table db1.dest values (3, 'c')")
+                            .await();
+                    verifyHiveQueryResult(
+                            "select * from db1.dest", Collections.singletonList("3\tc"));
 
-            // static partition
-            tableEnv.executeSql("create table db1.part(x int) partitioned by (y int)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {1})
-                    .commit("y=1");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {2})
-                    .commit("y=2");
-            tableEnv = getTableEnvWithHiveCatalog();
-            tableEnv.executeSql("insert overwrite table db1.part partition (y=1) select 100")
-                    .await();
-            verifyHiveQueryResult("select * from db1.part", Arrays.asList("100\t1", "2\t2"));
+                    // static partition
+                    tableEnvIn.executeSql("create table db1.part(x int) partitioned by (y int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {1})
+                            .commit("y=1");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {2})
+                            .commit("y=2");
+                    tableEnvIn = getTableEnvWithHiveCatalog();
+                    tableEnvIn
+                            .executeSql(
+                                    "insert overwrite table db1.part partition (y=1) select 100")
+                            .await();
+                    verifyHiveQueryResult(
+                            "select * from db1.part", Arrays.asList("100\t1", "2\t2"));
 
-            // dynamic partition
-            tableEnv = getTableEnvWithHiveCatalog();
-            tableEnv.executeSql("insert overwrite table db1.part values (200,2),(3,3)").await();
-            // only overwrite dynamically matched partitions, other existing partitions remain
-            // intact
-            verifyHiveQueryResult(
-                    "select * from db1.part", Arrays.asList("100\t1", "200\t2", "3\t3"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    // dynamic partition
+                    tableEnvIn = getTableEnvWithHiveCatalog();
+                    tableEnvIn
+                            .executeSql("insert overwrite table db1.part values (200,2),(3,3)")
+                            .await();
+                    // only overwrite dynamically matched partitions, other existing partitions
+                    // remain
+                    // intact
+                    verifyHiveQueryResult(
+                            "select * from db1.part", Arrays.asList("100\t1", "200\t2", "3\t3"));
+                });
     }
 
     @Test
     public void testStaticPartition() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x int)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {1})
-                    .addRow(new Object[] {2})
-                    .commit();
-            tableEnv.executeSql(
-                    "create table db1.dest (x int) partitioned by (p1 string, p2 double)");
-            tableEnv.executeSql(
-                            "insert into db1.dest partition (p1='1\\'1', p2=1.1) select x from db1.src")
-                    .await();
-            assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest"))).hasSize(1);
-            verifyHiveQueryResult(
-                    "select * from db1.dest", Arrays.asList("1\t1'1\t1.1", "2\t1'1\t1.1"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1})
+                            .addRow(new Object[] {2})
+                            .commit();
+                    tableEnv.executeSql(
+                            "create table db1.dest (x int) partitioned by (p1 string, p2 double)");
+                    tableEnv.executeSql(
+                                    "insert into db1.dest partition (p1='1\\'1', p2=1.1) select x from db1.src")
+                            .await();
+                    assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest")))
+                            .hasSize(1);
+                    verifyHiveQueryResult(
+                            "select * from db1.dest", Arrays.asList("1\t1'1\t1.1", "2\t1'1\t1.1"));
+                });
     }
 
     @Test
     public void testDynamicPartition() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x int, y string, z double)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {1, "a", 1.1})
-                    .addRow(new Object[] {2, "a", 2.2})
-                    .addRow(new Object[] {3, "b", 3.3})
-                    .commit();
-            tableEnv.executeSql(
-                    "create table db1.dest (x int) partitioned by (p1 string, p2 double)");
-            tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
-            assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest"))).hasSize(3);
-            verifyHiveQueryResult(
-                    "select * from db1.dest", Arrays.asList("1\ta\t1.1", "2\ta\t2.2", "3\tb\t3.3"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x int, y string, z double)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1, "a", 1.1})
+                            .addRow(new Object[] {2, "a", 2.2})
+                            .addRow(new Object[] {3, "b", 3.3})
+                            .commit();
+                    tableEnv.executeSql(
+                            "create table db1.dest (x int) partitioned by (p1 string, p2 double)");
+                    tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
+                    assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest")))
+                            .hasSize(3);
+                    verifyHiveQueryResult(
+                            "select * from db1.dest",
+                            Arrays.asList("1\ta\t1.1", "2\ta\t2.2", "3\tb\t3.3"));
+                });
     }
 
     @Test
     public void testPartialDynamicPartition() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x int, y string)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {1, "a"})
-                    .addRow(new Object[] {2, "b"})
-                    .commit();
-            tableEnv.executeSql(
-                    "create table db1.dest (x int) partitioned by (p1 double, p2 string)");
-            tableEnv.executeSql(
-                            "insert into db1.dest partition (p1=1.1,p2) select x,y from db1.src")
-                    .await();
-            assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest"))).hasSize(2);
-            verifyHiveQueryResult(
-                    "select * from db1.dest", Arrays.asList("1\t1.1\ta", "2\t1.1\tb"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x int, y string)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1, "a"})
+                            .addRow(new Object[] {2, "b"})
+                            .commit();
+                    tableEnv.executeSql(
+                            "create table db1.dest (x int) partitioned by (p1 double, p2 string)");
+                    tableEnv.executeSql(
+                                    "insert into db1.dest partition (p1=1.1,p2) select x,y from db1.src")
+                            .await();
+                    assertThat(hiveCatalog.listPartitions(new ObjectPath("db1", "dest")))
+                            .hasSize(2);
+                    verifyHiveQueryResult(
+                            "select * from db1.dest", Arrays.asList("1\t1.1\ta", "2\t1.1\tb"));
+                });
     }
 
     @Test
@@ -404,102 +419,108 @@ public class HiveRunnerITCase {
     @Test
     public void testTimestamp() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (ts timestamp)");
-            tableEnv.executeSql("create table db1.dest (ts timestamp)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {Timestamp.valueOf("2019-11-11 00:00:00")})
-                    .addRow(new Object[] {Timestamp.valueOf("2019-12-03 15:43:32.123456789")})
-                    .commit();
-            // test read timestamp from hive
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.src").execute().collect());
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0).getField(0)).isEqualTo(LocalDateTime.of(2019, 11, 11, 0, 0));
-            assertThat(results.get(1).getField(0))
-                    .isEqualTo(LocalDateTime.of(2019, 12, 3, 15, 43, 32, 123456789));
-            // test write timestamp to hive
-            tableEnv.executeSql("insert into db1.dest select max(ts) from db1.src").await();
-            verifyHiveQueryResult(
-                    "select * from db1.dest",
-                    Collections.singletonList("2019-12-03 15:43:32.123456789"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (ts timestamp)");
+                    tableEnv.executeSql("create table db1.dest (ts timestamp)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {Timestamp.valueOf("2019-11-11 00:00:00")})
+                            .addRow(
+                                    new Object[] {
+                                        Timestamp.valueOf("2019-12-03 15:43:32.123456789")
+                                    })
+                            .commit();
+                    // test read timestamp from hive
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.src").execute().collect());
+                    assertThat(results).hasSize(2);
+                    assertThat(results.get(0).getField(0))
+                            .isEqualTo(LocalDateTime.of(2019, 11, 11, 0, 0));
+                    assertThat(results.get(1).getField(0))
+                            .isEqualTo(LocalDateTime.of(2019, 12, 3, 15, 43, 32, 123456789));
+                    // test write timestamp to hive
+                    tableEnv.executeSql("insert into db1.dest select max(ts) from db1.src").await();
+                    verifyHiveQueryResult(
+                            "select * from db1.dest",
+                            Collections.singletonList("2019-12-03 15:43:32.123456789"));
+                });
     }
 
     @Test
     public void testDate() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (dt date)");
-            tableEnv.executeSql("create table db1.dest (dt date)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {Date.valueOf("2019-12-09")})
-                    .addRow(new Object[] {Date.valueOf("2019-12-12")})
-                    .commit();
-            // test read date from hive
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.src").execute().collect());
-            assertThat(results).hasSize(2);
-            assertThat(results.get(0).getField(0)).isEqualTo(LocalDate.of(2019, 12, 9));
-            assertThat(results.get(1).getField(0)).isEqualTo(LocalDate.of(2019, 12, 12));
-            // test write date to hive
-            tableEnv.executeSql("insert into db1.dest select max(dt) from db1.src").await();
-            verifyHiveQueryResult(
-                    "select * from db1.dest", Collections.singletonList("2019-12-12"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (dt date)");
+                    tableEnv.executeSql("create table db1.dest (dt date)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {Date.valueOf("2019-12-09")})
+                            .addRow(new Object[] {Date.valueOf("2019-12-12")})
+                            .commit();
+                    // test read date from hive
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.src").execute().collect());
+                    assertThat(results).hasSize(2);
+                    assertThat(results.get(0).getField(0)).isEqualTo(LocalDate.of(2019, 12, 9));
+                    assertThat(results.get(1).getField(0)).isEqualTo(LocalDate.of(2019, 12, 12));
+                    // test write date to hive
+                    tableEnv.executeSql("insert into db1.dest select max(dt) from db1.src").await();
+                    verifyHiveQueryResult(
+                            "select * from db1.dest", Collections.singletonList("2019-12-12"));
+                });
     }
 
     @Test
     public void testViews() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (key int,val string)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {1, "a"})
-                    .addRow(new Object[] {1, "aa"})
-                    .addRow(new Object[] {1, "aaa"})
-                    .addRow(new Object[] {2, "b"})
-                    .addRow(new Object[] {3, "c"})
-                    .addRow(new Object[] {3, "ccc"})
-                    .commit();
-            tableEnv.executeSql("create table db1.keys (key int,name string)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "keys")
-                    .addRow(new Object[] {1, "key1"})
-                    .addRow(new Object[] {2, "key2"})
-                    .addRow(new Object[] {3, "key3"})
-                    .addRow(new Object[] {4, "key4"})
-                    .commit();
-            hiveShell.execute(
-                    "create view db1.v1 as select key as k,val as v from db1.src limit 2");
-            hiveShell.execute(
-                    "create view db1.v2 as select key,count(*) from db1.src group by key having count(*)>1 order by key");
-            hiveShell.execute(
-                    "create view db1.v3 as select k.key,k.name,count(*) from db1.src s join db1.keys k on s.key=k.key group by k.key,k.name order by k.key");
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select count(v) from db1.v1").execute().collect());
-            assertThat(results.toString()).isEqualTo("[+I[2]]");
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.v2").execute().collect());
-            assertThat(results.toString()).isEqualTo("[+I[1, 3], +I[3, 2]]");
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.v3").execute().collect());
-            assertThat(results.toString())
-                    .isEqualTo("[+I[1, key1, 3], +I[2, key2, 1], +I[3, key3, 2]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (key int,val string)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1, "a"})
+                            .addRow(new Object[] {1, "aa"})
+                            .addRow(new Object[] {1, "aaa"})
+                            .addRow(new Object[] {2, "b"})
+                            .addRow(new Object[] {3, "c"})
+                            .addRow(new Object[] {3, "ccc"})
+                            .commit();
+                    tableEnv.executeSql("create table db1.keys (key int,name string)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "keys")
+                            .addRow(new Object[] {1, "key1"})
+                            .addRow(new Object[] {2, "key2"})
+                            .addRow(new Object[] {3, "key3"})
+                            .addRow(new Object[] {4, "key4"})
+                            .commit();
+                    hiveShell.execute(
+                            "create view db1.v1 as select key as k,val as v from db1.src limit 2");
+                    hiveShell.execute(
+                            "create view db1.v2 as select key,count(*) from db1.src group by key having count(*)>1 order by key");
+                    hiveShell.execute(
+                            "create view db1.v3 as select k.key,k.name,count(*) from db1.src s join db1.keys k on s.key=k.key group by k.key,k.name order by k.key");
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select count(v) from db1.v1")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[2]]");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.v2").execute().collect());
+                    assertThat(results.toString()).isEqualTo("[+I[1, 3], +I[3, 2]]");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.v3").execute().collect());
+                    assertThat(results.toString())
+                            .isEqualTo("[+I[1, key1, 3], +I[2, key2, 1], +I[3, key3, 2]]");
+                });
     }
 
     @Test
@@ -515,17 +536,18 @@ public class HiveRunnerITCase {
             assertThat(hiveShell.executeQuery("show partitions db1.dest").toString())
                     .isEqualTo("[p=  , p=a %09]");
         } finally {
+            tableEnv.useDatabase("default");
             tableEnv.executeSql("drop database db1 cascade");
         }
     }
 
     @Test
-    public void testBatchTransactionalTable() {
+    public void testBatchTransactionalTable() throws Exception {
         testTransactionalTable(true);
     }
 
     @Test
-    public void testStreamTransactionalTable() {
+    public void testStreamTransactionalTable() throws Exception {
         testTransactionalTable(false);
     }
 
@@ -535,81 +557,103 @@ public class HiveRunnerITCase {
         // https://issues.apache.org/jira/browse/HIVE-13178
         Assume.assumeTrue(HiveVersionTestUtil.HIVE_230_OR_LATER);
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x smallint,y int) stored as orc");
-            hiveShell.execute("insert into table db1.src values (1,100),(2,200)");
 
-            tableEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x smallint,y int) stored as orc");
+                    hiveShell.execute("insert into table db1.src values (1,100),(2,200)");
 
-            tableEnv.executeSql("alter table db1.src change x x int");
-            assertThat(
-                            CollectionUtil.iteratorToList(
-                                            tableEnv.sqlQuery("select * from db1.src")
-                                                    .execute()
-                                                    .collect())
-                                    .toString())
-                    .isEqualTo("[+I[1, 100], +I[2, 200]]");
+                    tableEnv.getConfig()
+                            .set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
 
-            tableEnv.executeSql("alter table db1.src change y y string");
-            assertThat(
-                            CollectionUtil.iteratorToList(
-                                            tableEnv.sqlQuery("select * from db1.src")
-                                                    .execute()
-                                                    .collect())
-                                    .toString())
-                    .isEqualTo("[+I[1, 100], +I[2, 200]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    tableEnv.executeSql("alter table db1.src change x x int");
+                    assertThat(
+                                    CollectionUtil.iteratorToList(
+                                                    tableEnv.sqlQuery("select * from db1.src")
+                                                            .execute()
+                                                            .collect())
+                                            .toString())
+                            .isEqualTo("[+I[1, 100], +I[2, 200]]");
+
+                    tableEnv.executeSql("alter table db1.src change y y string");
+                    assertThat(
+                                    CollectionUtil.iteratorToList(
+                                                    tableEnv.sqlQuery("select * from db1.src")
+                                                            .execute()
+                                                            .collect())
+                                            .toString())
+                            .isEqualTo("[+I[1, 100], +I[2, 200]]");
+                });
     }
 
-    private void testTransactionalTable(boolean batch) {
+    @Test
+    public void testCatalogLock() throws Exception {
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.DEFAULT);
+        tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+        tableEnv.useCatalog(hiveCatalog.getName());
+
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                true,
+                () -> {
+                    tableEnv.executeSql(
+                            "create table src (x int) with ('connector'='datagen','number-of-rows'='2')");
+                    tableEnv.executeSql(
+                            "create table lock_t (x int) with ('connector'='test-lock')");
+
+                    // see TestLockTableSinkFactory
+                    tableEnv.executeSql("insert into lock_t select * from src").await();
+                });
+    }
+
+    private void testTransactionalTable(boolean batch) throws Exception {
         TableEnvironment tableEnv =
                 batch ? getTableEnvWithHiveCatalog() : getStreamTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x string,y string)");
-            hiveShell.execute(
-                    "create table db1.dest (x string,y string) clustered by (x) into 3 buckets stored as orc tblproperties ('transactional'='true')");
-            assertThatThrownBy(
-                            () ->
-                                    tableEnv.executeSql(
-                                                    "insert into db1.src select * from db1.dest")
-                                            .await())
-                    .isInstanceOf(FlinkHiveException.class)
-                    .hasMessage("Reading or writing ACID table db1.dest is not supported.");
-            assertThatThrownBy(
-                            () ->
-                                    tableEnv.executeSql(
-                                                    "insert into db1.dest select * from db1.src")
-                                            .await())
-                    .isInstanceOf(FlinkHiveException.class)
-                    .hasMessage("Reading or writing ACID table db1.dest is not supported.");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x string,y string)");
+                    hiveShell.execute(
+                            "create table db1.dest (x string,y string) clustered by (x) into 3 buckets stored as orc tblproperties ('transactional'='true')");
+                    assertThatThrownBy(
+                                    () ->
+                                            tableEnv.executeSql(
+                                                            "insert into db1.src select * from db1.dest")
+                                                    .await())
+                            .isInstanceOf(FlinkHiveException.class)
+                            .hasMessage("Reading or writing ACID table db1.dest is not supported.");
+                    assertThatThrownBy(
+                                    () ->
+                                            tableEnv.executeSql(
+                                                            "insert into db1.dest select * from db1.src")
+                                                    .await())
+                            .isInstanceOf(FlinkHiveException.class)
+                            .hasMessage("Reading or writing ACID table db1.dest is not supported.");
+                });
     }
 
     private void testCompressTextTable(boolean batch) throws Exception {
         TableEnvironment tableEnv =
                 batch ? getTableEnvWithHiveCatalog() : getStreamTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.src (x string,y string)");
-            hiveShell.execute("create table db1.dest like db1.src");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {"a", "b"})
-                    .addRow(new Object[] {"c", "d"})
-                    .commit();
-            hiveCatalog.getHiveConf().setBoolVar(HiveConf.ConfVars.COMPRESSRESULT, true);
-            tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
-            List<String> expected = Arrays.asList("a\tb", "c\td");
-            verifyHiveQueryResult("select * from db1.dest", expected);
-            verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.dest"), expected);
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x string,y string)");
+                    hiveShell.execute("create table db1.dest like db1.src");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {"a", "b"})
+                            .addRow(new Object[] {"c", "d"})
+                            .commit();
+                    hiveCatalog.getHiveConf().setBoolVar(HiveConf.ConfVars.COMPRESSRESULT, true);
+                    tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
+                    List<String> expected = Arrays.asList("a\tb", "c\td");
+                    verifyHiveQueryResult("select * from db1.dest", expected);
+                    verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.dest"), expected);
+                });
     }
 
     private static TableEnvironment getTableEnvWithHiveCatalog() {
@@ -631,74 +675,86 @@ public class HiveRunnerITCase {
     private void readWriteFormat(String format) throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
 
-        tableEnv.executeSql("create database db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    // create source and dest tables
+                    String suffix;
+                    if (format.equals("csv")) {
+                        suffix = "row format serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'";
+                    } else {
+                        suffix = "stored as " + format;
+                    }
+                    String tableSchema;
+                    // use 2018-08-20 00:00:00.1 to avoid multi-version print difference.
+                    List<Object> row1 =
+                            new ArrayList<>(Arrays.asList(1, "a", "2018-08-20 00:00:00.1"));
+                    List<Object> row2 =
+                            new ArrayList<>(Arrays.asList(2, "b", "2019-08-26 00:00:00.1"));
+                    // some data types are not supported for parquet tables in early versions --
+                    // https://issues.apache.org/jira/browse/HIVE-6384
+                    if (HiveVersionTestUtil.HIVE_310_OR_LATER || !format.equals("parquet")) {
+                        tableSchema = "(i int,s string,ts timestamp,dt date)";
+                        row1.add("2018-08-20");
+                        row2.add("2019-08-26");
+                    } else {
+                        tableSchema = "(i int,s string,ts timestamp)";
+                    }
 
-        // create source and dest tables
-        String suffix;
-        if (format.equals("csv")) {
-            suffix = "row format serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'";
-        } else {
-            suffix = "stored as " + format;
-        }
-        String tableSchema;
-        // use 2018-08-20 00:00:00.1 to avoid multi-version print difference.
-        List<Object> row1 = new ArrayList<>(Arrays.asList(1, "a", "2018-08-20 00:00:00.1"));
-        List<Object> row2 = new ArrayList<>(Arrays.asList(2, "b", "2019-08-26 00:00:00.1"));
-        // some data types are not supported for parquet tables in early versions --
-        // https://issues.apache.org/jira/browse/HIVE-6384
-        if (HiveVersionTestUtil.HIVE_310_OR_LATER || !format.equals("parquet")) {
-            tableSchema = "(i int,s string,ts timestamp,dt date)";
-            row1.add("2018-08-20");
-            row2.add("2019-08-26");
-        } else {
-            tableSchema = "(i int,s string,ts timestamp)";
-        }
+                    tableEnv.executeSql(
+                            String.format(
+                                    "create table db1.src %s partitioned by (p1 string, p2 timestamp) %s",
+                                    tableSchema, suffix));
+                    tableEnv.executeSql(
+                            String.format(
+                                    "create table db1.dest %s partitioned by (p1 string, p2 timestamp) %s",
+                                    tableSchema, suffix));
 
-        tableEnv.executeSql(
-                String.format(
-                        "create table db1.src %s partitioned by (p1 string, p2 timestamp) %s",
-                        tableSchema, suffix));
-        tableEnv.executeSql(
-                String.format(
-                        "create table db1.dest %s partitioned by (p1 string, p2 timestamp) %s",
-                        tableSchema, suffix));
+                    // prepare source data with Hive
+                    // TABLE keyword in INSERT INTO is mandatory prior to 1.1.0
+                    hiveShell.execute(
+                            String.format(
+                                    "insert into table db1.src partition(p1='first',p2='2018-08-20 00:00:00.1') values (%s)",
+                                    toRowValue(row1)));
+                    hiveShell.execute(
+                            String.format(
+                                    "insert into table db1.src partition(p1='second',p2='2018-08-26 00:00:00.1') values (%s)",
+                                    toRowValue(row2)));
 
-        // prepare source data with Hive
-        // TABLE keyword in INSERT INTO is mandatory prior to 1.1.0
-        hiveShell.execute(
-                String.format(
-                        "insert into table db1.src partition(p1='first',p2='2018-08-20 00:00:00.1') values (%s)",
-                        toRowValue(row1)));
-        hiveShell.execute(
-                String.format(
-                        "insert into table db1.src partition(p1='second',p2='2018-08-26 00:00:00.1') values (%s)",
-                        toRowValue(row2)));
+                    List<String> expected =
+                            Arrays.asList(
+                                    String.join(
+                                            "\t",
+                                            ArrayUtils.concat(
+                                                    row1.stream()
+                                                            .map(Object::toString)
+                                                            .toArray(String[]::new),
+                                                    new String[] {
+                                                        "first", "2018-08-20 00:00:00.1"
+                                                    })),
+                                    String.join(
+                                            "\t",
+                                            ArrayUtils.concat(
+                                                    row2.stream()
+                                                            .map(Object::toString)
+                                                            .toArray(String[]::new),
+                                                    new String[] {
+                                                        "second", "2018-08-26 00:00:00.1"
+                                                    })));
 
-        List<String> expected =
-                Arrays.asList(
-                        String.join(
-                                "\t",
-                                ArrayUtils.concat(
-                                        row1.stream().map(Object::toString).toArray(String[]::new),
-                                        new String[] {"first", "2018-08-20 00:00:00.1"})),
-                        String.join(
-                                "\t",
-                                ArrayUtils.concat(
-                                        row2.stream().map(Object::toString).toArray(String[]::new),
-                                        new String[] {"second", "2018-08-26 00:00:00.1"})));
+                    verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.src"), expected);
 
-        verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.src"), expected);
+                    // Ignore orc write test for Hive version 2.0.x for now due to FLINK-13998
+                    if (!format.equals("orc")
+                            || !HiveShimLoader.getHiveVersion().startsWith("2.0")) {
+                        // populate dest table with source table
+                        tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
 
-        // Ignore orc write test for Hive version 2.0.x for now due to FLINK-13998
-        if (!format.equals("orc") || !HiveShimLoader.getHiveVersion().startsWith("2.0")) {
-            // populate dest table with source table
-            tableEnv.executeSql("insert into db1.dest select * from db1.src").await();
-
-            // verify data on hive side
-            verifyHiveQueryResult("select * from db1.dest", expected);
-        }
-
-        tableEnv.executeSql("drop database db1 cascade");
+                        // verify data on hive side
+                        verifyHiveQueryResult("select * from db1.dest", expected);
+                    }
+                });
     }
 
     private static void verifyWrittenData(List<Row> expected, List<String> results)
@@ -765,25 +821,5 @@ public class HiveRunnerITCase {
                             return res;
                         })
                 .collect(Collectors.joining(","));
-    }
-
-    @Test
-    public void testCatalogLock() throws Exception {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.DEFAULT);
-        tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
-        tableEnv.useCatalog(hiveCatalog.getName());
-
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.useDatabase("db1");
-            tableEnv.executeSql(
-                    "create table src (x int) with ('connector'='datagen','number-of-rows'='2')");
-            tableEnv.executeSql("create table lock_t (x int) with ('connector'='test-lock')");
-
-            // see TestLockTableSinkFactory
-            tableEnv.executeSql("insert into lock_t select * from src").await();
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -103,14 +103,14 @@ class HiveTableSinkITCase {
     }
 
     @Test
-    void testHiveTableSinkWithParallelismInBatch() {
+    void testHiveTableSinkWithParallelismInBatch() throws Exception {
         final TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         testHiveTableSinkWithParallelismBase(
                 tEnv, "/explain/testHiveTableSinkWithParallelismInBatch.out");
     }
 
     @Test
-    void testHiveTableSinkWithParallelismInStreaming() {
+    void testHiveTableSinkWithParallelismInStreaming() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final TableEnvironment tEnv =
                 HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
@@ -119,29 +119,32 @@ class HiveTableSinkITCase {
     }
 
     private void testHiveTableSinkWithParallelismBase(
-            final TableEnvironment tEnv, final String expectedResourceFileName) {
+            final TableEnvironment tEnv, final String expectedResourceFileName) throws Exception {
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
-        tEnv.executeSql("create database db1");
-        tEnv.useDatabase("db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    tEnv.executeSql(
+                            "CREATE TABLE test_table ("
+                                    + " id int,"
+                                    + " real_col int"
+                                    + ") TBLPROPERTIES ("
+                                    + " 'sink.parallelism' = '8'" // set sink parallelism = 8
+                                    + ")");
+                    tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    final String actual =
+                            tEnv.explainSql(
+                                    "insert into test_table select 1, 1",
+                                    ExplainDetail.JSON_EXECUTION_PLAN);
+                    final String expected = readFromResource(expectedResourceFileName);
 
-        tEnv.executeSql(
-                "CREATE TABLE test_table ("
-                        + " id int,"
-                        + " real_col int"
-                        + ") TBLPROPERTIES ("
-                        + " 'sink.parallelism' = '8'" // set sink parallelism = 8
-                        + ")");
-        tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
-        final String actual =
-                tEnv.explainSql(
-                        "insert into test_table select 1, 1", ExplainDetail.JSON_EXECUTION_PLAN);
-        final String expected = readFromResource(expectedResourceFileName);
-
-        assertThat(replaceNodeIdInOperator(replaceStreamNodeId(replaceStageId(actual))))
-                .isEqualTo(replaceNodeIdInOperator(replaceStreamNodeId(replaceStageId(expected))));
-
-        tEnv.executeSql("drop database db1 cascade");
+                    assertThat(replaceNodeIdInOperator(replaceStreamNodeId(replaceStageId(actual))))
+                            .isEqualTo(
+                                    replaceNodeIdInOperator(
+                                            replaceStreamNodeId(replaceStageId(expected))));
+                });
     }
 
     @Test
@@ -149,20 +152,19 @@ class HiveTableSinkITCase {
         TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
-        tEnv.executeSql("create database db1");
-        tEnv.useDatabase("db1");
-        try {
-            tEnv.executeSql("create table append_table (i int, j int)");
-            tEnv.executeSql("insert into append_table select 1, 1").await();
-            tEnv.executeSql("insert into append_table select 2, 2").await();
-            List<Row> rows =
-                    CollectionUtil.iteratorToList(
-                            tEnv.executeSql("select * from append_table").collect());
-            rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
-            assertThat(rows).isEqualTo(Arrays.asList(Row.of(1, 1), Row.of(2, 2)));
-        } finally {
-            tEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    tEnv.executeSql("create table append_table (i int, j int)");
+                    tEnv.executeSql("insert into append_table select 1, 1").await();
+                    tEnv.executeSql("insert into append_table select 2, 2").await();
+                    List<Row> rows =
+                            CollectionUtil.iteratorToList(
+                                    tEnv.executeSql("select * from append_table").collect());
+                    rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+                    assertThat(rows).isEqualTo(Arrays.asList(Row.of(1, 1), Row.of(2, 2)));
+                });
     }
 
     @Test
@@ -253,183 +255,188 @@ class HiveTableSinkITCase {
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
-        try {
-            tEnv.executeSql("create database db1");
-            tEnv.useDatabase("db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    // source table DDL
+                    tEnv.executeSql(
+                            "create external table source_table ("
+                                    + " a int,"
+                                    + " b string,"
+                                    + " c string,"
+                                    + " epoch_ts bigint)"
+                                    + " partitioned by ("
+                                    + " pt_day string, pt_hour string) TBLPROPERTIES("
+                                    + "'partition.time-extractor.timestamp-pattern'='$pt_day $pt_hour:00:00',"
+                                    + "'streaming-source.enable'='true',"
+                                    + "'streaming-source.monitor-interval'='1s',"
+                                    + "'streaming-source.consume-order'='partition-time'"
+                                    + ")");
 
-            // source table DDL
-            tEnv.executeSql(
-                    "create external table source_table ("
-                            + " a int,"
-                            + " b string,"
-                            + " c string,"
-                            + " epoch_ts bigint)"
-                            + " partitioned by ("
-                            + " pt_day string, pt_hour string) TBLPROPERTIES("
-                            + "'partition.time-extractor.timestamp-pattern'='$pt_day $pt_hour:00:00',"
-                            + "'streaming-source.enable'='true',"
-                            + "'streaming-source.monitor-interval'='1s',"
-                            + "'streaming-source.consume-order'='partition-time'"
-                            + ")");
+                    tEnv.executeSql(
+                            "create external table sink_table ("
+                                    + " a int,"
+                                    + " b string,"
+                                    + " c string)"
+                                    + " partitioned by ("
+                                    + " d string, e string) TBLPROPERTIES("
+                                    + " 'partition.time-extractor.timestamp-pattern' = '$d $e:00:00',"
+                                    + " 'auto-compaction'='true',"
+                                    + " 'compaction.file-size' = '128MB',"
+                                    + " 'sink.partition-commit.trigger'='partition-time',"
+                                    + " 'sink.partition-commit.delay'='30min',"
+                                    + " 'sink.partition-commit.watermark-time-zone'='Asia/Shanghai',"
+                                    + " 'sink.partition-commit.policy.kind'='metastore,success-file',"
+                                    + " 'sink.partition-commit.success-file.name'='_MY_SUCCESS',"
+                                    + " 'streaming-source.enable'='true',"
+                                    + " 'streaming-source.monitor-interval'='1s',"
+                                    + " 'streaming-source.consume-order'='partition-time'"
+                                    + ")");
 
-            tEnv.executeSql(
-                    "create external table sink_table ("
-                            + " a int,"
-                            + " b string,"
-                            + " c string)"
-                            + " partitioned by ("
-                            + " d string, e string) TBLPROPERTIES("
-                            + " 'partition.time-extractor.timestamp-pattern' = '$d $e:00:00',"
-                            + " 'auto-compaction'='true',"
-                            + " 'compaction.file-size' = '128MB',"
-                            + " 'sink.partition-commit.trigger'='partition-time',"
-                            + " 'sink.partition-commit.delay'='30min',"
-                            + " 'sink.partition-commit.watermark-time-zone'='Asia/Shanghai',"
-                            + " 'sink.partition-commit.policy.kind'='metastore,success-file',"
-                            + " 'sink.partition-commit.success-file.name'='_MY_SUCCESS',"
-                            + " 'streaming-source.enable'='true',"
-                            + " 'streaming-source.monitor-interval'='1s',"
-                            + " 'streaming-source.consume-order'='partition-time'"
-                            + ")");
+                    tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
 
-            tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    // Build a partitioned table source with watermark base on the streaming-hive
+                    // table
+                    DataStream<Row> dataStream =
+                            tEnv.toDataStream(
+                                    tEnv.sqlQuery(
+                                            "select a, b, c, epoch_ts, pt_day, pt_hour from source_table"));
+                    Table table =
+                            tEnv.fromDataStream(
+                                    dataStream,
+                                    Schema.newBuilder()
+                                            .column("a", DataTypes.INT())
+                                            .column("b", DataTypes.STRING())
+                                            .column("c", DataTypes.STRING())
+                                            .column("epoch_ts", DataTypes.BIGINT())
+                                            .column("pt_day", DataTypes.STRING())
+                                            .column("pt_hour", DataTypes.STRING())
+                                            .columnByExpression(
+                                                    "ts_ltz",
+                                                    Expressions.callSql(
+                                                            "TO_TIMESTAMP_LTZ(epoch_ts, 3)"))
+                                            .watermark("ts_ltz", "ts_ltz - INTERVAL '1' SECOND")
+                                            .build());
+                    tEnv.createTemporaryView("my_table", table);
+                    /*
+                     * prepare test data, we write two records into each partition in source table
+                     * the epoch mills used to define watermark, the watermark value is
+                     * the max timestamp value of all the partition data, i.e:
+                     * partition timestamp + 1 hour - 1 second in this case
+                     *
+                     * <pre>
+                     * epoch mills 1588461300000L <=>  local timestamp 2020-05-03 07:15:00 in Shanghai
+                     * epoch mills 1588463100000L <=>  local timestamp 2020-05-03 07:45:00 in Shanghai
+                     * epoch mills 1588464300000L <=>  local timestamp 2020-05-03 08:05:00 in Shanghai
+                     * epoch mills 1588466400000L <=>  local timestamp 2020-05-03 08:40:00 in Shanghai
+                     * epoch mills 1588468800000L <=>  local timestamp 2020-05-03 09:20:00 in Shanghai
+                     * epoch mills 1588470900000L <=>  local timestamp 2020-05-03 09:55:00 in Shanghai
+                     * epoch mills 1588471800000L <=>  local timestamp 2020-05-03 10:10:00 in Shanghai
+                     * epoch mills 1588473300000L <=>  local timestamp 2020-05-03 10:35:00 in Shanghai
+                     * epoch mills 1588476300000L <=>  local timestamp 2020-05-03 11:25:00 in Shanghai
+                     * epoch mills 1588477800000L <=>  local timestamp 2020-05-03 11:50:00 in Shanghai
+                     * </pre>
+                     */
+                    Map<Integer, Object[]> testData = new HashMap<>();
+                    testData.put(1, new Object[] {1, "a", "b", 1588461300000L});
+                    testData.put(2, new Object[] {1, "a", "b", 1588463100000L});
+                    testData.put(3, new Object[] {2, "p", "q", 1588464300000L});
+                    testData.put(4, new Object[] {2, "p", "q", 1588466400000L});
+                    testData.put(5, new Object[] {3, "x", "y", 1588468800000L});
+                    testData.put(6, new Object[] {3, "x", "y", 1588470900000L});
+                    testData.put(7, new Object[] {4, "x", "y", 1588471800000L});
+                    testData.put(8, new Object[] {4, "x", "y", 1588473300000L});
+                    testData.put(9, new Object[] {5, "x", "y", 1588476300000L});
+                    testData.put(10, new Object[] {5, "x", "y", 1588477800000L});
 
-            // Build a partitioned table source with watermark base on the streaming-hive table
-            DataStream<Row> dataStream =
-                    tEnv.toDataStream(
-                            tEnv.sqlQuery(
-                                    "select a, b, c, epoch_ts, pt_day, pt_hour from source_table"));
-            Table table =
-                    tEnv.fromDataStream(
-                            dataStream,
-                            Schema.newBuilder()
-                                    .column("a", DataTypes.INT())
-                                    .column("b", DataTypes.STRING())
-                                    .column("c", DataTypes.STRING())
-                                    .column("epoch_ts", DataTypes.BIGINT())
-                                    .column("pt_day", DataTypes.STRING())
-                                    .column("pt_hour", DataTypes.STRING())
-                                    .columnByExpression(
-                                            "ts_ltz",
-                                            Expressions.callSql("TO_TIMESTAMP_LTZ(epoch_ts, 3)"))
-                                    .watermark("ts_ltz", "ts_ltz - INTERVAL '1' SECOND")
-                                    .build());
-            tEnv.createTemporaryView("my_table", table);
-            /*
-             * prepare test data, we write two records into each partition in source table
-             * the epoch mills used to define watermark, the watermark value is
-             * the max timestamp value of all the partition data, i.e:
-             * partition timestamp + 1 hour - 1 second in this case
-             *
-             * <pre>
-             * epoch mills 1588461300000L <=>  local timestamp 2020-05-03 07:15:00 in Shanghai
-             * epoch mills 1588463100000L <=>  local timestamp 2020-05-03 07:45:00 in Shanghai
-             * epoch mills 1588464300000L <=>  local timestamp 2020-05-03 08:05:00 in Shanghai
-             * epoch mills 1588466400000L <=>  local timestamp 2020-05-03 08:40:00 in Shanghai
-             * epoch mills 1588468800000L <=>  local timestamp 2020-05-03 09:20:00 in Shanghai
-             * epoch mills 1588470900000L <=>  local timestamp 2020-05-03 09:55:00 in Shanghai
-             * epoch mills 1588471800000L <=>  local timestamp 2020-05-03 10:10:00 in Shanghai
-             * epoch mills 1588473300000L <=>  local timestamp 2020-05-03 10:35:00 in Shanghai
-             * epoch mills 1588476300000L <=>  local timestamp 2020-05-03 11:25:00 in Shanghai
-             * epoch mills 1588477800000L <=>  local timestamp 2020-05-03 11:50:00 in Shanghai
-             * </pre>
-             */
-            Map<Integer, Object[]> testData = new HashMap<>();
-            testData.put(1, new Object[] {1, "a", "b", 1588461300000L});
-            testData.put(2, new Object[] {1, "a", "b", 1588463100000L});
-            testData.put(3, new Object[] {2, "p", "q", 1588464300000L});
-            testData.put(4, new Object[] {2, "p", "q", 1588466400000L});
-            testData.put(5, new Object[] {3, "x", "y", 1588468800000L});
-            testData.put(6, new Object[] {3, "x", "y", 1588470900000L});
-            testData.put(7, new Object[] {4, "x", "y", 1588471800000L});
-            testData.put(8, new Object[] {4, "x", "y", 1588473300000L});
-            testData.put(9, new Object[] {5, "x", "y", 1588476300000L});
-            testData.put(10, new Object[] {5, "x", "y", 1588477800000L});
+                    Map<Integer, String> testPartition = new HashMap<>();
+                    testPartition.put(1, "pt_day='2020-05-03',pt_hour='7'");
+                    testPartition.put(2, "pt_day='2020-05-03',pt_hour='8'");
+                    testPartition.put(3, "pt_day='2020-05-03',pt_hour='9'");
+                    testPartition.put(4, "pt_day='2020-05-03',pt_hour='10'");
+                    testPartition.put(5, "pt_day='2020-05-03',pt_hour='11'");
 
-            Map<Integer, String> testPartition = new HashMap<>();
-            testPartition.put(1, "pt_day='2020-05-03',pt_hour='7'");
-            testPartition.put(2, "pt_day='2020-05-03',pt_hour='8'");
-            testPartition.put(3, "pt_day='2020-05-03',pt_hour='9'");
-            testPartition.put(4, "pt_day='2020-05-03',pt_hour='10'");
-            testPartition.put(5, "pt_day='2020-05-03',pt_hour='11'");
+                    Map<Integer, Object[]> expectedData = new HashMap<>();
+                    expectedData.put(1, new Object[] {1, "a", "b", "2020-05-03", "7"});
+                    expectedData.put(2, new Object[] {2, "p", "q", "2020-05-03", "8"});
+                    expectedData.put(3, new Object[] {3, "x", "y", "2020-05-03", "9"});
+                    expectedData.put(4, new Object[] {4, "x", "y", "2020-05-03", "10"});
+                    expectedData.put(5, new Object[] {5, "x", "y", "2020-05-03", "11"});
 
-            Map<Integer, Object[]> expectedData = new HashMap<>();
-            expectedData.put(1, new Object[] {1, "a", "b", "2020-05-03", "7"});
-            expectedData.put(2, new Object[] {2, "p", "q", "2020-05-03", "8"});
-            expectedData.put(3, new Object[] {3, "x", "y", "2020-05-03", "9"});
-            expectedData.put(4, new Object[] {4, "x", "y", "2020-05-03", "10"});
-            expectedData.put(5, new Object[] {5, "x", "y", "2020-05-03", "11"});
+                    tEnv.executeSql(
+                            "insert into sink_table select a, b, c, pt_day, pt_hour from my_table");
+                    CloseableIterator<Row> iter =
+                            tEnv.executeSql("select * from sink_table").collect();
 
-            tEnv.executeSql("insert into sink_table select a, b, c, pt_day, pt_hour from my_table");
-            CloseableIterator<Row> iter = tEnv.executeSql("select * from sink_table").collect();
-
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "source_table")
-                    .addRow(testData.get(1))
-                    .addRow(testData.get(2))
-                    .commit(testPartition.get(1));
-
-            for (int i = 2; i < 7; i++) {
-                try {
-                    Thread.sleep(1_000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                assertThat(fetchRows(iter, 2))
-                        .isEqualTo(
-                                Arrays.asList(
-                                        Row.of(expectedData.get(i - 1)).toString(),
-                                        Row.of(expectedData.get(i - 1)).toString()));
-
-                if (i < 6) {
                     HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "source_table")
-                            .addRow(testData.get(2 * i - 1))
-                            .addRow(testData.get(2 * i))
-                            .commit(testPartition.get(i));
-                }
-            }
-            this.checkSuccessFiles(
-                    URI.create(
-                                    hiveCatalog
-                                            .getHiveTable(ObjectPath.fromString("db1.sink_table"))
-                                            .getSd()
-                                            .getLocation())
-                            .getPath());
-        } finally {
-            tEnv.executeSql("drop database db1 cascade");
-        }
+                            .addRow(testData.get(1))
+                            .addRow(testData.get(2))
+                            .commit(testPartition.get(1));
+
+                    for (int i = 2; i < 7; i++) {
+                        try {
+                            Thread.sleep(1_000);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        assertThat(fetchRows(iter, 2))
+                                .isEqualTo(
+                                        Arrays.asList(
+                                                Row.of(expectedData.get(i - 1)).toString(),
+                                                Row.of(expectedData.get(i - 1)).toString()));
+
+                        if (i < 6) {
+                            HiveTestUtils.createTextTableInserter(
+                                            hiveCatalog, "db1", "source_table")
+                                    .addRow(testData.get(2 * i - 1))
+                                    .addRow(testData.get(2 * i))
+                                    .commit(testPartition.get(i));
+                        }
+                    }
+                    checkSuccessFiles(
+                            URI.create(
+                                            hiveCatalog
+                                                    .getHiveTable(
+                                                            ObjectPath.fromString("db1.sink_table"))
+                                                    .getSd()
+                                                    .getLocation())
+                                    .getPath());
+                });
     }
 
     @Test
-    void testStreamingSinkWithoutCommitPolicy() {
+    void testStreamingSinkWithoutCommitPolicy() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tableEnv = HiveTestUtils.createTableEnvInStreamingMode(env);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
 
-        tableEnv.executeSql("create database db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                true,
+                () -> {
+                    tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+                    tableEnv.executeSql("create table dest(x int) partitioned by (p string)");
 
-        tableEnv.useDatabase("db1");
-        tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
-        tableEnv.executeSql("create table dest(x int) partitioned by (p string)");
+                    tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    tableEnv.executeSql(
+                            "create table src (i int, p string) with ("
+                                    + "'connector'='datagen',"
+                                    + "'number-of-rows'='5')");
 
-        tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
-        tableEnv.executeSql(
-                "create table src (i int, p string) with ("
-                        + "'connector'='datagen',"
-                        + "'number-of-rows'='5')");
-
-        try {
-            assertThatThrownBy(
-                            () -> tableEnv.executeSql("insert into dest select * from src").await(),
-                            "Streaming write partitioned table without commit policy should fail")
-                    .isInstanceOf(FlinkHiveException.class)
-                    .hasMessageContaining(
-                            String.format(
-                                    "Streaming write to partitioned hive table `%s`.`%s`.`%s` without providing a commit policy",
-                                    hiveCatalog.getName(), "db1", "dest"));
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    assertThatThrownBy(
+                                    () ->
+                                            tableEnv.executeSql(
+                                                            "insert into dest select * from src")
+                                                    .await(),
+                                    "Streaming write partitioned table without commit policy should fail")
+                            .isInstanceOf(FlinkHiveException.class)
+                            .hasMessageContaining(
+                                    String.format(
+                                            "Streaming write to partitioned hive table `%s`.`%s`.`%s` without providing a commit policy",
+                                            hiveCatalog.getName(), "db1", "dest"));
+                });
     }
 
     @Test
@@ -773,78 +780,81 @@ class HiveTableSinkITCase {
         tEnv.useCatalog(hiveCatalog.getName());
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
 
-        try {
-            tEnv.executeSql("create database db1");
-            tEnv.useDatabase("db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    // prepare source
+                    List<Row> data =
+                            Arrays.asList(
+                                    Row.of(1, "a", "b", "2020-05-03", "7"),
+                                    Row.of(2, "p", "q", "2020-05-03", "8"),
+                                    Row.of(3, "x", "y", "2020-05-03", "9"),
+                                    Row.of(4, "x", "y", "2020-05-03", "10"),
+                                    Row.of(5, "x", "y", "2020-05-03", "11"));
+                    DataStream<Row> stream =
+                            env.addSource(
+                                    new FiniteTestSource<>(data),
+                                    new RowTypeInfo(
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.STRING,
+                                            Types.STRING,
+                                            Types.STRING));
+                    tEnv.createTemporaryView(
+                            "my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));
 
-            // prepare source
-            List<Row> data =
-                    Arrays.asList(
-                            Row.of(1, "a", "b", "2020-05-03", "7"),
-                            Row.of(2, "p", "q", "2020-05-03", "8"),
-                            Row.of(3, "x", "y", "2020-05-03", "9"),
-                            Row.of(4, "x", "y", "2020-05-03", "10"),
-                            Row.of(5, "x", "y", "2020-05-03", "11"));
-            DataStream<Row> stream =
-                    env.addSource(
-                            new FiniteTestSource<>(data),
-                            new RowTypeInfo(
-                                    Types.INT,
-                                    Types.STRING,
-                                    Types.STRING,
-                                    Types.STRING,
-                                    Types.STRING));
-            tEnv.createTemporaryView("my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));
+                    // DDL
+                    tEnv.executeSql(
+                            "create external table sink_table (a int,b string,c string"
+                                    + ") "
+                                    + "partitioned by (d string,e string) "
+                                    + " stored as textfile"
+                                    + " TBLPROPERTIES ("
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_DELAY.key()
+                                    + "'='1h',"
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_POLICY_KIND.key()
+                                    + "'='metastore,custom',"
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_POLICY_CLASS.key()
+                                    + "'='"
+                                    + customPartitionCommitPolicyClassName
+                                    + "'"
+                                    + ")");
 
-            // DDL
-            tEnv.executeSql(
-                    "create external table sink_table (a int,b string,c string"
-                            + ") "
-                            + "partitioned by (d string,e string) "
-                            + " stored as textfile"
-                            + " TBLPROPERTIES ("
-                            + "'"
-                            + SINK_PARTITION_COMMIT_DELAY.key()
-                            + "'='1h',"
-                            + "'"
-                            + SINK_PARTITION_COMMIT_POLICY_KIND.key()
-                            + "'='metastore,custom',"
-                            + "'"
-                            + SINK_PARTITION_COMMIT_POLICY_CLASS.key()
-                            + "'='"
-                            + customPartitionCommitPolicyClassName
-                            + "'"
-                            + ")");
+                    // hive dialect only works with hive tables at the moment, switch to default
+                    // dialect
+                    tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await();
 
-            // hive dialect only works with hive tables at the moment, switch to default dialect
-            tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
-            tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await();
-
-            // check committed partitions for CustomizedCommitPolicy
-            Set<String> committedPaths =
-                    TestCustomCommitPolicy.getCommittedPartitionPathsAndReset();
-            String base =
-                    URI.create(
-                                    hiveCatalog
-                                            .getHiveTable(ObjectPath.fromString("db1.sink_table"))
-                                            .getSd()
-                                            .getLocation())
-                            .getPath();
-            List<String> partitionKVs = Lists.newArrayList("e=7", "e=8", "e=9", "e=10", "e=11");
-            partitionKVs.forEach(
-                    partitionKV -> {
-                        String partitionPath =
-                                new Path(new Path(base, "d=2020-05-03"), partitionKV).toString();
-                        assertThat(committedPaths)
-                                .as(
-                                        "Partition(d=2020-05-03, "
-                                                + partitionKV
-                                                + ") is not committed successfully")
-                                .contains(partitionPath);
-                    });
-        } finally {
-            tEnv.executeSql("drop database if exists db1 cascade");
-        }
+                    // check committed partitions for CustomizedCommitPolicy
+                    Set<String> committedPaths =
+                            TestCustomCommitPolicy.getCommittedPartitionPathsAndReset();
+                    String base =
+                            URI.create(
+                                            hiveCatalog
+                                                    .getHiveTable(
+                                                            ObjectPath.fromString("db1.sink_table"))
+                                                    .getSd()
+                                                    .getLocation())
+                                    .getPath();
+                    List<String> partitionKVs =
+                            Lists.newArrayList("e=7", "e=8", "e=9", "e=10", "e=11");
+                    partitionKVs.forEach(
+                            partitionKV -> {
+                                String partitionPath =
+                                        new Path(new Path(base, "d=2020-05-03"), partitionKV)
+                                                .toString();
+                                assertThat(committedPaths)
+                                        .as(
+                                                "Partition(d=2020-05-03, "
+                                                        + partitionKV
+                                                        + ") is not committed successfully")
+                                        .contains(partitionPath);
+                            });
+                });
     }
 
     private void testStreamingWrite(
@@ -864,80 +874,81 @@ class HiveTableSinkITCase {
             tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_WRITER, false);
         }
 
-        try {
-            tEnv.executeSql("create database db1");
-            tEnv.useDatabase("db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    // prepare source
+                    List<Row> data =
+                            Arrays.asList(
+                                    Row.of(1, "a", "b", "2020-05-03", "7"),
+                                    Row.of(2, "p", "q", "2020-05-03", "8"),
+                                    Row.of(3, "x", "y", "2020-05-03", "9"),
+                                    Row.of(4, "x", "y", "2020-05-03", "10"),
+                                    Row.of(5, "x", "y", "2020-05-03", "11"));
+                    DataStream<Row> stream =
+                            env.addSource(
+                                    new FiniteTestSource<>(data),
+                                    new RowTypeInfo(
+                                            Types.INT,
+                                            Types.STRING,
+                                            Types.STRING,
+                                            Types.STRING,
+                                            Types.STRING));
+                    tEnv.createTemporaryView(
+                            "my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));
 
-            // prepare source
-            List<Row> data =
-                    Arrays.asList(
-                            Row.of(1, "a", "b", "2020-05-03", "7"),
-                            Row.of(2, "p", "q", "2020-05-03", "8"),
-                            Row.of(3, "x", "y", "2020-05-03", "9"),
-                            Row.of(4, "x", "y", "2020-05-03", "10"),
-                            Row.of(5, "x", "y", "2020-05-03", "11"));
-            DataStream<Row> stream =
-                    env.addSource(
-                            new FiniteTestSource<>(data),
-                            new RowTypeInfo(
-                                    Types.INT,
-                                    Types.STRING,
-                                    Types.STRING,
-                                    Types.STRING,
-                                    Types.STRING));
-            tEnv.createTemporaryView("my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));
+                    // DDL
+                    tEnv.executeSql(
+                            "create external table sink_table (a int,b string,c string"
+                                    + (part ? "" : ",d string,e string")
+                                    + ") "
+                                    + (part ? "partitioned by (d string,e string) " : "")
+                                    + " stored as "
+                                    + format
+                                    + " TBLPROPERTIES ("
+                                    + "'"
+                                    + PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()
+                                    + "'='$d $e:00:00',"
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_DELAY.key()
+                                    + "'='1h',"
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_POLICY_KIND.key()
+                                    + "'='metastore,success-file',"
+                                    + "'"
+                                    + SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()
+                                    + "'='_MY_SUCCESS'"
+                                    + ")");
 
-            // DDL
-            tEnv.executeSql(
-                    "create external table sink_table (a int,b string,c string"
-                            + (part ? "" : ",d string,e string")
-                            + ") "
-                            + (part ? "partitioned by (d string,e string) " : "")
-                            + " stored as "
-                            + format
-                            + " TBLPROPERTIES ("
-                            + "'"
-                            + PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()
-                            + "'='$d $e:00:00',"
-                            + "'"
-                            + SINK_PARTITION_COMMIT_DELAY.key()
-                            + "'='1h',"
-                            + "'"
-                            + SINK_PARTITION_COMMIT_POLICY_KIND.key()
-                            + "'='metastore,success-file',"
-                            + "'"
-                            + SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()
-                            + "'='_MY_SUCCESS'"
-                            + ")");
+                    // hive dialect only works with hive tables at the moment, switch to default
+                    // dialect
+                    tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await();
 
-            // hive dialect only works with hive tables at the moment, switch to default dialect
-            tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
-            tEnv.sqlQuery("select * from my_table").executeInsert("sink_table").await();
+                    assertBatch(
+                            "db1.sink_table",
+                            Arrays.asList(
+                                    "+I[1, a, b, 2020-05-03, 7]",
+                                    "+I[1, a, b, 2020-05-03, 7]",
+                                    "+I[2, p, q, 2020-05-03, 8]",
+                                    "+I[2, p, q, 2020-05-03, 8]",
+                                    "+I[3, x, y, 2020-05-03, 9]",
+                                    "+I[3, x, y, 2020-05-03, 9]",
+                                    "+I[4, x, y, 2020-05-03, 10]",
+                                    "+I[4, x, y, 2020-05-03, 10]",
+                                    "+I[5, x, y, 2020-05-03, 11]",
+                                    "+I[5, x, y, 2020-05-03, 11]"));
 
-            assertBatch(
-                    "db1.sink_table",
-                    Arrays.asList(
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[5, x, y, 2020-05-03, 11]",
-                            "+I[5, x, y, 2020-05-03, 11]"));
-
-            pathConsumer.accept(
-                    URI.create(
-                                    hiveCatalog
-                                            .getHiveTable(ObjectPath.fromString("db1.sink_table"))
-                                            .getSd()
-                                            .getLocation())
-                            .getPath());
-        } finally {
-            tEnv.executeSql("drop database db1 cascade");
-        }
+                    pathConsumer.accept(
+                            URI.create(
+                                            hiveCatalog
+                                                    .getHiveTable(
+                                                            ObjectPath.fromString("db1.sink_table"))
+                                                    .getSd()
+                                                    .getLocation())
+                                    .getPath());
+                });
     }
 
     private void assertBatch(String table, List<String> expected) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSpeculativeSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSpeculativeSinkITCase.java
@@ -52,7 +52,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,8 +89,7 @@ class HiveTableSpeculativeSinkITCase {
     }
 
     @Test
-    void testBatchWritingWithoutCompactionWithSpeculativeSink()
-            throws ExecutionException, InterruptedException {
+    void testBatchWritingWithoutCompactionWithSpeculativeSink() throws Exception {
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(configure(new Configuration()));
         StreamTableEnvironment tEnv =
@@ -101,79 +99,89 @@ class HiveTableSpeculativeSinkITCase {
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
-        tEnv.executeSql("create database db1");
-        tEnv.useDatabase("db1");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tEnv,
+                true,
+                () -> {
+                    tEnv.executeSql(
+                            "create table append_table("
+                                    + "i int, "
+                                    + "j int) TBLPROPERTIES ("
+                                    + "'sink.parallelism' ='"
+                                    + PARALLELISM
+                                    + "')"
+                                    + "");
+                    DataStream<Row> slowStream =
+                            tEnv.toChangelogStream(tEnv.sqlQuery("select 0, 0"));
+                    slowStream =
+                            slowStream
+                                    .map(
+                                            new RichMapFunction<Row, Row>() {
+                                                @Override
+                                                public Row map(Row value) throws Exception {
+                                                    if (getRuntimeContext().getAttemptNumber()
+                                                            <= 0) {
+                                                        Thread.sleep(Integer.MAX_VALUE);
+                                                    }
+                                                    assert getRuntimeContext().getAttemptNumber()
+                                                            > 0;
+                                                    value.setField(
+                                                            1,
+                                                            getRuntimeContext().getAttemptNumber());
+                                                    return value;
+                                                }
+                                            })
+                                    .name("slowMap")
+                                    .returns(
+                                            Types.ROW_NAMED(
+                                                    new String[] {"i", "j"}, Types.INT, Types.INT))
+                                    .setParallelism(PARALLELISM);
 
-        tEnv.executeSql(
-                "create table append_table("
-                        + "i int, "
-                        + "j int) TBLPROPERTIES ("
-                        + "'sink.parallelism' ='"
-                        + PARALLELISM
-                        + "')"
-                        + "");
-        DataStream<Row> slowStream = tEnv.toChangelogStream(tEnv.sqlQuery("select 0, 0"));
-        slowStream =
-                slowStream
-                        .map(
-                                new RichMapFunction<Row, Row>() {
-                                    @Override
-                                    public Row map(Row value) throws Exception {
-                                        if (getRuntimeContext().getAttemptNumber() <= 0) {
-                                            Thread.sleep(Integer.MAX_VALUE);
-                                        }
-                                        assert getRuntimeContext().getAttemptNumber() > 0;
-                                        value.setField(1, getRuntimeContext().getAttemptNumber());
-                                        return value;
-                                    }
-                                })
-                        .name("slowMap")
-                        .returns(Types.ROW_NAMED(new String[] {"i", "j"}, Types.INT, Types.INT))
-                        .setParallelism(PARALLELISM);
+                    Table t =
+                            tEnv.fromChangelogStream(
+                                    slowStream,
+                                    Schema.newBuilder()
+                                            .column("i", DataTypes.INT())
+                                            .column("j", DataTypes.INT())
+                                            .build(),
+                                    ChangelogMode.insertOnly());
 
-        Table t =
-                tEnv.fromChangelogStream(
-                        slowStream,
-                        Schema.newBuilder()
-                                .column("i", DataTypes.INT())
-                                .column("j", DataTypes.INT())
-                                .build(),
-                        ChangelogMode.insertOnly());
+                    tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+                    tEnv.createTemporaryView("mappedTable", t);
+                    String insertQuery = "insert into append_table select * from mappedTable";
 
-        tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
-        tEnv.createTemporaryView("mappedTable", t);
-        String insertQuery = "insert into append_table select * from mappedTable";
+                    // assert that the SlowMap operator is chained with the hive table sink, which
+                    // will lead
+                    // to a slow sink as well.
+                    StreamTableEnvironmentImpl tEnvImpl = (StreamTableEnvironmentImpl) tEnv;
+                    JobGraph jobGraph =
+                            tEnvImpl.execEnv()
+                                    .generateStreamGraph(
+                                            tEnvImpl.getPlanner()
+                                                    .translate(
+                                                            Collections.singletonList(
+                                                                    (ModifyOperation)
+                                                                            tEnvImpl.getParser()
+                                                                                    .parse(
+                                                                                            insertQuery)
+                                                                                    .get(0))))
+                                    .getJobGraph();
 
-        // assert that the SlowMap operator is chained with the hive table sink, which will lead
-        // to a slow sink as well.
-        StreamTableEnvironmentImpl tEnvImpl = (StreamTableEnvironmentImpl) tEnv;
-        JobGraph jobGraph =
-                tEnvImpl.execEnv()
-                        .generateStreamGraph(
-                                tEnvImpl.getPlanner()
-                                        .translate(
-                                                Collections.singletonList(
-                                                        (ModifyOperation)
-                                                                tEnvImpl.getParser()
-                                                                        .parse(insertQuery)
-                                                                        .get(0))))
-                        .getJobGraph();
+                    for (JobVertex jobVertex : jobGraph.getVertices()) {
+                        if (jobVertex.getName().contains("slowMap")) {
+                            assertThat(jobVertex.getName().contains("Sink")).isTrue();
+                        }
+                    }
+                    tEnv.executeSql(insertQuery).await();
 
-        for (JobVertex jobVertex : jobGraph.getVertices()) {
-            if (jobVertex.getName().contains("slowMap")) {
-                assertThat(jobVertex.getName().contains("Sink")).isTrue();
-            }
-        }
-        tEnv.executeSql(insertQuery).await();
+                    List<Row> rows =
+                            CollectionUtil.iteratorToList(
+                                    tEnv.executeSql("select * from append_table").collect());
+                    rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
 
-        List<Row> rows =
-                CollectionUtil.iteratorToList(
-                        tEnv.executeSql("select * from append_table").collect());
-        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
-
-        // Finally we will get the output value with attemptNumber larger than 0
-        assertThat(rows).isEqualTo(Collections.singletonList(Row.of(0, 1)));
-        tEnv.executeSql("drop database db1 cascade");
+                    // Finally we will get the output value with attemptNumber larger than 0
+                    assertThat(rows).isEqualTo(Collections.singletonList(Row.of(0, 1)));
+                });
     }
 
     private static Configuration configure(Configuration configuration) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvExecutorUtil.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvExecutorUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.table.api.TableEnvironment;
+
+import javax.annotation.Nullable;
+
+/** Table environment execution related utilities. */
+public final class TableEnvExecutorUtil {
+
+    public static void executeInSeparateDatabase(
+            TableEnvironment tEnv, boolean useDb, Callback execOp) throws Exception {
+        executeInSeparateDatabase(tEnv, useDb, execOp, null);
+    }
+
+    /**
+     * Creates a separate database "db1", calls any operation given in {@code execOp}, then cleans
+     * up the created database.
+     *
+     * @param tEnv table environment to create the database in
+     * @param useDb if true, call {@link TableEnvironment#useDatabase(String)} for the created
+     *     database
+     * @param execOp any operation to execute after the database creation
+     * @param cleanupOp custom cleanup operations after every operation is executed
+     * @throws Exception
+     */
+    public static void executeInSeparateDatabase(
+            TableEnvironment tEnv, boolean useDb, Callback execOp, @Nullable Callback cleanupOp)
+            throws Exception {
+        String originalDb = tEnv.getCurrentDatabase();
+        tEnv.executeSql("create database db1");
+        if (useDb) {
+            tEnv.useDatabase("db1");
+        }
+        try {
+            execOp.call();
+        } finally {
+            if (useDb) {
+                tEnv.useDatabase(originalDb);
+            }
+            tEnv.executeSql("drop database db1 cascade");
+            if (cleanupOp != null) {
+                cleanupOp.call();
+            }
+        }
+    }
+
+    /** Functional interface to handle operations in a callable manner. */
+    public interface Callback {
+
+        void call() throws Exception;
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -73,173 +73,184 @@ public class TableEnvHiveConnectorITCase {
     @Test
     public void testOverwriteWithEmptySource() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.useDatabase("db1");
-            tableEnv.executeSql("create table src (x int,p int)");
-            // non-partitioned table
-            tableEnv.executeSql("create table dest (x int)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "dest")
-                    .addRow(new Object[] {1})
-                    .addRow(new Object[] {2})
-                    .commit();
-            tableEnv.executeSql("insert overwrite table dest select x from src").await();
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select * from dest").collect());
-            assertThat(results).isEmpty();
-            // dynamic partitioned table
-            tableEnv.executeSql("create table destp (x int) partitioned by (p int)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "destp")
-                    .addRow(new Object[] {1})
-                    .commit("p=1");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "destp")
-                    .addRow(new Object[] {2})
-                    .commit("p=2");
-            tableEnv.executeSql("insert overwrite table destp partition (p) select * from src")
-                    .await();
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select * from destp order by x").collect());
-            assertThat(results.toString()).isEqualTo("[+I[1, 1], +I[2, 2]]");
-            // static partitioned table
-            // The semantics of overwrite is to overwrite the original data, so the
-            // p=1 partition is overwritten with an empty partition.
-            tableEnv.executeSql("insert overwrite table destp partition(p=1) select x from src")
-                    .await();
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select * from destp order by x").collect());
-            assertThat(results.toString()).isEqualTo("[+I[2, 2]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                true,
+                () -> {
+                    tableEnv.executeSql("create table src (x int,p int)");
+                    // non-partitioned table
+                    tableEnv.executeSql("create table dest (x int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "dest")
+                            .addRow(new Object[] {1})
+                            .addRow(new Object[] {2})
+                            .commit();
+                    tableEnv.executeSql("insert overwrite table dest select x from src").await();
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select * from dest").collect());
+                    assertThat(results).isEmpty();
+                    // dynamic partitioned table
+                    tableEnv.executeSql("create table destp (x int) partitioned by (p int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "destp")
+                            .addRow(new Object[] {1})
+                            .commit("p=1");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "destp")
+                            .addRow(new Object[] {2})
+                            .commit("p=2");
+                    tableEnv.executeSql(
+                                    "insert overwrite table destp partition (p) select * from src")
+                            .await();
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select * from destp order by x")
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[1, 1], +I[2, 2]]");
+                    // static partitioned table
+                    // The semantics of overwrite is to overwrite the original data, so the
+                    // p=1 partition is overwritten with an empty partition.
+                    tableEnv.executeSql(
+                                    "insert overwrite table destp partition(p=1) select x from src")
+                            .await();
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select * from destp order by x")
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[2, 2]]");
+                });
     }
 
     @Test
     public void testMultiInputBroadcast() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.useDatabase("db1");
-            tableEnv.executeSql("create table src1(key string, val string)");
-            tableEnv.executeSql("create table src2(key string, val string)");
-            tableEnv.executeSql("create table dest(key string, val string)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src1")
-                    .addRow(new Object[] {"1", "val1"})
-                    .addRow(new Object[] {"2", "val2"})
-                    .addRow(new Object[] {"3", "val3"})
-                    .commit();
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src2")
-                    .addRow(new Object[] {"3", "val4"})
-                    .addRow(new Object[] {"4", "val4"})
-                    .commit();
-            tableEnv.executeSql(
-                            "INSERT OVERWRITE TABLE dest\n"
-                                    + "SELECT j.*\n"
-                                    + "FROM (SELECT t1.key, p1.val\n"
-                                    + "      FROM src2 t1\n"
-                                    + "      LEFT OUTER JOIN src1 p1\n"
-                                    + "      ON (t1.key = p1.key)\n"
-                                    + "      UNION ALL\n"
-                                    + "      SELECT t2.key, p2.val\n"
-                                    + "      FROM src2 t2\n"
-                                    + "      LEFT OUTER JOIN src1 p2\n"
-                                    + "      ON (t2.key = p2.key)) j")
-                    .await();
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select * from dest order by key").collect());
-            assertThat(results.toString())
-                    .isEqualTo("[+I[3, val3], +I[3, val3], +I[4, null], +I[4, null]]");
-        } finally {
-            tableEnv.useDatabase("default");
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                true,
+                () -> {
+                    tableEnv.executeSql("create table src1(key string, val string)");
+                    tableEnv.executeSql("create table src2(key string, val string)");
+                    tableEnv.executeSql("create table dest(key string, val string)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src1")
+                            .addRow(new Object[] {"1", "val1"})
+                            .addRow(new Object[] {"2", "val2"})
+                            .addRow(new Object[] {"3", "val3"})
+                            .commit();
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src2")
+                            .addRow(new Object[] {"3", "val4"})
+                            .addRow(new Object[] {"4", "val4"})
+                            .commit();
+                    tableEnv.executeSql(
+                                    "INSERT OVERWRITE TABLE dest\n"
+                                            + "SELECT j.*\n"
+                                            + "FROM (SELECT t1.key, p1.val\n"
+                                            + "      FROM src2 t1\n"
+                                            + "      LEFT OUTER JOIN src1 p1\n"
+                                            + "      ON (t1.key = p1.key)\n"
+                                            + "      UNION ALL\n"
+                                            + "      SELECT t2.key, p2.val\n"
+                                            + "      FROM src2 t2\n"
+                                            + "      LEFT OUTER JOIN src1 p2\n"
+                                            + "      ON (t2.key = p2.key)) j")
+                            .await();
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select * from dest order by key")
+                                            .collect());
+                    assertThat(results.toString())
+                            .isEqualTo("[+I[3, val3], +I[3, val3], +I[4, null], +I[4, null]]");
+                });
     }
 
     @Test
     public void testDefaultPartitionName() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        tableEnv.executeSql("create table db1.src (x int, y int)");
-        tableEnv.executeSql("create table db1.part (x int) partitioned by (y int)");
-        HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                .addRow(new Object[] {1, 1})
-                .addRow(new Object[] {2, null})
-                .commit();
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (x int, y int)");
+                    tableEnv.executeSql("create table db1.part (x int) partitioned by (y int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1, 1})
+                            .addRow(new Object[] {2, null})
+                            .commit();
 
-        // test generating partitions with default name
-        tableEnv.executeSql("insert into db1.part select * from db1.src").await();
-        HiveConf hiveConf = hiveCatalog.getHiveConf();
-        String defaultPartName = hiveConf.getVar(HiveConf.ConfVars.DEFAULTPARTITIONNAME);
-        Table hiveTable = hmsClient.getTable("db1", "part");
-        Path defaultPartPath = new Path(hiveTable.getSd().getLocation(), "y=" + defaultPartName);
-        FileSystem fs = defaultPartPath.getFileSystem(hiveConf);
-        assertThat(fs.exists(defaultPartPath)).isTrue();
+                    // test generating partitions with default name
+                    tableEnv.executeSql("insert into db1.part select * from db1.src").await();
+                    HiveConf hiveConf = hiveCatalog.getHiveConf();
+                    String defaultPartName =
+                            hiveConf.getVar(HiveConf.ConfVars.DEFAULTPARTITIONNAME);
+                    Table hiveTable = hmsClient.getTable("db1", "part");
+                    Path defaultPartPath =
+                            new Path(hiveTable.getSd().getLocation(), "y=" + defaultPartName);
+                    FileSystem fs = defaultPartPath.getFileSystem(hiveConf);
+                    assertThat(fs.exists(defaultPartPath)).isTrue();
 
-        TableImpl flinkTable =
-                (TableImpl) tableEnv.sqlQuery("select y, x from db1.part order by x");
-        List<Row> rows = CollectionUtil.iteratorToList(flinkTable.execute().collect());
-        assertThat(rows.toString()).isEqualTo("[+I[1, 1], +I[null, 2]]");
-
-        tableEnv.executeSql("drop database db1 cascade");
+                    TableImpl flinkTable =
+                            (TableImpl) tableEnv.sqlQuery("select y, x from db1.part order by x");
+                    List<Row> rows = CollectionUtil.iteratorToList(flinkTable.execute().collect());
+                    assertThat(rows.toString()).isEqualTo("[+I[1, 1], +I[null, 2]]");
+                });
     }
 
     @Test
     public void testGetNonExistingFunction() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        tableEnv.executeSql("create table db1.src (d double, s string)");
-        tableEnv.executeSql("create table db1.dest (x bigint)");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.src (d double, s string)");
+                    tableEnv.executeSql("create table db1.dest (x bigint)");
 
-        // just make sure the query runs through, no need to verify result
-        tableEnv.executeSql("insert into db1.dest select count(d) from db1.src").await();
-
-        tableEnv.executeSql("drop database db1 cascade");
+                    // just make sure the query runs through, no need to verify result
+                    tableEnv.executeSql("insert into db1.dest select count(d) from db1.src")
+                            .await();
+                });
     }
 
     @Test
     public void testDateTimestampPartitionColumns() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql(
-                    "create table db1.part(x int) partitioned by (dt date,ts timestamp)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {1})
-                    .addRow(new Object[] {2})
-                    .commit("dt='2019-12-23',ts='2019-12-23 00:00:00'");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {3})
-                    .commit("dt='2019-12-25',ts='2019-12-25 16:23:43.012'");
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.part order by x")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString())
-                    .isEqualTo(
-                            "[+I[1, 2019-12-23, 2019-12-23T00:00], +I[2, 2019-12-23, 2019-12-23T00:00], +I[3, 2019-12-25, 2019-12-25T16:23:43.012]]");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql(
+                            "create table db1.part(x int) partitioned by (dt date,ts timestamp)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {1})
+                            .addRow(new Object[] {2})
+                            .commit("dt='2019-12-23',ts='2019-12-23 00:00:00'");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {3})
+                            .commit("dt='2019-12-25',ts='2019-12-25 16:23:43.012'");
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.part order by x")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString())
+                            .isEqualTo(
+                                    "[+I[1, 2019-12-23, 2019-12-23T00:00], +I[2, 2019-12-23, 2019-12-23T00:00], +I[3, 2019-12-25, 2019-12-25T16:23:43.012]]");
 
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery(
-                                            "select x from db1.part where dt=cast('2019-12-25' as date)")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString()).isEqualTo("[+I[3]]");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery(
+                                                    "select x from db1.part where dt=cast('2019-12-25' as date)")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[3]]");
 
-            tableEnv.executeSql(
-                            "insert into db1.part select 4,cast('2019-12-31' as date),cast('2019-12-31 12:00:00.0' as timestamp)")
-                    .await();
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select max(dt) from db1.part").execute().collect());
-            assertThat(results.toString()).isEqualTo("[+I[2019-12-31]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    tableEnv.executeSql(
+                                    "insert into db1.part select 4,cast('2019-12-31' as date),cast('2019-12-31 12:00:00.0' as timestamp)")
+                            .await();
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select max(dt) from db1.part")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[2019-12-31]]");
+                });
     }
 
     @Test
@@ -256,94 +267,96 @@ public class TableEnvHiveConnectorITCase {
         Assume.assumeTrue(
                 hiveVersion.compareTo("2.0.0") >= 0 || hiveVersion.compareTo("1.3.0") >= 0);
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.simple (i int,a array<int>)");
-            tableEnv.executeSql("create table db1.nested (a array<map<int, string>>)");
-            tableEnv.executeSql(
-                    "create function hiveudtf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDTFExplode'");
-            tableEnv.executeSql(
-                    "create function json_tuple as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDTFJSONTuple'");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "simple")
-                    .addRow(new Object[] {3, Arrays.asList(1, 2, 3)})
-                    .commit();
-            Map<Integer, String> map1 = new HashMap<>();
-            map1.put(1, "a");
-            map1.put(2, "b");
-            Map<Integer, String> map2 = new HashMap<>();
-            map2.put(3, "c");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "nested")
-                    .addRow(new Object[] {Arrays.asList(map1, map2)})
-                    .commit();
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.simple (i int,a array<int>)");
+                    tableEnv.executeSql("create table db1.nested (a array<map<int, string>>)");
+                    tableEnv.executeSql(
+                            "create function hiveudtf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDTFExplode'");
+                    tableEnv.executeSql(
+                            "create function json_tuple as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDTFJSONTuple'");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "simple")
+                            .addRow(new Object[] {3, Arrays.asList(1, 2, 3)})
+                            .commit();
+                    Map<Integer, String> map1 = new HashMap<>();
+                    map1.put(1, "a");
+                    map1.put(2, "b");
+                    Map<Integer, String> map2 = new HashMap<>();
+                    map2.put(3, "c");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "nested")
+                            .addRow(new Object[] {Arrays.asList(map1, map2)})
+                            .commit();
 
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery(
-                                            "select x from db1.simple lateral view hiveudtf(a) udtf_t as x")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString()).isEqualTo("[+I[1], +I[2], +I[3]]");
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery(
-                                            "select x from db1.nested lateral view hiveudtf(a) udtf_t as x")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString()).isEqualTo("[+I[{1=a, 2=b}], +I[{3=c}]]");
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery(
-                                            "select foo.i, b.role_id from db1.simple foo "
-                                                    + " lateral view json_tuple('{\"a\": \"0\", \"b\": \"1\"}', 'a') b as role_id")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString()).isEqualTo("[+I[3, 0]]");
-            tableEnv.executeSql("create table db1.ts (a array<timestamp>)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "ts")
-                    .addRow(
-                            new Object[] {
-                                new Object[] {
-                                    Timestamp.valueOf("2015-04-28 15:23:00"),
-                                    Timestamp.valueOf("2016-06-03 17:05:52")
-                                }
-                            })
-                    .commit();
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery(
-                                            "select x from db1.ts lateral view hiveudtf(a) udtf_t as x")
-                                    .execute()
-                                    .collect());
-            assertThat(results.toString())
-                    .isEqualTo("[+I[2015-04-28T15:23], +I[2016-06-03T17:05:52]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-            tableEnv.executeSql("drop function hiveudtf");
-        }
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery(
+                                                    "select x from db1.simple lateral view hiveudtf(a) udtf_t as x")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[1], +I[2], +I[3]]");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery(
+                                                    "select x from db1.nested lateral view hiveudtf(a) udtf_t as x")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[{1=a, 2=b}], +I[{3=c}]]");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery(
+                                                    "select foo.i, b.role_id from db1.simple foo "
+                                                            + " lateral view json_tuple('{\"a\": \"0\", \"b\": \"1\"}', 'a') b as role_id")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[3, 0]]");
+                    tableEnv.executeSql("create table db1.ts (a array<timestamp>)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "ts")
+                            .addRow(
+                                    new Object[] {
+                                        new Object[] {
+                                            Timestamp.valueOf("2015-04-28 15:23:00"),
+                                            Timestamp.valueOf("2016-06-03 17:05:52")
+                                        }
+                                    })
+                            .commit();
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery(
+                                                    "select x from db1.ts lateral view hiveudtf(a) udtf_t as x")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString())
+                            .isEqualTo("[+I[2015-04-28T15:23], +I[2016-06-03T17:05:52]]");
+                },
+                () -> tableEnv.executeSql("drop function hiveudtf"));
     }
 
     @Test
     public void testNotNullConstraints() throws Exception {
         Assume.assumeTrue(HiveVersionTestUtil.HIVE_310_OR_LATER);
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql(
-                    "create table db1.tbl (x int,y bigint not null enable rely,z string not null enable norely)");
-            CatalogBaseTable catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl"));
-            List<Schema.UnresolvedColumn> columns = catalogTable.getUnresolvedSchema().getColumns();
-            assertThat(HiveTestUtils.getType(columns.get(0)).getLogicalType().isNullable())
-                    .as("By default columns should be nullable")
-                    .isTrue();
-            assertThat(HiveTestUtils.getType(columns.get(1)).getLogicalType().isNullable())
-                    .as("NOT NULL columns should be reflected in table schema")
-                    .isFalse();
-            assertThat(HiveTestUtils.getType(columns.get(2)).getLogicalType().isNullable())
-                    .as("NOT NULL NORELY columns should be considered nullable")
-                    .isTrue();
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql(
+                            "create table db1.tbl (x int,y bigint not null enable rely,z string not null enable norely)");
+                    CatalogBaseTable catalogTable =
+                            hiveCatalog.getTable(new ObjectPath("db1", "tbl"));
+                    List<Schema.UnresolvedColumn> columns =
+                            catalogTable.getUnresolvedSchema().getColumns();
+                    assertThat(HiveTestUtils.getType(columns.get(0)).getLogicalType().isNullable())
+                            .as("By default columns should be nullable")
+                            .isTrue();
+                    assertThat(HiveTestUtils.getType(columns.get(1)).getLogicalType().isNullable())
+                            .as("NOT NULL columns should be reflected in table schema")
+                            .isFalse();
+                    assertThat(HiveTestUtils.getType(columns.get(2)).getLogicalType().isNullable())
+                            .as("NOT NULL NORELY columns should be considered nullable")
+                            .isTrue();
+                });
     }
 
     @Test
@@ -353,58 +366,60 @@ public class TableEnvHiveConnectorITCase {
         // So let's only test for 3.x.
         Assume.assumeTrue(HiveVersionTestUtil.HIVE_310_OR_LATER);
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            // test rely PK constraints
-            tableEnv.executeSql(
-                    "create table db1.tbl1 (x tinyint,y smallint,z int, primary key (x,z) disable novalidate rely)");
-            CatalogBaseTable catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl1"));
-            Schema schema = catalogTable.getUnresolvedSchema();
-            assertThat(schema.getPrimaryKey()).isPresent();
-            Schema.UnresolvedPrimaryKey pk = schema.getPrimaryKey().get();
-            assertThat(pk.getColumnNames()).hasSize(2);
-            assertThat(pk.getColumnNames().containsAll(Arrays.asList("x", "z"))).isTrue();
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    // test rely PK constraints
+                    tableEnv.executeSql(
+                            "create table db1.tbl1 (x tinyint,y smallint,z int, primary key (x,z) disable novalidate rely)");
+                    CatalogBaseTable catalogTable =
+                            hiveCatalog.getTable(new ObjectPath("db1", "tbl1"));
+                    Schema schema = catalogTable.getUnresolvedSchema();
+                    assertThat(schema.getPrimaryKey()).isPresent();
+                    Schema.UnresolvedPrimaryKey pk = schema.getPrimaryKey().get();
+                    assertThat(pk.getColumnNames()).hasSize(2);
+                    assertThat(pk.getColumnNames().containsAll(Arrays.asList("x", "z"))).isTrue();
 
-            // test norely PK constraints
-            tableEnv.executeSql(
-                    "create table db1.tbl2 (x tinyint,y smallint, primary key (x) disable norely)");
-            catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl2"));
-            schema = catalogTable.getUnresolvedSchema();
-            assertThat(schema.getPrimaryKey()).isNotPresent();
+                    // test norely PK constraints
+                    tableEnv.executeSql(
+                            "create table db1.tbl2 (x tinyint,y smallint, primary key (x) disable norely)");
+                    catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl2"));
+                    schema = catalogTable.getUnresolvedSchema();
+                    assertThat(schema.getPrimaryKey()).isNotPresent();
 
-            // test table w/o PK
-            tableEnv.executeSql("create table db1.tbl3 (x tinyint)");
-            catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl3"));
-            schema = catalogTable.getUnresolvedSchema();
-            assertThat(schema.getPrimaryKey()).isNotPresent();
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    // test table w/o PK
+                    tableEnv.executeSql("create table db1.tbl3 (x tinyint)");
+                    catalogTable = hiveCatalog.getTable(new ObjectPath("db1", "tbl3"));
+                    schema = catalogTable.getUnresolvedSchema();
+                    assertThat(schema.getPrimaryKey()).isNotPresent();
+                });
     }
 
     @Test
     public void testRegexSerDe() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql(
-                    "create table db1.src (x int,y string) "
-                            + "row format serde 'org.apache.hadoop.hive.serde2.RegexSerDe' "
-                            + "with serdeproperties ('input.regex'='([\\\\d]+)\\u0001([\\\\S]+)')");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
-                    .addRow(new Object[] {1, "a"})
-                    .addRow(new Object[] {2, "ab"})
-                    .commit();
-            assertThat(
-                            CollectionUtil.iteratorToList(
-                                            tableEnv.sqlQuery("select * from db1.src order by x")
-                                                    .execute()
-                                                    .collect())
-                                    .toString())
-                    .isEqualTo("[+I[1, a], +I[2, ab]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql(
+                            "create table db1.src (x int,y string) "
+                                    + "row format serde 'org.apache.hadoop.hive.serde2.RegexSerDe' "
+                                    + "with serdeproperties ('input.regex'='([\\\\d]+)\\u0001([\\\\S]+)')");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "src")
+                            .addRow(new Object[] {1, "a"})
+                            .addRow(new Object[] {2, "ab"})
+                            .commit();
+                    assertThat(
+                                    CollectionUtil.iteratorToList(
+                                                    tableEnv.sqlQuery(
+                                                                    "select * from db1.src order by x")
+                                                            .execute()
+                                                            .collect())
+                                            .toString())
+                            .isEqualTo("[+I[1, a], +I[2, ab]]");
+                });
     }
 
     @Test
@@ -434,67 +449,70 @@ public class TableEnvHiveConnectorITCase {
     @Test
     public void testParquetNameMapping() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.t1 (x int,y int) stored as parquet");
-            tableEnv.executeSql("insert into table db1.t1 values (1,10),(2,20)").await();
-            Table hiveTable = hiveCatalog.getHiveTable(new ObjectPath("db1", "t1"));
-            String location = hiveTable.getSd().getLocation();
-            tableEnv.executeSql(
-                    String.format(
-                            "create table db1.t2 (y int,x int) stored as parquet location '%s'",
-                            location));
-            tableEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
-            assertThat(
-                            CollectionUtil.iteratorToList(
-                                            tableEnv.sqlQuery("select x from db1.t1")
-                                                    .execute()
-                                                    .collect())
-                                    .toString())
-                    .isEqualTo("[+I[1], +I[2]]");
-            assertThat(
-                            CollectionUtil.iteratorToList(
-                                            tableEnv.sqlQuery("select x from db1.t2")
-                                                    .execute()
-                                                    .collect())
-                                    .toString())
-                    .isEqualTo("[+I[1], +I[2]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.t1 (x int,y int) stored as parquet");
+                    tableEnv.executeSql("insert into table db1.t1 values (1,10),(2,20)").await();
+                    Table hiveTable = hiveCatalog.getHiveTable(new ObjectPath("db1", "t1"));
+                    String location = hiveTable.getSd().getLocation();
+                    tableEnv.executeSql(
+                            String.format(
+                                    "create table db1.t2 (y int,x int) stored as parquet location '%s'",
+                                    location));
+                    tableEnv.getConfig()
+                            .set(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, true);
+                    assertThat(
+                                    CollectionUtil.iteratorToList(
+                                                    tableEnv.sqlQuery("select x from db1.t1")
+                                                            .execute()
+                                                            .collect())
+                                            .toString())
+                            .isEqualTo("[+I[1], +I[2]]");
+                    assertThat(
+                                    CollectionUtil.iteratorToList(
+                                                    tableEnv.sqlQuery("select x from db1.t2")
+                                                            .execute()
+                                                            .collect())
+                                            .toString())
+                            .isEqualTo("[+I[1], +I[2]]");
+                });
     }
 
     @Test
     public void testNonExistingPartitionFolder() throws Exception {
         TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.executeSql("create table db1.part (x int) partitioned by (p int)");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {1})
-                    .commit("p=1");
-            HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
-                    .addRow(new Object[] {2})
-                    .commit("p=2");
-            tableEnv.executeSql("alter table db1.part add partition (p=3)");
-            // remove one partition
-            Path toRemove =
-                    new Path(
-                            hiveCatalog
-                                    .getHiveTable(new ObjectPath("db1", "part"))
-                                    .getSd()
-                                    .getLocation(),
-                            "p=2");
-            FileSystem fs = toRemove.getFileSystem(hiveCatalog.getHiveConf());
-            fs.delete(toRemove, true);
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                false,
+                () -> {
+                    tableEnv.executeSql("create table db1.part (x int) partitioned by (p int)");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {1})
+                            .commit("p=1");
+                    HiveTestUtils.createTextTableInserter(hiveCatalog, "db1", "part")
+                            .addRow(new Object[] {2})
+                            .commit("p=2");
+                    tableEnv.executeSql("alter table db1.part add partition (p=3)");
+                    // remove one partition
+                    Path toRemove =
+                            new Path(
+                                    hiveCatalog
+                                            .getHiveTable(new ObjectPath("db1", "part"))
+                                            .getSd()
+                                            .getLocation(),
+                                    "p=2");
+                    FileSystem fs = toRemove.getFileSystem(hiveCatalog.getHiveConf());
+                    fs.delete(toRemove, true);
 
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.sqlQuery("select * from db1.part").execute().collect());
-            assertThat(results.toString()).isEqualTo("[+I[1, 1]]");
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.sqlQuery("select * from db1.part")
+                                            .execute()
+                                            .collect());
+                    assertThat(results.toString()).isEqualTo("[+I[1, 1]]");
+                });
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.connectors.hive.TableEnvExecutorUtil;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
@@ -513,50 +514,51 @@ public class HiveCatalogITCase {
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
 
-        tableEnv.executeSql("create database db1");
-        try {
-            tableEnv.useDatabase("db1");
-            tableEnv.executeSql(
-                    "create table src(x int,ts timestamp(3)) with ('connector'='datagen','number-of-rows'='10')");
-            tableEnv.executeSql("create view v1 as select x,ts from src order by x limit 3");
+        TableEnvExecutorUtil.executeInSeparateDatabase(
+                tableEnv,
+                true,
+                () -> {
+                    tableEnv.executeSql(
+                            "create table src(x int,ts timestamp(3)) with ('connector'='datagen','number-of-rows'='10')");
+                    tableEnv.executeSql(
+                            "create view v1 as select x,ts from src order by x limit 3");
 
-            CatalogView catalogView =
-                    (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v1"));
-            ResolvedSchema viewSchema =
-                    catalogView.getUnresolvedSchema().resolve(new TestSchemaResolver());
-            assertThat(viewSchema)
-                    .isEqualTo(
-                            new ResolvedSchema(
-                                    Lists.newArrayList(
-                                            Column.physical("x", DataTypes.INT()),
-                                            Column.physical("ts", DataTypes.TIMESTAMP(3))),
-                                    new ArrayList<>(),
-                                    null));
+                    CatalogView catalogView =
+                            (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v1"));
+                    ResolvedSchema viewSchema =
+                            catalogView.getUnresolvedSchema().resolve(new TestSchemaResolver());
+                    assertThat(viewSchema)
+                            .isEqualTo(
+                                    new ResolvedSchema(
+                                            Lists.newArrayList(
+                                                    Column.physical("x", DataTypes.INT()),
+                                                    Column.physical("ts", DataTypes.TIMESTAMP(3))),
+                                            new ArrayList<>(),
+                                            null));
 
-            List<Row> results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select x from v1").collect());
-            assertThat(results).hasSize(3);
+                    List<Row> results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select x from v1").collect());
+                    assertThat(results).hasSize(3);
 
-            tableEnv.executeSql(
-                    "create view v2 (v2_x,v2_ts) comment 'v2 comment' as select x,cast(ts as timestamp_ltz(3)) from v1");
-            catalogView = (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v2"));
-            assertThat(catalogView.getUnresolvedSchema().resolve(new TestSchemaResolver()))
-                    .isEqualTo(
-                            new ResolvedSchema(
-                                    Lists.newArrayList(
-                                            Column.physical("v2_x", DataTypes.INT()),
-                                            Column.physical("v2_ts", DataTypes.TIMESTAMP_LTZ(3))),
-                                    new ArrayList<>(),
-                                    null));
-            assertThat(catalogView.getComment()).isEqualTo("v2 comment");
-            results =
-                    CollectionUtil.iteratorToList(
-                            tableEnv.executeSql("select * from v2").collect());
-            assertThat(results).hasSize(3);
-        } finally {
-            tableEnv.executeSql("drop database db1 cascade");
-        }
+                    tableEnv.executeSql(
+                            "create view v2 (v2_x,v2_ts) comment 'v2 comment' as select x,cast(ts as timestamp_ltz(3)) from v1");
+                    catalogView = (CatalogView) hiveCatalog.getTable(new ObjectPath("db1", "v2"));
+                    assertThat(catalogView.getUnresolvedSchema().resolve(new TestSchemaResolver()))
+                            .isEqualTo(
+                                    new ResolvedSchema(
+                                            Lists.newArrayList(
+                                                    Column.physical("v2_x", DataTypes.INT()),
+                                                    Column.physical(
+                                                            "v2_ts", DataTypes.TIMESTAMP_LTZ(3))),
+                                            new ArrayList<>(),
+                                            null));
+                    assertThat(catalogView.getComment()).isEqualTo("v2 comment");
+                    results =
+                            CollectionUtil.iteratorToList(
+                                    tableEnv.executeSql("select * from v2").collect());
+                    assertThat(results).hasSize(3);
+                });
     }
 
     @Test

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -184,8 +184,9 @@ use `default`;
 !info
 
 drop database `default`;
-[INFO] Execute statement succeed.
-!info
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.ValidationException: Cannot drop a database which is currently in use.
+!error
 
 drop catalog `mod`;
 [ERROR] Could not execute SQL statement. Reason:

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -254,13 +254,8 @@ use `default`;
 
 drop database `default`;
 !output
-+--------+
-| result |
-+--------+
-|     OK |
-+--------+
-1 row in set
-!ok
+org.apache.flink.table.api.ValidationException: Cannot drop a database which is currently in use.
+!error
 
 drop catalog `mod`;
 !output

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -1404,6 +1405,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     public void dropDatabase(
             String catalogName, String databaseName, boolean ignoreIfNotExists, boolean cascade)
             throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        if (Objects.equals(currentCatalogName, catalogName)
+                && Objects.equals(currentDatabaseName, databaseName)) {
+            throw new ValidationException("Cannot drop a database which is currently in use.");
+        }
         Catalog catalog = getCatalogOrError(catalogName);
         catalog.dropDatabase(databaseName, ignoreIfNotExists, cascade);
         catalogModificationListeners.forEach(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.table.planner.catalog
 
+import org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
@@ -31,6 +32,7 @@ import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.types.Row
 import org.apache.flink.util.{FileUtils, UserClassLoaderJarTestUtils}
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.{Before, Rule, Test}
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.rules.ExpectedException
@@ -1271,6 +1273,11 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |)
       """.stripMargin
     tableEnv.executeSql(ddl2)
+    assertThatThrownBy(() => tableEnv.executeSql("drop database db1")).satisfies(
+      anyCauseMatches(
+        classOf[ValidationException],
+        "Cannot drop a database which is currently in use."))
+    tableEnv.executeSql("use `default`")
     try {
       tableEnv.executeSql("drop database db1")
       fail("ValidationException expected")


### PR DESCRIPTION
## What is the purpose of the change

Forbid to drop the currently used database.

## Brief change log
- `CatalogManager.dropDatabase(...)` now throws a `ValidationException` if it is called with `currentCatalogName` and `currentDatabaseName`.
- Added unit test in `CatalogManagerTest`.
- Adapted relevant IT cases.
- Introduced `TableEnvExecutorUtil` to `flink-hive-connector` tests to minimize test database management related code duplications.

## Verifying this change

Added new unit test to cover dropping current database.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
