### PR TITLE
[FLINK-33116][tests][release-1.17] Fix CliClientTest.testCancelExecutionInteractiveMode fails with NPE

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.cli;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
@@ -294,14 +295,13 @@ class CliClientTest {
         try (Terminal terminal = TerminalUtils.createDumbTerminal(inputStream, outputStream);
                 CliClient client =
                         new CliClient(() -> terminal, mockExecutor, historyFilePath, null)) {
-            Thread thread =
-                    new Thread(
-                            () -> {
-                                try {
-                                    client.executeInInteractiveMode();
-                                } catch (Exception ignore) {
-                                }
-                            });
+            CheckedThread thread =
+                    new CheckedThread() {
+                        @Override
+                        public void go() {
+                            client.executeInInteractiveMode();
+                        }
+                    };
             thread.start();
 
             while (!mockExecutor.isAwait) {
@@ -311,6 +311,8 @@ class CliClientTest {
             terminal.raise(Terminal.Signal.INT);
             CommonTestUtils.waitUntilCondition(
                     () -> outputStream.toString().contains(CliStrings.MESSAGE_HELP));
+            // Prevent NPE when closing the terminal. See FLINK-33116 for more information.
+            thread.sync();
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33116][tests] Fix CliClientTest.testCancelExecutionInteractiveMode fails with NPE

```shell
Sep 18 02:26:15 02:26:15.743 [ERROR] org.apache.flink.table.client.cli.CliClientTest.testCancelExecutionInteractiveMode  Time elapsed: 0.1 s  <<< ERROR!
Sep 18 02:26:15 java.lang.NullPointerException
Sep 18 02:26:15 	at org.apache.flink.table.client.cli.CliClient.closeTerminal(CliClient.java:284)
Sep 18 02:26:15 	at org.apache.flink.table.client.cli.CliClient.close(CliClient.java:108)
Sep 18 02:26:15 	at org.apache.flink.table.client.cli.CliClientTest.testCancelExecutionInteractiveMode(CliClientTest.java:314)
Sep 18 02:26:15 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
```

## Brief change log

The CliClient is not thread-safe: The close call fails with a NullPointerException because CliClient.close() calls closeTerminal() if a terminal set. But the test finishes the client.executeInInteractiveMode() in a separate thread which calls closeTerminal() in the end as well. 

Using `CheckedThread` instead of `Thread`.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)