### PR TITLE
[FLINK-33310] Scala before 2.12.18 doesn't compile on Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1130,6 +1130,11 @@ under the License.
 				<jdk>[21,)</jdk>
 			</activation>
 
+			<properties>
+				<!-- Bump Scala because before 2.12.18 doesn't compile on Java 21. -->
+				<scala.version>2.12.18</scala.version>
+			</properties>
+
 			<build>
 				<pluginManagement>
 					<plugins>


### PR DESCRIPTION

## What is the purpose of the change

based on release notes 2.12.18 - the first 2.12.x supporting jdk21
https://github.com/scala/scala/releases/tag/v2.12.18
the PR adds 2.12.18 for java 21
the PR is based on https://github.com/apache/flink/pull/23546



## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
