### PR TITLE
[FLINK-33295] Separate SinkV2 and SinkV1Adapter tests

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -28,7 +28,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
@@ -51,7 +51,7 @@ public class TestSinkInitContext implements Sink.InitContext {
     private final OperatorIOMetricGroup operatorIOMetricGroup =
             UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
     private final SinkWriterMetricGroup metricGroup =
-            InternalSinkWriterMetricGroup.mock(
+            MetricsGroupTestUtils.mockWriterMetricGroup(
                     metricListener.getMetricGroup(), operatorIOMetricGroup);
     private final MailboxExecutor mailboxExecutor;
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
@@ -292,7 +292,7 @@ class FileWriterTest {
         final OperatorIOMetricGroup operatorIOMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
         final SinkWriterMetricGroup sinkWriterMetricGroup =
-                InternalSinkWriterMetricGroup.mock(
+                MetricsGroupTestUtils.mockWriterMetricGroup(
                         metricListener.getMetricGroup(), operatorIOMetricGroup);
 
         Counter recordsCounter = sinkWriterMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
@@ -471,7 +471,7 @@ class FileWriterTest {
                 basePath,
                 rollingPolicy,
                 outputFileConfig,
-                InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()));
+                MetricsGroupTestUtils.mockWriterMetricGroup(metricListener.getMetricGroup()));
     }
 
     private FileWriter<String> createWriter(
@@ -484,7 +484,7 @@ class FileWriterTest {
             throws IOException {
         return new FileWriter<>(
                 basePath,
-                InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()),
+                MetricsGroupTestUtils.mockWriterMetricGroup(metricListener.getMetricGroup()),
                 bucketAssigner,
                 new DefaultFileWriterBucketFactory<>(),
                 new RowWiseBucketWriter<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
@@ -26,7 +26,6 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
 
 /** Special {@link org.apache.flink.metrics.MetricGroup} representing an Operator. */
@@ -40,7 +39,8 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
     private final Counter numBytesWritten;
     private final OperatorIOMetricGroup operatorIOMetricGroup;
 
-    private InternalSinkWriterMetricGroup(
+    @VisibleForTesting
+    InternalSinkWriterMetricGroup(
             MetricGroup parentMetricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
         super(parentMetricGroup);
         numRecordsOutErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_OUT_ERRORS);
@@ -59,18 +59,6 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
     public static InternalSinkWriterMetricGroup wrap(OperatorMetricGroup operatorMetricGroup) {
         return new InternalSinkWriterMetricGroup(
                 operatorMetricGroup, operatorMetricGroup.getIOMetricGroup());
-    }
-
-    @VisibleForTesting
-    public static InternalSinkWriterMetricGroup mock(MetricGroup metricGroup) {
-        return new InternalSinkWriterMetricGroup(
-                metricGroup, UnregisteredMetricsGroup.createOperatorIOMetricGroup());
-    }
-
-    @VisibleForTesting
-    public static InternalSinkWriterMetricGroup mock(
-            MetricGroup metricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
-        return new InternalSinkWriterMetricGroup(metricGroup, operatorIOMetricGroup);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+/** Util class to create metric groups for SinkV2 tests. */
+public class MetricsGroupTestUtils {
+
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup() {
+        return new InternalSinkWriterMetricGroup(
+                new UnregisteredMetricsGroup(),
+                UnregisteredMetricsGroup.createOperatorIOMetricGroup());
+    }
+
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup(MetricGroup metricGroup) {
+        return new InternalSinkWriterMetricGroup(
+                metricGroup, UnregisteredMetricsGroup.createOperatorIOMetricGroup());
+    }
+
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup(
+            MetricGroup metricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
+        return new InternalSinkWriterMetricGroup(metricGroup, operatorIOMetricGroup);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
-import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 
 import org.junit.Test;
 
@@ -33,13 +33,15 @@ public class DataStreamSinkTest {
     public void testGettingTransformationWithNewSinkAPI() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final Transformation<?> transformation =
-                env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).getTransformation();
+                env.fromElements(1, 2)
+                        .sinkTo(TestSinkV2.<Integer>newBuilder().build())
+                        .getTransformation();
         assertTrue(transformation instanceof SinkTransformation);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void throwExceptionWhenSetUidWithNewSinkAPI() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).setUidHash("Test");
+        env.fromElements(1, 2).sinkTo(TestSinkV2.<Integer>newBuilder().build()).setUidHash("Test");
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
@@ -26,8 +26,7 @@ import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.functions.sink.PrintSink;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -200,7 +199,7 @@ class PrintSinkTest {
 
         @Override
         public SinkWriterMetricGroup metricGroup() {
-            return InternalSinkWriterMetricGroup.mock(new UnregisteredMetricsGroup());
+            return MetricsGroupTestUtils.mockWriterMetricGroup();
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
+import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link org.apache.flink.streaming.api.transformations.SinkTransformation}.
+ *
+ * <p>ATTENTION: This test is extremely brittle. Do NOT remove, add or re-order test cases.
+ */
+@RunWith(Parameterized.class)
+public abstract class SinkTransformationTranslatorITCaseBase<SinkT> extends TestLogger {
+
+    @Parameterized.Parameters(name = "Execution Mode: {0}")
+    public static Collection<Object> data() {
+        return Arrays.asList(RuntimeExecutionMode.STREAMING, RuntimeExecutionMode.BATCH);
+    }
+
+    @Parameterized.Parameter() public RuntimeExecutionMode runtimeExecutionMode;
+
+    static final String NAME = "FileSink";
+    static final String SLOT_SHARE_GROUP = "FileGroup";
+    static final String UID = "FileUid";
+    static final int PARALLELISM = 2;
+
+    abstract SinkT simpleSink();
+
+    abstract SinkT sinkWithCommitter();
+
+    abstract DataStreamSink<Integer> sinkTo(DataStream<Integer> stream, SinkT sink);
+
+    @Test
+    public void generateWriterTopology() {
+        final StreamGraph streamGraph = buildGraph(simpleSink(), runtimeExecutionMode);
+
+        final StreamNode sourceNode = findNodeName(streamGraph, node -> node.contains("Source"));
+        final StreamNode writerNode = findWriter(streamGraph);
+
+        assertThat(streamGraph.getStreamNodes().size(), equalTo(2));
+
+        validateTopology(
+                sourceNode,
+                IntSerializer.class,
+                writerNode,
+                SinkWriterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+    }
+
+    @Test
+    public void generateWriterCommitterTopology() {
+
+        final StreamGraph streamGraph = buildGraph(sinkWithCommitter(), runtimeExecutionMode);
+
+        final StreamNode sourceNode = findNodeName(streamGraph, node -> node.contains("Source"));
+        final StreamNode writerNode = findWriter(streamGraph);
+
+        validateTopology(
+                sourceNode,
+                IntSerializer.class,
+                writerNode,
+                SinkWriterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+
+        final StreamNode committerNode =
+                findNodeName(streamGraph, name -> name.contains("Committer"));
+
+        assertThat(streamGraph.getStreamNodes().size(), equalTo(3));
+
+        validateTopology(
+                writerNode,
+                SimpleVersionedSerializerTypeSerializerProxy.class,
+                committerNode,
+                CommitterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+    }
+
+    StreamNode findWriter(StreamGraph streamGraph) {
+        return findNodeName(
+                streamGraph, name -> name.contains("Writer") && !name.contains("Committer"));
+    }
+
+    StreamNode findCommitter(StreamGraph streamGraph) {
+        return findNodeName(
+                streamGraph,
+                name -> name.contains("Committer") && !name.contains("Global Committer"));
+    }
+
+    StreamNode findGlobalCommitter(StreamGraph streamGraph) {
+        return findNodeName(streamGraph, name -> name.contains("Global Committer"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throwExceptionWithoutSettingUid() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, runtimeExecutionMode);
+        env.configure(config, getClass().getClassLoader());
+        // disable auto generating uid
+        env.getConfig().disableAutoGeneratedUIDs();
+        sinkTo(env.fromElements(1, 2), simpleSink());
+        env.getStreamGraph();
+    }
+
+    @Test
+    public void disableOperatorChain() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src, sinkWithCommitter()).name(NAME);
+        dataStreamSink.disableChaining();
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final StreamNode writer = findWriter(streamGraph);
+        final StreamNode committer = findCommitter(streamGraph);
+
+        assertThat(writer.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.NEVER));
+        assertThat(
+                committer.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.NEVER));
+    }
+
+    void validateTopology(
+            StreamNode src,
+            Class<?> srcOutTypeInfo,
+            StreamNode dest,
+            Class<? extends StreamOperatorFactory> operatorFactoryClass,
+            int expectedParallelism,
+            int expectedMaxParallelism) {
+
+        // verify src node
+        final StreamEdge srcOutEdge = src.getOutEdges().get(0);
+        assertThat(srcOutEdge.getTargetId(), equalTo(dest.getId()));
+        assertThat(src.getTypeSerializerOut(), instanceOf(srcOutTypeInfo));
+
+        // verify dest node input
+        final StreamEdge destInputEdge = dest.getInEdges().get(0);
+        assertThat(destInputEdge.getSourceId(), equalTo(src.getId()));
+        assertThat(dest.getTypeSerializersIn()[0], instanceOf(srcOutTypeInfo));
+
+        // make sure 2 sink operators have different names/uid
+        assertThat(dest.getOperatorName(), not(equalTo(src.getOperatorName())));
+        assertThat(dest.getTransformationUID(), not(equalTo(src.getTransformationUID())));
+
+        assertThat(dest.getOperatorFactory(), instanceOf(operatorFactoryClass));
+        assertThat(dest.getParallelism(), equalTo(expectedParallelism));
+        assertThat(dest.getMaxParallelism(), equalTo(expectedMaxParallelism));
+        assertThat(dest.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.ALWAYS));
+        assertThat(dest.getSlotSharingGroup(), equalTo(SLOT_SHARE_GROUP));
+    }
+
+    StreamGraph buildGraph(SinkT sink, RuntimeExecutionMode runtimeExecutionMode) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, runtimeExecutionMode);
+        env.configure(config, getClass().getClassLoader());
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src.rebalance(), sink);
+        setSinkProperty(dataStreamSink);
+        // Trigger the plan generation but do not clear the transformations
+        env.getExecutionPlan();
+        return env.getStreamGraph();
+    }
+
+    private void setSinkProperty(DataStreamSink<Integer> dataStreamSink) {
+        dataStreamSink.name(NAME);
+        dataStreamSink.uid(UID);
+        dataStreamSink.setParallelism(SinkTransformationTranslatorITCaseBase.PARALLELISM);
+        dataStreamSink.slotSharingGroup(SLOT_SHARE_GROUP);
+    }
+
+    StreamNode findNodeName(StreamGraph streamGraph, Predicate<String> predicate) {
+        return streamGraph.getStreamNodes().stream()
+                .filter(node -> predicate.test(node.getOperatorName()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Can not find the node"));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link org.apache.flink.streaming.api.transformations.SinkTransformation}.
+ *
+ * <p>ATTENTION: This test is extremely brittle. Do NOT remove, add or re-order test cases.
+ */
+@RunWith(Parameterized.class)
+public class SinkV2TransformationTranslatorITCase
+        extends SinkTransformationTranslatorITCaseBase<Sink<Integer>> {
+
+    @Override
+    Sink<Integer> simpleSink() {
+        return TestSinkV2.<Integer>newBuilder().build();
+    }
+
+    @Override
+    Sink<Integer> sinkWithCommitter() {
+        return TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build();
+    }
+
+    @Override
+    DataStreamSink<Integer> sinkTo(DataStream<Integer> stream, Sink<Integer> sink) {
+        return stream.sinkTo(sink);
+    }
+
+    @Test
+    public void testSettingOperatorUidHash() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final String writerHash = "f6b178ce445dc3ffaa06bad27a51fead";
+        final String committerHash = "68ac8ae79eae4e3135a54f9689c4aa10";
+        final CustomSinkOperatorUidHashes operatorsUidHashes =
+                CustomSinkOperatorUidHashes.builder()
+                        .setWriterUidHash(writerHash)
+                        .setCommitterUidHash(committerHash)
+                        .build();
+        src.sinkTo(
+                        TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build(),
+                        operatorsUidHashes)
+                .name(NAME);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+
+        assertEquals(findWriter(streamGraph).getUserHash(), writerHash);
+        assertEquals(findCommitter(streamGraph).getUserHash(), committerHash);
+    }
+
+    /**
+     * When ever you need to change something in this test case please think about possible state
+     * upgrade problems introduced by your changes.
+     */
+    @Test
+    public void testSettingOperatorUids() {
+        final String sinkUid = "f6b178ce445dc3ffaa06bad27a51fead";
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        src.sinkTo(TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build())
+                .name(NAME)
+                .uid(sinkUid);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(findWriter(streamGraph).getTransformationUID(), sinkUid);
+        assertEquals(
+                findCommitter(streamGraph).getTransformationUID(),
+                String.format("Sink Committer: %s", sinkUid));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkTestUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkTestUtil.java
@@ -52,7 +52,7 @@ class SinkTestUtil {
     static byte[] toBytes(String obj) {
         try {
             return SimpleVersionedSerialization.writeVersionAndSerialize(
-                    TestSink.StringCommittableSerializer.INSTANCE, obj);
+                    TestSinkV2.StringSerializer.INSTANCE, obj);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -83,7 +83,7 @@ class SinkTestUtil {
     static String fromBytes(byte[] obj) {
         try {
             return SimpleVersionedSerialization.readVersionAndDeSerialize(
-                    TestSink.StringCommittableSerializer.INSTANCE, obj);
+                    TestSinkV2.StringSerializer.INSTANCE, obj);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+
+import java.util.Collection;
+
+class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
+    @Override
+    SinkAndCounters sinkWithPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(true)
+                                .build(),
+                () -> committer.successfulCommits);
+    }
+
+    @Override
+    SinkAndCounters sinkWithPostCommitWithRetry() {
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(new TestSinkV2.RetryOnceCommitter())
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(true)
+                                .build(),
+                () -> 0);
+    }
+
+    @Override
+    SinkAndCounters sinkWithoutPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(false)
+                                .build(),
+                () -> committer.successfulCommits);
+    }
+
+    private static class ForwardingCommitter extends TestSinkV2.DefaultCommitter {
+        private int successfulCommits = 0;
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            successfulCommits += committables.size();
+        }
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+class SinkV2SinkWriterOperatorTest extends SinkWriterOperatorTestBase {
+
+    @Override
+    SinkAndSuppliers sinkWithoutCommitter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter = new TestSinkV2.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder().setWriter(sinkWriter).build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithCommitter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter =
+                new TestSinkV2.DefaultCommittingSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithTimeBasedWriter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter = new TimeBasedBufferingSinkWriter();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithSnapshottingWriter(boolean withState, String stateName) {
+        SnapshottingBufferingSinkWriter sinkWriter = new SnapshottingBufferingSinkWriter();
+        TestSinkV2.Builder<Integer> builder =
+                TestSinkV2.newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .setWithPostCommitTopology(true);
+        if (withState) {
+            builder.setWriterState(true);
+        }
+        if (stateName != null) {
+            builder.setCompatibleStateNames(stateName);
+        }
+        return new SinkAndSuppliers(
+                builder.build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> sinkWriter.lastCheckpointId,
+                () -> new TestSinkV2.StringSerializer());
+    }
+
+    private static class TimeBasedBufferingSinkWriter
+            extends TestSinkV2.DefaultCommittingSinkWriter<Integer>
+            implements ProcessingTimeService.ProcessingTimeCallback {
+
+        private final List<String> cachedCommittables = new ArrayList<>();
+        private ProcessingTimeService processingTimeService;
+
+        @Override
+        public void write(Integer element, Context context) {
+            cachedCommittables.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void onProcessingTime(long time) {
+            elements.addAll(cachedCommittables);
+            cachedCommittables.clear();
+            this.processingTimeService.registerTimer(time + 1000, this);
+        }
+
+        @Override
+        public void init(org.apache.flink.api.connector.sink2.Sink.InitContext context) {
+            this.processingTimeService = context.getProcessingTimeService();
+            this.processingTimeService.registerTimer(1000, this);
+        }
+    }
+
+    private static class SnapshottingBufferingSinkWriter
+            extends TestSinkV2.DefaultStatefulSinkWriter {
+        public static final int NOT_SNAPSHOTTED = -1;
+        long lastCheckpointId = NOT_SNAPSHOTTED;
+        boolean endOfInput = false;
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            this.endOfInput = endOfInput;
+        }
+
+        @Override
+        public List<String> snapshotState(long checkpointId) throws IOException {
+            lastCheckpointId = checkpointId;
+            return super.snapshotState(checkpointId);
+        }
+
+        @Override
+        public Collection<String> prepareCommit() {
+            if (!endOfInput) {
+                return ImmutableList.of();
+            }
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -49,7 +49,13 @@ import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertNotNull;
 
-/** A {@link Sink TestSink} for all the sink related tests. */
+/**
+ * A {@link Sink TestSink} for all the sink related tests. Use only for tests where {@link
+ * SinkV1Adapter} should be tested.
+ *
+ * @deprecated Use {@link TestSinkV2} instead.
+ */
+@Deprecated
 public class TestSink<T> implements Sink<T, String, String, String> {
 
     public static final String END_OF_INPUT_STR = "end of input";
@@ -178,11 +184,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
         public Builder<T> setDefaultCommitter(Supplier<Queue<String>> queueSupplier) {
             this.committer = new DefaultCommitter(queueSupplier);
             this.committableSerializer = StringCommittableSerializer.INSTANCE;
-            return this;
-        }
-
-        public Builder<T> setGlobalCommitter(GlobalCommitter<String, String> globalCommitter) {
-            this.globalCommitter = globalCommitter;
             return this;
         }
 
@@ -363,10 +364,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
 
         private final String committedSuccessData;
 
-        DefaultGlobalCommitter() {
-            this("");
-        }
-
         DefaultGlobalCommitter(String committedSuccessData) {
             this.committedSuccessData = committedSuccessData;
         }
@@ -394,39 +391,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
         @Override
         public void endOfInput() {
             commit(Collections.singletonList(END_OF_INPUT_STR));
-        }
-    }
-
-    /** A {@link GlobalCommitter} that always re-commits global committables it received. */
-    static class RetryOnceGlobalCommitter extends DefaultGlobalCommitter {
-
-        private final Set<String> seen = new LinkedHashSet<>();
-
-        @Override
-        public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
-            return globalCommittables;
-        }
-
-        @Override
-        public String combine(List<String> committables) {
-            return String.join("|", committables);
-        }
-
-        @Override
-        public void endOfInput() {}
-
-        @Override
-        public List<String> commit(List<String> committables) {
-            committables.forEach(
-                    c -> {
-                        if (seen.remove(c)) {
-                            checkNotNull(committedData);
-                            committedData.add(c);
-                        } else {
-                            seen.add(c);
-                        }
-                    });
-            return new ArrayList<>(seen);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertNotNull;
+
+/** A {@link org.apache.flink.api.connector.sink2.Sink} for all the sink related tests. */
+public class TestSinkV2<InputT> implements Sink<InputT> {
+
+    private final DefaultSinkWriter<InputT> writer;
+
+    private TestSinkV2(DefaultSinkWriter<InputT> writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public SinkWriter<InputT> createWriter(InitContext context) {
+        writer.init(context);
+        return writer;
+    }
+
+    DefaultSinkWriter<InputT> getWriter() {
+        return writer;
+    }
+
+    public static <InputT> Builder<InputT> newBuilder() {
+        return new Builder<>();
+    }
+
+    /** A builder class for {@link TestSinkV2}. */
+    public static class Builder<InputT> {
+        private DefaultSinkWriter<InputT> writer = null;
+        private DefaultCommitter committer;
+        private SimpleVersionedSerializer<String> committableSerializer;
+        private boolean withPostCommitTopology = false;
+        private boolean withWriterState = false;
+        private String compatibleStateNames;
+
+        public Builder<InputT> setWriter(DefaultSinkWriter<InputT> writer) {
+            this.writer = checkNotNull(writer);
+            return this;
+        }
+
+        public Builder<InputT> setCommitter(DefaultCommitter committer) {
+            this.committer = committer;
+            return this;
+        }
+
+        public Builder<InputT> setCommittableSerializer(
+                SimpleVersionedSerializer<String> committableSerializer) {
+            this.committableSerializer = committableSerializer;
+            return this;
+        }
+
+        public Builder<InputT> setDefaultCommitter() {
+            this.committer = new DefaultCommitter();
+            this.committableSerializer = StringSerializer.INSTANCE;
+            return this;
+        }
+
+        public Builder<InputT> setDefaultCommitter(
+                Supplier<Queue<Committer.CommitRequest<String>>> queueSupplier) {
+            this.committer = new DefaultCommitter(queueSupplier);
+            this.committableSerializer = StringSerializer.INSTANCE;
+            return this;
+        }
+
+        public Builder<InputT> setWithPostCommitTopology(boolean withPostCommitTopology) {
+            this.withPostCommitTopology = withPostCommitTopology;
+            return this;
+        }
+
+        public Builder<InputT> setWriterState(boolean withWriterState) {
+            this.withWriterState = withWriterState;
+            return this;
+        }
+
+        public Builder<InputT> setCompatibleStateNames(String compatibleStateNames) {
+            this.compatibleStateNames = compatibleStateNames;
+            return this;
+        }
+
+        public TestSinkV2<InputT> build() {
+            if (committer == null) {
+                if (writer == null) {
+                    writer = new DefaultSinkWriter<>();
+                }
+                // SinkV2 with a simple writer
+                return new TestSinkV2<>(writer);
+            } else {
+                if (writer == null) {
+                    writer = new DefaultCommittingSinkWriter<>();
+                }
+                if (!withPostCommitTopology) {
+                    // TwoPhaseCommittingSink with a stateless writer and a committer
+                    return new TestSinkV2TwoPhaseCommittingSink<>(
+                            writer, committableSerializer, committer);
+                } else {
+                    if (withWriterState) {
+                        // TwoPhaseCommittingSink with a stateful writer and a committer and post
+                        // commit topology
+                        Preconditions.checkArgument(
+                                writer instanceof DefaultStatefulSinkWriter,
+                                "Please provide a DefaultStatefulSinkWriter instance");
+                        return new TestStatefulSinkV2(
+                                (DefaultStatefulSinkWriter) writer,
+                                committableSerializer,
+                                committer,
+                                compatibleStateNames);
+                    } else {
+                        // TwoPhaseCommittingSink with a stateless writer and a committer and post
+                        // commit topology
+                        Preconditions.checkArgument(
+                                writer instanceof DefaultCommittingSinkWriter,
+                                "Please provide a DefaultCommittingSinkWriter instance");
+                        return new TestSinkV2WithPostCommitTopology<>(
+                                (DefaultCommittingSinkWriter) writer,
+                                committableSerializer,
+                                committer);
+                    }
+                }
+            }
+        }
+    }
+
+    private static class TestSinkV2TwoPhaseCommittingSink<InputT> extends TestSinkV2<InputT>
+            implements TwoPhaseCommittingSink<InputT, String> {
+        private final DefaultCommitter committer;
+        private final SimpleVersionedSerializer<String> committableSerializer;
+
+        public TestSinkV2TwoPhaseCommittingSink(
+                DefaultSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer) {
+            super(writer);
+            this.committer = committer;
+            this.committableSerializer = committableSerializer;
+        }
+
+        @Override
+        public Committer<String> createCommitter() {
+            committer.init();
+            return committer;
+        }
+
+        @Override
+        public SimpleVersionedSerializer<String> getCommittableSerializer() {
+            return committableSerializer;
+        }
+
+        @Override
+        public PrecommittingSinkWriter<InputT, String> createWriter(InitContext context) {
+            return (PrecommittingSinkWriter<InputT, String>) super.createWriter(context);
+        }
+    }
+
+    // -------------------------------------- Sink With PostCommitTopology -------------------------
+
+    private static class TestSinkV2WithPostCommitTopology<InputT>
+            extends TestSinkV2TwoPhaseCommittingSink<InputT>
+            implements WithPostCommitTopology<InputT, String> {
+        public TestSinkV2WithPostCommitTopology(
+                DefaultSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer) {
+            super(writer, committableSerializer, committer);
+        }
+
+        @Override
+        public void addPostCommitTopology(DataStream<CommittableMessage<String>> committables) {
+            // We do not need to do anything for tests
+        }
+    }
+
+    private static class TestStatefulSinkV2<InputT> extends TestSinkV2WithPostCommitTopology<InputT>
+            implements StatefulSink<InputT, String>, StatefulSink.WithCompatibleState {
+        private String compatibleState;
+
+        public TestStatefulSinkV2(
+                DefaultStatefulSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer,
+                String compatibleState) {
+            super(writer, committableSerializer, committer);
+            this.compatibleState = compatibleState;
+        }
+
+        @Override
+        public DefaultStatefulSinkWriter<InputT> createWriter(InitContext context) {
+            return (DefaultStatefulSinkWriter<InputT>) super.createWriter(context);
+        }
+
+        @Override
+        public StatefulSinkWriter<InputT, String> restoreWriter(
+                InitContext context, Collection<String> recoveredState) {
+            DefaultStatefulSinkWriter<InputT> statefulWriter =
+                    (DefaultStatefulSinkWriter) getWriter();
+
+            statefulWriter.restore(recoveredState);
+            return statefulWriter;
+        }
+
+        @Override
+        public SimpleVersionedSerializer<String> getWriterStateSerializer() {
+            return new StringSerializer();
+        }
+
+        @Override
+        public Collection<String> getCompatibleWriterStateNames() {
+            return compatibleState == null ? ImmutableSet.of() : ImmutableSet.of(compatibleState);
+        }
+    }
+
+    // -------------------------------------- Sink Writer ------------------------------------------
+
+    /** Base class for out testing {@link SinkWriter}. */
+    public static class DefaultSinkWriter<InputT> implements SinkWriter<InputT>, Serializable {
+
+        protected List<String> elements;
+
+        protected List<Watermark> watermarks;
+
+        protected DefaultSinkWriter() {
+            this.elements = new ArrayList<>();
+            this.watermarks = new ArrayList<>();
+        }
+
+        @Override
+        public void write(InputT element, Context context) {
+            elements.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            elements = new ArrayList<>();
+        }
+
+        @Override
+        public void writeWatermark(Watermark watermark) {
+            watermarks.add(watermark);
+        }
+
+        @Override
+        public void close() throws Exception {
+            // noting to do here
+        }
+
+        public void init(InitContext context) {
+            // context is not used in default case
+        }
+    }
+
+    /** Base class for out testing {@link TwoPhaseCommittingSink.PrecommittingSinkWriter}. */
+    protected static class DefaultCommittingSinkWriter<InputT> extends DefaultSinkWriter<InputT>
+            implements TwoPhaseCommittingSink.PrecommittingSinkWriter<InputT, String>,
+                    Serializable {
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            // We empty the elements on prepareCommit
+        }
+
+        @Override
+        public Collection<String> prepareCommit() {
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+
+    /**
+     * Base class for out testing {@link StatefulSink.StatefulSinkWriter}. Extends the {@link
+     * DefaultCommittingSinkWriter} for simplicity.
+     */
+    protected static class DefaultStatefulSinkWriter<InputT>
+            extends DefaultCommittingSinkWriter<InputT>
+            implements StatefulSink.StatefulSinkWriter<InputT, String> {
+
+        @Override
+        public List<String> snapshotState(long checkpointId) throws IOException {
+            return elements;
+        }
+
+        protected void restore(Collection<String> recoveredState) {
+            this.elements = new ArrayList<>(recoveredState);
+        }
+    }
+
+    // -------------------------------------- Sink Committer ---------------------------------------
+
+    /** Base class for testing {@link Committer}. */
+    static class DefaultCommitter implements Committer<String>, Serializable {
+
+        @Nullable protected Queue<CommitRequest<String>> committedData;
+
+        private boolean isClosed;
+
+        @Nullable private final Supplier<Queue<CommitRequest<String>>> queueSupplier;
+
+        public DefaultCommitter() {
+            this.committedData = new ConcurrentLinkedQueue<>();
+            this.isClosed = false;
+            this.queueSupplier = null;
+        }
+
+        public DefaultCommitter(@Nullable Supplier<Queue<CommitRequest<String>>> queueSupplier) {
+            this.queueSupplier = queueSupplier;
+            this.isClosed = false;
+            this.committedData = null;
+        }
+
+        public List<CommitRequest<String>> getCommittedData() {
+            if (committedData != null) {
+                return new ArrayList<>(committedData);
+            } else {
+                return Collections.emptyList();
+            }
+        }
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            if (committedData == null) {
+                assertNotNull(queueSupplier);
+                committedData = queueSupplier.get();
+            }
+            committedData.addAll(committables);
+        }
+
+        public void close() throws Exception {
+            isClosed = true;
+        }
+
+        public boolean isClosed() {
+            return isClosed;
+        }
+
+        public void init() {
+            // context is not used for this implementation
+        }
+    }
+
+    /** A {@link Committer} that always re-commits the committables data it received. */
+    static class RetryOnceCommitter extends DefaultCommitter {
+
+        private final Set<CommitRequest<String>> seen = new LinkedHashSet<>();
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            committables.forEach(
+                    c -> {
+                        if (seen.remove(c)) {
+                            checkNotNull(committedData);
+                            committedData.add(c);
+                        } else {
+                            seen.add(c);
+                            c.retryLater();
+                        }
+                    });
+        }
+    }
+
+    /**
+     * We introduce this {@link StringSerializer} is because that all the fields of {@link
+     * TestSinkV2} should be serializable.
+     */
+    public static class StringSerializer
+            implements SimpleVersionedSerializer<String>, Serializable {
+
+        public static final StringSerializer INSTANCE = new StringSerializer();
+
+        @Override
+        public int getVersion() {
+            return SimpleVersionedStringSerializer.INSTANCE.getVersion();
+        }
+
+        @Override
+        public byte[] serialize(String obj) {
+            return SimpleVersionedStringSerializer.INSTANCE.serialize(obj);
+        }
+
+        @Override
+        public String deserialize(int version, byte[] serialized) throws IOException {
+            return SimpleVersionedStringSerializer.INSTANCE.deserialize(version, serialized);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+
+import java.util.Collections;
+import java.util.List;
+
+class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
+
+    @Override
+    SinkAndCounters sinkWithPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(committer)
+                                .setDefaultGlobalCommitter()
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> committer.successfulCommits);
+    }
+
+    @Override
+    SinkAndCounters sinkWithPostCommitWithRetry() {
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(new TestSink.RetryOnceCommitter())
+                                .setDefaultGlobalCommitter()
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> 0);
+    }
+
+    @Override
+    SinkAndCounters sinkWithoutPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> committer.successfulCommits);
+    }
+
+    private static class ForwardingCommitter extends TestSink.DefaultCommitter {
+        private int successfulCommits = 0;
+
+        @Override
+        public List<String> commit(List<String> committables) {
+            successfulCommits += committables.size();
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterSinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterSinkWriterOperatorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class WithAdapterSinkWriterOperatorTest extends SinkWriterOperatorTestBase {
+
+    @Override
+    SinkAndSuppliers sinkWithoutCommitter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TestSink.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithCommitter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TestSink.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter().build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithTimeBasedWriter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TimeBasedBufferingSinkWriter();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter().build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithSnapshottingWriter(boolean withState, String stateName) {
+        SnapshottingBufferingSinkWriter sinkWriter = new SnapshottingBufferingSinkWriter();
+        TestSink.Builder<Integer> builder =
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter();
+        if (withState) {
+            builder.withWriterState();
+        }
+        if (stateName != null) {
+            builder.setCompatibleStateNames(stateName);
+        }
+        return new SinkAndSuppliers(
+                builder.build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> sinkWriter.lastCheckpointId,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    private static class TimeBasedBufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer>
+            implements Sink.ProcessingTimeService.ProcessingTimeCallback {
+
+        private final List<String> cachedCommittables = new ArrayList<>();
+
+        @Override
+        public void write(Integer element, Context context) {
+            cachedCommittables.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        void setProcessingTimerService(Sink.ProcessingTimeService processingTimerService) {
+            super.setProcessingTimerService(processingTimerService);
+            this.processingTimerService.registerProcessingTimer(1000, this);
+        }
+
+        @Override
+        public void onProcessingTime(long time) {
+            elements.addAll(cachedCommittables);
+            cachedCommittables.clear();
+            this.processingTimerService.registerProcessingTimer(time + 1000, this);
+        }
+    }
+
+    private static class SnapshottingBufferingSinkWriter
+            extends TestSink.DefaultSinkWriter<Integer> {
+        public static final int NOT_SNAPSHOTTED = -1;
+        long lastCheckpointId = NOT_SNAPSHOTTED;
+
+        @Override
+        public List<String> snapshotState(long checkpointId) {
+            lastCheckpointId = checkpointId;
+            return elements;
+        }
+
+        @Override
+        void restoredFrom(List<String> states) {
+            this.elements = new ArrayList<>(states);
+        }
+
+        @Override
+        public List<String> prepareCommit(boolean flush) {
+            if (!flush) {
+                return Collections.emptyList();
+            }
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Integration test for {@link org.apache.flink.api.connector.sink.Sink} run time implementation.
+ */
+public class SinkV2ITCase extends AbstractTestBase {
+    static final List<Integer> SOURCE_DATA =
+            Arrays.asList(
+                    895, 127, 148, 161, 148, 662, 822, 491, 275, 122, 850, 630, 682, 765, 434, 970,
+                    714, 795, 288, 422);
+
+    // source send data two times
+    static final int STREAMING_SOURCE_SEND_ELEMENTS_NUM = SOURCE_DATA.size() * 2;
+
+    static final List<String> EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE =
+            SOURCE_DATA.stream()
+                    // source send data two times
+                    .flatMap(
+                            x ->
+                                    Collections.nCopies(
+                                            2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                                            .stream())
+                    .collect(Collectors.toList());
+
+    static final List<String> EXPECTED_COMMITTED_DATA_IN_BATCH_MODE =
+            SOURCE_DATA.stream()
+                    .map(x -> Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                    .collect(Collectors.toList());
+
+    static final Queue<Committer.CommitRequest<String>> COMMIT_QUEUE =
+            new ConcurrentLinkedQueue<>();
+
+    static final BooleanSupplier COMMIT_QUEUE_RECEIVE_ALL_DATA =
+            (BooleanSupplier & Serializable)
+                    () -> COMMIT_QUEUE.size() == STREAMING_SOURCE_SEND_ELEMENTS_NUM;
+
+    @Before
+    public void init() {
+        COMMIT_QUEUE.clear();
+    }
+
+    @Test
+    public void writerAndCommitterExecuteInStreamingMode() throws Exception {
+        final StreamExecutionEnvironment env = buildStreamEnv();
+        final FiniteTestSource<Integer> source =
+                new FiniteTestSource<>(COMMIT_QUEUE_RECEIVE_ALL_DATA, SOURCE_DATA);
+
+        env.addSource(source, IntegerTypeInfo.INT_TYPE_INFO)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                        & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        env.execute();
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));
+    }
+
+    @Test
+    public void writerAndCommitterExecuteInBatchMode() throws Exception {
+        final StreamExecutionEnvironment env = buildBatchEnv();
+
+        env.fromCollection(SOURCE_DATA)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                        & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        env.execute();
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_BATCH_MODE.toArray()));
+    }
+
+    private StreamExecutionEnvironment buildStreamEnv() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+        return env;
+    }
+
+    private StreamExecutionEnvironment buildBatchEnv() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        return env;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.testutils.InMemoryReporter;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatCounter;
+import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGauge;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
+public class SinkV2MetricsITCase extends TestLogger {
+
+    private static final String TEST_SINK_NAME = "MetricTestSink";
+    // please refer to SinkTransformationTranslator#WRITER_NAME
+    private static final String DEFAULT_WRITER_NAME = "Writer";
+    private static final int DEFAULT_PARALLELISM = 4;
+
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    private static final InMemoryReporter reporter = InMemoryReporter.createWithRetainedMetrics();
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .setConfiguration(reporter.addToConfiguration(new Configuration()))
+                            .build());
+
+    @Test
+    public void testMetrics() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        int numSplits = Math.max(1, env.getParallelism() - 2);
+
+        int numRecordsPerSplit = 10;
+
+        // make sure all parallel instances have processed the same amount of records before
+        // validating metrics
+        SharedReference<CyclicBarrier> beforeBarrier =
+                sharedObjects.add(new CyclicBarrier(numSplits + 1));
+        SharedReference<CyclicBarrier> afterBarrier =
+                sharedObjects.add(new CyclicBarrier(numSplits + 1));
+        int stopAtRecord1 = 4;
+        int stopAtRecord2 = numRecordsPerSplit - 1;
+
+        env.fromSequence(0, numSplits - 1)
+                .<Long>flatMap(
+                        (split, collector) ->
+                                LongStream.range(0, numRecordsPerSplit).forEach(collector::collect))
+                .returns(BasicTypeInfo.LONG_TYPE_INFO)
+                .map(
+                        i -> {
+                            if (i % numRecordsPerSplit == stopAtRecord1
+                                    || i % numRecordsPerSplit == stopAtRecord2) {
+                                beforeBarrier.get().await();
+                                afterBarrier.get().await();
+                            }
+                            return i;
+                        })
+                .sinkTo(TestSinkV2.<Long>newBuilder().setWriter(new MetricWriter()).build())
+                .name(TEST_SINK_NAME);
+        JobClient jobClient = env.executeAsync();
+        final JobID jobId = jobClient.getJobID();
+
+        beforeBarrier.get().await();
+        assertSinkMetrics(jobId, stopAtRecord1, env.getParallelism(), numSplits);
+        afterBarrier.get().await();
+
+        beforeBarrier.get().await();
+        assertSinkMetrics(jobId, stopAtRecord2, env.getParallelism(), numSplits);
+        afterBarrier.get().await();
+
+        jobClient.getJobExecutionResult().get();
+    }
+
+    @SuppressWarnings("checkstyle:WhitespaceAfter")
+    private void assertSinkMetrics(
+            JobID jobId, long processedRecordsPerSubtask, int parallelism, int numSplits) {
+        List<OperatorMetricGroup> groups =
+                reporter.findOperatorMetricGroups(
+                        jobId, TEST_SINK_NAME + ": " + DEFAULT_WRITER_NAME);
+        assertThat(groups, hasSize(parallelism));
+
+        int subtaskWithMetrics = 0;
+        for (OperatorMetricGroup group : groups) {
+            Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
+            // There are only 2 splits assigned; so two groups will not update metrics.
+            if (group.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
+                continue;
+            }
+            subtaskWithMetrics++;
+
+            // SinkWriterMetricGroup metrics
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_RECORDS_OUT))
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_BYTES_OUT))
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
+            // MetricWriter is just incrementing errors every even record
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_OUT_ERRORS))
+                    .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
+            // Test "send" metric series has the same value as "out" metric series.
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND))
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(metrics.get(MetricNames.NUM_BYTES_SEND))
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND_ERRORS))
+                    .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
+            // check if the latest send time is fetched
+            assertThatGauge(metrics.get(MetricNames.CURRENT_SEND_TIME))
+                    .isEqualTo((processedRecordsPerSubtask - 1) * MetricWriter.BASE_SEND_TIME);
+        }
+        assertThat(subtaskWithMetrics, equalTo(numSplits));
+    }
+
+    private static class MetricWriter extends TestSinkV2.DefaultSinkWriter<Long> {
+        static final long BASE_SEND_TIME = 100;
+        static final long RECORD_SIZE_IN_BYTES = 10;
+        private SinkWriterMetricGroup metricGroup;
+        private long sendTime;
+
+        @Override
+        public void init(Sink.InitContext context) {
+            this.metricGroup = context.metricGroup();
+            metricGroup.setCurrentSendTimeGauge(() -> sendTime);
+        }
+
+        @Override
+        public void write(Long element, Context context) {
+            super.write(element, context);
+            sendTime = element * BASE_SEND_TIME;
+            metricGroup.getIOMetricGroup().getNumRecordsOutCounter().inc();
+            if (element % 2 == 0) {
+                metricGroup.getNumRecordsOutErrorsCounter().inc();
+            }
+            metricGroup.getIOMetricGroup().getNumBytesOutCounter().inc(RECORD_SIZE_IN_BYTES);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Creating direct test for SinkV2

## Brief change log

- Created TestSinkV2 which instantiates a SinkV2 directly
- Refactored tests where we want to keep both V1 and V2 test parallel to have a base class:
    - SinkTransformationTranslatorITCaseBase
    - CommitterOperatorTestBase
    - SinkWriterOperatorTestBase
- Created new tests where it did not worth to create the base test case:
    - SinkV2ITCase
    - SinkV2MetricsITCase
- Moved the new tests to use TestSinkV2 where we do not want duplicated tests:
   - DataStreamSinkTest

As a bit unrelated change moved  the `InternalSinkWriterMetricGroup.mock` methods a `MetricsGroupTestUtils` class, so we do not mix test and production code

## Verifying this change

This is a test change, so the CI will tell if it is correct, or not.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
