### PR TITLE
[FLINK-33316][runtime] Avoid unnecessary heavy getStreamOperatorFactory

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -641,9 +641,7 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     @Nullable
     private Counter getOperatorRecordsOutCounter(
             StreamTask<?, ?> containingTask, StreamConfig operatorConfig) {
-        ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
-        StreamOperatorFactory<?> operatorFactory =
-                operatorConfig.getStreamOperatorFactory(userCodeClassloader);
+        String streamOperatorFactoryClassName = operatorConfig.getStreamOperatorFactoryClassName();
         // Do not use the numRecordsOut counter on output if this operator is SinkWriterOperator.
         //
         // Metric "numRecordsOut" is defined as the total number of records written to the
@@ -651,7 +649,7 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         // number of records sent to downstream operators, which is number of Committable batches
         // sent to SinkCommitter. So we skip registering this metric on output and leave this metric
         // to sink writer implementations to report.
-        if (operatorFactory instanceof SinkWriterOperatorFactory) {
+        if (SinkWriterOperatorFactory.class.getName().equals(streamOperatorFactoryClassName)) {
             return null;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR is FLINK-33316, it's a subtask of FLINK-33315. See [FLINK-33315](https://issues.apache.org/jira/browse/FLINK-33315) for details.

When creating a successor operator to a SourceOperator, the call stack is:

- OperatorChain#createOperatorChain ->
- wrapOperatorIntoOutput ->
- getOperatorRecordsOutCounter ->
- operatorConfig.getStreamOperatorFactory(userCodeClassloader)

It will generate the SourceOperatorFactory temporarily and just check whether it's SinkWriterOperatorFactory

This PR focus on avoid unnecessary heavy getStreamOperatorFactory, it can optimize the memory and cpu cost of Replica_2 in [FLINK-33315](https://issues.apache.org/jira/browse/FLINK-33315).

This heavy operation is introduced in [FLINK-30536](https://issues.apache.org/jira/browse/FLINK-30536) (1.17), and it's not necessary. ([code link](https://github.com/apache/flink/blob/c2e14ff411e806f9ccf176c85eb8249b8ff12e56/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java#L646)) . 


## Brief change log

Solution: We can store the serializedUdfClassName at StreamConfig, and using the getStreamOperatorFactoryClassName instead of the heavy getStreamOperatorFactory in OperatorChain#getOperatorRecordsOutCounter.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?no
