### PR TITLE
[FLINK-33291][build] Sets the enforced range for Maven and JDK within the release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1365,11 +1365,13 @@ under the License.
 								</goals>
 								<configuration>
 									<rules>
+										<!-- versions for certain build tools are enforced to match the CI setup -->
+										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireMavenVersion>
-											<version>3.8.6</version>
+											<version>[3.8.6]</version>
 										</requireMavenVersion>
 										<requireJavaVersion>
-											<version>1.8.0</version>
+											<version>[1.8.0,1.8.1)</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>


### PR DESCRIPTION
## What is the purpose of the change

We want to enforce the Maven and JDK version for releases based on the versions that are used in Flink's CI pipeline to ensure a certain level of quality control.

## Brief change log

* Adds proper range for Maven and JDK
* For the JDK version, it looks like we cannot use `${target.java.version}` or `[1.8]` to cover any minor releases

## Verifying this change

Manual verification by running `./mvn -pl flink-annotations -DskipTests -Prelease validate` with different Java and Maven versions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable