### PR TITLE
[FLINK-32986][test] Fix createTemporaryFunction type inference error

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -278,7 +278,7 @@ class AsyncLookupJoinITCase(
 
   @TestTemplate
   def testAsyncJoinTemporalTableWithUdfFilter(): Unit = {
-    tEnv.createTemporarySystemFunction("add", new TestAddWithOpen)
+    tEnv.createTemporaryFunction("add", new TestAddWithOpen)
 
     val sql = "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table " +
       "for system_time as of T.proctime AS D ON T.id = D.id " +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -217,7 +217,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
 
   @TestTemplate
   def testJoinTemporalTableWithUdfFilter(): Unit = {
-    tEnv.createTemporarySystemFunction("add", new TestAddWithOpen)
+    tEnv.createTemporaryFunction("add", new TestAddWithOpen)
 
     val sql = "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table " +
       "for system_time as of T.proctime AS D ON T.id = D.id " +
@@ -426,9 +426,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
 
   @TestTemplate
   def testLeftJoinTemporalTableWithUdfPreFilter(): Unit = {
-    tEnv.createTemporarySystemFunction("add", new TestAddWithOpen)
-    // use the new api when FLINK-32986 is resolved
-    // tEnv.createTemporaryFunction("add", classOf[TestAddWithOpen])
+    tEnv.createTemporaryFunction("add", new TestAddWithOpen)
 
     // 'add(T.id, 2) > 4' is equal to 'T.id > 2', here we are testing a udf
     val sql = "SELECT T.id, T.len, T.content, D.name FROM src AS T LEFT JOIN user_table " +


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes tests in `LookupJoinITCase`. The errors in tests occured when changing `registerFunction` to `createTemporaryFunction `. The main issue was that existing `UserDefinedFunctionTestUtils.TestAddWithOpen` class's `eval` method was enforcing `NOT NULL` on types, because `Int` and `Long` types cannot be null in `scala`. This was creating a discrepancy between table schema and the registered function. The issue was resolved in the meantime (between this PR was submitted and reviewed). So, this PR becomes just a refactor.

## Brief change log

  -  Refactor `createTemporarySystemFunction` with `createTemporaryFunction` in `AsyncLookupJoinITCase` and `LookupJoinITCase`, because the latter can override the former


## Verifying this change

This change is already covered by existing tests, such as `UserDefinedFunctionTestUtils`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no