### PR TITLE
[FLINK-33057][Checkpointing] Add options to disable creating job-id subdirectories under the checkpoint directory

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -33,6 +33,12 @@
             <td>Option whether to discard a checkpoint's states in parallel using the ExecutorService passed into the cleaner</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoints.create-subdir</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to create sub-directories named by job id under the '<code class="highlighter-rouge">state.checkpoints.dir</code>' to store the data files and meta data of checkpoints. The default value is true to enable user could run several jobs with the same checkpoint directory at the same time. If this value is set to false, pay attention not to run several jobs with the same directory simultaneously. <br />WARNING: This is an advanced configuration. If set to false, users must ensure that no multiple jobs are run with the same checkpoint directory, and that no files exist other than those necessary for the restoration of the current job when starting a new job.</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/expert_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/expert_state_backends_section.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>state.checkpoints.create-subdir</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to create sub-directories named by job id under the '<code class="highlighter-rouge">state.checkpoints.dir</code>' to store the data files and meta data of checkpoints. The default value is true to enable user could run several jobs with the same checkpoint directory at the same time. If this value is set to false, pay attention not to run several jobs with the same directory simultaneously. <br />WARNING: This is an advanced configuration. If set to false, users must ensure that no multiple jobs are run with the same checkpoint directory, and that no files exist other than those necessary for the restoration of the current job when starting a new job.</td>
+        </tr>
+        <tr>
             <td><h5>state.storage.fs.memory-threshold</h5></td>
             <td style="word-wrap: break-word;">20 kb</td>
             <td>MemorySize</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -229,6 +229,32 @@ public class CheckpointingOptions {
                                     + "(i.e. all TaskManagers and JobManagers).");
 
     /**
+     * Whether to create sub-directories named by job id to store the data files and meta data of
+     * checkpoints. The default value is true to enable user could run several jobs with the same
+     * checkpoint directory at the same time. If this value is set to false, pay attention not to
+     * run several jobs with the same directory simultaneously.
+     */
+    @Documentation.Section(Documentation.Sections.EXPERT_STATE_BACKENDS)
+    public static final ConfigOption<Boolean> CREATE_CHECKPOINT_SUB_DIR =
+            ConfigOptions.key("state.checkpoints.create-subdir")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Whether to create sub-directories named by job id under the '%s' to store the data files and meta data "
+                                                    + "of checkpoints. The default value is true to enable user could run several jobs with the same "
+                                                    + "checkpoint directory at the same time. If this value is set to false, pay attention not to "
+                                                    + "run several jobs with the same directory simultaneously. ",
+                                            TextElement.code(CHECKPOINTS_DIRECTORY.key()))
+                                    .linebreak()
+                                    .text(
+                                            "WARNING: This is an advanced configuration. If set to false, users must ensure that no multiple jobs are run "
+                                                    + "with the same checkpoint directory, and that no files exist other than those necessary for the "
+                                                    + "restoration of the current job when starting a new job.")
+                                    .build());
+
+    /**
      * The minimum size of state data files. All state chunks smaller than that are stored inline in
      * the root checkpoint metadata file.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -69,6 +69,26 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
                 checkpointBaseDirectory.getFileSystem(),
                 checkpointBaseDirectory,
                 defaultSavepointDirectory,
+                true,
+                jobId,
+                fileSizeThreshold,
+                writeBufferSize);
+    }
+
+    public FsCheckpointStorageAccess(
+            Path checkpointBaseDirectory,
+            @Nullable Path defaultSavepointDirectory,
+            boolean createCheckpointSubDirs,
+            JobID jobId,
+            int fileSizeThreshold,
+            int writeBufferSize)
+            throws IOException {
+
+        this(
+                checkpointBaseDirectory.getFileSystem(),
+                checkpointBaseDirectory,
+                defaultSavepointDirectory,
+                createCheckpointSubDirs,
                 jobId,
                 fileSizeThreshold,
                 writeBufferSize);
@@ -78,6 +98,7 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
             FileSystem fs,
             Path checkpointBaseDirectory,
             @Nullable Path defaultSavepointDirectory,
+            boolean createCheckpointSubDirs,
             JobID jobId,
             int fileSizeThreshold,
             int writeBufferSize)
@@ -89,7 +110,10 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
         checkArgument(writeBufferSize >= 0);
 
         this.fileSystem = checkNotNull(fs);
-        this.checkpointsDirectory = getCheckpointDirectoryForJob(checkpointBaseDirectory, jobId);
+        this.checkpointsDirectory =
+                createCheckpointSubDirs
+                        ? getCheckpointDirectoryForJob(checkpointBaseDirectory, jobId)
+                        : checkpointBaseDirectory;
         this.sharedStateDirectory = new Path(checkpointsDirectory, CHECKPOINT_SHARED_STATE_DIR);
         this.taskOwnedStateDirectory =
                 new Path(checkpointsDirectory, CHECKPOINT_TASK_OWNED_STATE_DIR);
@@ -209,7 +233,7 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
             throws IOException {
         return new FsMergingCheckpointStorageAccess(
                 fileSystem,
-                checkpointsDirectory.getParent(),
+                checkpointsDirectory,
                 getDefaultSavepointDirectory(),
                 environment.getJobID(),
                 fileSizeThreshold,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
@@ -53,6 +53,7 @@ public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess 
                 fs,
                 checkpointBaseDirectory,
                 defaultSavepointDirectory,
+                false,
                 jobId,
                 fileSizeThreshold,
                 writeBufferSize);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -131,6 +131,12 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
      */
     private final int writeBufferSize;
 
