### PR TITLE
[FLINK-33327] Window TVF column expansion does not work with an INSERT INTO

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -54,6 +54,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSnapshot;
+import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindowTableFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -441,7 +442,7 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
         }
         final SqlFunction function = (SqlFunction) call.getOperator();
 
-        if (function.getFunctionType() != SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION) {
+        if (!isTableFunction(function)) {
             return null;
         }
 
@@ -458,5 +459,10 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
                             return null;
                         })
                 .collect(Collectors.toList());
+    }
+
+    private static boolean isTableFunction(SqlFunction function) {
+        return function instanceof SqlTableFunction
+                || function.getFunctionType() == SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes expanding explicit columns if the `TableFunction` is resolved.


## Verifying this change

Added test: `org.apache.flink.table.planner.plan.stream.sql.ColumnExpansionTest#testExplicitTableWithinTableFunctionWithInsertIntoNamedColumns`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
