### PR TITLE
[FLINK-31065] New split assigner  to reduce task failover cost in batch mode.

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
+import org.apache.flink.connector.file.src.assigners.FixedFileSplitAssigner;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
 import org.apache.flink.connector.file.src.impl.ContinuousFileSplitEnumerator;
 import org.apache.flink.connector.file.src.impl.FileSourceReader;
@@ -194,6 +195,10 @@ public abstract class AbstractFileSource<T, SplitT extends FileSourceSplit>
                 (SplitEnumeratorContext<FileSourceSplit>) context;
 
         final FileSplitAssigner splitAssigner = assignerFactory.create(splits);
+        if (splitAssigner instanceof FixedFileSplitAssigner) {
+            ((FixedFileSplitAssigner) splitAssigner)
+                    .setTaskParallelism(context.currentParallelism());
+        }
 
         if (continuousEnumerationSettings == null) {
             // bounded case

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
@@ -40,7 +40,17 @@ public interface FileSplitAssigner {
      * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
      * be done and the source will finish once the readers finished their current splits.
      */
-    Optional<FileSourceSplit> getNext(@Nullable String hostname);
+    default Optional<FileSourceSplit> getNext(@Nullable String hostname) {
+        return getNext(hostname, null);
+    }
+
+    /**
+     * Gets the next split.
+     *
+     * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
+     * be done and the source will finish once the readers finished their current splits.
+     */
+    Optional<FileSourceSplit> getNext(@Nullable String hostname, @Nullable Integer subTask);
 
     /**
      * Adds a set of splits to this assigner. This happens for example when some split processing

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FixedFileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FixedFileSplitAssigner.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Assign every split to fixed task id to reduce the failover cost in batch source. */
+public class FixedFileSplitAssigner implements FileSplitAssigner {
+    private static final int FILE_OPEN_COST = 4 * 1024 * 1024;
+
+    private final Set<FileSourceSplit> unsignedSplits = new HashSet<>();
+    private ArrayList<FileSourceSplit>[] fileSourceSplitsList;
+    private final Map<String, Integer> splitIdToTaskId = new HashMap<>();
+
+    public FixedFileSplitAssigner(Collection<FileSourceSplit> splits) {
+        this.unsignedSplits.addAll(splits);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setTaskParallelism(int parallelism) {
+        Preconditions.checkState(parallelism > 0);
+        fileSourceSplitsList = new ArrayList[parallelism];
+        PriorityQueue<TaskAssignInfo> queue = new PriorityQueue<>();
+        for (int i = 0; i < parallelism; i++) {
+            fileSourceSplitsList[i] = new ArrayList<>();
+            queue.add(new TaskAssignInfo(i, 0));
+        }
+        List<FileSourceSplit> sortedSplits =
+                unsignedSplits.stream()
+                        .sorted(Comparator.comparing(f -> -f.fileSize()))
+                        .collect(Collectors.toList());
+        for (FileSourceSplit split : sortedSplits) {
+            TaskAssignInfo taskAssignInfo = queue.remove();
+            splitIdToTaskId.put(split.splitId(), taskAssignInfo.subTask);
+            fileSourceSplitsList[taskAssignInfo.subTask].add(split);
+            taskAssignInfo.totalSize += FILE_OPEN_COST + split.length();
+            queue.add(taskAssignInfo);
+        }
+    }
+
+    @Override
+    public Optional<FileSourceSplit> getNext(@Nullable String hostname, Integer subTask) {
+        Preconditions.checkNotNull(subTask);
+        List<FileSourceSplit> fileSourceSplits = fileSourceSplitsList[subTask];
+        int size = fileSourceSplits.size();
+        Optional<FileSourceSplit> splitOptional =
+                size == 0 ? Optional.empty() : Optional.of(fileSourceSplits.remove(size - 1));
+        splitOptional.ifPresent(unsignedSplits::remove);
+        return splitOptional;
+    }
+
+    @Override
+    public void addSplits(Collection<FileSourceSplit> splits) {
+        for (FileSourceSplit split : splits) {
+            Integer taskId = splitIdToTaskId.get(split.splitId());
+            // It should be used in non-continuous mode, so it can't happen.
+            Preconditions.checkNotNull(
+                    taskId, "The returned split not exits, " + "it can't happen!");
+            fileSourceSplitsList[taskId].add(split);
+            unsignedSplits.add(split);
+        }
+    }
+
+    @Override
+    public Collection<FileSourceSplit> remainingSplits() {
+        return Collections.unmodifiableCollection(unsignedSplits);
+    }
+
+    private static final class TaskAssignInfo implements Comparable<TaskAssignInfo> {
+        private final int subTask;
+        private long totalSize;
+
+        public TaskAssignInfo(int subTask, long totalSize) {
+            this.totalSize = totalSize;
+            this.subTask = subTask;
+        }
+
+        @Override
+        public int compareTo(FixedFileSplitAssigner.TaskAssignInfo o) {
+            if (o.totalSize == totalSize) {
+                return Integer.compare(subTask, o.subTask);
+            }
+            return Long.compare(totalSize, o.totalSize);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
@@ -84,7 +84,7 @@ public class LocalityAwareSplitAssigner implements FileSplitAssigner {
     // --------------------------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(@Nullable String host) {
+    public Optional<FileSourceSplit> getNext(@Nullable String host, @Nullable Integer subTask) {
         // for a null host, we always return a remote split
         if (StringUtils.isNullOrWhitespaceOnly(host)) {
             final Optional<FileSourceSplit> split = getRemoteSplit();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
@@ -21,6 +21,8 @@ package org.apache.flink.connector.file.src.assigners;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -41,7 +43,7 @@ public class SimpleSplitAssigner implements FileSplitAssigner {
     // ------------------------------------------------------------------------
 
     @Override
-    public Optional<FileSourceSplit> getNext(String hostname) {
+    public Optional<FileSourceSplit> getNext(String hostname, @Nullable Integer subTask) {
         final int size = splits.size();
         return size == 0 ? Optional.empty() : Optional.of(splits.remove(size - 1));
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -95,7 +95,7 @@ public class StaticFileSplitEnumerator
             LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
         }
 
-        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname, subtask);
         if (nextSplit.isPresent()) {
             final FileSourceSplit split = nextSplit.get();
             context.assignSplit(split, subtask);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -80,6 +80,16 @@ public class FileSystemConnectorOptions {
                                     + "the table should set 'path'='/dir' and 'source.regex-pattern'='/dir/.*'."
                                     + "The hidden files and directories will not be matched.");
 
+    public static final ConfigOption<Boolean> SOURCE_USE_FIXED_SPLIT_ASSIGNER =
+            key("source.use-fixed-split-assigner")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If set to true, every split will bind with fixed task id, "
+                                    + "it can reduce the cost of failover "
+                                    + "because it avoid too many splits assign to some task. "
+                                    + "And it will be ignored in streaming mode.");
+
     public static final ConfigOption<MemorySize> SINK_ROLLING_POLICY_FILE_SIZE =
             key("sink.rolling-policy.file-size")
                     .memoryType()

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/FixedFileSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/FixedFileSplitAssignerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/** Unit tests for the {@link FixedFileSplitAssigner}. */
+public class FixedFileSplitAssignerTest {
+    private static final Path TEST_PATH =
+            Path.fromLocalFile(new File(System.getProperty("java.io.tmpdir")));
+
+    @Test
+    public void testRandomAssignment() {
+        Random random = new Random();
+        int splitCount = random.nextInt(20) + 1;
+        int taskParallelism = random.nextInt(20) + 1;
+        Collection<FileSourceSplit> sourceSplits = genFileSourceSplits(splitCount);
+        FixedFileSplitAssigner fixedFileSplitAssigner = new FixedFileSplitAssigner(sourceSplits);
+        Set<String> expectIdSet =
+                sourceSplits.stream().map(FileSourceSplit::splitId).collect(Collectors.toSet());
+        fixedFileSplitAssigner.setTaskParallelism(taskParallelism);
+        List<List<FileSourceSplit>> allSplits =
+                collectAllSplits(taskParallelism, fixedFileSplitAssigner);
+        assertEquals(splitCount, allSplits.stream().mapToInt(List::size).sum());
+        assertEquals(expectIdSet, getAllSplitsIdFromListList(allSplits));
+    }
+
+    @Test
+    public void testReturnSplits() {
+        int splitCount = 4;
+        int taskParallelism = 2;
+        Collection<FileSourceSplit> sourceSplits = genFileSourceSplits(splitCount);
+        FixedFileSplitAssigner fixedFileSplitAssigner = new FixedFileSplitAssigner(sourceSplits);
+        fixedFileSplitAssigner.setTaskParallelism(taskParallelism);
+        List<List<FileSourceSplit>> allSplits =
+                collectAllSplits(taskParallelism, fixedFileSplitAssigner);
+        assertEquals(2, allSplits.size());
+        assertEquals(2, allSplits.get(0).size());
+        assertEquals(2, allSplits.get(1).size());
+
+        // Add all back for one task
+        List<FileSourceSplit> splitsBack = allSplits.get(0);
+        fixedFileSplitAssigner.addSplits(splitsBack);
+        List<List<FileSourceSplit>> newAllSplits =
+                collectAllSplits(taskParallelism, fixedFileSplitAssigner);
+        assertEquals(2, newAllSplits.size());
+        assertEquals(2, newAllSplits.get(0).size());
+        assertEquals(0, newAllSplits.get(1).size());
+        assertEquals(getAllSplitsIdFromList(splitsBack), getAllSplitsIdFromList(allSplits.get(0)));
+
+        // Add some back for one task
+        splitsBack = Arrays.asList(allSplits.get(1).get(0));
+        fixedFileSplitAssigner.addSplits(splitsBack);
+        newAllSplits = collectAllSplits(taskParallelism, fixedFileSplitAssigner);
+        assertEquals(1, newAllSplits.get(1).size());
+        assertEquals(
+                getAllSplitsIdFromList(splitsBack), getAllSplitsIdFromList(newAllSplits.get(1)));
+    }
+
+    @Test
+    public void testAssignmentWithDifferentSize() {
+        int taskParallelism = 4;
+        long MB_BYTES = 1024 * 1024;
+        int fileIndex = 0;
+        List<FileSourceSplit> sourceSplits = new ArrayList<>();
+        sourceSplits.add(createFileSourceSplit(fileIndex++, 100 * MB_BYTES));
+        sourceSplits.add(createFileSourceSplit(fileIndex++, MB_BYTES));
+        sourceSplits.add(createFileSourceSplit(fileIndex++, MB_BYTES));
+        sourceSplits.add(createFileSourceSplit(fileIndex++, MB_BYTES));
+        sourceSplits.add(createFileSourceSplit(fileIndex++, MB_BYTES));
+        sourceSplits.add(createFileSourceSplit(fileIndex++, MB_BYTES * 20));
+        sourceSplits.add(createFileSourceSplit(fileIndex, MB_BYTES * 7));
+
+        FixedFileSplitAssigner fixedFileSplitAssigner = new FixedFileSplitAssigner(sourceSplits);
+        fixedFileSplitAssigner.setTaskParallelism(taskParallelism);
+        List<List<FileSourceSplit>> allSplits =
+                collectAllSplits(taskParallelism, fixedFileSplitAssigner);
+        assertEquals(1, allSplits.get(0).size());
+        assertEquals(1, allSplits.get(1).size());
+        assertEquals(2, allSplits.get(2).size());
+        assertEquals(3, allSplits.get(3).size());
+        assertEquals(100 * MB_BYTES, allSplits.get(0).get(0).length());
+        assertEquals(20 * MB_BYTES, allSplits.get(1).get(0).length());
+        assertEquals(
+                8 * MB_BYTES, allSplits.get(2).stream().mapToLong(FileSourceSplit::length).sum());
+    }
+
+    private Set<String> getAllSplitsIdFromListList(List<List<FileSourceSplit>> allSplits) {
+        return allSplits.stream()
+                .flatMap(List::stream)
+                .map(FileSourceSplit::splitId)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<String> getAllSplitsIdFromList(List<FileSourceSplit> allSplits) {
+        return allSplits.stream().map(FileSourceSplit::splitId).collect(Collectors.toSet());
+    }
+
+    private List<List<FileSourceSplit>> collectAllSplits(
+            int taskParallelism, FixedFileSplitAssigner fixedFileSplitAssigner) {
+        List<List<FileSourceSplit>> tasksSplits = new ArrayList<>();
+        for (int i = 0; i < taskParallelism; i++) {
+            List<FileSourceSplit> taskSplits = new ArrayList<>();
+
+            while (true) {
+                Optional<FileSourceSplit> fileSourceSplit = fixedFileSplitAssigner.getNext(null, i);
+                if (fileSourceSplit.isPresent()) {
+                    taskSplits.add(fileSourceSplit.get());
+                } else {
+                    break;
+                }
+            }
+            tasksSplits.add(taskSplits);
+        }
+        return tasksSplits;
+    }
+
+    private FileSourceSplit createFileSourceSplit(int splitId, long length) {
+        return new FileSourceSplit(String.valueOf(splitId), TEST_PATH, 0, length, 0, length);
+    }
+
+    private Collection<FileSourceSplit> genFileSourceSplits(int count) {
+        List<FileSourceSplit> fileSourceSplitList = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            fileSourceSplitList.add(createFileSourceSplit(i, 1024));
+        }
+        return fileSourceSplitList;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
We can see background in https://issues.apache.org/jira/browse/FLINK-31065
This commit create  a new split assigner to reduce task failover cost in batch mode.

## Brief change log
Introduce FixedFileSplitAssigner that will assign split to every task by it's length to every task in advance.

## Verifying this change
This change is verified by added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (Yes)
    Changed the interface org.apache.flink.connector.file.src.assigners.FileSplitAssigner#getNext
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
