### PR TITLE
[FLINK-33033][test] Add curator-test for flink-benchmarks

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -163,6 +163,17 @@ under the License.
 			<scope>runtime</scope>
 		</dependency>
 
+		<!-- This dependency is added for `flink-benchmarks` project which will
+		use zookeeper testing server to benchmark olap performance. This dependency
+		is added here to ensure that its version is consistent with the flink
+		version in the `flink-benchmarks` and to avoid conflicts. Removing this
+		dependency may cause failure of `flink-benchmarks`. -->
+		<dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>${curator.version}</version>
+		</dependency>
+
 	</dependencies>
 
 	<!-- build a test jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,8 @@ under the License.
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
 		<zookeeper.version>3.7.1</zookeeper.version>
+		<!-- Project `flink-benchmarks` uses zk testing server in `curator-test` for performance
+		benchmark, please confirm it will not affect the benchmarks when the version is bumped. -->
 		<curator.version>5.4.0</curator.version>
 		<avro.version>1.11.1</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add curator-test dependency in flink-test-utils project which will used in flink-benchmarks. Then we can use zookeeper testing server in flink-benchmarks and the version of curator-test can be consistent with flink version.

## Brief change log
  - Add curator-test in flink-test-utils

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
