### PR TITLE
[FLINK-33314][table] Fix the named parameter example in window tvf

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/window-tvf.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/window-tvf.md
@@ -312,13 +312,13 @@ CUMULATE(TABLE data, DESCRIPTOR(timecol), step, size)
 Flink SQL> SELECT * FROM TABLE(
    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES));
 -- or with the named params
--- note: the DATA param must be the first
+-- note: the DATA param must be the first and `OFFSET` should be wrapped with double quotes
 Flink SQL> SELECT * FROM TABLE(
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
      SIZE => INTERVAL '10' MINUTES,
-     OFFSET => INTERVAL '1' MINUTES));
+     `OFFSET` => INTERVAL '1' MINUTES));
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+

--- a/docs/content/docs/dev/table/sql/queries/window-tvf.md
+++ b/docs/content/docs/dev/table/sql/queries/window-tvf.md
@@ -312,13 +312,13 @@ We show an example to describe how to use offset in Tumble window in the followi
 Flink SQL> SELECT * FROM TABLE(
    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES));
 -- or with the named params
--- note: the DATA param must be the first
+-- note: the DATA param must be the first and `OFFSET` should be wrapped with double quotes
 Flink SQL> SELECT * FROM TABLE(
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
      SIZE => INTERVAL '10' MINUTES,
-     OFFSET => INTERVAL '1' MINUTES));
+     `OFFSET` => INTERVAL '1' MINUTES));
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.xml
@@ -194,6 +194,37 @@ Calc(select=[a, b, c, d, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, wi
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testHopTVFWithNamedParams">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM TABLE(TUMBLE(
+   DATA => TABLE MyTable,
+   TIMECOL => DESCRIPTOR(rowtime),
+   SIZE => INTERVAL '15' MINUTE,
+   `OFFSET` => INTERVAL '5' MINUTE))
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5], window_start=[$6], window_end=[$7], window_time=[$8])
++- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time])
++- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min], offset=[5 min])])
+   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testHopTVFWithNegativeOffset">
     <Resource name="sql">
       <![CDATA[
@@ -320,6 +351,37 @@ Calc(select=[a, b, c, d, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, wi
 SELECT *
 FROM TABLE(TUMBLE(
    TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '15' MINUTE, INTERVAL '5' MINUTE))
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5], window_start=[$6], window_end=[$7], window_time=[$8])
++- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($4), 900000:INTERVAL MINUTE, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP(3) *ROWTIME* window_time)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[$5])
+      +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($4, 1000:INTERVAL SECOND)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rowtime=[$4], proctime=[PROCTIME()])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, c, d, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, window_start, window_end, window_time])
++- WindowTableFunction(window=[TUMBLE(time_col=[rowtime], size=[15 min], offset=[5 min])])
+   +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+      +- Calc(select=[a, b, c, d, rowtime, PROCTIME() AS proctime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTumbleTVFWithNamedParams">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM TABLE(TUMBLE(
+   DATA => TABLE MyTable,
+   TIMECOL => DESCRIPTOR(rowtime),
+   SIZE => INTERVAL '15' MINUTE,
+   `OFFSET` => INTERVAL '5' MINUTE))
 ]]>
     </Resource>
     <Resource name="ast">

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -168,6 +168,20 @@ class WindowTableFunctionTest extends TableTestBase {
   }
 
   @Test
+  def testTumbleTVFWithNamedParams(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM TABLE(TUMBLE(
+        |   DATA => TABLE MyTable,
+        |   TIMECOL => DESCRIPTOR(rowtime),
+        |   SIZE => INTERVAL '15' MINUTE,
+        |   `OFFSET` => INTERVAL '5' MINUTE))
+        |""".stripMargin
+    util.verifyRelPlan(sql)
+  }
+
+  @Test
   def testHopTVFWithOffset(): Unit = {
     val sql =
       """
@@ -195,6 +209,20 @@ class WindowTableFunctionTest extends TableTestBase {
         |    INTERVAL '1' MINUTE,
         |    INTERVAL '15' MINUTE,
         |    INTERVAL '-5' MINUTE))
+        |""".stripMargin
+    util.verifyRelPlan(sql)
+  }
+
+  @Test
+  def testHopTVFWithNamedParams(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM TABLE(TUMBLE(
+        |   DATA => TABLE MyTable,
+        |   TIMECOL => DESCRIPTOR(rowtime),
+        |   SIZE => INTERVAL '15' MINUTE,
+        |   `OFFSET` => INTERVAL '5' MINUTE))
         |""".stripMargin
     util.verifyRelPlan(sql)
   }
@@ -230,4 +258,5 @@ class WindowTableFunctionTest extends TableTestBase {
         |""".stripMargin
     util.verifyRelPlan(sql)
   }
+
 }


### PR DESCRIPTION
## What is the purpose of the change
The current named params example with 'OFFSET' in window tvf is invalid, this pr aims to fix the doc and add some tests.

## Brief change log
Add tests and update the documentation

## Verifying this change
Streaming sql's `WindowTableFunctionTest` newly added test cases

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)