### PR TITLE
[FLINK-33203][sql-gateway] Introduce env.java.opts.sql-gateway to spe…

### DIFF
--- a/docs/layouts/shortcodes/generated/environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/environment_configuration.html
@@ -45,6 +45,12 @@
             <td>Java options to start the JVM of the JobManager with.</td>
         </tr>
         <tr>
+            <td><h5>env.java.opts.sql-gateway</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Java options to start the JVM of the Flink SQL Gateway with.</td>
+        </tr>
+        <tr>
             <td><h5>env.java.opts.taskmanager</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -272,6 +272,16 @@ public class CoreOptions {
                                     .text("Java options to start the JVM of the Flink Client with.")
                                     .build());
 
+    public static final ConfigOption<String> FLINK_SQL_GATEWAY_JVM_OPTIONS =
+            ConfigOptions.key("env.java.opts.sql-gateway")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Java options to start the JVM of the Flink SQL Gateway with.")
+                                    .build());
+
     /**
      * This option is here only for documentation generation, it is only evaluated in the shell
      * scripts.

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -159,6 +159,7 @@ DEFAULT_ENV_JAVA_OPTS_JM=""                         # Optional JVM args (JobMana
 DEFAULT_ENV_JAVA_OPTS_TM=""                         # Optional JVM args (TaskManager)
 DEFAULT_ENV_JAVA_OPTS_HS=""                         # Optional JVM args (HistoryServer)
 DEFAULT_ENV_JAVA_OPTS_CLI=""                        # Optional JVM args (Client)
+DEFAULT_ENV_JAVA_OPTS_SQL_GATEWAY=""                # Optional JVM args (Sql-Gateway)
 DEFAULT_ENV_SSH_OPTS=""                             # Optional SSH parameters running in cluster mode
 DEFAULT_YARN_CONF_DIR=""                            # YARN Configuration Directory, if necessary
 DEFAULT_HADOOP_CONF_DIR=""                          # Hadoop Configuration Directory, if necessary
@@ -184,6 +185,7 @@ KEY_ENV_JAVA_OPTS_JM="env.java.opts.jobmanager"
 KEY_ENV_JAVA_OPTS_TM="env.java.opts.taskmanager"
 KEY_ENV_JAVA_OPTS_HS="env.java.opts.historyserver"
 KEY_ENV_JAVA_OPTS_CLI="env.java.opts.client"
+KEY_ENV_JAVA_OPTS_SQL_GATEWAY="env.java.opts.sql-gateway"
 KEY_ENV_SSH_OPTS="env.ssh.opts"
 KEY_HIGH_AVAILABILITY="high-availability.type"
 KEY_ZK_HEAP_MB="zookeeper.heap.mb"
@@ -356,6 +358,12 @@ if [ -z "${FLINK_ENV_JAVA_OPTS_CLI}" ]; then
     FLINK_ENV_JAVA_OPTS_CLI=$(readFromConfig ${KEY_ENV_JAVA_OPTS_CLI} "${DEFAULT_ENV_JAVA_OPTS_CLI}" "${YAML_CONF}")
     # Remove leading and ending double quotes (if present) of value
     FLINK_ENV_JAVA_OPTS_CLI="$( echo "${FLINK_ENV_JAVA_OPTS_CLI}" | sed -e 's/^"//'  -e 's/"$//' )"
+fi
+
+if [ -z "${FLINK_ENV_JAVA_OPTS_SQL_GATEWAY}" ]; then
+    FLINK_ENV_JAVA_OPTS_SQL_GATEWAY=$(readFromConfig ${KEY_ENV_JAVA_OPTS_SQL_GATEWAY} "${DEFAULT_ENV_JAVA_OPTS_SQL_GATEWAY}" "${YAML_CONF}")
+    # Remove leading and ending double quotes (if present) of value
+    FLINK_ENV_JAVA_OPTS_SQL_GATEWAY="$( echo "${FLINK_ENV_JAVA_OPTS_SQL_GATEWAY}" | sed -e 's/^"//'  -e 's/"$//' )"
 fi
 
 if [ -z "${FLINK_SSH_OPTS}" ]; then

--- a/flink-table/flink-sql-gateway/bin/sql-gateway.sh
+++ b/flink-table/flink-sql-gateway/bin/sql-gateway.sh
@@ -87,6 +87,10 @@ if [[ "$STARTSTOP" = start* ]] && ( [[ "$*" = *--help* ]] || [[ "$*" = *-h* ]] )
   exit 0
 fi
 
+if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
+    export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_SQL_GATEWAY}"
+fi
+
 if [[ $STARTSTOP == "start-foreground" ]]; then
     exec "${FLINK_BIN_DIR}"/flink-console.sh $ENTRYPOINT "${@:2}"
 else


### PR DESCRIPTION
…cify the jvm options of sql gateway


## What is the purpose of the change

Introduce env.java.opts.sql-gateway to specify the jvm options of sql gateway.


## Verifying this change

Manually launch a sql-gateway and check the jvm args.

<img width="1414" alt="截屏2023-10-16 11 05 01" src="https://github.com/apache/flink/assets/8684799/8c0db37b-2fea-4cea-a110-2cfc0cd94a41">
<img width="299" alt="截屏2023-10-16 11 05 50" src="https://github.com/apache/flink/assets/8684799/e2224abf-06f6-47f9-9093-1b9ed96300f6">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
 
## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs 
