### PR TITLE
[FLINK-33249][table-planner] comment should be parsed by StringLitera…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -177,7 +177,7 @@ SqlCreate SqlCreateDatabase(Span s, boolean replace) :
 {
     SqlParserPos startPos;
     SqlIdentifier databaseName;
-    SqlCharStringLiteral comment = null;
+    SqlNode comment = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
     boolean ifNotExists = false;
 }
@@ -187,11 +187,8 @@ SqlCreate SqlCreateDatabase(Span s, boolean replace) :
     ifNotExists = IfNotExistsOpt()
 
     databaseName = CompoundIdentifier()
-    [ <COMMENT> <QUOTED_STRING>
-        {
-            String p = SqlParserUtil.parseString(token.image);
-            comment = SqlLiteral.createCharString(p, getPos());
-        }
+    [
+        <COMMENT> comment = StringLiteral()
     ]
     [
         <WITH>
@@ -1316,7 +1313,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
     List<SqlTableConstraint> constraints = new ArrayList<SqlTableConstraint>();
     SqlWatermark watermark = null;
     SqlNodeList columnList = SqlNodeList.EMPTY;
-	SqlCharStringLiteral comment = null;
+	SqlNode comment = null;
 	SqlTableLike tableLike = null;
     SqlNode asQuery = null;
 
@@ -1344,10 +1341,9 @@ SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
         }
         <RPAREN>
     ]
-    [ <COMMENT> <QUOTED_STRING> {
-        String p = SqlParserUtil.parseString(token.image);
-        comment = SqlLiteral.createCharString(p, getPos());
-    }]
+    [
+        <COMMENT> comment = StringLiteral()
+    ]
     [
         <PARTITIONED> <BY>
         partitionColumns = ParenthesizedSimpleIdentifierList()
@@ -1502,7 +1498,7 @@ SqlDrop SqlDropTable(Span s, boolean replace, boolean isTemporary) :
 SqlNode SqlReplaceTable() :
 {
     SqlIdentifier tableName;
-    SqlCharStringLiteral comment = null;
+    SqlNode comment = null;
     SqlNode asQuery = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
     SqlParserPos pos;
@@ -1537,10 +1533,9 @@ SqlNode SqlReplaceTable() :
         }
         <RPAREN>
     ]
-    [ <COMMENT> <QUOTED_STRING> {
-        String p = SqlParserUtil.parseString(token.image);
-        comment = SqlLiteral.createCharString(p, getPos());
-    }]
+    [
+        <COMMENT> comment = StringLiteral()
+    ]
     [
         <PARTITIONED> <BY>
         partitionColumns = ParenthesizedSimpleIdentifierList()
@@ -1668,7 +1663,7 @@ void PartitionSpecCommaList(SqlNodeList list) :
 */
 SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
     SqlIdentifier viewName;
-    SqlCharStringLiteral comment = null;
+    SqlNode comment = null;
     SqlNode query;
     SqlNodeList fieldList = SqlNodeList.EMPTY;
     boolean ifNotExists = false;
@@ -1682,10 +1677,8 @@ SqlCreate SqlCreateView(Span s, boolean replace, boolean isTemporary) : {
     [
         fieldList = ParenthesizedSimpleIdentifierList()
     ]
-    [ <COMMENT> <QUOTED_STRING> {
-            String p = SqlParserUtil.parseString(token.image);
-            comment = SqlLiteral.createCharString(p, getPos());
-        }
+    [
+        <COMMENT> comment = StringLiteral()
     ]
     <AS>
     query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
@@ -1883,11 +1876,12 @@ SqlTypeNameSpec SqlRawTypeName() :
 void ExtendedFieldNameTypeCommaList(
         List<SqlIdentifier> fieldNames,
         List<SqlDataTypeSpec> fieldTypes,
-        List<SqlCharStringLiteral> comments) :
+        List<SqlNode> comments) :
 {
     SqlIdentifier fName;
     SqlDataTypeSpec fType;
     boolean nullable;
+    SqlNode comment;
 }
 {
     [
@@ -1898,10 +1892,8 @@ void ExtendedFieldNameTypeCommaList(
             fieldTypes.add(fType);
         }
         (
-            <QUOTED_STRING> {
-                String p = SqlParserUtil.parseString(token.image);
-                comments.add(SqlLiteral.createCharString(p, getPos()));
-            }
+            comment = StringLiteral()
+            { comments.add(comment); }
         |
             { comments.add(null); }
         )
@@ -1915,10 +1907,8 @@ void ExtendedFieldNameTypeCommaList(
             fieldTypes.add(fType);
         }
         (
-            <QUOTED_STRING> {
-                String p = SqlParserUtil.parseString(token.image);
-                comments.add(SqlLiteral.createCharString(p, getPos()));
-            }
+            comment = StringLiteral()
+            { comments.add(comment); }
         |
             { comments.add(null); }
         )
@@ -1942,7 +1932,7 @@ SqlTypeNameSpec ExtendedSqlRowTypeName() :
 {
     List<SqlIdentifier> fieldNames = new ArrayList<SqlIdentifier>();
     List<SqlDataTypeSpec> fieldTypes = new ArrayList<SqlDataTypeSpec>();
-    List<SqlCharStringLiteral> comments = new ArrayList<SqlCharStringLiteral>();
+    List<SqlNode> comments = new ArrayList<SqlNode>();
     final boolean unparseAsStandard;
 }
 {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -47,13 +46,13 @@ public class SqlCreateDatabase extends SqlCreate {
 
     private final SqlNodeList propertyList;
 
-    @Nullable private final SqlCharStringLiteral comment;
+    @Nullable private final SqlNode comment;
 
     public SqlCreateDatabase(
             SqlParserPos pos,
             SqlIdentifier databaseName,
             SqlNodeList propertyList,
-            SqlCharStringLiteral comment,
+            SqlNode comment,
             boolean ifNotExists) {
         super(OPERATOR, pos, false, ifNotExists);
         this.databaseName = requireNonNull(databaseName, "databaseName should not be null");
@@ -79,7 +78,7 @@ public class SqlCreateDatabase extends SqlCreate {
         return propertyList;
     }
 
-    public Optional<SqlCharStringLiteral> getComment() {
+    public Optional<SqlNode> getComment() {
         return Optional.ofNullable(comment);
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -67,7 +67,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 
     private final SqlWatermark watermark;
 
-    private final SqlCharStringLiteral comment;
+    private final SqlNode comment;
 
     private final boolean isTemporary;
 
@@ -79,7 +79,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
             SqlNodeList propertyList,
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
-            @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlNode comment,
             boolean isTemporary,
             boolean ifNotExists) {
         this(
@@ -105,7 +105,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
             SqlNodeList propertyList,
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
-            @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlNode comment,
             boolean isTemporary,
             boolean ifNotExists) {
         super(operator, pos, false, ifNotExists);
@@ -162,7 +162,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
         return Optional.ofNullable(watermark);
     }
 
-    public Optional<SqlCharStringLiteral> getComment() {
+    public Optional<SqlNode> getComment() {
         return Optional.ofNullable(comment);
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
@@ -21,7 +21,6 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
-import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
@@ -81,7 +80,7 @@ public class SqlCreateTableAs extends SqlCreateTable {
             SqlNodeList propertyList,
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
-            @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlNode comment,
             SqlNode asQuery,
             boolean isTemporary,
             boolean ifNotExists) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableLike.java
@@ -21,7 +21,6 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
-import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
@@ -83,7 +82,7 @@ public class SqlCreateTableLike extends SqlCreateTable {
             SqlNodeList propertyList,
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
-            @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlNode comment,
             SqlTableLike tableLike,
             boolean isTemporary,
             boolean ifNotExists) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -47,7 +46,7 @@ public class SqlCreateView extends SqlCreate {
     private final SqlNode query;
     private final boolean isTemporary;
 
-    @Nullable private final SqlCharStringLiteral comment;
+    @Nullable private final SqlNode comment;
 
     @Nullable private final SqlNodeList properties;
 
@@ -59,7 +58,7 @@ public class SqlCreateView extends SqlCreate {
             boolean replace,
             boolean isTemporary,
             boolean ifNotExists,
-            SqlCharStringLiteral comment,
+            SqlNode comment,
             SqlNodeList properties) {
         super(OPERATOR, pos, replace, ifNotExists);
         this.viewName = requireNonNull(viewName, "viewName should not be null");
@@ -92,7 +91,7 @@ public class SqlCreateView extends SqlCreate {
         return query;
     }
 
-    public Optional<SqlCharStringLiteral> getComment() {
+    public Optional<SqlNode> getComment() {
         return Optional.ofNullable(comment);
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
@@ -93,7 +93,7 @@ public class SqlReplaceTableAs extends SqlCreate implements ExtendedSqlNode {
 
     private final SqlWatermark watermark;
 
-    private final SqlCharStringLiteral comment;
+    private final SqlNode comment;
 
     private final boolean isTemporary;
 
@@ -109,7 +109,7 @@ public class SqlReplaceTableAs extends SqlCreate implements ExtendedSqlNode {
             SqlNodeList propertyList,
             SqlNodeList partitionKeyList,
             @Nullable SqlWatermark watermark,
-            @Nullable SqlCharStringLiteral comment,
+            @Nullable SqlNode comment,
             SqlNode asQuery,
             boolean isTemporary,
             boolean ifNotExists,
@@ -223,7 +223,7 @@ public class SqlReplaceTableAs extends SqlCreate implements ExtendedSqlNode {
         return Optional.ofNullable(watermark);
     }
 
-    public Optional<SqlCharStringLiteral> getComment() {
+    public Optional<SqlNode> getComment() {
         return Optional.ofNullable(comment);
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
@@ -20,7 +20,7 @@ package org.apache.flink.sql.parser.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlRowTypeNameSpec;
@@ -50,7 +50,7 @@ public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
 
     private final List<SqlIdentifier> fieldNames;
     private final List<SqlDataTypeSpec> fieldTypes;
-    private final List<SqlCharStringLiteral> comments;
+    private final List<SqlNode> comments;
 
     private final boolean unparseAsStandard;
 
@@ -67,7 +67,7 @@ public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
             SqlParserPos pos,
             List<SqlIdentifier> fieldNames,
             List<SqlDataTypeSpec> fieldTypes,
-            List<SqlCharStringLiteral> comments,
+            List<SqlNode> comments,
             boolean unparseAsStandard) {
         super(new SqlIdentifier(SqlTypeName.ROW.getName(), pos), pos);
         this.fieldNames = fieldNames;
@@ -84,7 +84,7 @@ public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
         return fieldTypes;
     }
 
-    public List<SqlCharStringLiteral> getComments() {
+    public List<SqlNode> getComments() {
         return comments;
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -810,7 +810,7 @@ public class SqlNodeToOperationConversion {
         String databaseComment =
                 sqlCreateDatabase
                         .getComment()
-                        .map(comment -> comment.getValueAs(NlsString.class).getValue())
+                        .map(SqlNode::toString)
                         .orElse(null);
         // set with properties
         Map<String, String> properties = new HashMap<>();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateViewConverter.java
@@ -48,7 +48,7 @@ public class SqlCreateViewConverter implements SqlNodeConverter<SqlCreateView> {
         String viewComment =
                 sqlCreateView
                         .getComment()
-                        .map(c -> c.getValueAs(NlsString.class).getValue())
+                        .map(SqlNode::toString)
                         .orElse(null);
         Map<String, String> viewOptions =
                 OperationConverterUtils.extractProperties(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.utils;
 
+import org.apache.calcite.sql.SqlNode;
+
 import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.table.catalog.Column;
@@ -86,8 +88,8 @@ public class OperationConverterUtils {
                 .orElse(null);
     }
 
-    public static @Nullable String getTableComment(Optional<SqlCharStringLiteral> tableComment) {
-        return tableComment.map(comment -> comment.getValueAs(String.class)).orElse(null);
+    public static @Nullable String getTableComment(Optional<SqlNode> tableComment) {
+        return tableComment.map(SqlNode::toString).orElse(null);
     }
 
     public static Map<String, String> extractProperties(SqlNodeList propList) {


### PR DESCRIPTION
…l() instead of SqlCharStringLiteral to avoid parsing failure

## What is the purpose of the change

make flink parser able to parse calcite unparsed ASCII comment


## Brief change log

modify the calcite parserimpl.ftl


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing



This change is a trivial rework / code cleanup without any test coverage.






## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
