### PR TITLE
[FLINK-33301][release] Add Java and Maven version check script

### DIFF
--- a/tools/releasing/check_java_maven_versions.sh
+++ b/tools/releasing/check_java_maven_versions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Define the required versions
+required_java_version="1.8"
+required_maven_version="3.8.6"
+
+# Check Java version
+java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+if [[ "$java_version" == "$required_java_version"* ]]; then
+    echo "Java version is correct: $java_version"
+else
+    echo "Java version is incorrect. Required version: $required_java_version, but it is $java_version"
+    exit 1
+fi
+
+# Check Maven version
+maven_version=$(mvn -v | grep -oE 'Apache Maven [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $3}')
+if [[ "$maven_version" == "$required_maven_version" ]]; then
+    echo "Maven version is correct: $maven_version"
+else
+    echo "Maven version is incorrect. Required version: $required_maven_version, but it is $maven_version"
+    exit 1
+fi

--- a/tools/releasing/check_java_maven_versions.sh
+++ b/tools/releasing/check_java_maven_versions.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Define the required versions
 required_java_version="1.8"
 required_maven_version="3.8.6"

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+## check required Java and Maven version
+. check_java_maven_versions.sh
+
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+## check required Java and Maven version
+. check_java_maven_versions.sh
+
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+## check required Java and Maven version
+. check_java_maven_versions.sh
+
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##


### PR DESCRIPTION
## What is the purpose of the change

During the release, [Flink requires specific version of Java and Maven](https://lists.apache.org/thread/fbdl2w6wjmwk55y94ml91bpnhmh4rnm0). It makes sense to check those versions at the very beginning of some bash scripts to let it fail fast and therefore improve the efficiency.

## Brief change log

  - add check_java_maven_versions.sh to check Java and Maven version.
  - call check_java_maven_versions.sh first in create_binary_release.sh, create_source_release.sh, deploy_staging_jars.sh


## Verifying this change

Users can set different Java or Maven versions in the terminal and call one of the added or modified script to test if the process will be aborted. the process will be moving forward only when the required Java and Maven versions are used.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
