### PR TITLE
[FLINK-33346][runtime][test] Removes timeout

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -575,9 +575,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
         final CompletableFuture<? extends Throwable> errorFuture =
                 this.testingFatalErrorHandlerResource.getFatalErrorHandler().getErrorFuture();
-        assertThat(
-                errorFuture.get(100, TimeUnit.MILLISECONDS),
-                IsInstanceOf.instanceOf(FlinkException.class));
+        assertThat(errorFuture.get(), IsInstanceOf.instanceOf(FlinkException.class));
         testingFatalErrorHandlerResource.getFatalErrorHandler().clearError();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The instability is caused by the timeout. The fatal error hides the actual cause (i.e. the TimeoutException). It can be reproduced by setting the timeout of the test to 0ms. The actual cause is revealed when disabling the fatal error handling or not throwing a AssertionError in case of the fatal error.

I checked the rest of the class: The other test methods that use timeouts need it.

## Brief change log

* Removes timeout

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable