### PR TITLE
[hotfix][docs] Remove the OverrideDefault annotation for option slotmanager.number-of-slots.min

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -148,7 +148,7 @@
         </tr>
         <tr>
             <td><h5>slotmanager.number-of-slots.min</h5></td>
-            <td style="word-wrap: break-word;">infinite</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
             <td>Defines the minimum number of slots that the Flink cluster allocates. This configuration option is meant for cluster to initialize certain workers in best efforts when starting. This can be used to speed up a job startup process. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -88,7 +88,7 @@
         </tr>
         <tr>
             <td><h5>slotmanager.number-of-slots.min</h5></td>
-            <td style="word-wrap: break-word;">infinite</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
             <td>Defines the minimum number of slots that the Flink cluster allocates. This configuration option is meant for cluster to initialize certain workers in best efforts when starting. This can be used to speed up a job startup process. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -63,7 +63,6 @@ public class ResourceManagerOptions {
                                     + " Its not possible to use this configuration key to define port ranges.");
 
     @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
-    @Documentation.OverrideDefault("infinite")
     public static final ConfigOption<Integer> MIN_SLOT_NUM =
             ConfigOptions.key("slotmanager.number-of-slots.min")
                     .intType()


### PR DESCRIPTION
## What is the purpose of the change

Remove the OverrideDefault annotation for option `slotmanager.number-of-slots.min`.


## Brief change log

Remove the OverrideDefault annotation for option `slotmanager.number-of-slots.min`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no