### PR TITLE
[FLINK-33255] [table] Validate argument count during type inference

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -210,6 +210,48 @@ public final class TypeInferenceUtil {
     }
 
     /**
+     * Validates argument counts.
+     *
+     * @param argumentCount expected argument count
+     * @param actualCount actual argument count
+     * @param throwOnFailure if true, the function throws a {@link ValidationException} if the
+     *     actual value does not meet the expected argument count
+     * @return a boolean indicating if expected argument counts match the actual counts
+     */
+    public static boolean validateArgumentCount(
+            ArgumentCount argumentCount, int actualCount, boolean throwOnFailure) {
+        final int minCount = argumentCount.getMinCount().orElse(0);
+        if (actualCount < minCount) {
+            if (throwOnFailure) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid number of arguments. At least %d arguments expected but %d passed.",
+                                minCount, actualCount));
+            }
+            return false;
+        }
+        final int maxCount = argumentCount.getMaxCount().orElse(Integer.MAX_VALUE);
+        if (actualCount > maxCount) {
+            if (throwOnFailure) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid number of arguments. At most %d arguments expected but %d passed.",
+                                maxCount, actualCount));
+            }
+            return false;
+        }
+        if (!argumentCount.isValidCount(actualCount)) {
+            if (throwOnFailure) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid number of arguments. %d arguments passed.", actualCount));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Information what the outer world (i.e. an outer wrapping call) expects from the current
      * function call. This can be helpful for an {@link InputTypeStrategy}.
      *
@@ -383,39 +425,6 @@ public final class TypeInferenceUtil {
         arg.getName().ifPresent(n -> stringBuilder.append(n).append(" "));
         stringBuilder.append(arg.getType());
         return stringBuilder.toString();
-    }
-
-    private static boolean validateArgumentCount(
-            ArgumentCount argumentCount, int actualCount, boolean throwOnFailure) {
-        final int minCount = argumentCount.getMinCount().orElse(0);
-        if (actualCount < minCount) {
-            if (throwOnFailure) {
-                throw new ValidationException(
-                        String.format(
-                                "Invalid number of arguments. At least %d arguments expected but %d passed.",
-                                minCount, actualCount));
-            }
-            return false;
-        }
-        final int maxCount = argumentCount.getMaxCount().orElse(Integer.MAX_VALUE);
-        if (actualCount > maxCount) {
-            if (throwOnFailure) {
-                throw new ValidationException(
-                        String.format(
-                                "Invalid number of arguments. At most %d arguments expected but %d passed.",
-                                maxCount, actualCount));
-            }
-            return false;
-        }
-        if (!argumentCount.isValidCount(actualCount)) {
-            if (throwOnFailure) {
-                throw new ValidationException(
-                        String.format(
-                                "Invalid number of arguments. %d arguments passed.", actualCount));
-            }
-            return false;
-        }
-        return true;
     }
 
     private static AdaptedCallContext inferInputTypes(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/ExtraCalciteResource.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/validate/ExtraCalciteResource.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.sql.validate;
+
+import org.apache.calcite.runtime.Resources;
+
+/**
+ * Compiler-checked resources similar to CalciteResource in Calcite project. These are extra
+ * exceptions we want to extend Calcite with. Ref:
+ * https://issues.apache.org/jira/browse/CALCITE-6069
+ */
+public interface ExtraCalciteResource {
+
+    @Resources.BaseMessage(
+            "No match found for function signature {0}.\nSupported signatures are:\n{1}")
+    Resources.ExInst<SqlValidatorException> validatorNoFunctionMatch(
+            String invocation, String allowedSignatures);
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandInference.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceOperandInference.java
@@ -68,7 +68,12 @@ public final class TypeInferenceOperandInference implements SqlOperandTypeInfere
         final CallContext callContext =
                 new CallBindingCallContext(dataTypeFactory, definition, callBinding, returnType);
         try {
-            inferOperandTypesOrError(unwrapTypeFactory(callBinding), callContext, operandTypes);
+            if (TypeInferenceUtil.validateArgumentCount(
+                    typeInference.getInputTypeStrategy().getArgumentCount(),
+                    callContext.getArgumentDataTypes().size(),
+                    false)) {
+                inferOperandTypesOrError(unwrapTypeFactory(callBinding), callContext, operandTypes);
+            }
         } catch (ValidationException | CalciteContextException e) {
             // let operand checker fail
         } catch (Throwable t) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -975,11 +975,16 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.STRING().nullable())
                         .testSqlValidationError(
                                 "ARRAY_JOIN(f0)",
-                                "No match found for function "
-                                        + "signature ARRAY_JOIN(<VARCHAR(2147483647) ARRAY>)")
+                                "No match found for function signature ARRAY_JOIN(<VARCHAR(2147483647) ARRAY>).\n"
+                                        + "Supported signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
                         .testSqlValidationError(
                                 "ARRAY_JOIN()",
-                                "No match found for function signature ARRAY_JOIN()")
+                                "No match found for function signature ARRAY_JOIN().\n"
+                                        + "Supported signatures are:\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>)\n"
+                                        + "ARRAY_JOIN(ARRAY<STRING>, <CHARACTER_STRING>, <CHARACTER_STRING>)")
                         .testSqlValidationError(
                                 "ARRAY_JOIN(f5, '+')",
                                 "Invalid input arguments. Expected signatures are:\n"
@@ -1190,7 +1195,16 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "ARRAY_SLICE(<ARRAY>, <INTEGER>, <INTEGER>)")
                         .testSqlValidationError(
                                 "ARRAY_SLICE()",
-                                " No match found for function signature ARRAY_SLICE()")
+                                "No match found for function signature ARRAY_SLICE().\n"
+                                        + "Supported signatures are:\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>, <INTEGER>)\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>)")
+                        .testSqlValidationError(
+                                "ARRAY_SLICE(1)",
+                                "No match found for function signature ARRAY_SLICE(<NUMERIC>).\n"
+                                        + "Supported signatures are:\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>, <INTEGER>)\n"
+                                        + "ARRAY_SLICE(<ARRAY>, <INTEGER>)")
                         .testSqlValidationError("ARRAY_SLICE(null)", "Illegal use of 'NULL'"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -659,9 +659,12 @@ class CalcITCase extends StreamingTestBase {
     } catch {
       case e: Exception =>
         assertEquals(
-          "SQL validation failed. From line 1, column 12 to line 1, column 30: " +
-            "No match found for function signature CURRENT_WATERMARK()",
-          e.getMessage)
+          "SQL validation failed. From line 1, column 12 to line 1, column 30: No match found for function signature CURRENT_WATERMARK().\n" +
+            "Supported signatures are:\n" +
+            "CURRENT_WATERMARK(<TIMESTAMP_WITHOUT_TIME_ZONE *ROWTIME*>)\n" +
+            "CURRENT_WATERMARK(<TIMESTAMP_WITH_LOCAL_TIME_ZONE *ROWTIME*>)",
+          e.getMessage
+        )
     }
   }
 


### PR DESCRIPTION
- Previously, TypeInferenceOperandInference was not validating argument counts which led to bugs like FLINK-33248
- This commit adds a check to validate argument count and throws an exception if the argument count doesn't match the expected number of arguments


## What is the purpose of the change

Validate argument count during type inference to avoid bugs like [FLINK-33248]


## Brief change log
  - *Adds a check to validate argument count and throws an exception if the argument count doesn't match the expected number of arguments*
  - *Also leads to better error messages*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test to verify a ValidationException message is seen when functions are invoked without arguments*
  - *Updated existing function tests with improved error message*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
