### PR TITLE
[FLINK-33321] VertexFlameGraphFactoryTest#verifyRecursively fails on Java 21

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactory.java
@@ -105,6 +105,9 @@ public class VertexFlameGraphFactory {
     private static final Pattern LAMBDA_CLASS_NAME =
             Pattern.compile("(\\$Lambda\\$)\\d+/(0x)?\\p{XDigit}+$");
 
+    private static final Pattern JDK21_LAMBDA_CLASS_NAME =
+            Pattern.compile("(\\$\\$Lambda)/(0x)?\\p{XDigit}+$");
+
     // Drops stack trace elements with class names matching the above regular expression.
     // These elements are useless, because they don't provide any additional information
     // except the fact that a lambda is used (they don't have source information, for example),
@@ -115,9 +118,12 @@ public class VertexFlameGraphFactory {
     // lambdas, so we have to clean them up explicitly.
     private static StackTraceElement[] cleanLambdaNames(StackTraceElement[] stackTrace) {
         StackTraceElement[] result = new StackTraceElement[stackTrace.length];
+        final String javaVersion = System.getProperty("java.version");
+        final Pattern lambdaClassName =
+                javaVersion.compareTo("21") >= 0 ? JDK21_LAMBDA_CLASS_NAME : LAMBDA_CLASS_NAME;
         for (int i = 0; i < stackTrace.length; i++) {
             StackTraceElement element = stackTrace[i];
-            Matcher matcher = LAMBDA_CLASS_NAME.matcher(element.getClassName());
+            Matcher matcher = lambdaClassName.matcher(element.getClassName());
             if (matcher.find()) {
                 // org.apache.flink.streaming.runtime.io.RecordProcessorUtils$$Lambda$773/0x00000001007f84a0
                 //  -->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
@@ -58,7 +58,9 @@ class VertexFlameGraphFactoryTest {
     private int verifyRecursively(VertexFlameGraph.Node node) {
         String location = node.getStackTraceLocation();
         int lambdas = 0;
-        if (location.contains("$Lambda$")) {
+        final String javaVersion = System.getProperty("java.version");
+        if (javaVersion.compareTo("21") < 0 && location.contains("$Lambda$")
+                || javaVersion.compareTo("21") >= 0 && location.contains("$$Lambda")) {
             lambdas++;
             //    com.example.ClassName.method:123
             // -> com.example.ClassName.method
@@ -72,10 +74,12 @@ class VertexFlameGraphFactoryTest {
                             new Condition<String>() {
                                 @Override
                                 public boolean matches(String value) {
-                                    String javaVersion = System.getProperty("java.version");
+
                                     return javaVersion.startsWith("1.8")
                                                     && value.endsWith("$Lambda$0/0")
-                                            || value.endsWith("$Lambda$0/0x0");
+                                            || javaVersion.compareTo("21") < 0
+                                                    && value.endsWith("$Lambda$0/0x0")
+                                            || value.endsWith("$$Lambda0/0");
                                 }
                             });
         }


### PR DESCRIPTION
## What is the purpose of the change

in java 21 it was changed representation of lambda in stack trace which is used in current test
The PR makes the test aware of it

## Verifying this change

This change is a trivial rework + adapting test itself

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