+    /**
+     * Switch to create checkpoint sub-directory with name of jobId. A value of 'undefined' means
+     * not yet configured, in which case the default will be used.
+     */
+    private boolean createCheckpointSubDirs;
+
     // -----------------------------------------------------------------------
 
     /**
@@ -364,6 +370,8 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 
         this.fileStateThreshold = fileStateSizeThreshold;
         this.writeBufferSize = writeBufferSize;
+        this.createCheckpointSubDirs =
+                CheckpointingOptions.CREATE_CHECKPOINT_SUB_DIR.defaultValue();
     }
 
     /**
@@ -407,6 +415,10 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
                         : configuration.get(CheckpointingOptions.FS_WRITE_BUFFER_SIZE);
 
         this.writeBufferSize = Math.max(bufferSize, this.fileStateThreshold);
+        this.createCheckpointSubDirs =
+                configuration
+                        .getOptional(CheckpointingOptions.CREATE_CHECKPOINT_SUB_DIR)
+                        .orElse(original.createCheckpointSubDirs);
         // configure latency tracking
         latencyTrackingConfigBuilder =
                 original.latencyTrackingConfigBuilder.configure(configuration);
@@ -524,6 +536,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
         return new FsCheckpointStorageAccess(
                 getCheckpointPath(),
                 getSavepointPath(),
+                createCheckpointSubDirs,
                 jobId,
                 getMinFileSizeThreshold(),
                 getWriteBufferSize());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
@@ -64,6 +64,7 @@ public class MemoryBackendCheckpointStorageAccess extends AbstractFsCheckpointSt
      * @param checkpointsBaseDirectory The directory to write checkpoints to. May be null, in which
      *     case this storage does not support durable persistence.
      * @param defaultSavepointLocation The default savepoint directory, or null, if none is set.
+     * @param createCheckpointSubDirs Whether to create sub-directory with name of jobId.
      * @param maxStateSize The maximum size of each individual piece of state.
      * @throws IOException Thrown if a checkpoint base directory is given configured and the
      *     checkpoint directory cannot be created within that directory.
@@ -72,6 +73,7 @@ public class MemoryBackendCheckpointStorageAccess extends AbstractFsCheckpointSt
             JobID jobId,
             @Nullable Path checkpointsBaseDirectory,
             @Nullable Path defaultSavepointLocation,
+            boolean createCheckpointSubDirs,
             int maxStateSize)
             throws IOException {
 
@@ -86,7 +88,9 @@ public class MemoryBackendCheckpointStorageAccess extends AbstractFsCheckpointSt
         } else {
             this.fileSystem = checkpointsBaseDirectory.getFileSystem();
             this.checkpointsDirectory =
-                    getCheckpointDirectoryForJob(checkpointsBaseDirectory, jobId);
+                    createCheckpointSubDirs
+                            ? getCheckpointDirectoryForJob(checkpointsBaseDirectory, jobId)
+                            : checkpointsBaseDirectory;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -3618,7 +3618,7 @@ class CheckpointCoordinatorTest {
                                     public CheckpointStorageAccess createCheckpointStorage(
                                             JobID jobId) throws IOException {
                                         return new MemoryBackendCheckpointStorageAccess(
-                                                jobId, null, null, 100) {
+                                                jobId, null, null, true, 100) {
                                             @Override
                                             public CheckpointStorageLocation
                                                     initializeLocationForCheckpoint(
@@ -4155,7 +4155,7 @@ class CheckpointCoordinatorTest {
     private static class IOExceptionCheckpointStorage extends JobManagerCheckpointStorage {
         @Override
         public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
-            return new MemoryBackendCheckpointStorageAccess(jobId, null, null, 100) {
+            return new MemoryBackendCheckpointStorageAccess(jobId, null, null, true, 100) {
                 @Override
                 public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId)
                         throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccessTest.java
@@ -61,16 +61,28 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
     // ------------------------------------------------------------------------
 
     @Override
-    protected CheckpointStorageAccess createCheckpointStorage(Path checkpointDir) throws Exception {
+    protected CheckpointStorageAccess createCheckpointStorage(
+            Path checkpointDir, boolean createCheckpointSubDir) throws Exception {
         return new FsCheckpointStorageAccess(
-                checkpointDir, null, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+                checkpointDir,
+                null,
+                createCheckpointSubDir,
+                new JobID(),
+                FILE_SIZE_THRESHOLD,
+                WRITE_BUFFER_SIZE);
     }
 
     @Override
     protected CheckpointStorageAccess createCheckpointStorageWithSavepointDir(
-            Path checkpointDir, Path savepointDir) throws Exception {
+            Path checkpointDir, Path savepointDir, boolean createCheckpointSubDir)
+            throws Exception {
         return new FsCheckpointStorageAccess(
-                checkpointDir, savepointDir, new JobID(), FILE_SIZE_THRESHOLD, WRITE_BUFFER_SIZE);
+                checkpointDir,
+                savepointDir,
+                createCheckpointSubDir,
+                new JobID(),
+                FILE_SIZE_THRESHOLD,
+                WRITE_BUFFER_SIZE);
     }
 
     // ------------------------------------------------------------------------
@@ -85,6 +97,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         Path.fromLocalFile(TempDirUtils.newFolder(tmp)),
                         defaultSavepointDir,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);
@@ -109,6 +122,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         Path.fromLocalFile(TempDirUtils.newFolder(tmp)),
                         null,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);
@@ -135,6 +149,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         Path.fromLocalFile(TempDirUtils.newFolder(tmp)),
                         null,
+                        true,
                         new JobID(),
                         10,
                         WRITE_BUFFER_SIZE);
@@ -224,6 +239,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         randomTempPath(),
                         null,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);
@@ -240,6 +256,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         randomTempPath(),
                         null,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);
@@ -261,6 +278,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                 new FsCheckpointStorageAccess(
                         new TestingPath("hdfs:///checkpoint/", checkpointFileSystem),
                         null,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);
@@ -284,7 +302,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
 
     @Test
     void testNotDuplicationCheckpointStateToolset() throws Exception {
-        CheckpointStorageAccess checkpointStorage = createCheckpointStorage(randomTempPath());
+        CheckpointStorageAccess checkpointStorage = createCheckpointStorage(randomTempPath(), true);
         assertThat(checkpointStorage.createTaskOwnedCheckpointStateToolset())
                 .isInstanceOf(NotDuplicatingCheckpointStateToolset.class);
     }
@@ -296,6 +314,7 @@ class FsCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessT
                         new TestDuplicatingFileSystem(),
                         randomTempPath(),
                         null,
+                        true,
                         new JobID(),
                         FILE_SIZE_THRESHOLD,
                         WRITE_BUFFER_SIZE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -57,7 +57,7 @@ class FsStateBackendEntropyTest {
 
         final FsCheckpointStorageAccess storage =
                 new FsCheckpointStorageAccess(
-                        fs, checkpointDir, null, new JobID(), fileSizeThreshold, 4096);
+                        fs, checkpointDir, null, true, new JobID(), fileSizeThreshold, 4096);
         storage.initializeBaseLocationsForCheckpoint();
 
         final FsCheckpointStorageLocation location =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageAccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageAccessTest.java
@@ -55,16 +55,22 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
     // ------------------------------------------------------------------------
 
     @Override
-    protected CheckpointStorageAccess createCheckpointStorage(Path checkpointDir) throws Exception {
+    protected CheckpointStorageAccess createCheckpointStorage(
+            Path checkpointDir, boolean createCheckpointSubDir) throws Exception {
         return new MemoryBackendCheckpointStorageAccess(
-                new JobID(), checkpointDir, null, DEFAULT_MAX_STATE_SIZE);
+                new JobID(), checkpointDir, null, createCheckpointSubDir, DEFAULT_MAX_STATE_SIZE);
     }
 
     @Override
     protected CheckpointStorageAccess createCheckpointStorageWithSavepointDir(
-            Path checkpointDir, Path savepointDir) throws Exception {
+            Path checkpointDir, Path savepointDir, boolean createCheckpointSubDir)
+            throws Exception {
         return new MemoryBackendCheckpointStorageAccess(
-                new JobID(), checkpointDir, savepointDir, DEFAULT_MAX_STATE_SIZE);
+                new JobID(),
+                checkpointDir,
+                savepointDir,
+                createCheckpointSubDir,
+                DEFAULT_MAX_STATE_SIZE);
     }
 
     // ------------------------------------------------------------------------
@@ -120,7 +126,7 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
     void testNonPersistentCheckpointLocation() throws Exception {
         MemoryBackendCheckpointStorageAccess storage =
                 new MemoryBackendCheckpointStorageAccess(
-                        new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+                        new JobID(), null, null, true, DEFAULT_MAX_STATE_SIZE);
 
         CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(9);
 
@@ -142,7 +148,7 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
         {
             MemoryBackendCheckpointStorageAccess storage =
                     new MemoryBackendCheckpointStorageAccess(
-                            new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+                            new JobID(), null, null, true, DEFAULT_MAX_STATE_SIZE);
             CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
             assertThat(location.getLocationReference().isDefaultReference()).isTrue();
         }
@@ -151,7 +157,7 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
         {
             MemoryBackendCheckpointStorageAccess storage =
                     new MemoryBackendCheckpointStorageAccess(
-                            new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
+                            new JobID(), randomTempPath(), null, true, DEFAULT_MAX_STATE_SIZE);
             CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
             assertThat(location.getLocationReference().isDefaultReference()).isTrue();
         }
@@ -160,7 +166,7 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
         {
             MemoryBackendCheckpointStorageAccess storage =
                     new MemoryBackendCheckpointStorageAccess(
-                            new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+                            new JobID(), null, null, true, DEFAULT_MAX_STATE_SIZE);
             CheckpointStorageLocation location =
                     storage.initializeLocationForSavepoint(1337, randomTempPath().toString());
             assertThat(location.getLocationReference().isDefaultReference()).isTrue();
@@ -173,7 +179,7 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
 
         final MemoryBackendCheckpointStorageAccess storage =
                 new MemoryBackendCheckpointStorageAccess(
-                        new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
+                        new JobID(), null, null, true, DEFAULT_MAX_STATE_SIZE);
 
         StreamStateHandle stateHandle;
 
@@ -197,7 +203,11 @@ public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointSto
     void testStorageLocationMkdirs() throws Exception {
         MemoryBackendCheckpointStorageAccess storage =
                 new MemoryBackendCheckpointStorageAccess(
-                        new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
+                        new JobID(),
+                        new Path(randomTempPath(), "chk"),
+                        null,
+                        true,
+                        DEFAULT_MAX_STATE_SIZE);
 
         File baseDir = new File(storage.getCheckpointsDirectory().getPath());
         assertThat(baseDir).doesNotExist();

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
@@ -289,7 +289,7 @@ public class ChangelogStateDiscardTest {
                 writer,
                 emptyList(),
                 new MemoryBackendCheckpointStorageAccess(
-                        jobId, null, null, 1 /* don't expect any materialization */));
+                        jobId, null, null, true, 1 /* don't expect any materialization */));
     }
 
     private static String randomString() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -265,7 +265,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 
         @Override
         public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
-            return new MemoryBackendCheckpointStorageAccess(jobId, null, null, Integer.MAX_VALUE);
+            return new MemoryBackendCheckpointStorageAccess(
+                    jobId, null, null, true, Integer.MAX_VALUE);
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -96,7 +96,7 @@ public class StateBackendITCase extends AbstractTestBase {
 
         @Override
         public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
-            return new MemoryBackendCheckpointStorageAccess(jobId, null, null, 1_000_000);
+            return new MemoryBackendCheckpointStorageAccess(jobId, null, null, true, 1_000_000);
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

By default, Flink creates subdirectories named by UUID (job id) under checkpoint directory for each job. It's a good means to avoid collision. However, it also bring in some effort to remember/find the right directory when recovering from previous checkpoint, as well as cleaning the old subdirectories. According to previous discussion ([Yun Tang's](https://issues.apache.org/jira/browse/FLINK-11789?focusedCommentId=16782314&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16782314) and [Stephan Ewen's](https://issues.apache.org/jira/browse/FLINK-9043?focusedCommentId=16409254&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16409254) ), I think it would be useful to add an option to disable creating the UUID subdirectories under the checkpoint directory. For compatibility considerations, we create the subdirectories by default.


## Brief change log

 - Provide a new configuration named 'state.checkpoints.create-subdir' to control the behavior of creating job-id subdirectories under the checkpoint directory or not. This is an advanced option, which is well documented and warned.


## Verifying this change

This change is already covered by newly added tests, a parameterized AbstractFileCheckpointStorageAccessTestBase#testCreateCheckpointSubDirs .

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), **Checkpointing**, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
