### PR TITLE
[FLINK-33198][Format/Avro] support local timezone timestamp logic type in AVRO

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.flink.formats.avro.AvroFormatOptions.AVRO_ENCODING;
+import static org.apache.flink.formats.avro.AvroFormatOptions.AVRO_TIMESTAMP_LEGACY_MAPPING;
 
 /**
  * Table format factory for providing configured instances of Avro to RowData {@link
@@ -61,6 +62,7 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
         FactoryUtil.validateFactoryOptions(this, formatOptions);
 
         AvroEncoding encoding = formatOptions.get(AVRO_ENCODING);
+        boolean legacyTimestampMapping = formatOptions.get(AVRO_TIMESTAMP_LEGACY_MAPPING);
 
         return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
             @Override
@@ -73,7 +75,8 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
                 final RowType rowType = (RowType) producedDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);
-                return new AvroRowDataDeserializationSchema(rowType, rowDataTypeInfo, encoding);
+                return new AvroRowDataDeserializationSchema(
+                        rowType, rowDataTypeInfo, encoding, legacyTimestampMapping);
             }
 
             @Override
@@ -89,13 +92,15 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
         FactoryUtil.validateFactoryOptions(this, formatOptions);
 
         AvroEncoding encoding = formatOptions.get(AVRO_ENCODING);
+        boolean legacyTimestampMapping = formatOptions.get(AVRO_TIMESTAMP_LEGACY_MAPPING);
 
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
             public SerializationSchema<RowData> createRuntimeEncoder(
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
-                return new AvroRowDataSerializationSchema(rowType, encoding);
+                return new AvroRowDataSerializationSchema(
+                        rowType, encoding, legacyTimestampMapping);
             }
 
             @Override
@@ -119,6 +124,7 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(AVRO_ENCODING);
+        options.add(AVRO_TIMESTAMP_LEGACY_MAPPING);
         return options;
     }
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatOptions.java
@@ -36,7 +36,6 @@ public class AvroFormatOptions {
                     .stringType()
                     .defaultValue(SNAPPY_CODEC)
                     .withDescription("The compression codec for avro");
-
     public static final ConfigOption<AvroEncoding> AVRO_ENCODING =
             ConfigOptions.key("encoding")
                     .enumType(AvroEncoding.class)
@@ -70,6 +69,19 @@ public class AvroFormatOptions {
             return description;
         }
     }
+
+    public static final ConfigOption<Boolean> AVRO_TIMESTAMP_LEGACY_MAPPING =
+            ConfigOptions.key("timestamp_mapping.legacy")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Use the legacy mapping of timestamp in avro. "
+                                    + "Before 1.19, The default behavior of Flink wrongly mapped "
+                                    + "both SQL TIMESTAMP and TIMESTAMP_LTZ type to AVRO TIMESTAMP. "
+                                    + "The correct behavior is Flink SQL TIMESTAMP maps Avro LOCAL "
+                                    + "TIMESTAMP and Flink SQL TIMESTAMP_LTZ maps Avro TIMESTAMP, "
+                                    + "you can obtain the correct mapping by disable using this legacy mapping."
+                                    + " Use legacy behavior by default for compatibility consideration.");
 
     private AvroFormatOptions() {}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
@@ -59,18 +59,18 @@ public class AvroRowDataDeserializationSchema implements DeserializationSchema<R
     private final AvroToRowDataConverters.AvroToRowDataConverter runtimeConverter;
 
     /**
-     * Creates a Avro deserialization schema for the given logical type.
+     * Creates an Avro deserialization schema for the given logical type.
      *
      * @param rowType The logical type used to deserialize the data.
      * @param typeInfo The TypeInformation to be used by {@link
      *     AvroRowDataDeserializationSchema#getProducedType()}.
      */
     public AvroRowDataDeserializationSchema(RowType rowType, TypeInformation<RowData> typeInfo) {
-        this(rowType, typeInfo, AvroEncoding.BINARY);
+        this(rowType, typeInfo, AvroEncoding.BINARY, true);
     }
 
     /**
-     * Creates a Avro deserialization schema for the given logical type.
+     * Creates an Avro deserialization schema for the given logical type.
      *
      * @param rowType The logical type used to deserialize the data.
      * @param typeInfo The TypeInformation to be used by {@link
@@ -83,6 +83,28 @@ public class AvroRowDataDeserializationSchema implements DeserializationSchema<R
                 AvroDeserializationSchema.forGeneric(
                         AvroSchemaConverter.convertToSchema(rowType), encoding),
                 AvroToRowDataConverters.createRowConverter(rowType),
+                typeInfo);
+    }
+
+    /**
+     * Creates an Avro deserialization schema for the given logical type.
+     *
+     * @param rowType The logical type used to deserialize the data.
+     * @param typeInfo The TypeInformation to be used by {@link
+     *     AvroRowDataDeserializationSchema#getProducedType()}.
+     * @param encoding The serialization approach used to deserialize the data.
+     * @param legacyTimestampMapping Whether to use legacy timestamp mapping.
+     */
+    public AvroRowDataDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> typeInfo,
+            AvroEncoding encoding,
+            boolean legacyTimestampMapping) {
+        this(
+                AvroDeserializationSchema.forGeneric(
+                        AvroSchemaConverter.convertToSchema(rowType, legacyTimestampMapping),
+                        encoding),
+                AvroToRowDataConverters.createRowConverter(rowType, legacyTimestampMapping),
                 typeInfo);
     }
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -73,6 +73,23 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
     }
 
     /**
+     * Creates an Avro serialization schema with the given record row type and legacy timestamp
+     * mapping flag.
+     *
+     * @param encoding The serialization approach used to serialize the data.
+     * @param legacyTimestampMapping Use the legacy timestamp mapping.
+     */
+    public AvroRowDataSerializationSchema(
+            RowType rowType, AvroEncoding encoding, boolean legacyTimestampMapping) {
+        this(
+                rowType,
+                AvroSerializationSchema.forGeneric(
+                        AvroSchemaConverter.convertToSchema(rowType, legacyTimestampMapping),
+                        encoding),
+                RowDataToAvroConverters.createConverter(rowType, legacyTimestampMapping));
+    }
+
+    /**
      * Creates an Avro serialization schema with the given record row type, nested schema and
      * runtime converters.
      */

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -36,6 +36,7 @@ import org.apache.avro.util.Utf8;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,11 @@ public class RowDataToAvroConverters {
      * Flink Table & SQL internal data structures to corresponding Avro data structures.
      */
     public static RowDataToAvroConverter createConverter(LogicalType type) {
+        return createConverter(type, true);
+    }
+
+    public static RowDataToAvroConverter createConverter(
+            LogicalType type, boolean legacyTimestampMapping) {
         final RowDataToAvroConverter converter;
         switch (type.getTypeRoot()) {
             case NULL:
@@ -150,15 +156,45 @@ public class RowDataToAvroConverters {
                         };
                 break;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                converter =
-                        new RowDataToAvroConverter() {
-                            private static final long serialVersionUID = 1L;
+                if (legacyTimestampMapping) {
+                    converter =
+                            new RowDataToAvroConverter() {
+                                private static final long serialVersionUID = 1L;
 
-                            @Override
-                            public Object convert(Schema schema, Object object) {
-                                return ((TimestampData) object).toInstant().toEpochMilli();
-                            }
-                        };
+                                @Override
+                                public Object convert(Schema schema, Object object) {
+                                    return ((TimestampData) object).toInstant().toEpochMilli();
+                                }
+                            };
+                } else {
+                    converter =
+                            new RowDataToAvroConverter() {
+                                private static final long serialVersionUID = 1L;
+
+                                @Override
+                                public Object convert(Schema schema, Object object) {
+                                    return ((TimestampData) object)
+                                            .toLocalDateTime()
+                                            .toInstant(ZoneOffset.UTC)
+                                            .toEpochMilli();
+                                }
+                            };
+                }
+                break;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                if (legacyTimestampMapping) {
+                    throw new UnsupportedOperationException("Unsupported type: " + type);
+                } else {
+                    converter =
+                            new RowDataToAvroConverter() {
+                                private static final long serialVersionUID = 1L;
+
+                                @Override
+                                public Object convert(Schema schema, Object object) {
+                                    return ((TimestampData) object).toInstant().toEpochMilli();
+                                }
+                            };
+                }
                 break;
             case DECIMAL:
                 converter =
@@ -172,14 +208,14 @@ public class RowDataToAvroConverters {
                         };
                 break;
             case ARRAY:
-                converter = createArrayConverter((ArrayType) type);
+                converter = createArrayConverter((ArrayType) type, legacyTimestampMapping);
                 break;
             case ROW:
-                converter = createRowConverter((RowType) type);
+                converter = createRowConverter((RowType) type, legacyTimestampMapping);
                 break;
             case MAP:
             case MULTISET:
-                converter = createMapConverter(type);
+                converter = createMapConverter(type, legacyTimestampMapping);
                 break;
             case RAW:
             default:
@@ -217,10 +253,11 @@ public class RowDataToAvroConverters {
         };
     }
 
-    private static RowDataToAvroConverter createRowConverter(RowType rowType) {
+    private static RowDataToAvroConverter createRowConverter(
+            RowType rowType, boolean legacyTimestampMapping) {
         final RowDataToAvroConverter[] fieldConverters =
                 rowType.getChildren().stream()
-                        .map(RowDataToAvroConverters::createConverter)
+                        .map(legacyType -> createConverter(legacyType, legacyTimestampMapping))
                         .toArray(RowDataToAvroConverter[]::new);
         final LogicalType[] fieldTypes =
                 rowType.getFields().stream()
@@ -259,10 +296,12 @@ public class RowDataToAvroConverters {
         };
     }
 
-    private static RowDataToAvroConverter createArrayConverter(ArrayType arrayType) {
+    private static RowDataToAvroConverter createArrayConverter(
+            ArrayType arrayType, boolean legacyTimestampMapping) {
         LogicalType elementType = arrayType.getElementType();
         final ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
-        final RowDataToAvroConverter elementConverter = createConverter(arrayType.getElementType());
+        final RowDataToAvroConverter elementConverter =
+                createConverter(arrayType.getElementType(), legacyTimestampMapping);
 
         return new RowDataToAvroConverter() {
             private static final long serialVersionUID = 1L;
@@ -282,10 +321,12 @@ public class RowDataToAvroConverters {
         };
     }
 
-    private static RowDataToAvroConverter createMapConverter(LogicalType type) {
+    private static RowDataToAvroConverter createMapConverter(
+            LogicalType type, boolean legacyTimestampMapping) {
         LogicalType valueType = extractValueTypeToAvroMap(type);
         final ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(valueType);
-        final RowDataToAvroConverter valueConverter = createConverter(valueType);
+        final RowDataToAvroConverter valueConverter =
+                createConverter(valueType, legacyTimestampMapping);
 
         return new RowDataToAvroConverter() {
             private static final long serialVersionUID = 1L;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
@@ -33,13 +33,16 @@ import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContex
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link AvroFormatFactory}. */
 class AvroFormatFactoryTest {
@@ -48,10 +51,24 @@ class AvroFormatFactoryTest {
             ResolvedSchema.of(
                     Column.physical("a", DataTypes.STRING()),
                     Column.physical("b", DataTypes.INT()),
-                    Column.physical("c", DataTypes.BOOLEAN()));
+                    Column.physical("c", DataTypes.BOOLEAN()),
+                    Column.physical("d", DataTypes.TIMESTAMP(3)));
+
+    private static final ResolvedSchema NEW_SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("a", DataTypes.STRING()),
+                    Column.physical("b", DataTypes.INT()),
+                    Column.physical("c", DataTypes.BOOLEAN()),
+                    Column.physical("d", DataTypes.TIMESTAMP(3)),
+                    Column.physical("e", DataTypes.TIMESTAMP(6)),
+                    Column.physical("f", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                    Column.physical("g", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(6)));
 
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
+
+    private static final RowType NEW_ROW_TYPE =
+            (RowType) NEW_SCHEMA.toPhysicalRowDataType().getLogicalType();
 
     @ParameterizedTest
     @EnumSource(AvroEncoding.class)
@@ -60,7 +77,7 @@ class AvroFormatFactoryTest {
                 new AvroRowDataDeserializationSchema(
                         ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), encoding);
 
-        final Map<String, String> options = getAllOptions();
+        final Map<String, String> options = getAllOptions(true);
 
         final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, options);
         assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
@@ -87,15 +104,86 @@ class AvroFormatFactoryTest {
         assertThat(actualSer).isEqualTo(expectedSer);
     }
 
+    @Test
+    void testOldSeDeNewSchema() {
+        assertThatThrownBy(
+                        () -> {
+                            new AvroRowDataDeserializationSchema(
+                                    NEW_ROW_TYPE, InternalTypeInfo.of(NEW_ROW_TYPE));
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Avro does not support TIMESTAMP type with precision: 6, it only supports precision less than 3.");
+
+        assertThatThrownBy(
+                        () -> {
+                            new AvroRowDataSerializationSchema(NEW_ROW_TYPE);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Avro does not support TIMESTAMP type with precision: 6, it only supports precision less than 3.");
+    }
+
+    @Test
+    void testNewSeDeNewSchema() {
+        testSeDeSchema(NEW_ROW_TYPE, NEW_SCHEMA, false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSeDeSchema(boolean legacyTimestampMapping) {
+        testSeDeSchema(ROW_TYPE, SCHEMA, legacyTimestampMapping);
+    }
+
+    void testSeDeSchema(RowType rowType, ResolvedSchema schema, boolean legacyTimestampMapping) {
+        final AvroRowDataDeserializationSchema expectedDeser =
+                new AvroRowDataDeserializationSchema(
+                        rowType,
+                        InternalTypeInfo.of(rowType),
+                        AvroEncoding.BINARY,
+                        legacyTimestampMapping);
+
+        final Map<String, String> options = getAllOptions(legacyTimestampMapping);
+
+        final DynamicTableSource actualSource = FactoryMocks.createTableSource(schema, options);
+        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+        TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
+                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+
+        DeserializationSchema<RowData> actualDeser =
+                scanSourceMock.valueFormat.createRuntimeDecoder(
+                        ScanRuntimeProviderContext.INSTANCE, schema.toPhysicalRowDataType());
+
+        assertThat(actualDeser).isEqualTo(expectedDeser);
+
+        final AvroRowDataSerializationSchema expectedSer =
+                new AvroRowDataSerializationSchema(
+                        rowType, AvroEncoding.BINARY, legacyTimestampMapping);
+
+        final DynamicTableSink actualSink = FactoryMocks.createTableSink(schema, options);
+        assertThat(actualSink).isInstanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class);
+        TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
+                (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+
+        SerializationSchema<RowData> actualSer =
+                sinkMock.valueFormat.createRuntimeEncoder(null, schema.toPhysicalRowDataType());
+
+        assertThat(actualSer).isEqualTo(expectedSer);
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
 
-    private Map<String, String> getAllOptions() {
+    private Map<String, String> getAllOptions(boolean legacyTimestampMapping) {
         final Map<String, String> options = new HashMap<>();
         options.put("connector", TestDynamicTableFactory.IDENTIFIER);
         options.put("target", "MyTarget");
         options.put("buffer-size", "1000");
+
+        if (!legacyTimestampMapping) {
+            options.put("avro.timestamp_mapping.legacy", "false");
+        }
 
         options.put("format", AvroFormatFactory.IDENTIFIER);
         return options;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDeSerializationSchemaTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.InstantiationUtil;
@@ -26,33 +27,22 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificRecord;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for the Avro serialization and deserialization schema. */
 class AvroRowDeSerializationSchemaTest {
 
-    @Test
-    void testSpecificSerializeDeserializeFromClass() throws IOException {
-        final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
-                AvroTestUtils.getSpecificTestData();
-
-        final AvroRowSerializationSchema serializationSchema =
-                new AvroRowSerializationSchema(testData.f0);
-        final AvroRowDeserializationSchema deserializationSchema =
-                new AvroRowDeserializationSchema(testData.f0);
-
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
-    }
-
-    @Test
-    void testSpecificSerializeDeserializeFromSchema() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSpecificSerializeDeserializeFromSchema(boolean legacyTimestampMapping)
+            throws IOException {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
         final String schemaString = testData.f1.getSchema().toString();
@@ -62,14 +52,20 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(schemaString);
 
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serializationSchema.serialize(testData.f2);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f2);
+        } else {
+            final byte[] bytes = serializationSchema.serialize(testData.f2, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f2);
+        }
     }
 
-    @Test
-    void testGenericSerializeDeserialize() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testGenericSerializeDeserialize(boolean legacyTimestampMapping) throws IOException {
         final Tuple3<GenericRecord, Row, Schema> testData = AvroTestUtils.getGenericTestData();
 
         final AvroRowSerializationSchema serializationSchema =
@@ -77,14 +73,21 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(testData.f2.toString());
 
-        final byte[] bytes = serializationSchema.serialize(testData.f1);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f1);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serializationSchema.serialize(testData.f1);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f1);
+        } else {
+            final byte[] bytes = serializationSchema.serialize(testData.f1, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f1);
+        }
     }
 
-    @Test
-    void testSpecificSerializeFromClassSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSpecificSerializeFromClassSeveralTimes(boolean legacyTimestampMapping)
+            throws IOException {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
 
@@ -93,16 +96,25 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(testData.f0);
 
-        serializationSchema.serialize(testData.f2);
-        serializationSchema.serialize(testData.f2);
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
+        if (legacyTimestampMapping) {
+            serializationSchema.serialize(testData.f2);
+            serializationSchema.serialize(testData.f2);
+            final byte[] bytes = serializationSchema.serialize(testData.f2);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f2);
+        } else {
+            serializationSchema.serialize(testData.f2, false);
+            serializationSchema.serialize(testData.f2, false);
+            final byte[] bytes = serializationSchema.serialize(testData.f2, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f2);
+        }
     }
 
-    @Test
-    void testSpecificSerializeFromSchemaSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSpecificSerializeFromSchemaSeveralTimes(boolean legacyTimestampMapping)
+            throws IOException {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
         final String schemaString = testData.f1.getSchema().toString();
@@ -112,16 +124,24 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(schemaString);
 
-        serializationSchema.serialize(testData.f2);
-        serializationSchema.serialize(testData.f2);
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
+        if (legacyTimestampMapping) {
+            serializationSchema.serialize(testData.f2);
+            serializationSchema.serialize(testData.f2);
+            final byte[] bytes = serializationSchema.serialize(testData.f2);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f2);
+        } else {
+            serializationSchema.serialize(testData.f2, false);
+            serializationSchema.serialize(testData.f2, false);
+            final byte[] bytes = serializationSchema.serialize(testData.f2, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f2);
+        }
     }
 
-    @Test
-    void testGenericSerializeSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testGenericSerializeSeveralTimes(boolean legacyTimestampMapping) throws IOException {
         final Tuple3<GenericRecord, Row, Schema> testData = AvroTestUtils.getGenericTestData();
 
         final AvroRowSerializationSchema serializationSchema =
@@ -129,16 +149,25 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(testData.f2.toString());
 
-        serializationSchema.serialize(testData.f1);
-        serializationSchema.serialize(testData.f1);
-        final byte[] bytes = serializationSchema.serialize(testData.f1);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f1);
+        if (legacyTimestampMapping) {
+            serializationSchema.serialize(testData.f1);
+            serializationSchema.serialize(testData.f1);
+            final byte[] bytes = serializationSchema.serialize(testData.f1);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f1);
+        } else {
+            serializationSchema.serialize(testData.f1, false);
+            serializationSchema.serialize(testData.f1, false);
+            final byte[] bytes = serializationSchema.serialize(testData.f1, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f1);
+        }
     }
 
-    @Test
-    void testSpecificDeserializeFromClassSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSpecificDeserializeFromClassSeveralTimes(boolean legacyTimestampMapping)
+            throws IOException {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
 
@@ -147,16 +176,25 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(testData.f0);
 
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        deserializationSchema.deserialize(bytes);
-        deserializationSchema.deserialize(bytes);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serializationSchema.serialize(testData.f2);
+            deserializationSchema.deserialize(bytes);
+            deserializationSchema.deserialize(bytes);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f2);
+        } else {
+            final byte[] bytes = serializationSchema.serialize(testData.f2, false);
+            deserializationSchema.deserialize(bytes, false);
+            deserializationSchema.deserialize(bytes, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f2);
+        }
     }
 
-    @Test
-    void testSpecificDeserializeFromSchemaSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSpecificDeserializeFromSchemaSeveralTimes(boolean legacyTimestampMapping)
+            throws IOException {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
         final String schemaString = testData.f1.getSchema().toString();
@@ -166,16 +204,24 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(schemaString);
 
-        final byte[] bytes = serializationSchema.serialize(testData.f2);
-        deserializationSchema.deserialize(bytes);
-        deserializationSchema.deserialize(bytes);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f2);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serializationSchema.serialize(testData.f2);
+            deserializationSchema.deserialize(bytes);
+            deserializationSchema.deserialize(bytes);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f2);
+        } else {
+            final byte[] bytes = serializationSchema.serialize(testData.f2, false);
+            deserializationSchema.deserialize(bytes, false);
+            deserializationSchema.deserialize(bytes, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f2);
+        }
     }
 
-    @Test
-    void testGenericDeserializeSeveralTimes() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testGenericDeserializeSeveralTimes(boolean legacyTimestampMapping) throws IOException {
         final Tuple3<GenericRecord, Row, Schema> testData = AvroTestUtils.getGenericTestData();
 
         final AvroRowSerializationSchema serializationSchema =
@@ -183,16 +229,24 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowDeserializationSchema deserializationSchema =
                 new AvroRowDeserializationSchema(testData.f2.toString());
 
-        final byte[] bytes = serializationSchema.serialize(testData.f1);
-        deserializationSchema.deserialize(bytes);
-        deserializationSchema.deserialize(bytes);
-        final Row actual = deserializationSchema.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(testData.f1);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serializationSchema.serialize(testData.f1);
+            deserializationSchema.deserialize(bytes);
+            deserializationSchema.deserialize(bytes);
+            final Row actual = deserializationSchema.deserialize(bytes);
+            assertThat(actual).isEqualTo(testData.f1);
+        } else {
+            final byte[] bytes = serializationSchema.serialize(testData.f1, false);
+            deserializationSchema.deserialize(bytes, false);
+            deserializationSchema.deserialize(bytes, false);
+            final Row actual = deserializationSchema.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(testData.f1);
+        }
     }
 
-    @Test
-    void testSerializability() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSerializability(boolean legacyTimestampMapping) throws Exception {
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
                 AvroTestUtils.getSpecificTestData();
         final String schemaString = testData.f1.getSchema().toString();
@@ -201,17 +255,97 @@ class AvroRowDeSerializationSchemaTest {
         final AvroRowSerializationSchema classSer = new AvroRowSerializationSchema(testData.f0);
         final AvroRowDeserializationSchema classDeser =
                 new AvroRowDeserializationSchema(testData.f0);
-        testSerializability(classSer, classDeser, testData.f2);
+        testSerializability(classSer, classDeser, testData.f2, legacyTimestampMapping);
 
         // from schema string
         final AvroRowSerializationSchema schemaSer = new AvroRowSerializationSchema(schemaString);
         final AvroRowDeserializationSchema schemaDeser =
                 new AvroRowDeserializationSchema(schemaString);
-        testSerializability(schemaSer, schemaDeser, testData.f2);
+        testSerializability(schemaSer, schemaDeser, testData.f2, legacyTimestampMapping);
+    }
+
+    void testTimestampSerializeDeserializeLegacyMapping() throws Exception {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+
+        final String schemaString = testData.f1.getSchema().toString();
+
+        final AvroRowSerializationSchema serializationSchema =
+                new AvroRowSerializationSchema(schemaString);
+        final AvroRowDeserializationSchema deserializationSchema =
+                new AvroRowDeserializationSchema(schemaString);
+
+        assertThatThrownBy(
+                        () -> {
+                            serializationSchema.serialize(testData.f3);
+                        })
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Unsupported local timestamp type.");
+
+        final byte[] bytes = serializationSchema.serialize(testData.f3, false);
+
+        assertThatThrownBy(
+                        () -> {
+                            deserializationSchema.deserialize(bytes);
+                        })
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Unsupported local timestamp type.");
+    }
+
+    @Test
+    void testTimestampSpecificSerializeDeserializeNewMapping() throws Exception {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+
+        final String schemaString = testData.f1.getSchema().toString();
+
+        final AvroRowSerializationSchema serializationSchema =
+                new AvroRowSerializationSchema(schemaString);
+        final AvroRowDeserializationSchema deserializationSchema =
+                new AvroRowDeserializationSchema(schemaString);
+
+        final byte[] bytes = serializationSchema.serialize(testData.f3, false);
+        final Row actual = deserializationSchema.deserialize(bytes, false);
+        assertThat(actual).isEqualTo(testData.f3);
+    }
+
+    @Test
+    void testTimestampGenericGenericSerializeDeserializeNewMapping() throws Exception {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+
+        final String schemaString = testData.f2.getSchema().toString();
+
+        final AvroRowSerializationSchema serializationSchema =
+                new AvroRowSerializationSchema(schemaString);
+        final AvroRowDeserializationSchema deserializationSchema =
+                new AvroRowDeserializationSchema(schemaString);
+
+        final byte[] bytes = serializationSchema.serialize(testData.f3);
+        final Row actual = deserializationSchema.deserialize(bytes);
+        assertThat(actual).isEqualTo(testData.f3);
+    }
+
+    @Test
+    void testTimestampClassSerializeDeserializeNewMapping() throws Exception {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+
+        final AvroRowSerializationSchema serializationSchema =
+                new AvroRowSerializationSchema(testData.f0);
+        final AvroRowDeserializationSchema deserializationSchema =
+                new AvroRowDeserializationSchema(testData.f0);
+
+        final byte[] bytes = serializationSchema.serialize(testData.f3);
+        final Row actual = deserializationSchema.deserialize(bytes);
+        assertThat(actual).isEqualTo(testData.f3);
     }
 
     private void testSerializability(
-            AvroRowSerializationSchema ser, AvroRowDeserializationSchema deser, Row data)
+            AvroRowSerializationSchema ser,
+            AvroRowDeserializationSchema deser,
+            Row data,
+            boolean legacyTimestampMapping)
             throws Exception {
         final byte[] serBytes = InstantiationUtil.serializeObject(ser);
         final byte[] deserBytes = InstantiationUtil.serializeObject(deser);
@@ -223,11 +357,18 @@ class AvroRowDeSerializationSchemaTest {
                 InstantiationUtil.deserializeObject(
                         deserBytes, Thread.currentThread().getContextClassLoader());
 
-        final byte[] bytes = serCopy.serialize(data);
-        deserCopy.deserialize(bytes);
-        deserCopy.deserialize(bytes);
-        final Row actual = deserCopy.deserialize(bytes);
-
-        assertThat(actual).isEqualTo(data);
+        if (legacyTimestampMapping) {
+            final byte[] bytes = serCopy.serialize(data);
+            deserCopy.deserialize(bytes);
+            deserCopy.deserialize(bytes);
+            final Row actual = deserCopy.deserialize(bytes);
+            assertThat(actual).isEqualTo(data);
+        } else {
+            final byte[] bytes = serCopy.serialize(data, false);
+            deserCopy.deserialize(bytes, false);
+            deserCopy.deserialize(bytes, false);
+            final Row actual = deserCopy.deserialize(bytes, false);
+            assertThat(actual).isEqualTo(data);
+        }
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.avro.typeutils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.generated.User;
@@ -41,6 +42,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -533,6 +535,47 @@ class AvroSchemaConverterTest {
         assertThat(schema).isEqualTo(new Schema.Parser().parse(schemaStr));
     }
 
+    @Test
+    void testTimestampsSchemaToDataTypeToSchemaLegacyTimestampMapping() {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+        String schemaStr = testData.f1.getSchema().toString();
+        DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr);
+        assertThatThrownBy(() -> AvroSchemaConverter.convertToSchema(dataType.getLogicalType()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Avro does not support TIMESTAMP type with precision: 6, it only supports precision less than 3.");
+    }
+
+    @Test
+    void testTimestampsSchemaToTypeInfoLegacyTimestampMapping() {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+        String schemaStr = testData.f1.getSchema().toString();
+        TypeInformation<Row> typeInfo = AvroSchemaConverter.convertToTypeInfo(schemaStr);
+        validateLegacyTimestampsSchema(typeInfo);
+    }
+
+    @Test
+    void testTimestampsSchemaToDataTypeToSchemaNewMapping() {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+        String schemaStr = testData.f1.getSchema().toString();
+        DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr, false);
+        Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType(), false);
+        DataType dataType2 = AvroSchemaConverter.convertToDataType(schema.toString(), false);
+        validateTimestampsSchema(dataType2);
+    }
+
+    @Test
+    void testTimestampsSchemaToTypeInfoNewMapping() {
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> testData =
+                AvroTestUtils.getTimestampTestData();
+        String schemaStr = testData.f1.getSchema().toString();
+        TypeInformation<Row> typeInfo = AvroSchemaConverter.convertToTypeInfo(schemaStr, false);
+        validateTimestampsSchema(typeInfo);
+    }
+
     private void validateUserSchema(TypeInformation<?> actual) {
         final TypeInformation<Row> address =
                 Types.ROW_NAMED(
@@ -598,6 +641,78 @@ class AvroSchemaConverterTest {
 
         final RowTypeInfo userRowInfo = (RowTypeInfo) user;
         assertThat(userRowInfo.schemaEquals(actual)).isTrue();
+    }
+
+    private void validateTimestampsSchema(TypeInformation<?> actual) {
+        final TypeInformation<Row> timestamps =
+                Types.ROW_NAMED(
+                        new String[] {
+                            "type_timestamp_millis",
+                            "type_timestamp_micros",
+                            "type_local_timestamp_millis",
+                            "type_local_timestamp_micros"
+                        },
+                        Types.INSTANT,
+                        Types.INSTANT,
+                        Types.LOCAL_DATE_TIME,
+                        Types.LOCAL_DATE_TIME);
+        final RowTypeInfo timestampsRowTypeInfo = (RowTypeInfo) timestamps;
+        assertThat(timestampsRowTypeInfo.schemaEquals(actual)).isTrue();
+    }
+
+    private void validateLegacyTimestampsSchema(TypeInformation<?> actual) {
+        final TypeInformation<Row> timestamps =
+                Types.ROW_NAMED(
+                        new String[] {
+                            "type_timestamp_millis",
+                            "type_timestamp_micros",
+                            "type_local_timestamp_millis",
+                            "type_local_timestamp_micros"
+                        },
+                        Types.SQL_TIMESTAMP,
+                        Types.SQL_TIMESTAMP,
+                        Types.LONG,
+                        Types.LONG);
+        final RowTypeInfo timestampsRowTypeInfo = (RowTypeInfo) timestamps;
+        assertThat(timestampsRowTypeInfo.schemaEquals(actual)).isTrue();
+    }
+
+    private void validateLegacyTimestampsSchema(DataType actual) {
+        final DataType timestamps =
+                DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "type_timestamp_millis", DataTypes.TIMESTAMP(3).notNull()),
+                                DataTypes.FIELD(
+                                        "type_timestamp_micros", DataTypes.TIMESTAMP(6).notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_millis",
+                                        DataTypes.BIGINT().notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_micros",
+                                        DataTypes.BIGINT().notNull()))
+                        .notNull();
+
+        assertThat(actual).isEqualTo(timestamps);
+    }
+
+    private void validateTimestampsSchema(DataType actual) {
+        final DataType timestamps =
+                DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        "type_timestamp_millis",
+                                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull()),
+                                DataTypes.FIELD(
+                                        "type_timestamp_micros",
+                                        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(6).notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_millis",
+                                        DataTypes.TIMESTAMP(3).notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_micros",
+                                        DataTypes.TIMESTAMP(6).notNull()))
+                        .notNull();
+
+        assertThat(actual).isEqualTo(timestamps);
     }
 
     private void validateUserSchema(DataType actual) {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
@@ -111,8 +111,8 @@ class AvroTypeExtractionTest {
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
-                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
+                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -123,7 +123,8 @@ class AvroTypeExtractionTest {
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
-                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
+                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
+                        + "\"type_decimal_bytes\": \"\\u0007Ð\", "
                         + "\"type_decimal_fixed\": [7, -48]}\n";
     }
 
@@ -162,8 +163,8 @@ class AvroTypeExtractionTest {
                         + " \"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
-                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
+                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -174,8 +175,8 @@ class AvroTypeExtractionTest {
                         + "\"type_bytes\": \"\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000\", "
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
-                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n";
+                        + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", "
+                        + "\"type_decimal_bytes\": \"\\u0007Ð\", \"type_decimal_fixed\": [7, -48]}\n";
     }
 
     @ParameterizedTest

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -19,11 +19,13 @@
 package org.apache.flink.formats.avro.utils;
 
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.Fixed16;
 import org.apache.flink.formats.avro.generated.Fixed2;
+import org.apache.flink.formats.avro.generated.Timestamps;
 import org.apache.flink.formats.avro.generated.User;
 import org.apache.flink.formats.avro.typeutils.AvroSerializerLargeGenericRecordTest;
 import org.apache.flink.types.Row;
@@ -48,6 +50,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -259,6 +262,53 @@ public final class AvroTestUtils {
         t.f0 = user;
         t.f1 = rowUser;
         t.f2 = schema;
+
+        return t;
+    }
+
+    public static Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row>
+            getTimestampTestData() {
+
+        final String schemaString =
+                "{\"type\":\"record\",\"name\":\"GenericTimestamps\",\"namespace\":\"org.apache.flink.formats.avro.generated\","
+                        + "\"fields\": [{\"name\":\"type_timestamp_millis\",\"type\":{\"type\":\"long\","
+                        + "\"logicalType\":\"timestamp-millis\"}},{\"name\":\"type_timestamp_micros\",\"type\":{\"type\":\"long\","
+                        + "\"logicalType\":\"timestamp-micros\"}},{\"name\": \"type_local_timestamp_millis\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-millis\"}},"
+                        + "{\"name\": \"type_local_timestamp_micros\", \"type\": {\"type\": \"long\", \"logicalType\": \"local-timestamp-micros\"}}]}";
+        final Schema schema = new Schema.Parser().parse(schemaString);
+        final GenericRecord timestampRecord = new GenericData.Record(schema);
+        timestampRecord.put("type_timestamp_millis", Instant.parse("2014-03-01T12:12:12.321Z"));
+        timestampRecord.put(
+                "type_timestamp_micros", Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS));
+        timestampRecord.put(
+                "type_local_timestamp_millis", LocalDateTime.parse("2014-03-01T12:12:12.321"));
+        timestampRecord.put(
+                "type_local_timestamp_micros", LocalDateTime.parse("1970-01-01T00:00:00.123456"));
+
+        final Timestamps timestamps =
+                Timestamps.newBuilder()
+                        .setTypeTimestampMillis(Instant.parse("2014-03-01T12:12:12.321Z"))
+                        .setTypeTimestampMicros(
+                                Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS))
+                        .setTypeLocalTimestampMillis(LocalDateTime.parse("2014-03-01T12:12:12.321"))
+                        .setTypeLocalTimestampMicros(
+                                LocalDateTime.parse("1970-01-01T00:00:00.123456"))
+                        .build();
+
+        final Row timestampRow = new Row(4);
+        timestampRow.setField(0, Timestamp.valueOf("2014-03-01 12:12:12.321"));
+        timestampRow.setField(
+                1, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
+        timestampRow.setField(2, Timestamp.valueOf(LocalDateTime.parse("2014-03-01T12:12:12.321")));
+        timestampRow.setField(
+                3, Timestamp.valueOf(LocalDateTime.parse("1970-01-01T00:00:00.123456")));
+
+        final Tuple4<Class<? extends SpecificRecord>, SpecificRecord, GenericRecord, Row> t =
+                new Tuple4<>();
+        t.f0 = Timestamps.class;
+        t.f1 = timestamps;
+        t.f2 = timestampRecord;
+        t.f3 = timestampRow;
 
         return t;
     }

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -115,4 +115,15 @@
        {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
        {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
    ]
- }]
+},
+{"namespace": "org.apache.flink.formats.avro.generated",
+ "type": "record",
+ "name": "Timestamps",
+ "fields": [
+     {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+     {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+     {"name": "type_local_timestamp_millis", "type": {"type": "long", "logicalType": "local-timestamp-millis"}},
+     {"name": "type_local_timestamp_micros", "type": {"type": "long", "logicalType": "local-timestamp-micros"}}
+ ]
+}
+]


### PR DESCRIPTION
## What is the purpose of the change
From the latest Avro Spec, local-timestamp-millis and local-timestamp-micros logical types are added. This PR is to support Local timezone logic type in Avro related classes. 


## Brief change log

 - Add logic to handle TIMESTAMP_WITH_LOCAL_TIME_ZONE in AvroToRowDataConverters
 - Add logic to handle TIMESTAMP_WITH_LOCAL_TIME_ZONE in RowDataToAvroConverters
 - Add logic to handle TIMESTAMP_WITH_LOCAL_TIME_ZONE in legacy AvroRow Ser and Des Schema
 - Add new fields for test cases
 
## Verifying this change

Extended existing test cases for Avro


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
