### PR TITLE
[FLINK-33308] Upgrade lombok to 1.8.30

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -147,7 +147,7 @@ under the License.
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.30</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION

## What is the purpose of the change

Since current version of lombok is incompatible with jdk21 the PR is aiming to upgrade lombok version as this issue has been fixed at https://github.com/projectlombok/lombok/issues/3393

## Brief change log

pom.xml


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
