### PR TITLE
 [FLINK-33289] Fix the conversion of InetSocketAddress to URL in Network utils to work with ipv6 address correctly

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -135,7 +135,16 @@ public class NetUtils {
      * @return a URL object representing the provided socket address with "http://" schema
      */
     public static URL socketToUrl(InetSocketAddress socketAddress) {
-        String hostPort = socketAddress.getHostString() + ":" + socketAddress.getPort();
+        String hostString = socketAddress.getHostString();
+        // If the hostString is an IPv6 address, it needs to be enclosed in square brackets
+        // at the beginning and end.
+        if (socketAddress.getAddress() != null
+                && socketAddress.getAddress() instanceof Inet6Address
+                && hostString.equals(socketAddress.getAddress().getHostAddress())) {
+            hostString = "[" + hostString + "]";
+        }
+        String hostPort = hostString + ":" + socketAddress.getPort();
+
         return validateHostPortString(hostPort);
     }
 

--- a/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/NetUtilsTest.java
@@ -396,4 +396,20 @@ public class NetUtilsTest extends TestLogger {
 
         Assertions.assertThat(socketToUrl(socketAddress)).isEqualTo(expectedResult);
     }
+
+    @Test
+    public void testIpv6SocketToUrl() throws MalformedURLException {
+        InetSocketAddress socketAddress = new InetSocketAddress("[2001:1db8::ff00:42:8329]", 8080);
+        URL expectedResult = new URL("http://[2001:1db8::ff00:42:8329]:8080");
+
+        Assertions.assertThat(socketToUrl(socketAddress)).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void testIpv4SocketToUrl() throws MalformedURLException {
+        InetSocketAddress socketAddress = new InetSocketAddress("192.168.0.1", 8080);
+        URL expectedResult = new URL("http://192.168.0.1:8080");
+
+        Assertions.assertThat(socketToUrl(socketAddress)).isEqualTo(expectedResult);
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the failure of creating a connection when the gateway address is an IPv6 address.



## Brief change log

  -  Fix `NetUtils.socketToUrl` to work properly if the hostString in the socketAddress is an IPv6 address.


## Verifying this change

  - Add `testIpv6SocketToUrl` and `testIpv4SocketToUrl` in `NetUtilsTest`.
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
