### PR TITLE
[FLINK-20539][table-planner] fix type mismatch when using ROW in computed column

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
@@ -73,14 +73,16 @@ import java.util.AbstractList;
  * <p>Once Flink applies same logic for both table api and sql, this first changes should be
  * removed.
  *
- * <p>2. It uses PEEK_FIELDS_NO_EXPAND with a nested struct type (Flink [[RowType]]).
+ * <p>2. It uses {@link StructKind#PEEK_FIELDS_NO_EXPAND} with a nested struct type (Flink [[{@link
+ * org.apache.flink.table.types.logical.RowType}]]).
  *
- * <p>See more at {@code LogicalRelDataTypeConverter} and {@code FlinkTypeFactory}.
+ * <p>See more at {@link org.apache.flink.table.planner.typeutils.LogicalRelDataTypeConverter} and
+ * {@link org.apache.flink.table.planner.calcite.FlinkTypeFactory}.
  *
  * <p>Changed lines
  *
  * <ol>
- *   <li>Line 103 ~ 134
+ *   <li>Line 106 ~ 137
  * </ol>
  */
 public class SqlRowOperator extends SqlSpecialOperator {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlRowOperator.java
@@ -19,6 +19,7 @@
 package org.apache.calcite.sql.fun;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperatorBinding;
@@ -27,14 +28,17 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
-import org.apache.calcite.util.Pair;
 
 import java.util.AbstractList;
-import java.util.Map;
 
 /**
- * Copied to keep null semantics of table api and sql in sync. At the same time SQL standard says
- * that the next about `ROW`:
+ * Copied to keep null semantics of table api and sql in sync.
+ *
+ * <p>There are differences following:
+ *
+ * <p>1. The return value about {@code R IS NULL} and {@code R IS NOT NULL}.
+ *
+ * <p>At the same time SQL standard says that the next about `ROW`:
  *
  * <ul>
  *   <li>The value of {@code R IS NULL} is:
@@ -66,12 +70,17 @@ import java.util.Map;
  *       </ul>
  * </ul>
  *
- * Once Flink applies same logic for both table api and sql, this class should be removed.
+ * <p>Once Flink applies same logic for both table api and sql, this first changes should be
+ * removed.
+ *
+ * <p>2. It uses PEEK_FIELDS_NO_EXPAND with a nested struct type (Flink [[RowType]]).
+ *
+ * <p>See more at {@code LogicalRelDataTypeConverter} and {@code FlinkTypeFactory}.
  *
  * <p>Changed lines
  *
  * <ol>
- *   <li>Line 92 ~ 112
+ *   <li>Line 103 ~ 134
  * </ol>
  */
 public class SqlRowOperator extends SqlSpecialOperator {
@@ -96,20 +105,31 @@ public class SqlRowOperator extends SqlSpecialOperator {
         // The type of a ROW(e1,e2) expression is a record with the types
         // {e1type,e2type}.  According to the standard, field names are
         // implementation-defined.
+        int fieldCount = opBinding.getOperandCount();
         return opBinding
                 .getTypeFactory()
                 .createStructType(
-                        new AbstractList<Map.Entry<String, RelDataType>>() {
+                        StructKind.PEEK_FIELDS_NO_EXPAND,
+                        new AbstractList<RelDataType>() {
                             @Override
-                            public Map.Entry<String, RelDataType> get(int index) {
-                                return Pair.of(
-                                        SqlUtil.deriveAliasFromOrdinal(index),
-                                        opBinding.getOperandType(index));
+                            public RelDataType get(int index) {
+                                return opBinding.getOperandType(index);
                             }
 
                             @Override
                             public int size() {
-                                return opBinding.getOperandCount();
+                                return fieldCount;
+                            }
+                        },
+                        new AbstractList<String>() {
+                            @Override
+                            public String get(int index) {
+                                return SqlUtil.deriveAliasFromOrdinal(index);
+                            }
+
+                            @Override
+                            public int size() {
+                                return fieldCount;
                             }
                         });
         // ----- FLINK MODIFICATION END -----

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -236,6 +236,24 @@ Calc(select=[timestamp, metadata_timestamp, other, UPPER(other) AS computed_othe
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDDLWithRowTypeComputedColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM t1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalProject(a=[$0], b=[$1], c=[ROW($0, $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, ROW(a, b) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDDLWithWatermarkComputedColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM t1]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -79,6 +79,20 @@ class TableScanTest extends TableTestBase {
   }
 
   @Test
+  def testDDLWithRowTypeComputedColumn(): Unit = {
+    util.addTable(s"""
+                     |create table t1(
+                     |  a int,
+                     |  b varchar,
+                     |  c as row(a, b)
+                     |) with (
+                     |  'connector' = 'values'
+                     |)
+       """.stripMargin)
+    util.verifyExecPlan("SELECT * FROM t1")
+  }
+
+  @Test
   def testDDLWithMetadataColumn(): Unit = {
     // tests reordering, skipping, and casting of metadata
     util.addTable(


### PR DESCRIPTION
## What is the purpose of the change

When using row as a computed column and select the computed column as a query, an exception will be thrown by calcite because of the type mismatch about ROW.

The cause is that in Flink, we always treat the ROW as a struct type PEEK_FIELDS_NO_EXPAND (refs to LogicalRelDataTypeConverter and FlinkTypeFactory), but in calcite, the struct type about ROW is FULLY_QUALIFIED (refs to SqlRowOperator#inferReturnType). And when selecting the column, the difference causes this bug.

## Brief change log

  - *Modify the SqlRowOperator to return the true struct type about ROW*
  - *Add tests about this pr*


## Verifying this change

Necessary tests have been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
