### PR TITLE
[BP-1.17][FLINK-33291][build] Sets the enforced range for Maven and JDK within the release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1311,12 +1311,14 @@ under the License.
 								</goals>
 								<configuration>
 									<rules>
+										<!-- versions for certain build tools are enforced to match the CI setup -->
+										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireMavenVersion>
 											<!-- maven version must be lower than 3.3. See FLINK-3158 -->
 											<version>(,3.3)</version>
 										</requireMavenVersion>
 										<requireJavaVersion>
-											<version>1.8.0</version>
+											<version>[1.8.0,1.8.1)</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>


### PR DESCRIPTION
1.17 backport of parent PR https://github.com/apache/flink/pull/23529

I left the Maven range as is because the Java version actually causing the problem and the branch is soon to be gone, anyway.