### PR TITLE
[FLINK-32896][Runtime/Coordination] Incorrect `Map.computeIfAbsent(..., ...::new)` usage which misinterprets key as initial capacity

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -160,7 +160,7 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
         checkArgument(firstBufferInRegion.subpartitionId == lastBufferInRegion.subpartitionId);
         checkArgument(firstBufferInRegion.bufferIndex <= lastBufferInRegion.bufferIndex);
         internalRegionsBySubpartition
-                .computeIfAbsent(firstBufferInRegion.subpartitionId, ArrayList::new)
+                .computeIfAbsent(firstBufferInRegion.subpartitionId, k -> new ArrayList<>())
                 .add(
                         new InternalRegion(
                                 firstBufferInRegion.bufferIndex,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
@@ -125,36 +125,48 @@ public interface HsSpillingStrategy {
             private Builder() {}
 
             public Builder addBufferToSpill(BufferIndexAndChannel buffer) {
-                bufferToSpill.computeIfAbsent(buffer.getChannel(), ArrayList::new).add(buffer);
+                bufferToSpill
+                        .computeIfAbsent(buffer.getChannel(), k -> new ArrayList<>())
+                        .add(buffer);
                 return this;
             }
 
             public Builder addBufferToSpill(
                     int subpartitionId, List<BufferIndexAndChannel> buffers) {
-                bufferToSpill.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
+                bufferToSpill
+                        .computeIfAbsent(subpartitionId, k -> new ArrayList<>())
+                        .addAll(buffers);
                 return this;
             }
 
             public Builder addBufferToSpill(
                     int subpartitionId, Deque<BufferIndexAndChannel> buffers) {
-                bufferToSpill.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
+                bufferToSpill
+                        .computeIfAbsent(subpartitionId, k -> new ArrayList<>())
+                        .addAll(buffers);
                 return this;
             }
 
             public Builder addBufferToRelease(BufferIndexAndChannel buffer) {
-                bufferToRelease.computeIfAbsent(buffer.getChannel(), ArrayList::new).add(buffer);
+                bufferToRelease
+                        .computeIfAbsent(buffer.getChannel(), k -> new ArrayList<>())
+                        .add(buffer);
                 return this;
             }
 
             public Builder addBufferToRelease(
                     int subpartitionId, List<BufferIndexAndChannel> buffers) {
-                bufferToRelease.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
+                bufferToRelease
+                        .computeIfAbsent(subpartitionId, k -> new ArrayList<>())
+                        .addAll(buffers);
                 return this;
             }
 
             public Builder addBufferToRelease(
                     int subpartitionId, Deque<BufferIndexAndChannel> buffers) {
-                bufferToRelease.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
+                bufferToRelease
+                        .computeIfAbsent(subpartitionId, k -> new ArrayList<>())
+                        .addAll(buffers);
                 return this;
             }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategyUtils.java
@@ -73,7 +73,7 @@ public class HsSpillingStrategyUtils {
             BufferConsumptionPriorityIterator bufferConsumptionPriorityIterator = heap.poll();
             BufferIndexAndChannel bufferIndexAndChannel = bufferConsumptionPriorityIterator.next();
             subpartitionToHighPriorityBuffers
-                    .computeIfAbsent(bufferIndexAndChannel.getChannel(), ArrayList::new)
+                    .computeIfAbsent(bufferIndexAndChannel.getChannel(), k -> new ArrayList<>())
                     .add(bufferIndexAndChannel);
             // if this iterator has next, re-added it.
             if (bufferConsumptionPriorityIterator.hasNext()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/file/ProducerMergedPartitionFileIndex.java
@@ -168,7 +168,7 @@ public class ProducerMergedPartitionFileIndex {
         checkArgument(firstBufferInRegion.getBufferIndex() <= lastBufferInRegion.getBufferIndex());
 
         subpartitionRegionMap
-                .computeIfAbsent(firstBufferInRegion.getSubpartitionId(), ArrayList::new)
+                .computeIfAbsent(firstBufferInRegion.getSubpartitionId(), k -> new ArrayList<>())
                 .add(
                         new FixedSizeRegion(
                                 firstBufferInRegion.getBufferIndex(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
@@ -198,14 +198,16 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
 
         public Builder addSubpartitionBuffers(
                 int subpartitionId, List<BufferIndexAndChannel> subpartitionBuffers) {
-            allBuffers.computeIfAbsent(subpartitionId, ArrayList::new).addAll(subpartitionBuffers);
+            allBuffers
+                    .computeIfAbsent(subpartitionId, k -> new ArrayList<>())
+                    .addAll(subpartitionBuffers);
             return this;
         }
 
         public Builder addSpillBuffers(
                 int subpartitionId, List<Integer> subpartitionSpillBufferIndexes) {
             spillBufferIndexes
-                    .computeIfAbsent(subpartitionId, HashSet::new)
+                    .computeIfAbsent(subpartitionId, k -> new HashSet<>())
                     .addAll(subpartitionSpillBufferIndexes);
             return this;
         }
@@ -213,7 +215,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
         public Builder addConsumedBuffers(
                 int subpartitionId, List<Integer> subpartitionConsumedBufferIndexes) {
             consumedBufferIndexes
-                    .computeIfAbsent(subpartitionId, HashSet::new)
+                    .computeIfAbsent(subpartitionId, k -> new HashSet<>())
                     .addAll(subpartitionConsumedBufferIndexes);
             return this;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
@@ -266,7 +266,9 @@ class SourceCoordinatorConcurrentAttemptsTest extends SourceCoordinatorTestBase 
 
         @Override
         public void handleSourceEvent(int subtaskId, int attemptNumber, SourceEvent sourceEvent) {
-            sourceEvents.computeIfAbsent(subtaskId, HashMap::new).put(attemptNumber, sourceEvent);
+            sourceEvents
+                    .computeIfAbsent(subtaskId, k -> new HashMap<>())
+                    .put(attemptNumber, sourceEvent);
             handleSourceEvent(subtaskId, sourceEvent);
         }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The are multiple cases in the code which look like this:

`map.computeIfAbsent(..., ArrayList::new)`

Not only does this create a new collection (here an ArrayList), but computeIfAbsent also passes the map key as argument to the mapping function, so instead of calling the no-args constructor such as new ArrayList<>(), this actually calls the constructor with int initial capacity parameter, such as new ArrayList<>(initialCapacity).

This can lead either to runtime exceptions in case the map key is negative, since the collection constructors reject negative initial capacity values, or it can lead to bad performance if the key (which is misinterpreted as initial capacity) is pretty low, such as 0, or is pretty large and therefore pre-allocates a lot of memory for the collection.

it might be good to replace them with lambda expressions to make this more explicit:

`map.computeIfAbsent(..., k -> new ArrayList<>())`

## Brief change log

- *Replace all `map.computeIfAbsent(..., ... ::new)` with `map.computeIfAbsent(..., k -> new ...)`*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *HsSpillingStrategyUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
