### PR TITLE
[FLINK-33329] Upgrade commons-compress to 1.24.0

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.11.0
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-math3:3.6.1
 - org.apache.commons:commons-text:1.10.0

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -36,7 +36,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.airlift:units:1.3
 - joda-time:joda-time:2.5
 - org.alluxio:alluxio-shaded-client:2.7.3
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.confluent:common-utils:7.2.2
 - io.confluent:kafka-schema-registry-client:7.2.2
 - org.apache.avro:avro:1.11.3
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0
 - org.apache.kafka:kafka-clients:7.2.2-ccs
 - org.glassfish.jersey.core:jersey-common:2.30
 - org.xerial.snappy:snappy-java:1.1.10.4

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -10,4 +10,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.14.3
 - com.fasterxml.jackson.core:jackson-databind:2.14.3
 - com.fasterxml.jackson.core:jackson-annotations:2.14.3
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.24.0

--- a/pom.xml
+++ b/pom.xml
@@ -720,7 +720,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.21</version>
+				<version>1.24.0</version>
 				<exclusions>
 					<exclusion>
 						<!-- Causes unnecessary dependency convergence errors; see MENFORCER-437 -->


### PR DESCRIPTION
## What is the purpose of the change

The PR is addressing CVE-2023-42503

## Verifying this change


This change is a trivial rework 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
