### PR TITLE
[FLINK-32806]EmbeddedJobResultStore set ttly for non dirty job

### DIFF
--- a/docs/layouts/shortcodes/generated/common_high_availability_jrs_section.html
+++ b/docs/layouts/shortcodes/generated/common_high_availability_jrs_section.html
@@ -20,5 +20,11 @@
             <td>String</td>
             <td>Defines where job results should be stored. This should be an underlying file-system that provides read-after-write consistency. By default, this is <code class="highlighter-rouge">{high-availability.storageDir}/job-result-store/{high-availability.cluster-id}</code>.</td>
         </tr>
+        <tr>
+            <td><h5>job-result-store.ttl-clean-job-result</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Provide ttl for the clean job result in minutes</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/job_result_store_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_result_store_configuration.html
@@ -20,5 +20,11 @@
             <td>String</td>
             <td>Defines where job results should be stored. This should be an underlying file-system that provides read-after-write consistency. By default, this is <code class="highlighter-rouge">{high-availability.storageDir}/job-result-store/{high-availability.cluster-id}</code>.</td>
         </tr>
+        <tr>
+            <td><h5>job-result-store.ttl-clean-job-result</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Provide ttl for the clean job result in minutes</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/JobResultStoreOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/JobResultStoreOptions.java
@@ -65,4 +65,11 @@ public class JobResultStoreOptions {
                                     + "are, instead, marked as clean to indicate their state. In this "
                                     + "case, Flink no longer has ownership and the resources need to "
                                     + "be cleaned up by the user.");
+
+    @Documentation.Section(Documentation.Sections.COMMON_HIGH_AVAILABILITY_JOB_RESULT_STORE)
+    public static final ConfigOption<Integer> TIME_TO_REMOVE_CLEAN_JOB_RESULT =
+            ConfigOptions.key("job-result-store.ttl-clean-job-result")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription("Provide ttl for the clean job result in minutes");
 }


### PR DESCRIPTION

## What is the purpose of the change
- Convert cleaned-up jobs map to Cache with ttl set 
- Introduce new config to add ttl for cleaned-up jobs in `EmbeddedJobResultStore` 

## Verifying this change
Tested the code in cluster of 2 machines with flink on yarn 
1. Start flink yarn session 
2. Set newly introduced config `job-result-store.ttl-clean-job-result`
3. run a word count job to read from file in batch mode and garcefully stop the job 
4. monitor the content of cleaned-up jobs map and it should remove the entry when time to live condition is satisfied.  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) No 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) N/A
