### PR TITLE
[FLINK-33342][ci] Enables Java17 as a target version for the Java 17 CI jobs

### DIFF
--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -146,7 +146,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12 -Djdk11 -Djdk17"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17


### PR DESCRIPTION
## What is the purpose of the change

@gyfora noticed in his [FLINK-32380 PR](https://github.com/apache/flink/pull/23490#issuecomment-1774559892) that we're not setting the target version profile to Java 17. This PR fixes the issue

## Brief change log

* Adds `java17-target` profile
* Adds Maven output for printing the activated profiles (for debugging/verification purposes in the future)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. Manual testing is done by checking whether the activated profiles are printed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable