### PR TITLE
[FLINK-33236][config] Deprecate the unused high-availability.zookeeper.path.running-registry option

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
@@ -56,11 +56,5 @@
             <td>String</td>
             <td>ZooKeeper root path (ZNode) for job graphs</td>
         </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
-            <td style="word-wrap: break-word;">"/running_job_registry/"</td>
-            <td>String</td>
-            <td></td>
-        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -87,12 +87,6 @@
             <td>The root path under which Flink stores its entries in ZooKeeper.</td>
         </tr>
         <tr>
-            <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
-            <td style="word-wrap: break-word;">"/running_job_registry/"</td>
-            <td>String</td>
-            <td></td>
-        </tr>
-        <tr>
             <td><h5>high-availability.zookeeper.quorum</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -168,12 +168,6 @@ public class HighAvailabilityOptions {
                             "Defines the number of connection retries before the client gives up.");
 
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
-    public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
-            key("high-availability.zookeeper.path.running-registry")
-                    .stringType()
-                    .defaultValue("/running_job_registry/");
-
-    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =
             key("high-availability.zookeeper.client.acl")
                     .stringType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -173,7 +173,10 @@ public class HighAvailabilityOptions {
     public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
             key("high-availability.zookeeper.path.running-registry")
                     .stringType()
-                    .defaultValue("/running_job_registry/");
+                    .defaultValue("/running_job_registry/")
+                    .withDescription(
+                            "Don't use this option anymore. It has no effect on Flink. The RunningJobRegistry has been "
+                                    + "replaced by the JobResultStore in Flink 1.15.");
 
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -167,6 +167,14 @@ public class HighAvailabilityOptions {
                     .withDescription(
                             "Defines the number of connection retries before the client gives up.");
 
+    /** @deprecated Don't use this option anymore. It has no effect on Flink. */
+    @Deprecated
+    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
+    public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
+            key("high-availability.zookeeper.path.running-registry")
+                    .stringType()
+                    .defaultValue("/running_job_registry/");
+
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =
             key("high-availability.zookeeper.client.acl")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The running registry subcomponent of Flink HA has been removed in [FLINK-25430](https://issues.apache.org/jira/browse/FLINK-25430) and the "high-availability.zookeeper.path.running-registry" option is of no use after that. We should Deprecate the option and regenerate the config doc to remove the relevant descriptions to avoid user's confusion.

## Brief change log

Deprecate the unused high-availability.zookeeper.pth.running-registry option and remove the relevant doc.

## Verifying this change

This change is a trivial code cleanup.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
