### PR TITLE
[FLINK-33228][flink-runtime] Fix the total current resource calculation when fulfilling requirement

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -53,13 +53,13 @@ import static org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUt
  * resources and cannot fit into the pre-defined total resource profile.
  *
  * <p>Note: This strategy tries to find a feasible allocation result, rather than an optimal one (in
- * term of resource utilization). It also does not guarantee always finding a feasible solution when
- * exist.
+ * terms of resource utilization). It also does not guarantee always finding a feasible solution
+ * when exists.
  *
  * <p>Note: The current implementation of this strategy is non-optimal, in terms of computation
  * efficiency. In the worst case, for each distinctly profiled requirement it checks all registered
  * and pending resources. Further optimization requires complex data structures for ordering
- * multi-dimensional resource profiles. The complexity is not necessary.
+ * multidimensional resource profiles. The complexity is not necessary.
  */
 public class DefaultResourceAllocationStrategy implements ResourceAllocationStrategy {
     private final ResourceProfile defaultSlotResourceProfile;
@@ -71,7 +71,7 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
 
     /**
      * Always use any matching strategy for pending resources to use as less pending workers as
-     * possible, so that the rest can be canceled
+     * possible, so that the rest can be canceled.
      */
     private final ResourceMatchingStrategy pendingResourceMatchingStrategy =
             AnyMatchingResourceMatchingStrategy.INSTANCE;
@@ -144,7 +144,7 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
         // to the latest state after a new PendingTaskManager is created,
         // tryFulFillRequiredResources will not update pendingResources even after new
         // PendingTaskManagers are created.
-        // This is because the pendingResources are no longer needed afterwards.
+        // This is because the pendingResources are no longer needed afterward.
         tryFulFillRequiredResources(
                 registeredResources, pendingResources, totalCurrentResources, resultBuilder);
         return resultBuilder.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -553,8 +553,22 @@ class DefaultResourceAllocationStrategyTest {
                         .getCpuCores()
                         .multiply(NUM_OF_SLOTS)
                         .multiply(BigDecimal.valueOf(4.5));
-
         testMinRequiredResourceLimitInFulfillRequirements(minRequiredCPU, MemorySize.ZERO, 4);
+    }
+
+    @Test
+    void testMinRequiredCPULimitInTryFulfillWithRequirement() {
+        CPUResource minRequiredCPU =
+                DEFAULT_SLOT_RESOURCE
+                        .getCpuCores()
+                        .multiply(NUM_OF_SLOTS)
+                        .multiply(BigDecimal.valueOf(4.5));
+        List<ResourceRequirement> resourceRequirements =
+                Collections.singletonList(
+                        ResourceRequirement.create(DEFAULT_SLOT_RESOURCE, 3 * NUM_OF_SLOTS));
+
+        testMinRequiredResourceLimitInFulfillRequirements(
+                minRequiredCPU, MemorySize.ZERO, 4, resourceRequirements);
     }
 
     @Test
@@ -563,6 +577,20 @@ class DefaultResourceAllocationStrategyTest {
                 DEFAULT_SLOT_RESOURCE.getTotalMemory().multiply(NUM_OF_SLOTS).multiply(3.5);
         testMinRequiredResourceLimitInFulfillRequirements(
                 new CPUResource(0.0), minRequiredMemory, 3);
+    }
+
+    @Test
+    void testMinRequiredMemoryLimitInTryFulfillWithRequirement() {
+        CPUResource minRequiredCPU =
+                DEFAULT_SLOT_RESOURCE
+                        .getCpuCores()
+                        .multiply(NUM_OF_SLOTS)
+                        .multiply(BigDecimal.valueOf(4.5));
+        List<ResourceRequirement> resourceRequirements =
+                Collections.singletonList(
+                        ResourceRequirement.create(DEFAULT_SLOT_RESOURCE, 3 * NUM_OF_SLOTS));
+        testMinRequiredResourceLimitInFulfillRequirements(
+                minRequiredCPU, MemorySize.ZERO, 4, resourceRequirements);
     }
 
     void testMinResourceLimitInReconcile(
@@ -631,10 +659,19 @@ class DefaultResourceAllocationStrategyTest {
             CPUResource minRequiredCPU,
             MemorySize minRequiredMemory,
             int pendingTaskManagersToAllocate) {
+        testMinRequiredResourceLimitInFulfillRequirements(
+                minRequiredCPU,
+                minRequiredMemory,
+                pendingTaskManagersToAllocate,
+                Collections.emptyList());
+    }
 
+    void testMinRequiredResourceLimitInFulfillRequirements(
+            CPUResource minRequiredCPU,
+            MemorySize minRequiredMemory,
+            int pendingTaskManagersToAllocate,
+            List<ResourceRequirement> requirements) {
         final JobID jobId = new JobID();
-        final List<ResourceRequirement> requirements = Collections.emptyList();
-
         final PendingTaskManager pendingTaskManager =
                 new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), NUM_OF_SLOTS);
 


### PR DESCRIPTION

## What is the purpose of the change

- Fix the total current resource calculation when fulfilling requirements in DefaultResourceAllocationStrategy
- Fix typos in DefaultResourceAllocationStrategy comments

## Brief change log

- Makeing `tryFulfillRequirementsForJobWithPendingResources` return new added resource profile to track the total current resource profile


## Verifying this change

- Added UnitTests `DefaultResourceAllocationStrategyTest#testMinRequiredCPULimitInTryFulfillWithRequirement` and `DefaultResourceAllocationStrategyTest#testMinRequiredMemoryLimitInTryFulfillWithRequirement`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
