### PR TITLE
[FLINK-33321][hotfix] VertexFlameGraphFactoryTest#verifyRecursively doesn't work on java 21

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactoryTest.java
@@ -79,7 +79,7 @@ class VertexFlameGraphFactoryTest {
                                                     && value.endsWith("$Lambda$0/0")
                                             || javaVersion.compareTo("21") < 0
                                                     && value.endsWith("$Lambda$0/0x0")
-                                            || value.endsWith("$$Lambda0/0");
+                                            || value.endsWith("$$Lambda0/0x0");
                                 }
                             });
         }


### PR DESCRIPTION

## What is the purpose of the change

looks like in the first PR https://github.com/apache/flink/pull/23556 there was a mistake, sorry for that
this PR is going to address it

## Verifying this change

i 've set java21 for my pipeline and here the results
Current version of test 
https://dev.azure.com/snuyanzin/flink/_build/results?buildId=2435&view=logs&j=9dc1b5dc-bcfa-5f83-eaa7-0cb181ddc267&t=511d2595-ec54-5ab7-86ce-92f328796f20&l=8087

and fixed version
Proof  link https://dev.azure.com/snuyanzin/flink/_build/results?buildId=2436&view=logs&j=9dc1b5dc-bcfa-5f83-eaa7-0cb181ddc267&t=511d2595-ec54-5ab7-86ce-92f328796f20&l=76



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
