### PR TITLE
[BP 1.18][FLINK-33238][Formats/Avro] Upgrade used AVRO version to 1.11.3

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
@@ -85,7 +85,7 @@ class RegistryAvroDeserializationSchemaTest {
                                         + " \"fields\": [\n"
                                         + "     {\"name\": \"name\", \"type\": \"string\"}"
                                         + " ]\n"
-                                        + "}]");
+                                        + "}");
         RegistryAvroDeserializationSchema<SimpleRecord> deserializer =
                 new RegistryAvroDeserializationSchema<>(
                         SimpleRecord.class,

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.confluent:common-config:7.2.2
 - io.confluent:common-utils:7.2.2
 - io.confluent:kafka-schema-registry-client:7.2.2
-- org.apache.avro:avro:1.11.1
+- org.apache.avro:avro:1.11.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.kafka:kafka-clients:7.2.2-ccs
 - org.glassfish.jersey.core:jersey-common:2.30

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.avro:avro:1.11.1
+- org.apache.avro:avro:1.11.3
 - com.fasterxml.jackson.core:jackson-core:2.14.3
 - com.fasterxml.jackson.core:jackson-databind:2.14.3
 - com.fasterxml.jackson.core:jackson-annotations:2.14.3

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@ under the License.
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
 		<zookeeper.version>3.7.1</zookeeper.version>
 		<curator.version>5.4.0</curator.version>
-		<avro.version>1.11.1</avro.version>
+		<avro.version>1.11.3</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson-bom.version>2.14.3</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>


### PR DESCRIPTION
Unchanged backport of https://github.com/apache/flink/pull/23508