### PR TITLE
[FLINK-33328] Allow TwoPhaseCommittingSink WithPreCommitTopology to alter the type of the Committable

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -28,7 +28,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
@@ -51,7 +51,7 @@ public class TestSinkInitContext implements Sink.InitContext {
     private final OperatorIOMetricGroup operatorIOMetricGroup =
             UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
     private final SinkWriterMetricGroup metricGroup =
-            InternalSinkWriterMetricGroup.mock(
+            MetricsGroupTestUtils.mockWriterMetricGroup(
                     metricListener.getMetricGroup(), operatorIOMetricGroup);
     private final MailboxExecutor mailboxExecutor;
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -131,7 +131,7 @@ public class FileSink<IN>
         implements StatefulSink<IN, FileWriterBucketState>,
                 TwoPhaseCommittingSink<IN, FileSinkCommittable>,
                 WithCompatibleState,
-                WithPreCommitTopology<IN, FileSinkCommittable>,
+                WithPreCommitTopology<FileSinkCommittable, FileSinkCommittable>,
                 SupportsConcurrentExecutionAttempts {
 
     private final BucketsBuilder<IN, ? extends BucketsBuilder<IN, ?>> bucketsBuilder;
@@ -181,6 +181,12 @@ public class FileSink<IN>
             // IOException.
             throw new FlinkRuntimeException("Could not create committable serializer.", e);
         }
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileSinkCommittable> getWriteResultSerializer() {
+        // This is the same in this case
+        return getCommittableSerializer();
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
@@ -292,7 +292,7 @@ class FileWriterTest {
         final OperatorIOMetricGroup operatorIOMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup().getIOMetricGroup();
         final SinkWriterMetricGroup sinkWriterMetricGroup =
-                InternalSinkWriterMetricGroup.mock(
+                MetricsGroupTestUtils.mockWriterMetricGroup(
                         metricListener.getMetricGroup(), operatorIOMetricGroup);
 
         Counter recordsCounter = sinkWriterMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
@@ -471,7 +471,7 @@ class FileWriterTest {
                 basePath,
                 rollingPolicy,
                 outputFileConfig,
-                InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()));
+                MetricsGroupTestUtils.mockWriterMetricGroup(metricListener.getMetricGroup()));
     }
 
     private FileWriter<String> createWriter(
@@ -484,7 +484,7 @@ class FileWriterTest {
             throws IOException {
         return new FileWriter<>(
                 basePath,
-                InternalSinkWriterMetricGroup.mock(metricListener.getMetricGroup()),
+                MetricsGroupTestUtils.mockWriterMetricGroup(metricListener.getMetricGroup()),
                 bucketAssigner,
                 new DefaultFileWriterBucketFactory<>(),
                 new RowWiseBucketWriter<>(

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSink.java
@@ -19,14 +19,9 @@
 package org.apache.flink.api.connector.sink2;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.OptionalLong;
 
 /**
  * A {@link Sink} for exactly-once semantics using a two-phase commit protocol. The {@link Sink}
@@ -42,17 +37,8 @@ import java.util.OptionalLong;
  * @param <CommT> The type of the committables.
  */
 @PublicEvolving
-public interface TwoPhaseCommittingSink<InputT, CommT> extends Sink<InputT> {
-
-    /**
-     * Creates a {@link PrecommittingSinkWriter} that creates committables on checkpoint or end of
-     * input.
-     *
-     * @param context the runtime context.
-     * @return A sink writer for the two-phase commit protocol.
-     * @throws IOException for any failure during creation.
-     */
-    PrecommittingSinkWriter<InputT, CommT> createWriter(InitContext context) throws IOException;
+public interface TwoPhaseCommittingSink<InputT, CommT>
+        extends TwoPhaseCommittingSinkWithPreCommitTopology<InputT, CommT, CommT> {
 
     /**
      * Creates a {@link Committer} that permanently makes the previously written data visible
@@ -78,61 +64,5 @@ public interface TwoPhaseCommittingSink<InputT, CommT> extends Sink<InputT> {
      */
     default Committer<CommT> createCommitter(CommitterInitContext context) throws IOException {
         return createCommitter();
-    }
-
-    /** Returns the serializer of the committable type. */
-    SimpleVersionedSerializer<CommT> getCommittableSerializer();
-
-    /** A {@link SinkWriter} that performs the first part of a two-phase commit protocol. */
-    @PublicEvolving
-    interface PrecommittingSinkWriter<InputT, CommT> extends SinkWriter<InputT> {
-        /**
-         * Prepares for a commit.
-         *
-         * <p>This method will be called after {@link #flush(boolean)} and before {@link
-         * StatefulSinkWriter#snapshotState(long)}.
-         *
-         * @return The data to commit as the second step of the two-phase commit protocol.
-         * @throws IOException if fail to prepare for a commit.
-         */
-        Collection<CommT> prepareCommit() throws IOException, InterruptedException;
-    }
-
-    /** The interface exposes some runtime info for creating a {@link Committer}. */
-    @PublicEvolving
-    interface CommitterInitContext {
-        /**
-         * The first checkpoint id when an application is started and not recovered from a
-         * previously taken checkpoint or savepoint.
-         */
-        long INITIAL_CHECKPOINT_ID = 1;
-
-        /** @return The id of task where the committer is running. */
-        int getSubtaskId();
-
-        /** @return The number of parallel committer tasks. */
-        int getNumberOfParallelSubtasks();
-
-        /**
-         * Gets the attempt number of this parallel subtask. First attempt is numbered 0.
-         *
-         * @return Attempt number of the subtask.
-         */
-        int getAttemptNumber();
-
-        /** @return The metric group this committer belongs to. */
-        SinkCommitterMetricGroup metricGroup();
-
-        /**
-         * Returns id of the restored checkpoint, if state was restored from the snapshot of a
-         * previous execution.
-         */
-        OptionalLong getRestoredCheckpointId();
-
-        /**
-         * The ID of the current job. Note that Job ID can change in particular upon manual restart.
-         * The returned ID should NOT be used for any job management tasks.
-         */
-        JobID getJobId();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSinkWithPreCommitTopology.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSinkWithPreCommitTopology.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink2;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.OptionalLong;
+
+/**
+ * A {@link Sink} for exactly-once semantics using a two-phase commit protocol. The {@link Sink}
+ * consists of a {@link SinkWriter} that performs the precommits and a {@link Committer} that
+ * actually commits the data. To facilitate the separation the {@link SinkWriter} creates
+ * <i>committables</i> on checkpoint or end of input and the sends it to the {@link Committer}.
+ *
+ * <p>The {@link TwoPhaseCommittingSink} needs to be serializable. All configuration should be
+ * validated eagerly. The respective sink writers and committers are transient and will only be
+ * created in the subtasks on the taskmanagers.
+ *
+ * @param <InputT> The type of the sink's input
+ * @param <WriterResultT> The type of the writer result
+ * @param <CommittableT> The type of the committer input
+ */
+@PublicEvolving
+public interface TwoPhaseCommittingSinkWithPreCommitTopology<InputT, WriterResultT, CommittableT>
+        extends Sink<InputT> {
+
+    /**
+     * Creates a {@link TwoPhaseCommittingSink.PrecommittingSinkWriter} that creates committables on
+     * checkpoint or end of input.
+     *
+     * @param context the runtime context.
+     * @return A sink writer for the two-phase commit protocol.
+     * @throws IOException for any failure during creation.
+     */
+    PrecommittingSinkWriter<InputT, WriterResultT> createWriter(InitContext context)
+            throws IOException;
+
+    /**
+     * Creates a {@link Committer} that permanently makes the previously written data visible
+     * through {@link Committer#commit(Collection)}.
+     *
+     * @param context The context information for the committer initialization.
+     * @return A committer for the two-phase commit protocol.
+     * @throws IOException for any failure during creation.
+     */
+    Committer<CommittableT> createCommitter(CommitterInitContext context) throws IOException;
+
+    /** Returns the serializer of the committable type. */
+    SimpleVersionedSerializer<CommittableT> getCommittableSerializer();
+
+    /** A {@link SinkWriter} that performs the first part of a two-phase commit protocol. */
+    @PublicEvolving
+    interface PrecommittingSinkWriter<InputT, WriterResultT> extends SinkWriter<InputT> {
+        /**
+         * Prepares for a commit.
+         *
+         * <p>This method will be called after {@link #flush(boolean)} and before {@link
+         * StatefulSink.StatefulSinkWriter#snapshotState(long)}.
+         *
+         * @return The data to commit as the second step of the two-phase commit protocol.
+         * @throws IOException if fail to prepare for a commit.
+         */
+        Collection<WriterResultT> prepareCommit() throws IOException, InterruptedException;
+    }
+
+    /** The interface exposes some runtime info for creating a {@link Committer}. */
+    @PublicEvolving
+    interface CommitterInitContext {
+        /**
+         * The first checkpoint id when an application is started and not recovered from a
+         * previously taken checkpoint or savepoint.
+         */
+        long INITIAL_CHECKPOINT_ID = 1;
+
+        /** @return The id of task where the committer is running. */
+        int getSubtaskId();
+
+        /** @return The number of parallel committer tasks. */
+        int getNumberOfParallelSubtasks();
+
+        /**
+         * Gets the attempt number of this parallel subtask. First attempt is numbered 0.
+         *
+         * @return Attempt number of the subtask.
+         */
+        int getAttemptNumber();
+
+        /** @return The metric group this committer belongs to. */
+        SinkCommitterMetricGroup metricGroup();
+
+        /**
+         * Returns id of the restored checkpoint, if state was restored from the snapshot of a
+         * previous execution.
+         */
+        OptionalLong getRestoredCheckpointId();
+
+        /**
+         * The ID of the current job. Note that Job ID can change in particular upon manual restart.
+         * The returned ID should NOT be used for any job management tasks.
+         */
+        JobID getJobId();
+    }
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkCommitterMetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkCommitterMetricGroup.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.groups;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+
+/**
+ * Pre-defined metrics for sinks.
+ *
+ * <p>You should only update the metrics in the main operator thread.
+ */
+@PublicEvolving
+public interface SinkCommitterMetricGroup extends OperatorMetricGroup {
+
+    /** The total number of committables arrived. */
+    Counter getNumCommittablesTotalCounter();
+
+    /** The total number of committable failures. */
+    Counter getNumCommittablesFailureCounter();
+
+    /** The total number of committable retry. */
+    Counter getNumCommittablesRetryCounter();
+
+    /** The total number of successful committables. */
+    Counter getNumCommittablesSuccessCounter();
+
+    /** The total number of already committed committables. */
+    Counter getNumCommittablesAlreadyCommittedCounter();
+
+    /** The pending committables. */
+    void setCurrentPendingCommittablesGauge(Gauge<Integer> currentPendingCommittablesGauge);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -127,4 +127,12 @@ public class MetricNames {
 
     // FLIP-27 for split enumerator
     public static final String UNASSIGNED_SPLITS = "unassignedSplits";
+
+    // FLIP-371 for sink committer
+    public static final String TOTAL_COMMITTABLES = "totalCommittables";
+    public static final String SUCCESSFUL_COMMITTABLES = "successfulCommittables";
+    public static final String ALREADY_COMMITTED_COMMITTABLES = "alreadyCommittedCommittables";
+    public static final String FAILED_COMMITTABLES = "failedCommittables";
+    public static final String RETRIED_COMMITTABLES = "retriedCommittables";
+    public static final String PENDING_COMMITTABLES = "pendingCommittables";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkCommitterMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkCommitterMetricGroup.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+
+/** Special {@link MetricGroup} representing an Operator. */
+@Internal
+public class InternalSinkCommitterMetricGroup extends ProxyMetricGroup<MetricGroup>
+        implements SinkCommitterMetricGroup {
+
+    private final Counter numCommittablesTotal;
+    private final Counter numCommittablesFailure;
+    private final Counter numCommittablesRetry;
+    private final Counter numCommitatblesSuccess;
+    private final Counter numCommitatblesAlreadyCommitted;
+    private final OperatorIOMetricGroup operatorIOMetricGroup;
+
+    @VisibleForTesting
+    InternalSinkCommitterMetricGroup(
+            MetricGroup parentMetricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
+        super(parentMetricGroup);
+        numCommittablesTotal = parentMetricGroup.counter(MetricNames.TOTAL_COMMITTABLES);
+        numCommittablesFailure = parentMetricGroup.counter(MetricNames.FAILED_COMMITTABLES);
+        numCommittablesRetry = parentMetricGroup.counter(MetricNames.RETRIED_COMMITTABLES);
+        numCommitatblesSuccess = parentMetricGroup.counter(MetricNames.SUCCESSFUL_COMMITTABLES);
+        numCommitatblesAlreadyCommitted =
+                parentMetricGroup.counter(MetricNames.ALREADY_COMMITTED_COMMITTABLES);
+
+        this.operatorIOMetricGroup = operatorIOMetricGroup;
+    }
+
+    public static InternalSinkCommitterMetricGroup wrap(OperatorMetricGroup operatorMetricGroup) {
+        return new InternalSinkCommitterMetricGroup(
+                operatorMetricGroup, operatorMetricGroup.getIOMetricGroup());
+    }
+
+    @Override
+    public OperatorIOMetricGroup getIOMetricGroup() {
+        return operatorIOMetricGroup;
+    }
+
+    @Override
+    public Counter getNumCommittablesTotalCounter() {
+        return numCommittablesTotal;
+    }
+
+    @Override
+    public Counter getNumCommittablesFailureCounter() {
+        return numCommittablesFailure;
+    }
+
+    @Override
+    public Counter getNumCommittablesRetryCounter() {
+        return numCommittablesRetry;
+    }
+
+    @Override
+    public Counter getNumCommittablesSuccessCounter() {
+        return numCommitatblesSuccess;
+    }
+
+    @Override
+    public Counter getNumCommittablesAlreadyCommittedCounter() {
+        return numCommitatblesAlreadyCommitted;
+    }
+
+    @Override
+    public void setCurrentPendingCommittablesGauge(Gauge<Integer> currentPendingCommittablesGauge) {
+        parentMetricGroup.gauge(MetricNames.PENDING_COMMITTABLES, currentPendingCommittablesGauge);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
@@ -26,7 +26,6 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
 
 /** Special {@link org.apache.flink.metrics.MetricGroup} representing an Operator. */
@@ -40,7 +39,8 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
     private final Counter numBytesWritten;
     private final OperatorIOMetricGroup operatorIOMetricGroup;
 
-    private InternalSinkWriterMetricGroup(
+    @VisibleForTesting
+    InternalSinkWriterMetricGroup(
             MetricGroup parentMetricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
         super(parentMetricGroup);
         numRecordsOutErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_OUT_ERRORS);
@@ -59,18 +59,6 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
     public static InternalSinkWriterMetricGroup wrap(OperatorMetricGroup operatorMetricGroup) {
         return new InternalSinkWriterMetricGroup(
                 operatorMetricGroup, operatorMetricGroup.getIOMetricGroup());
-    }
-
-    @VisibleForTesting
-    public static InternalSinkWriterMetricGroup mock(MetricGroup metricGroup) {
-        return new InternalSinkWriterMetricGroup(
-                metricGroup, UnregisteredMetricsGroup.createOperatorIOMetricGroup());
-    }
-
-    @VisibleForTesting
-    public static InternalSinkWriterMetricGroup mock(
-            MetricGroup metricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
-        return new InternalSinkWriterMetricGroup(metricGroup, operatorIOMetricGroup);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+/** Util class to create metric groups for SinkV2 tests. */
+public class MetricsGroupTestUtils {
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup() {
+        return new InternalSinkWriterMetricGroup(
+                new UnregisteredMetricsGroup(), UnregisteredMetricsGroup.createOperatorIOMetricGroup());
+    }
+
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup(MetricGroup metricGroup) {
+        return new InternalSinkWriterMetricGroup(
+                metricGroup, UnregisteredMetricsGroup.createOperatorIOMetricGroup());
+    }
+
+    @VisibleForTesting
+    public static InternalSinkWriterMetricGroup mockWriterMetricGroup(
+            MetricGroup metricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
+        return new InternalSinkWriterMetricGroup(metricGroup, operatorIOMetricGroup);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricsGroupTestUtils.java
@@ -15,31 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.runtime.metrics.groups;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 /** Util class to create metric groups for SinkV2 tests. */
 public class MetricsGroupTestUtils {
-    @VisibleForTesting
     public static InternalSinkWriterMetricGroup mockWriterMetricGroup() {
         return new InternalSinkWriterMetricGroup(
-                new UnregisteredMetricsGroup(), UnregisteredMetricsGroup.createOperatorIOMetricGroup());
+                new UnregisteredMetricsGroup(),
+                UnregisteredMetricsGroup.createOperatorIOMetricGroup());
     }
 
-    @VisibleForTesting
     public static InternalSinkWriterMetricGroup mockWriterMetricGroup(MetricGroup metricGroup) {
         return new InternalSinkWriterMetricGroup(
                 metricGroup, UnregisteredMetricsGroup.createOperatorIOMetricGroup());
     }
 
-    @VisibleForTesting
     public static InternalSinkWriterMetricGroup mockWriterMetricGroup(
             MetricGroup metricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
         return new InternalSinkWriterMetricGroup(metricGroup, operatorIOMetricGroup);
+    }
+
+    public static InternalSinkCommitterMetricGroup mockCommitterMetricGroup() {
+        return new InternalSinkCommitterMetricGroup(
+                new UnregisteredMetricsGroup(),
+                UnregisteredMetricsGroup.createOperatorIOMetricGroup());
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerial
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -69,6 +71,7 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
     private CommittableCollector<CommT> committableCollector;
     private long lastCompletedCheckpointId = -1;
     private SimpleVersionedSerializer<CommT> committableSerializer;
+    private SinkCommitterMetricGroup metricGroup;
 
     @Nullable private GlobalCommitter<CommT, GlobalCommT> globalCommitter;
     @Nullable private SimpleVersionedSerializer<GlobalCommT> globalCommittableSerializer;
@@ -88,7 +91,8 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
             Output<StreamRecord<Void>> output) {
         super.setup(containingTask, config, output);
         committer = committerFactory.get();
-        committableCollector = CommittableCollector.of(getRuntimeContext());
+        metricGroup = InternalSinkCommitterMetricGroup.wrap(metrics);
+        committableCollector = CommittableCollector.of(getRuntimeContext(), metricGroup);
         committableSerializer = committableSerializerFactory.get();
         if (committer instanceof SinkV1Adapter.GlobalCommitterAdapter) {
             final SinkV1Adapter<?, CommT, ?, GlobalCommT>.GlobalCommitterAdapter gc =
@@ -115,13 +119,15 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
                 new CommittableCollectorSerializer<>(
                         committableSerializer,
                         getRuntimeContext().getIndexOfThisSubtask(),
-                        getRuntimeContext().getMaxNumberOfParallelSubtasks());
+                        getRuntimeContext().getMaxNumberOfParallelSubtasks(),
+                        metricGroup);
         final SimpleVersionedSerializer<GlobalCommittableWrapper<CommT, GlobalCommT>> serializer =
                 new GlobalCommitterSerializer<>(
                         committableCollectorSerializer,
                         globalCommittableSerializer,
                         getRuntimeContext().getIndexOfThisSubtask(),
-                        getRuntimeContext().getMaxNumberOfParallelSubtasks());
+                        getRuntimeContext().getMaxNumberOfParallelSubtasks(),
+                        metricGroup);
         globalCommitterState =
                 new SimpleVersionedListState<>(
                         context.getOperatorStateStore()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPostCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPostCommitTopology.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
@@ -30,8 +29,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  * unexpected side-effects.
  */
 @Experimental
-public interface WithPostCommitTopology<InputT, CommT>
-        extends TwoPhaseCommittingSink<InputT, CommT> {
+public interface WithPostCommitTopology<CommT> {
 
     /**
      * Adds a custom post-commit topology where all committables can be processed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPreCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPreCommitTopology.java
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.api.connector.sink2;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
@@ -32,16 +32,18 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  * unexpected side-effects.
  */
 @Experimental
-public interface WithPreCommitTopology<InputT, CommT>
-        extends TwoPhaseCommittingSink<InputT, CommT> {
+public interface WithPreCommitTopology<WriteResultT, CommitterInputT> {
+
+    /** Returns the serializer of the write result type. */
+    SimpleVersionedSerializer<WriteResultT> getWriteResultSerializer();
 
     /**
      * Intercepts and modifies the committables sent on checkpoint or at end of input. Implementers
      * need to ensure to modify all {@link CommittableMessage}s appropriately.
      *
-     * @param committables the stream of committables.
+     * @param writeResults the stream of committables.
      * @return the custom topology before {@link Committer}.
      */
-    DataStream<CommittableMessage<CommT>> addPreCommitTopology(
-            DataStream<CommittableMessage<CommT>> committables);
+    DataStream<CommittableMessage<CommitterInputT>> addPreCommitTopology(
+            DataStream<CommittableMessage<WriteResultT>> writeResults);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
@@ -336,7 +336,7 @@ public class SinkV1Adapter<InputT, CommT, WriterStateT, GlobalCommT> implements 
     private class TwoPhaseCommittingSinkAdapter extends PlainSinkAdapter
             implements TwoPhaseCommittingSink<InputT, CommT>, WithCompatibleState {
         @Override
-        public Committer<CommT> createCommitter() throws IOException {
+        public Committer<CommT> createCommitter(CommitterInitContext context) throws IOException {
             return new CommitterAdapter<>(
                     sink.createCommitter().orElse(new SinkV1Adapter.NoopCommitter<>()));
         }
@@ -374,8 +374,8 @@ public class SinkV1Adapter<InputT, CommT, WriterStateT, GlobalCommT> implements 
         TwoPhaseCommittingSinkAdapter adapter = new TwoPhaseCommittingSinkAdapter();
 
         @Override
-        public Committer<CommT> createCommitter() throws IOException {
-            return adapter.createCommitter();
+        public Committer<CommT> createCommitter(CommitterInitContext context) throws IOException {
+            return adapter.createCommitter(context);
         }
 
         @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
@@ -32,7 +32,7 @@ import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSink.WithCompatibleState;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSinkWithPreCommitTopology.PrecommittingSinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -357,7 +357,7 @@ public class SinkV1Adapter<InputT, CommT, WriterStateT, GlobalCommT> implements 
     }
 
     private class GlobalCommittingSinkAdapter extends TwoPhaseCommittingSinkAdapter
-            implements WithPostCommitTopology<InputT, CommT> {
+            implements WithPostCommitTopology<CommT> {
 
         @Override
         public void addPostCommitTopology(DataStream<CommittableMessage<CommT>> committables) {
@@ -390,8 +390,7 @@ public class SinkV1Adapter<InputT, CommT, WriterStateT, GlobalCommT> implements 
     }
 
     private class StatefulGlobalTwoPhaseCommittingSinkAdapter
-            extends StatefulTwoPhaseCommittingSinkAdapter
-            implements WithPostCommitTopology<InputT, CommT> {
+            extends StatefulTwoPhaseCommittingSinkAdapter implements WithPostCommitTopology<CommT> {
         GlobalCommittingSinkAdapter globalCommittingSinkAdapter = new GlobalCommittingSinkAdapter();
 
         @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -17,11 +17,14 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -31,6 +34,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.runtime.operators.sink.committables.CheckpointCommittableManager;
 import org.apache.flink.streaming.runtime.operators.sink.committables.CommittableCollector;
@@ -39,12 +43,14 @@ import org.apache.flink.streaming.runtime.operators.sink.committables.Committabl
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.function.FunctionWithException;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.OptionalLong;
 
+import static org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.CommitterInitContext;
 import static org.apache.flink.util.IOUtils.closeAll;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -62,10 +68,13 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private static final long RETRY_DELAY = 1000;
     private final SimpleVersionedSerializer<CommT> committableSerializer;
-    private final Committer<CommT> committer;
+    private final FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
+            committerSupplier;
     private final boolean emitDownstream;
     private final boolean isBatchMode;
     private final boolean isCheckpointingEnabled;
+    private SinkCommitterMetricGroup metricGroup;
+    private Committer<CommT> committer;
     private CommittableCollector<CommT> committableCollector;
     private long lastCompletedCheckpointId = -1;
 
@@ -82,7 +91,8 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
     public CommitterOperator(
             ProcessingTimeService processingTimeService,
             SimpleVersionedSerializer<CommT> committableSerializer,
-            Committer<CommT> committer,
+            FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
+                    committerSupplier,
             boolean emitDownstream,
             boolean isBatchMode,
             boolean isCheckpointingEnabled) {
@@ -91,7 +101,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         this.isCheckpointingEnabled = isCheckpointingEnabled;
         this.processingTimeService = checkNotNull(processingTimeService);
         this.committableSerializer = checkNotNull(committableSerializer);
-        this.committer = checkNotNull(committer);
+        this.committerSupplier = checkNotNull(committerSupplier);
     }
 
     @Override
@@ -100,12 +110,16 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
             StreamConfig config,
             Output<StreamRecord<CommittableMessage<CommT>>> output) {
         super.setup(containingTask, config, output);
-        committableCollector = CommittableCollector.of(getRuntimeContext());
+        metricGroup = InternalSinkCommitterMetricGroup.wrap(getMetricGroup());
+        committableCollector = CommittableCollector.of(getRuntimeContext(), metricGroup);
     }
 
     @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
+        OptionalLong checkpointId = context.getRestoredCheckpointId();
+        CommitterInitContext initContext = createInitContext(checkpointId);
+        committer = committerSupplier.apply(initContext);
         committableCollectorState =
                 new SimpleVersionedListState<>(
                         context.getOperatorStateStore()
@@ -113,10 +127,11 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
                         new CommittableCollectorSerializer<>(
                                 committableSerializer,
                                 getRuntimeContext().getIndexOfThisSubtask(),
-                                getRuntimeContext().getNumberOfParallelSubtasks()));
+                                getRuntimeContext().getNumberOfParallelSubtasks(),
+                                metricGroup));
         if (context.isRestored()) {
             committableCollectorState.get().forEach(cc -> committableCollector.merge(cc));
-            lastCompletedCheckpointId = context.getRestoredCheckpointId().getAsLong();
+            lastCompletedCheckpointId = checkpointId.getAsLong();
             // try to re-commit recovered transactions as quickly as possible
             commitAndEmitCheckpoints();
         }
@@ -203,5 +218,57 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
     @Override
     public void close() throws Exception {
         closeAll(committer, super::close);
+    }
+
+    private CommitterInitContext createInitContext(OptionalLong restoredCheckpointId) {
+        return new CommitterInitContextImp(getRuntimeContext(), metricGroup, restoredCheckpointId);
+    }
+
+    private static class CommitterInitContextImp implements CommitterInitContext {
+
+        private final SinkCommitterMetricGroup metricGroup;
+
+        private final OptionalLong restoredCheckpointId;
+
+        private final StreamingRuntimeContext runtimeContext;
+
+        public CommitterInitContextImp(
+                StreamingRuntimeContext runtimeContext,
+                SinkCommitterMetricGroup metricGroup,
+                OptionalLong restoredCheckpointId) {
+            this.runtimeContext = checkNotNull(runtimeContext);
+            this.metricGroup = checkNotNull(metricGroup);
+            this.restoredCheckpointId = restoredCheckpointId;
+        }
+
+        @Override
+        public int getNumberOfParallelSubtasks() {
+            return runtimeContext.getNumberOfParallelSubtasks();
+        }
+
+        @Override
+        public int getAttemptNumber() {
+            return runtimeContext.getAttemptNumber();
+        }
+
+        @Override
+        public int getSubtaskId() {
+            return runtimeContext.getIndexOfThisSubtask();
+        }
+
+        @Override
+        public SinkCommitterMetricGroup metricGroup() {
+            return metricGroup;
+        }
+
+        @Override
+        public OptionalLong getRestoredCheckpointId() {
+            return restoredCheckpointId;
+        }
+
+        @Override
+        public JobID getJobId() {
+            return runtimeContext.getJobId();
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -64,7 +64,7 @@ public final class CommitterOperatorFactory<CommT>
                     new CommitterOperator<>(
                             processingTimeService,
                             sink.getCommittableSerializer(),
-                            sink.createCommitter(),
+                            context -> sink.createCommitter(context),
                             sink instanceof WithPostCommitTopology,
                             isBatchMode,
                             isCheckpointingEnabled);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSinkWithPreCommitTopology;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
@@ -41,12 +41,12 @@ public final class CommitterOperatorFactory<CommT>
         implements OneInputStreamOperatorFactory<
                 CommittableMessage<CommT>, CommittableMessage<CommT>> {
 
-    private final TwoPhaseCommittingSink<?, CommT> sink;
+    private final TwoPhaseCommittingSinkWithPreCommitTopology<?, ?, CommT> sink;
     private final boolean isBatchMode;
     private final boolean isCheckpointingEnabled;
 
     public CommitterOperatorFactory(
-            TwoPhaseCommittingSink<?, CommT> sink,
+            TwoPhaseCommittingSinkWithPreCommitTopology<?, ?, CommT> sink,
             boolean isBatchMode,
             boolean isCheckpointingEnabled) {
         this.sink = checkNotNull(sink);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -30,7 +30,7 @@ import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSinkWithPreCommitTopology.PrecommittingSinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommitRequestImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommitRequestImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 
 /**
  * Internal implementation to commit a specific committable and handle the response.
@@ -32,16 +33,27 @@ public class CommitRequestImpl<CommT> implements Committer.CommitRequest<CommT> 
     private CommT committable;
     private int numRetries;
     private CommitRequestState state;
+    private SinkCommitterMetricGroup metricGroup;
 
-    protected CommitRequestImpl(CommT committable) {
+    protected CommitRequestImpl(CommT committable, SinkCommitterMetricGroup metricGroup) {
         this.committable = committable;
+        this.metricGroup = metricGroup;
         state = CommitRequestState.RECEIVED;
+
+        // Currently only the SubtaskCommittableManager uses this constructor to create a new
+        // CommitRequestImpl, so we can increment the metrics here
+        metricGroup.getNumCommittablesTotalCounter().inc();
     }
 
-    protected CommitRequestImpl(CommT committable, int numRetries, CommitRequestState state) {
+    protected CommitRequestImpl(
+            CommT committable,
+            int numRetries,
+            CommitRequestState state,
+            SinkCommitterMetricGroup metricGroup) {
         this.committable = committable;
         this.numRetries = numRetries;
         this.state = state;
+        this.metricGroup = metricGroup;
     }
 
     boolean isFinished() {
@@ -65,14 +77,14 @@ public class CommitRequestImpl<CommT> implements Committer.CommitRequest<CommT> 
     @Override
     public void signalFailedWithKnownReason(Throwable t) {
         state = CommitRequestState.FAILED;
-        // TODO: FLINK-25857 add metric later
+        metricGroup.getNumCommittablesFailureCounter().inc();
         // let the user configure a strategy for failing and apply it here
     }
 
     @Override
     public void signalFailedWithUnknownReason(Throwable t) {
         state = CommitRequestState.FAILED;
-        // TODO: FLINK-25857 add metric later
+        metricGroup.getNumCommittablesFailureCounter().inc();
         // let the user configure a strategy for failing and apply it here
         throw new IllegalStateException("Failed to commit " + committable, t);
     }
@@ -81,7 +93,7 @@ public class CommitRequestImpl<CommT> implements Committer.CommitRequest<CommT> 
     public void retryLater() {
         state = CommitRequestState.RETRY;
         numRetries++;
-        // TODO: FLINK-25857 add metric later
+        metricGroup.getNumCommittablesRetryCounter().inc();
     }
 
     @Override
@@ -92,8 +104,8 @@ public class CommitRequestImpl<CommT> implements Committer.CommitRequest<CommT> 
 
     @Override
     public void signalAlreadyCommitted() {
-        // TODO: FLINK-25857 add metric later
         state = CommitRequestState.COMMITTED;
+        metricGroup.getNumCommittablesAlreadyCommittedCounter().inc();
     }
 
     void setSelected() {
@@ -103,10 +115,11 @@ public class CommitRequestImpl<CommT> implements Committer.CommitRequest<CommT> 
     void setCommittedIfNoError() {
         if (state == CommitRequestState.RECEIVED) {
             state = CommitRequestState.COMMITTED;
+            metricGroup.getNumCommittablesSuccessCounter().inc();
         }
     }
 
     CommitRequestImpl<CommT> copy() {
-        return new CommitRequestImpl<>(committable, numRetries, state);
+        return new CommitRequestImpl<>(committable, numRetries, state, metricGroup);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
@@ -54,21 +55,26 @@ public class CommittableCollector<CommT> {
     private final int subtaskId;
 
     private final int numberOfSubtasks;
+    private final SinkCommitterMetricGroup metricGroup;
 
-    public CommittableCollector(int subtaskId, int numberOfSubtasks) {
+    public CommittableCollector(
+            int subtaskId, int numberOfSubtasks, SinkCommitterMetricGroup metricGroup) {
         this.subtaskId = subtaskId;
         this.numberOfSubtasks = numberOfSubtasks;
         this.checkpointCommittables = new TreeMap<>();
+        this.metricGroup = metricGroup;
     }
 
     /** For deep-copy. */
     CommittableCollector(
             Map<Long, CheckpointCommittableManagerImpl<CommT>> checkpointCommittables,
             int subtaskId,
-            int numberOfSubtasks) {
+            int numberOfSubtasks,
+            SinkCommitterMetricGroup metricGroup) {
         this.checkpointCommittables = new TreeMap<>(checkNotNull(checkpointCommittables));
         this.subtaskId = subtaskId;
         this.numberOfSubtasks = numberOfSubtasks;
+        this.metricGroup = metricGroup;
     }
 
     /**
@@ -76,12 +82,16 @@ public class CommittableCollector<CommT> {
      * should be used for to instantiate a collector for all Sink V2.
      *
      * @param context holding runtime of information
+     * @param metricGroup storing the committable metrics
      * @param <CommT> type of the committable
      * @return {@link CommittableCollector}
      */
-    public static <CommT> CommittableCollector<CommT> of(RuntimeContext context) {
+    public static <CommT> CommittableCollector<CommT> of(
+            RuntimeContext context, SinkCommitterMetricGroup metricGroup) {
         return new CommittableCollector<>(
-                context.getIndexOfThisSubtask(), context.getNumberOfParallelSubtasks());
+                context.getIndexOfThisSubtask(),
+                context.getNumberOfParallelSubtasks(),
+                metricGroup);
     }
 
     /**
@@ -89,11 +99,14 @@ public class CommittableCollector<CommT> {
      * to create a collector from the state of Sink V1.
      *
      * @param committables list of committables
+     * @param metricGroup storing the committable metrics
      * @param <CommT> type of committables
      * @return {@link CommittableCollector}
      */
-    static <CommT> CommittableCollector<CommT> ofLegacy(List<CommT> committables) {
-        CommittableCollector<CommT> committableCollector = new CommittableCollector<>(0, 1);
+    static <CommT> CommittableCollector<CommT> ofLegacy(
+            List<CommT> committables, SinkCommitterMetricGroup metricGroup) {
+        CommittableCollector<CommT> committableCollector =
+                new CommittableCollector<>(0, 1, metricGroup);
         // add a checkpoint with the lowest checkpoint id, this will be merged into the next
         // checkpoint data, subtask id is arbitrary
         CommittableSummary<CommT> summary =
@@ -211,7 +224,8 @@ public class CommittableCollector<CommT> {
                         .map(e -> Tuple2.of(e.getKey(), e.getValue().copy()))
                         .collect(Collectors.toMap((t) -> t.f0, (t) -> t.f1)),
                 subtaskId,
-                numberOfSubtasks);
+                numberOfSubtasks,
+                metricGroup);
     }
 
     Collection<CheckpointCommittableManagerImpl<CommT>> getCheckpointCommittables() {
@@ -226,7 +240,8 @@ public class CommittableCollector<CommT> {
                                 new CheckpointCommittableManagerImpl<>(
                                         subtaskId,
                                         numberOfSubtasks,
-                                        summary.getCheckpointId().orElse(EOI)))
+                                        summary.getCheckpointId().orElse(EOI),
+                                        metricGroup))
                 .upsertSummary(summary);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
 import javax.annotation.Nullable;
@@ -45,10 +46,21 @@ class SubtaskCommittableManager<CommT> {
     private final int subtaskId;
     private int numDrained;
     private int numFailed;
+    private SinkCommitterMetricGroup metricGroup;
 
     SubtaskCommittableManager(
-            int numExpectedCommittables, int subtaskId, @Nullable Long checkpointId) {
-        this(Collections.emptyList(), numExpectedCommittables, 0, 0, subtaskId, checkpointId);
+            int numExpectedCommittables,
+            int subtaskId,
+            @Nullable Long checkpointId,
+            SinkCommitterMetricGroup metricGroup) {
+        this(
+                Collections.emptyList(),
+                numExpectedCommittables,
+                0,
+                0,
+                subtaskId,
+                checkpointId,
+                metricGroup);
     }
 
     SubtaskCommittableManager(
@@ -57,13 +69,15 @@ class SubtaskCommittableManager<CommT> {
             int numDrained,
             int numFailed,
             int subtaskId,
-            @Nullable Long checkpointId) {
+            @Nullable Long checkpointId,
+            SinkCommitterMetricGroup metricGroup) {
         this.checkpointId = checkpointId;
         this.subtaskId = subtaskId;
         this.numExpectedCommittables = numExpectedCommittables;
         this.requests = new ArrayDeque<>(checkNotNull(requests));
         this.numDrained = numDrained;
         this.numFailed = numFailed;
+        this.metricGroup = metricGroup;
     }
 
     void add(CommittableWithLineage<CommT> committable) {
@@ -72,7 +86,7 @@ class SubtaskCommittableManager<CommT> {
 
     void add(CommT committable) {
         checkState(requests.size() < numExpectedCommittables, "Already received all committables.");
-        requests.add(new CommitRequestImpl<>(committable));
+        requests.add(new CommitRequestImpl<>(committable, metricGroup));
     }
 
     /**
@@ -189,6 +203,7 @@ class SubtaskCommittableManager<CommT> {
                 numDrained,
                 numFailed,
                 subtaskId,
-                checkpointId);
+                checkpointId,
+                metricGroup);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSinkTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
-import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 
 import org.junit.Test;
 
@@ -33,13 +33,15 @@ public class DataStreamSinkTest {
     public void testGettingTransformationWithNewSinkAPI() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final Transformation<?> transformation =
-                env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).getTransformation();
+                env.fromElements(1, 2)
+                        .sinkTo(TestSinkV2.<Integer>newBuilder().build())
+                        .getTransformation();
         assertTrue(transformation instanceof SinkTransformation);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void throwExceptionWhenSetUidWithNewSinkAPI() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.fromElements(1, 2).sinkTo(TestSink.newBuilder().build()).setUidHash("Test");
+        env.fromElements(1, 2).sinkTo(TestSinkV2.<Integer>newBuilder().build()).setUidHash("Test");
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.functions.sink.PrintSink;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -200,7 +200,7 @@ class PrintSinkTest {
 
         @Override
         public SinkWriterMetricGroup metricGroup() {
-            return InternalSinkWriterMetricGroup.mock(new UnregisteredMetricsGroup());
+            return MetricsGroupTestUtils.mockWriterMetricGroup();
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.functions.sink.PrintSink;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
+import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link org.apache.flink.streaming.api.transformations.SinkTransformation}.
+ *
+ * <p>ATTENTION: This test is extremely brittle. Do NOT remove, add or re-order test cases.
+ */
+@RunWith(Parameterized.class)
+public abstract class SinkTransformationTranslatorITCaseBase<SinkT> extends TestLogger {
+
+    @Parameterized.Parameters(name = "Execution Mode: {0}")
+    public static Collection<Object> data() {
+        return Arrays.asList(RuntimeExecutionMode.STREAMING, RuntimeExecutionMode.BATCH);
+    }
+
+    @Parameterized.Parameter() public RuntimeExecutionMode runtimeExecutionMode;
+
+    static final String NAME = "FileSink";
+    static final String SLOT_SHARE_GROUP = "FileGroup";
+    static final String UID = "FileUid";
+    static final int PARALLELISM = 2;
+
+    abstract SinkT simpleSink();
+
+    abstract SinkT sinkWithCommitter();
+
+    abstract DataStreamSink<Integer> sinkTo(DataStream<Integer> stream, SinkT sink);
+
+    @Test
+    public void generateWriterTopology() {
+        final StreamGraph streamGraph = buildGraph(simpleSink(), runtimeExecutionMode);
+
+        final StreamNode sourceNode = findNodeName(streamGraph, node -> node.contains("Source"));
+        final StreamNode writerNode = findWriter(streamGraph);
+
+        assertThat(streamGraph.getStreamNodes().size(), equalTo(2));
+
+        validateTopology(
+                sourceNode,
+                IntSerializer.class,
+                writerNode,
+                SinkWriterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+    }
+
+    @Test
+    public void generateWriterCommitterTopology() {
+
+        final StreamGraph streamGraph = buildGraph(sinkWithCommitter(), runtimeExecutionMode);
+
+        final StreamNode sourceNode = findNodeName(streamGraph, node -> node.contains("Source"));
+        final StreamNode writerNode = findWriter(streamGraph);
+
+        validateTopology(
+                sourceNode,
+                IntSerializer.class,
+                writerNode,
+                SinkWriterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+
+        final StreamNode committerNode =
+                findNodeName(streamGraph, name -> name.contains("Committer"));
+
+        assertThat(streamGraph.getStreamNodes().size(), equalTo(3));
+
+        validateTopology(
+                writerNode,
+                SimpleVersionedSerializerTypeSerializerProxy.class,
+                committerNode,
+                CommitterOperatorFactory.class,
+                PARALLELISM,
+                -1);
+    }
+
+    StreamNode findWriter(StreamGraph streamGraph) {
+        return findNodeName(
+                streamGraph, name -> name.contains("Writer") && !name.contains("Committer"));
+    }
+
+    StreamNode findCommitter(StreamGraph streamGraph) {
+        return findNodeName(
+                streamGraph,
+                name -> name.contains("Committer") && !name.contains("Global Committer"));
+    }
+
+    StreamNode findGlobalCommitter(StreamGraph streamGraph) {
+        return findNodeName(streamGraph, name -> name.contains("Global Committer"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throwExceptionWithoutSettingUid() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, runtimeExecutionMode);
+        env.configure(config, getClass().getClassLoader());
+        // disable auto generating uid
+        env.getConfig().disableAutoGeneratedUIDs();
+        sinkTo(env.fromElements(1, 2), simpleSink());
+        env.getStreamGraph();
+    }
+
+    @Test
+    public void disableOperatorChain() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src, sinkWithCommitter()).name(NAME);
+        dataStreamSink.disableChaining();
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final StreamNode writer = findWriter(streamGraph);
+        final StreamNode committer = findCommitter(streamGraph);
+
+        assertThat(writer.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.NEVER));
+        assertThat(
+                committer.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.NEVER));
+    }
+
+    void validateTopology(
+            StreamNode src,
+            Class<?> srcOutTypeInfo,
+            StreamNode dest,
+            Class<? extends StreamOperatorFactory> operatorFactoryClass,
+            int expectedParallelism,
+            int expectedMaxParallelism) {
+
+        // verify src node
+        final StreamEdge srcOutEdge = src.getOutEdges().get(0);
+        assertThat(srcOutEdge.getTargetId(), equalTo(dest.getId()));
+        assertThat(src.getTypeSerializerOut(), instanceOf(srcOutTypeInfo));
+
+        // verify dest node input
+        final StreamEdge destInputEdge = dest.getInEdges().get(0);
+        assertThat(destInputEdge.getSourceId(), equalTo(src.getId()));
+        assertThat(dest.getTypeSerializersIn()[0], instanceOf(srcOutTypeInfo));
+
+        // make sure 2 sink operators have different names/uid
+        assertThat(dest.getOperatorName(), not(equalTo(src.getOperatorName())));
+        assertThat(dest.getTransformationUID(), not(equalTo(src.getTransformationUID())));
+
+        assertThat(dest.getOperatorFactory(), instanceOf(operatorFactoryClass));
+        assertThat(dest.getParallelism(), equalTo(expectedParallelism));
+        assertThat(dest.getMaxParallelism(), equalTo(expectedMaxParallelism));
+        assertThat(dest.getOperatorFactory().getChainingStrategy(), is(ChainingStrategy.ALWAYS));
+        assertThat(dest.getSlotSharingGroup(), equalTo(SLOT_SHARE_GROUP));
+    }
+
+    StreamGraph buildGraph(SinkT sink, RuntimeExecutionMode runtimeExecutionMode) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final Configuration config = new Configuration();
+        config.set(ExecutionOptions.RUNTIME_MODE, runtimeExecutionMode);
+        env.configure(config, getClass().getClassLoader());
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src.rebalance(), sink);
+        setSinkProperty(dataStreamSink);
+        // Trigger the plan generation but do not clear the transformations
+        env.getExecutionPlan();
+        return env.getStreamGraph();
+    }
+
+    private void setSinkProperty(DataStreamSink<Integer> dataStreamSink) {
+        dataStreamSink.name(NAME);
+        dataStreamSink.uid(UID);
+        dataStreamSink.setParallelism(SinkTransformationTranslatorITCaseBase.PARALLELISM);
+        dataStreamSink.slotSharingGroup(SLOT_SHARE_GROUP);
+    }
+
+    StreamNode findNodeName(StreamGraph streamGraph, Predicate<String> predicate) {
+        return streamGraph.getStreamNodes().stream()
+                .filter(node -> predicate.test(node.getOperatorName()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Can not find the node"));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link org.apache.flink.streaming.api.transformations.SinkTransformation}.
+ *
+ * <p>ATTENTION: This test is extremely brittle. Do NOT remove, add or re-order test cases.
+ */
+@RunWith(Parameterized.class)
+public class SinkV2TransformationTranslatorITCase
+        extends SinkTransformationTranslatorITCaseBase<Sink<Integer>> {
+
+    @Override
+    Sink<Integer> simpleSink() {
+        return TestSinkV2.<Integer>newBuilder().build();
+    }
+
+    @Override
+    Sink<Integer> sinkWithCommitter() {
+        return TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build();
+    }
+
+    @Override
+    DataStreamSink<Integer> sinkTo(DataStream<Integer> stream, Sink<Integer> sink) {
+        return stream.sinkTo(sink);
+    }
+
+    @Test
+    public void testSettingOperatorUidHash() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        final String writerHash = "f6b178ce445dc3ffaa06bad27a51fead";
+        final String committerHash = "68ac8ae79eae4e3135a54f9689c4aa10";
+        final CustomSinkOperatorUidHashes operatorsUidHashes =
+                CustomSinkOperatorUidHashes.builder()
+                        .setWriterUidHash(writerHash)
+                        .setCommitterUidHash(committerHash)
+                        .build();
+        src.sinkTo(
+                        TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build(),
+                        operatorsUidHashes)
+                .name(NAME);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+
+        assertEquals(findWriter(streamGraph).getUserHash(), writerHash);
+        assertEquals(findCommitter(streamGraph).getUserHash(), committerHash);
+    }
+
+    /**
+     * When ever you need to change something in this test case please think about possible state
+     * upgrade problems introduced by your changes.
+     */
+    @Test
+    public void testSettingOperatorUids() {
+        final String sinkUid = "f6b178ce445dc3ffaa06bad27a51fead";
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromElements(1, 2);
+        src.sinkTo(TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build())
+                .name(NAME)
+                .uid(sinkUid);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(findWriter(streamGraph).getTransformationUID(), sinkUid);
+        assertEquals(
+                findCommitter(streamGraph).getTransformationUID(),
+                String.format("Sink Committer: %s", sinkUid));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -2345,7 +2345,7 @@ class StreamingJobGraphGeneratorTest {
         }
 
         @Override
-        public Committer<Void> createCommitter() throws IOException {
+        public Committer<Void> createCommitter(CommitterInitContext context) throws IOException {
             return new Committer<Void>() {
                 @Override
                 public void commit(Collection<CommitRequest<Void>> committables)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkTestUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkTestUtil.java
@@ -52,7 +52,7 @@ class SinkTestUtil {
     static byte[] toBytes(String obj) {
         try {
             return SimpleVersionedSerialization.writeVersionAndSerialize(
-                    TestSink.StringCommittableSerializer.INSTANCE, obj);
+                    TestSinkV2.StringSerializer.INSTANCE, obj);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -83,7 +83,7 @@ class SinkTestUtil {
     static String fromBytes(byte[] obj) {
         try {
             return SimpleVersionedSerialization.readVersionAndDeSerialize(
-                    TestSink.StringCommittableSerializer.INSTANCE, obj);
+                    TestSinkV2.StringSerializer.INSTANCE, obj);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+
+import java.util.Collection;
+
+class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
+    @Override
+    SinkAndCounters sinkWithPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(true)
+                                .build(),
+                () -> committer.successfulCommits);
+    }
+
+    @Override
+    SinkAndCounters sinkWithPostCommitWithRetry() {
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(new TestSinkV2.RetryOnceCommitter())
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(true)
+                                .build(),
+                () -> 0);
+    }
+
+    @Override
+    SinkAndCounters sinkWithoutPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSinkV2.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .setWithPostCommitTopology(false)
+                                .build(),
+                () -> committer.successfulCommits);
+    }
+
+    private static class ForwardingCommitter extends TestSinkV2.DefaultCommitter {
+        private int successfulCommits = 0;
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            successfulCommits += committables.size();
+        }
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+class SinkV2SinkWriterOperatorTest extends SinkWriterOperatorTestBase {
+
+    @Override
+    SinkAndSuppliers sinkWithoutCommitter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter = new TestSinkV2.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder().setWriter(sinkWriter).build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithCommitter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter =
+                new TestSinkV2.DefaultCommittingSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithTimeBasedWriter() {
+        TestSinkV2.DefaultSinkWriter<Integer> sinkWriter = new TimeBasedBufferingSinkWriter();
+        return new SinkAndSuppliers(
+                TestSinkV2.<Integer>newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                TestSinkV2.StringSerializer::new);
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithSnapshottingWriter(boolean withState, String stateName) {
+        SnapshottingBufferingSinkWriter sinkWriter = new SnapshottingBufferingSinkWriter();
+        TestSinkV2.Builder<Integer> builder =
+                TestSinkV2.newBuilder()
+                        .setWriter(sinkWriter)
+                        .setDefaultCommitter()
+                        .setWithPostCommitTopology(true);
+        if (withState) {
+            builder.setWriterState(true);
+        }
+        if (stateName != null) {
+            builder.setCompatibleStateNames(stateName);
+        }
+        return new SinkAndSuppliers(
+                builder.build(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> sinkWriter.lastCheckpointId,
+                () -> new TestSinkV2.StringSerializer());
+    }
+
+    private static class TimeBasedBufferingSinkWriter
+            extends TestSinkV2.DefaultCommittingSinkWriter<Integer>
+            implements ProcessingTimeService.ProcessingTimeCallback {
+
+        private final List<String> cachedCommittables = new ArrayList<>();
+        private ProcessingTimeService processingTimeService;
+
+        @Override
+        public void write(Integer element, Context context) {
+            cachedCommittables.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void onProcessingTime(long time) {
+            elements.addAll(cachedCommittables);
+            cachedCommittables.clear();
+            this.processingTimeService.registerTimer(time + 1000, this);
+        }
+
+        @Override
+        public void init(org.apache.flink.api.connector.sink2.Sink.InitContext context) {
+            this.processingTimeService = context.getProcessingTimeService();
+            this.processingTimeService.registerTimer(1000, this);
+        }
+    }
+
+    private static class SnapshottingBufferingSinkWriter
+            extends TestSinkV2.DefaultStatefulSinkWriter {
+        public static final int NOT_SNAPSHOTTED = -1;
+        long lastCheckpointId = NOT_SNAPSHOTTED;
+        boolean endOfInput = false;
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            this.endOfInput = endOfInput;
+        }
+
+        @Override
+        public List<String> snapshotState(long checkpointId) throws IOException {
+            lastCheckpointId = checkpointId;
+            return super.snapshotState(checkpointId);
+        }
+
+        @Override
+        public Collection<String> prepareCommit() {
+            if (!endOfInput) {
+                return ImmutableList.of();
+            }
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -49,7 +49,13 @@ import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertNotNull;
 
-/** A {@link Sink TestSink} for all the sink related tests. */
+/**
+ * A {@link Sink TestSink} for all the sink related tests. Use only for tests where {@link
+ * SinkV1Adapter} should be tested.
+ *
+ * @deprecated Use {@link TestSinkV2} instead.
+ */
+@Deprecated
 public class TestSink<T> implements Sink<T, String, String, String> {
 
     public static final String END_OF_INPUT_STR = "end of input";
@@ -178,11 +184,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
         public Builder<T> setDefaultCommitter(Supplier<Queue<String>> queueSupplier) {
             this.committer = new DefaultCommitter(queueSupplier);
             this.committableSerializer = StringCommittableSerializer.INSTANCE;
-            return this;
-        }
-
-        public Builder<T> setGlobalCommitter(GlobalCommitter<String, String> globalCommitter) {
-            this.globalCommitter = globalCommitter;
             return this;
         }
 
@@ -363,10 +364,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
 
         private final String committedSuccessData;
 
-        DefaultGlobalCommitter() {
-            this("");
-        }
-
         DefaultGlobalCommitter(String committedSuccessData) {
             this.committedSuccessData = committedSuccessData;
         }
@@ -394,39 +391,6 @@ public class TestSink<T> implements Sink<T, String, String, String> {
         @Override
         public void endOfInput() {
             commit(Collections.singletonList(END_OF_INPUT_STR));
-        }
-    }
-
-    /** A {@link GlobalCommitter} that always re-commits global committables it received. */
-    static class RetryOnceGlobalCommitter extends DefaultGlobalCommitter {
-
-        private final Set<String> seen = new LinkedHashSet<>();
-
-        @Override
-        public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
-            return globalCommittables;
-        }
-
-        @Override
-        public String combine(List<String> committables) {
-            return String.join("|", committables);
-        }
-
-        @Override
-        public void endOfInput() {}
-
-        @Override
-        public List<String> commit(List<String> committables) {
-            committables.forEach(
-                    c -> {
-                        if (seen.remove(c)) {
-                            checkNotNull(committedData);
-                            committedData.add(c);
-                        } else {
-                            seen.add(c);
-                        }
-                    });
-            return new ArrayList<>(seen);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableSet;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertNotNull;
+
+/** A {@link org.apache.flink.api.connector.sink2.Sink} for all the sink related tests. */
+public class TestSinkV2<InputT> implements Sink<InputT> {
+
+    private final DefaultSinkWriter<InputT> writer;
+
+    private TestSinkV2(DefaultSinkWriter<InputT> writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public SinkWriter<InputT> createWriter(InitContext context) {
+        writer.init(context);
+        return writer;
+    }
+
+    DefaultSinkWriter<InputT> getWriter() {
+        return writer;
+    }
+
+    public static <InputT> Builder<InputT> newBuilder() {
+        return new Builder<>();
+    }
+
+    /** A builder class for {@link TestSinkV2}. */
+    public static class Builder<InputT> {
+        private DefaultSinkWriter<InputT> writer = null;
+        private DefaultCommitter committer;
+        private SimpleVersionedSerializer<String> committableSerializer;
+        private boolean withPostCommitTopology = false;
+        private boolean withWriterState = false;
+        private String compatibleStateNames;
+
+        public Builder<InputT> setWriter(DefaultSinkWriter<InputT> writer) {
+            this.writer = checkNotNull(writer);
+            return this;
+        }
+
+        public Builder<InputT> setCommitter(DefaultCommitter committer) {
+            this.committer = committer;
+            return this;
+        }
+
+        public Builder<InputT> setCommittableSerializer(
+                SimpleVersionedSerializer<String> committableSerializer) {
+            this.committableSerializer = committableSerializer;
+            return this;
+        }
+
+        public Builder<InputT> setDefaultCommitter() {
+            this.committer = new DefaultCommitter();
+            this.committableSerializer = StringSerializer.INSTANCE;
+            return this;
+        }
+
+        public Builder<InputT> setDefaultCommitter(
+                Supplier<Queue<Committer.CommitRequest<String>>> queueSupplier) {
+            this.committer = new DefaultCommitter(queueSupplier);
+            this.committableSerializer = StringSerializer.INSTANCE;
+            return this;
+        }
+
+        public Builder<InputT> setWithPostCommitTopology(boolean withPostCommitTopology) {
+            this.withPostCommitTopology = withPostCommitTopology;
+            return this;
+        }
+
+        public Builder<InputT> setWriterState(boolean withWriterState) {
+            this.withWriterState = withWriterState;
+            return this;
+        }
+
+        public Builder<InputT> setCompatibleStateNames(String compatibleStateNames) {
+            this.compatibleStateNames = compatibleStateNames;
+            return this;
+        }
+
+        public TestSinkV2<InputT> build() {
+            if (committer == null) {
+                if (writer == null) {
+                    writer = new DefaultSinkWriter<>();
+                }
+                // SinkV2 with a simple writer
+                return new TestSinkV2<>(writer);
+            } else {
+                if (writer == null) {
+                    writer = new DefaultCommittingSinkWriter<>();
+                }
+                if (!withPostCommitTopology) {
+                    // TwoPhaseCommittingSink with a stateless writer and a committer
+                    return new TestSinkV2TwoPhaseCommittingSink<>(
+                            writer, committableSerializer, committer);
+                } else {
+                    if (withWriterState) {
+                        // TwoPhaseCommittingSink with a stateful writer and a committer and post
+                        // commit topology
+                        Preconditions.checkArgument(
+                                writer instanceof DefaultStatefulSinkWriter,
+                                "Please provide a DefaultStatefulSinkWriter instance");
+                        return new TestStatefulSinkV2(
+                                (DefaultStatefulSinkWriter) writer,
+                                committableSerializer,
+                                committer,
+                                compatibleStateNames);
+                    } else {
+                        // TwoPhaseCommittingSink with a stateless writer and a committer and post
+                        // commit topology
+                        Preconditions.checkArgument(
+                                writer instanceof DefaultCommittingSinkWriter,
+                                "Please provide a DefaultCommittingSinkWriter instance");
+                        return new TestSinkV2WithPostCommitTopology<>(
+                                (DefaultCommittingSinkWriter) writer,
+                                committableSerializer,
+                                committer);
+                    }
+                }
+            }
+        }
+    }
+
+    private static class TestSinkV2TwoPhaseCommittingSink<InputT> extends TestSinkV2<InputT>
+            implements TwoPhaseCommittingSink<InputT, String> {
+        private final DefaultCommitter committer;
+        private final SimpleVersionedSerializer<String> committableSerializer;
+
+        public TestSinkV2TwoPhaseCommittingSink(
+                DefaultSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer) {
+            super(writer);
+            this.committer = committer;
+            this.committableSerializer = committableSerializer;
+        }
+
+        @Override
+        public Committer<String> createCommitter() {
+            committer.init();
+            return committer;
+        }
+
+        @Override
+        public SimpleVersionedSerializer<String> getCommittableSerializer() {
+            return committableSerializer;
+        }
+
+        @Override
+        public PrecommittingSinkWriter<InputT, String> createWriter(InitContext context) {
+            return (PrecommittingSinkWriter<InputT, String>) super.createWriter(context);
+        }
+    }
+
+    // -------------------------------------- Sink With PostCommitTopology -------------------------
+
+    private static class TestSinkV2WithPostCommitTopology<InputT>
+            extends TestSinkV2TwoPhaseCommittingSink<InputT>
+            implements WithPostCommitTopology<InputT, String> {
+        public TestSinkV2WithPostCommitTopology(
+                DefaultSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer) {
+            super(writer, committableSerializer, committer);
+        }
+
+        @Override
+        public void addPostCommitTopology(DataStream<CommittableMessage<String>> committables) {
+            // We do not need to do anything for tests
+        }
+    }
+
+    private static class TestStatefulSinkV2<InputT> extends TestSinkV2WithPostCommitTopology<InputT>
+            implements StatefulSink<InputT, String>, StatefulSink.WithCompatibleState {
+        private String compatibleState;
+
+        public TestStatefulSinkV2(
+                DefaultStatefulSinkWriter<InputT> writer,
+                SimpleVersionedSerializer<String> committableSerializer,
+                DefaultCommitter committer,
+                String compatibleState) {
+            super(writer, committableSerializer, committer);
+            this.compatibleState = compatibleState;
+        }
+
+        @Override
+        public DefaultStatefulSinkWriter<InputT> createWriter(InitContext context) {
+            return (DefaultStatefulSinkWriter<InputT>) super.createWriter(context);
+        }
+
+        @Override
+        public StatefulSinkWriter<InputT, String> restoreWriter(
+                InitContext context, Collection<String> recoveredState) {
+            DefaultStatefulSinkWriter<InputT> statefulWriter =
+                    (DefaultStatefulSinkWriter) getWriter();
+
+            statefulWriter.restore(recoveredState);
+            return statefulWriter;
+        }
+
+        @Override
+        public SimpleVersionedSerializer<String> getWriterStateSerializer() {
+            return new StringSerializer();
+        }
+
+        @Override
+        public Collection<String> getCompatibleWriterStateNames() {
+            return compatibleState == null ? ImmutableSet.of() : ImmutableSet.of(compatibleState);
+        }
+    }
+
+    // -------------------------------------- Sink Writer ------------------------------------------
+
+    /** Base class for out testing {@link SinkWriter}. */
+    public static class DefaultSinkWriter<InputT> implements SinkWriter<InputT>, Serializable {
+
+        protected List<String> elements;
+
+        protected List<Watermark> watermarks;
+
+        protected DefaultSinkWriter() {
+            this.elements = new ArrayList<>();
+            this.watermarks = new ArrayList<>();
+        }
+
+        @Override
+        public void write(InputT element, Context context) {
+            elements.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            elements = new ArrayList<>();
+        }
+
+        @Override
+        public void writeWatermark(Watermark watermark) {
+            watermarks.add(watermark);
+        }
+
+        @Override
+        public void close() throws Exception {
+            // noting to do here
+        }
+
+        public void init(InitContext context) {
+            // context is not used in default case
+        }
+    }
+
+    /** Base class for out testing {@link TwoPhaseCommittingSink.PrecommittingSinkWriter}. */
+    protected static class DefaultCommittingSinkWriter<InputT> extends DefaultSinkWriter<InputT>
+            implements TwoPhaseCommittingSink.PrecommittingSinkWriter<InputT, String>,
+                    Serializable {
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            // We empty the elements on prepareCommit
+        }
+
+        @Override
+        public Collection<String> prepareCommit() {
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+
+    /**
+     * Base class for out testing {@link StatefulSink.StatefulSinkWriter}. Extends the {@link
+     * DefaultCommittingSinkWriter} for simplicity.
+     */
+    protected static class DefaultStatefulSinkWriter<InputT>
+            extends DefaultCommittingSinkWriter<InputT>
+            implements StatefulSink.StatefulSinkWriter<InputT, String> {
+
+        @Override
+        public List<String> snapshotState(long checkpointId) throws IOException {
+            return elements;
+        }
+
+        protected void restore(Collection<String> recoveredState) {
+            this.elements = new ArrayList<>(recoveredState);
+        }
+    }
+
+    // -------------------------------------- Sink Committer ---------------------------------------
+
+    /** Base class for testing {@link Committer}. */
+    static class DefaultCommitter implements Committer<String>, Serializable {
+
+        @Nullable protected Queue<CommitRequest<String>> committedData;
+
+        private boolean isClosed;
+
+        @Nullable private final Supplier<Queue<CommitRequest<String>>> queueSupplier;
+
+        public DefaultCommitter() {
+            this.committedData = new ConcurrentLinkedQueue<>();
+            this.isClosed = false;
+            this.queueSupplier = null;
+        }
+
+        public DefaultCommitter(@Nullable Supplier<Queue<CommitRequest<String>>> queueSupplier) {
+            this.queueSupplier = queueSupplier;
+            this.isClosed = false;
+            this.committedData = null;
+        }
+
+        public List<CommitRequest<String>> getCommittedData() {
+            if (committedData != null) {
+                return new ArrayList<>(committedData);
+            } else {
+                return Collections.emptyList();
+            }
+        }
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            if (committedData == null) {
+                assertNotNull(queueSupplier);
+                committedData = queueSupplier.get();
+            }
+            committedData.addAll(committables);
+        }
+
+        public void close() throws Exception {
+            isClosed = true;
+        }
+
+        public boolean isClosed() {
+            return isClosed;
+        }
+
+        public void init() {
+            // context is not used for this implementation
+        }
+    }
+
+    /** A {@link Committer} that always re-commits the committables data it received. */
+    static class RetryOnceCommitter extends DefaultCommitter {
+
+        private final Set<CommitRequest<String>> seen = new LinkedHashSet<>();
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            committables.forEach(
+                    c -> {
+                        if (seen.remove(c)) {
+                            checkNotNull(committedData);
+                            committedData.add(c);
+                        } else {
+                            seen.add(c);
+                            c.retryLater();
+                        }
+                    });
+        }
+    }
+
+    /**
+     * We introduce this {@link StringSerializer} is because that all the fields of {@link
+     * TestSinkV2} should be serializable.
+     */
+    public static class StringSerializer
+            implements SimpleVersionedSerializer<String>, Serializable {
+
+        public static final StringSerializer INSTANCE = new StringSerializer();
+
+        @Override
+        public int getVersion() {
+            return SimpleVersionedStringSerializer.INSTANCE.getVersion();
+        }
+
+        @Override
+        public byte[] serialize(String obj) {
+            return SimpleVersionedStringSerializer.INSTANCE.serialize(obj);
+        }
+
+        @Override
+        public String deserialize(int version, byte[] serialized) throws IOException {
+            return SimpleVersionedStringSerializer.INSTANCE.deserialize(version, serialized);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -337,7 +337,7 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
     // -------------------------------------- Sink Committer ---------------------------------------
 
     /** Base class for testing {@link Committer}. */
-    static class DefaultCommitter implements Committer<String>, Serializable {
+    public static class DefaultCommitter implements Committer<String>, Serializable {
 
         @Nullable protected Queue<CommitRequest<String>> committedData;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -205,7 +205,7 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
 
     private static class TestSinkV2WithPostCommitTopology<InputT>
             extends TestSinkV2TwoPhaseCommittingSink<InputT>
-            implements WithPostCommitTopology<InputT, String> {
+            implements WithPostCommitTopology<String> {
         public TestSinkV2WithPostCommitTopology(
                 DefaultSinkWriter<InputT> writer,
                 SimpleVersionedSerializer<String> committableSerializer,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+
+import java.util.Collections;
+import java.util.List;
+
+class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
+
+    @Override
+    SinkAndCounters sinkWithPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(committer)
+                                .setDefaultGlobalCommitter()
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> committer.successfulCommits);
+    }
+
+    @Override
+    SinkAndCounters sinkWithPostCommitWithRetry() {
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(new TestSink.RetryOnceCommitter())
+                                .setDefaultGlobalCommitter()
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> 0);
+    }
+
+    @Override
+    SinkAndCounters sinkWithoutPostCommit() {
+        ForwardingCommitter committer = new ForwardingCommitter();
+        return new SinkAndCounters(
+                (TwoPhaseCommittingSink<?, String>)
+                        TestSink.newBuilder()
+                                .setCommitter(committer)
+                                .setCommittableSerializer(
+                                        TestSink.StringCommittableSerializer.INSTANCE)
+                                .build()
+                                .asV2(),
+                () -> committer.successfulCommits);
+    }
+
+    private static class ForwardingCommitter extends TestSink.DefaultCommitter {
+        private int successfulCommits = 0;
+
+        @Override
+        public List<String> commit(List<String> committables) {
+            successfulCommits += committables.size();
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() throws Exception {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterSinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterSinkWriterOperatorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.sink;
+
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class WithAdapterSinkWriterOperatorTest extends SinkWriterOperatorTestBase {
+
+    @Override
+    SinkAndSuppliers sinkWithoutCommitter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TestSink.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithCommitter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TestSink.DefaultSinkWriter<>();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter().build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithTimeBasedWriter() {
+        TestSink.DefaultSinkWriter<Integer> sinkWriter = new TimeBasedBufferingSinkWriter();
+        return new SinkAndSuppliers(
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter().build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> -1,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    @Override
+    SinkAndSuppliers sinkWithSnapshottingWriter(boolean withState, String stateName) {
+        SnapshottingBufferingSinkWriter sinkWriter = new SnapshottingBufferingSinkWriter();
+        TestSink.Builder<Integer> builder =
+                TestSink.newBuilder().setWriter(sinkWriter).setDefaultCommitter();
+        if (withState) {
+            builder.withWriterState();
+        }
+        if (stateName != null) {
+            builder.setCompatibleStateNames(stateName);
+        }
+        return new SinkAndSuppliers(
+                builder.build().asV2(),
+                () -> sinkWriter.elements,
+                () -> sinkWriter.watermarks,
+                () -> sinkWriter.lastCheckpointId,
+                () -> new TestSink.StringCommittableSerializer());
+    }
+
+    private static class TimeBasedBufferingSinkWriter extends TestSink.DefaultSinkWriter<Integer>
+            implements Sink.ProcessingTimeService.ProcessingTimeCallback {
+
+        private final List<String> cachedCommittables = new ArrayList<>();
+
+        @Override
+        public void write(Integer element, Context context) {
+            cachedCommittables.add(
+                    Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        void setProcessingTimerService(Sink.ProcessingTimeService processingTimerService) {
+            super.setProcessingTimerService(processingTimerService);
+            this.processingTimerService.registerProcessingTimer(1000, this);
+        }
+
+        @Override
+        public void onProcessingTime(long time) {
+            elements.addAll(cachedCommittables);
+            cachedCommittables.clear();
+            this.processingTimerService.registerProcessingTimer(time + 1000, this);
+        }
+    }
+
+    private static class SnapshottingBufferingSinkWriter
+            extends TestSink.DefaultSinkWriter<Integer> {
+        public static final int NOT_SNAPSHOTTED = -1;
+        long lastCheckpointId = NOT_SNAPSHOTTED;
+
+        @Override
+        public List<String> snapshotState(long checkpointId) {
+            lastCheckpointId = checkpointId;
+            return elements;
+        }
+
+        @Override
+        void restoredFrom(List<String> states) {
+            this.elements = new ArrayList<>(states);
+        }
+
+        @Override
+        public List<String> prepareCommit(boolean flush) {
+            if (!flush) {
+                return Collections.emptyList();
+            }
+            List<String> result = elements;
+            elements = new ArrayList<>();
+            return result;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.connector.sink2.IntegerSerializer;
@@ -48,9 +50,11 @@ class CommittableCollectorSerializerTest {
             new IntegerSerializer();
     private static final int SUBTASK_ID = 1;
     private static final int NUMBER_OF_SUBTASKS = 1;
+    private static final SinkCommitterMetricGroup METRIC_GROUP =
+            MetricsGroupTestUtils.mockCommitterMetricGroup();
     private static final CommittableCollectorSerializer<Integer> SERIALIZER =
             new CommittableCollectorSerializer<>(
-                    COMMITTABLE_SERIALIZER, SUBTASK_ID, NUMBER_OF_SUBTASKS);
+                    COMMITTABLE_SERIALIZER, SUBTASK_ID, NUMBER_OF_SUBTASKS, METRIC_GROUP);
 
     @Test
     void testCommittableCollectorV1SerDe() throws IOException {
@@ -85,10 +89,10 @@ class CommittableCollectorSerializerTest {
 
         final CommittableCollectorSerializer<Integer> ccSerializer =
                 new CommittableCollectorSerializer<>(
-                        COMMITTABLE_SERIALIZER, subtaskId, numberOfSubtasks);
+                        COMMITTABLE_SERIALIZER, subtaskId, numberOfSubtasks, METRIC_GROUP);
 
         final CommittableCollector<Integer> committableCollector =
-                new CommittableCollector<>(subtaskId, numberOfSubtasks);
+                new CommittableCollector<>(subtaskId, numberOfSubtasks, METRIC_GROUP);
         committableCollector.addMessage(
                 new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1, 1, 0));
         committableCollector.addMessage(
@@ -129,10 +133,10 @@ class CommittableCollectorSerializerTest {
 
         final CommittableCollectorSerializer<Integer> ccSerializer =
                 new CommittableCollectorSerializer<>(
-                        COMMITTABLE_SERIALIZER, subtaskId, numberOfSubtasks);
+                        COMMITTABLE_SERIALIZER, subtaskId, numberOfSubtasks, METRIC_GROUP);
 
         final CommittableCollector<Integer> committableCollector =
-                new CommittableCollector<>(subtaskId, numberOfSubtasks);
+                new CommittableCollector<>(subtaskId, numberOfSubtasks, METRIC_GROUP);
         committableCollector.addMessage(
                 new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1, 1, 0));
         committableCollector.addMessage(
@@ -172,7 +176,7 @@ class CommittableCollectorSerializerTest {
         // Sink.InitContext#INITIAL_CHECKPOINT_ID
         long checkpointId = Sink.InitContext.INITIAL_CHECKPOINT_ID + 1;
         final CommittableCollector<Integer> committableCollector =
-                new CommittableCollector<>(SUBTASK_ID, NUMBER_OF_SUBTASKS);
+                new CommittableCollector<>(SUBTASK_ID, NUMBER_OF_SUBTASKS, METRIC_GROUP);
         committableCollector.addMessage(
                 new CommittableSummary<>(SUBTASK_ID, NUMBER_OF_SUBTASKS, checkpointId, 1, 1, 0));
         committableCollector.addMessage(new CommittableWithLineage<>(1, checkpointId, SUBTASK_ID));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.runtime.operators.sink.committables;
 
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
@@ -26,10 +28,13 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CommittableCollectorTest {
+    private static final SinkCommitterMetricGroup METRIC_GROUP =
+            MetricsGroupTestUtils.mockCommitterMetricGroup();
 
     @Test
     void testGetCheckpointCommittablesUpTo() {
-        final CommittableCollector<Integer> committableCollector = new CommittableCollector<>(1, 1);
+        final CommittableCollector<Integer> committableCollector =
+                new CommittableCollector<>(1, 1, METRIC_GROUP);
         CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
         committableCollector.addMessage(first);
         CommittableSummary<Integer> second = new CommittableSummary<>(1, 1, 2L, 1, 0, 0);
@@ -43,7 +48,8 @@ class CommittableCollectorTest {
 
     @Test
     void testGetEndOfInputCommittable() {
-        final CommittableCollector<Integer> committableCollector = new CommittableCollector<>(1, 1);
+        final CommittableCollector<Integer> committableCollector =
+                new CommittableCollector<>(1, 1, METRIC_GROUP);
         CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, null, 1, 0, 0);
         committableCollector.addMessage(first);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
@@ -60,7 +60,7 @@ public class TestExpandingSink
     }
 
     @Override
-    public Committer<Integer> createCommitter() {
+    public Committer<Integer> createCommitter(CommitterInitContext context) {
         return null;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
@@ -33,9 +34,10 @@ import java.io.IOException;
 /** A test sink that expands into a simple subgraph. Do not use in runtime. */
 public class TestExpandingSink
         implements Sink<Integer>,
+                TwoPhaseCommittingSink<Integer, Integer>,
                 WithPreWriteTopology<Integer>,
                 WithPreCommitTopology<Integer, Integer>,
-                WithPostCommitTopology<Integer, Integer> {
+                WithPostCommitTopology<Integer> {
 
     @Override
     public void addPostCommitTopology(DataStream<CommittableMessage<Integer>> committables) {
@@ -46,6 +48,11 @@ public class TestExpandingSink
     public DataStream<CommittableMessage<Integer>> addPreCommitTopology(
             DataStream<CommittableMessage<Integer>> committables) {
         return committables.map(value -> value).returns(committables.getType());
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getWriteResultSerializer() {
+        return null;
     }
 
     @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
@@ -533,7 +533,8 @@ class SpeculativeSchedulerITCase {
         }
 
         @Override
-        public Committer<Tuple3<Integer, Integer, Map<Long, Long>>> createCommitter() {
+        public Committer<Tuple3<Integer, Integer, Map<Long, Long>>> createCommitter(
+                CommitterInitContext context) {
             return new DummyCommitter();
         }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Integration test for {@link org.apache.flink.api.connector.sink.Sink} run time implementation.
+ */
+public class SinkV2ITCase extends AbstractTestBase {
+    static final List<Integer> SOURCE_DATA =
+            Arrays.asList(
+                    895, 127, 148, 161, 148, 662, 822, 491, 275, 122, 850, 630, 682, 765, 434, 970,
+                    714, 795, 288, 422);
+
+    // source send data two times
+    static final int STREAMING_SOURCE_SEND_ELEMENTS_NUM = SOURCE_DATA.size() * 2;
+
+    static final List<String> EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE =
+            SOURCE_DATA.stream()
+                    // source send data two times
+                    .flatMap(
+                            x ->
+                                    Collections.nCopies(
+                                            2, Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                                            .stream())
+                    .collect(Collectors.toList());
+
+    static final List<String> EXPECTED_COMMITTED_DATA_IN_BATCH_MODE =
+            SOURCE_DATA.stream()
+                    .map(x -> Tuple3.of(x, null, Long.MIN_VALUE).toString())
+                    .collect(Collectors.toList());
+
+    static final Queue<Committer.CommitRequest<String>> COMMIT_QUEUE =
+            new ConcurrentLinkedQueue<>();
+
+    static final BooleanSupplier COMMIT_QUEUE_RECEIVE_ALL_DATA =
+            (BooleanSupplier & Serializable)
+                    () -> COMMIT_QUEUE.size() == STREAMING_SOURCE_SEND_ELEMENTS_NUM;
+
+    @Before
+    public void init() {
+        COMMIT_QUEUE.clear();
+    }
+
+    @Test
+    public void writerAndCommitterExecuteInStreamingMode() throws Exception {
+        final StreamExecutionEnvironment env = buildStreamEnv();
+        final FiniteTestSource<Integer> source =
+                new FiniteTestSource<>(COMMIT_QUEUE_RECEIVE_ALL_DATA, SOURCE_DATA);
+
+        env.addSource(source, IntegerTypeInfo.INT_TYPE_INFO)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                        & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        env.execute();
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));
+    }
+
+    @Test
+    public void writerAndCommitterExecuteInBatchMode() throws Exception {
+        final StreamExecutionEnvironment env = buildBatchEnv();
+
+        env.fromCollection(SOURCE_DATA)
+                .sinkTo(
+                        TestSinkV2.<Integer>newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<Committer.CommitRequest<String>>>
+                                                        & Serializable)
+                                                () -> COMMIT_QUEUE)
+                                .build());
+        env.execute();
+        assertThat(
+                COMMIT_QUEUE.stream()
+                        .map(Committer.CommitRequest::getCommittable)
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_COMMITTED_DATA_IN_BATCH_MODE.toArray()));
+    }
+
+    private StreamExecutionEnvironment buildStreamEnv() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.enableCheckpointing(100);
+        return env;
+    }
+
+    private StreamExecutionEnvironment buildBatchEnv() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        return env;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.testutils.InMemoryReporter;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatCounter;
+import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGauge;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
+public class SinkV2MetricsITCase extends TestLogger {
+
+    private static final String TEST_SINK_NAME = "MetricTestSink";
+    // please refer to SinkTransformationTranslator#WRITER_NAME
+    private static final String DEFAULT_WRITER_NAME = "Writer";
+    private static final int DEFAULT_PARALLELISM = 4;
+
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    private static final InMemoryReporter reporter = InMemoryReporter.createWithRetainedMetrics();
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .setConfiguration(reporter.addToConfiguration(new Configuration()))
+                            .build());
+
+    @Test
+    public void testMetrics() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        int numSplits = Math.max(1, env.getParallelism() - 2);
+
+        int numRecordsPerSplit = 10;
+
+        // make sure all parallel instances have processed the same amount of records before
+        // validating metrics
+        SharedReference<CyclicBarrier> beforeBarrier =
+                sharedObjects.add(new CyclicBarrier(numSplits + 1));
+        SharedReference<CyclicBarrier> afterBarrier =
+                sharedObjects.add(new CyclicBarrier(numSplits + 1));
+        int stopAtRecord1 = 4;
+        int stopAtRecord2 = numRecordsPerSplit - 1;
+
+        env.fromSequence(0, numSplits - 1)
+                .<Long>flatMap(
+                        (split, collector) ->
+                                LongStream.range(0, numRecordsPerSplit).forEach(collector::collect))
+                .returns(BasicTypeInfo.LONG_TYPE_INFO)
+                .map(
+                        i -> {
+                            if (i % numRecordsPerSplit == stopAtRecord1
+                                    || i % numRecordsPerSplit == stopAtRecord2) {
+                                beforeBarrier.get().await();
+                                afterBarrier.get().await();
+                            }
+                            return i;
+                        })
+                .sinkTo(TestSinkV2.<Long>newBuilder().setWriter(new MetricWriter()).build())
+                .name(TEST_SINK_NAME);
+        JobClient jobClient = env.executeAsync();
+        final JobID jobId = jobClient.getJobID();
+
+        beforeBarrier.get().await();
+        assertSinkMetrics(jobId, stopAtRecord1, env.getParallelism(), numSplits);
+        afterBarrier.get().await();
+
+        beforeBarrier.get().await();
+        assertSinkMetrics(jobId, stopAtRecord2, env.getParallelism(), numSplits);
+        afterBarrier.get().await();
+
+        jobClient.getJobExecutionResult().get();
+    }
+
+    @SuppressWarnings("checkstyle:WhitespaceAfter")
+    private void assertSinkMetrics(
+            JobID jobId, long processedRecordsPerSubtask, int parallelism, int numSplits) {
+        List<OperatorMetricGroup> groups =
+                reporter.findOperatorMetricGroups(
+                        jobId, TEST_SINK_NAME + ": " + DEFAULT_WRITER_NAME);
+        assertThat(groups, hasSize(parallelism));
+
+        int subtaskWithMetrics = 0;
+        for (OperatorMetricGroup group : groups) {
+            Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
+            // There are only 2 splits assigned; so two groups will not update metrics.
+            if (group.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
+                continue;
+            }
+            subtaskWithMetrics++;
+
+            // SinkWriterMetricGroup metrics
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_RECORDS_OUT))
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_BYTES_OUT))
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
+            // MetricWriter is just incrementing errors every even record
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_OUT_ERRORS))
+                    .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
+            // Test "send" metric series has the same value as "out" metric series.
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND))
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(metrics.get(MetricNames.NUM_BYTES_SEND))
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND_ERRORS))
+                    .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
+            // check if the latest send time is fetched
+            assertThatGauge(metrics.get(MetricNames.CURRENT_SEND_TIME))
+                    .isEqualTo((processedRecordsPerSubtask - 1) * MetricWriter.BASE_SEND_TIME);
+        }
+        assertThat(subtaskWithMetrics, equalTo(numSplits));
+    }
+
+    private static class MetricWriter extends TestSinkV2.DefaultSinkWriter<Long> {
+        static final long BASE_SEND_TIME = 100;
+        static final long RECORD_SIZE_IN_BYTES = 10;
+        private SinkWriterMetricGroup metricGroup;
+        private long sendTime;
+
+        @Override
+        public void init(Sink.InitContext context) {
+            this.metricGroup = context.metricGroup();
+            metricGroup.setCurrentSendTimeGauge(() -> sendTime);
+        }
+
+        @Override
+        public void write(Long element, Context context) {
+            super.write(element, context);
+            sendTime = element * BASE_SEND_TIME;
+            metricGroup.getIOMetricGroup().getNumRecordsOutCounter().inc();
+            if (element % 2 == 0) {
+                metricGroup.getNumRecordsOutErrorsCounter().inc();
+            }
+            metricGroup.getIOMetricGroup().getNumBytesOutCounter().inc(RECORD_SIZE_IN_BYTES);
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -35,12 +37,17 @@ import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.stream.LongStream;
 
@@ -48,6 +55,7 @@ import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatCoun
 import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGauge;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 
 /** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
@@ -56,6 +64,7 @@ public class SinkV2MetricsITCase extends TestLogger {
     private static final String TEST_SINK_NAME = "MetricTestSink";
     // please refer to SinkTransformationTranslator#WRITER_NAME
     private static final String DEFAULT_WRITER_NAME = "Writer";
+    private static final String DEFAULT_COMMITTER_NAME = "Committer";
     private static final int DEFAULT_PARALLELISM = 4;
 
     @Rule public final SharedObjects sharedObjects = SharedObjects.create();
@@ -116,6 +125,58 @@ public class SinkV2MetricsITCase extends TestLogger {
         jobClient.getJobExecutionResult().get();
     }
 
+    @Test
+    public void testCommitterMetrics() throws Exception {
+        final int NUM_COMMITTABLES = 7;
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // make sure all parallel instances have processed the same amount of records before
+        // validating metrics
+        SharedReference<CyclicBarrier> beforeBarrier =
+                sharedObjects.add(new CyclicBarrier(env.getParallelism() + 1));
+        SharedReference<CyclicBarrier> afterBarrier =
+                sharedObjects.add(new CyclicBarrier(env.getParallelism() + 1));
+
+        env.fromSequence(0, NUM_COMMITTABLES - 1)
+                .returns(BasicTypeInfo.LONG_TYPE_INFO)
+                .sinkTo(
+                        TestSinkV2.<Long>newBuilder()
+                                .setCommitter(new MetricCommitter(beforeBarrier, afterBarrier))
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .build())
+                .name(TEST_SINK_NAME);
+        JobClient jobClient = env.executeAsync();
+        final JobID jobId = jobClient.getJobID();
+
+        // Run until every committer finished with 1 commit round - everything should be retried and
+        // pending
+        beforeBarrier.get().await();
+        assertSinkCommitterMetrics(
+                jobId,
+                env.getParallelism(),
+                ImmutableMap.of(
+                        MetricNames.ALREADY_COMMITTED_COMMITTABLES, 0L,
+                        MetricNames.FAILED_COMMITTABLES, 0L,
+                        MetricNames.RETRIED_COMMITTABLES, 7L,
+                        MetricNames.SUCCESSFUL_COMMITTABLES, 0L,
+                        MetricNames.TOTAL_COMMITTABLES, 7L,
+                        MetricNames.PENDING_COMMITTABLES, 7L));
+        afterBarrier.get().await();
+
+        // Run until finished
+        jobClient.getJobExecutionResult().get();
+        assertSinkCommitterMetrics(
+                jobId,
+                env.getParallelism(),
+                ImmutableMap.of(
+                        MetricNames.ALREADY_COMMITTED_COMMITTABLES, 1L,
+                        MetricNames.FAILED_COMMITTABLES, 2L,
+                        MetricNames.RETRIED_COMMITTABLES, 10L,
+                        MetricNames.SUCCESSFUL_COMMITTABLES, 4L,
+                        MetricNames.TOTAL_COMMITTABLES, 7L,
+                        MetricNames.PENDING_COMMITTABLES, 0L));
+    }
+
     @SuppressWarnings("checkstyle:WhitespaceAfter")
     private void assertSinkMetrics(
             JobID jobId, long processedRecordsPerSubtask, int parallelism, int numSplits) {
@@ -157,6 +218,49 @@ public class SinkV2MetricsITCase extends TestLogger {
         assertThat(subtaskWithMetrics, equalTo(numSplits));
     }
 
+    private void assertSinkCommitterMetrics(
+            JobID jobId, int parallelism, Map<String, Long> expected) {
+        List<OperatorMetricGroup> groups =
+                reporter.findOperatorMetricGroups(
+                        jobId, TEST_SINK_NAME + ": " + DEFAULT_COMMITTER_NAME);
+        assertThat(groups, hasSize(parallelism));
+
+        Map<String, Long> aggregated = new HashMap<>(6);
+        for (OperatorMetricGroup group : groups) {
+            Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
+
+            aggregated.merge(
+                    MetricNames.SUCCESSFUL_COMMITTABLES,
+                    ((Counter) metrics.get(MetricNames.SUCCESSFUL_COMMITTABLES)).getCount(),
+                    Long::sum);
+            aggregated.merge(
+                    MetricNames.ALREADY_COMMITTED_COMMITTABLES,
+                    ((Counter) metrics.get(MetricNames.ALREADY_COMMITTED_COMMITTABLES)).getCount(),
+                    Long::sum);
+            aggregated.merge(
+                    MetricNames.RETRIED_COMMITTABLES,
+                    ((Counter) metrics.get(MetricNames.RETRIED_COMMITTABLES)).getCount(),
+                    Long::sum);
+            aggregated.merge(
+                    MetricNames.FAILED_COMMITTABLES,
+                    ((Counter) metrics.get(MetricNames.FAILED_COMMITTABLES)).getCount(),
+                    Long::sum);
+            aggregated.merge(
+                    MetricNames.TOTAL_COMMITTABLES,
+                    ((Counter) metrics.get(MetricNames.TOTAL_COMMITTABLES)).getCount(),
+                    Long::sum);
+            aggregated.merge(
+                    MetricNames.PENDING_COMMITTABLES,
+                    ((Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES))
+                            .getValue()
+                            .longValue(),
+                    Long::sum);
+        }
+
+        expected.entrySet()
+                .forEach(e -> assertThat(aggregated, hasEntry(e.getKey(), e.getValue())));
+    }
+
     private static class MetricWriter extends TestSinkV2.DefaultSinkWriter<Long> {
         static final long BASE_SEND_TIME = 100;
         static final long RECORD_SIZE_IN_BYTES = 10;
@@ -178,6 +282,66 @@ public class SinkV2MetricsITCase extends TestLogger {
                 metricGroup.getNumRecordsOutErrorsCounter().inc();
             }
             metricGroup.getIOMetricGroup().getNumBytesOutCounter().inc(RECORD_SIZE_IN_BYTES);
+        }
+    }
+
+    private static class MetricCommitter extends TestSinkV2.DefaultCommitter {
+        private int counter = 0;
+        private SharedReference<CyclicBarrier> beforeBarrier;
+        private SharedReference<CyclicBarrier> afterBarrier;
+
+        MetricCommitter(
+                SharedReference<CyclicBarrier> beforeBarrier,
+                SharedReference<CyclicBarrier> afterBarrier) {
+            this.beforeBarrier = beforeBarrier;
+            this.afterBarrier = afterBarrier;
+            this.counter = 0;
+        }
+
+        @Override
+        public void commit(Collection<CommitRequest<String>> committables) {
+            if (counter == 0) {
+                committables.forEach(c -> c.retryLater());
+            } else {
+                if (counter == 1) {
+                    // Wait for metrics check before continue
+                    try {
+                        beforeBarrier.get().await();
+                        afterBarrier.get().await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    } catch (BrokenBarrierException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                committables.forEach(
+                        c -> {
+                            switch (c.getCommittable().charAt(1)) {
+                                case '0':
+                                    c.signalAlreadyCommitted();
+                                    // 1 already committed
+                                    break;
+                                case '1':
+                                case '2':
+                                    // 2 failed
+                                    c.signalFailedWithKnownReason(new RuntimeException());
+                                    break;
+                                case '3':
+                                    // Retry without change
+                                    if (counter == 1) {
+                                        c.retryLater();
+                                    }
+                                    break;
+                                case '4':
+                                case '5':
+                                    // Retry with change
+                                    c.updateAndRetryLater("Retry-" + c.getCommittable());
+                            }
+                        });
+            }
+            counter++;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This is the implementation of [FLIP-372](https://cwiki.apache.org/confluence/display/FLINK/FLIP-372%3A+Allow+TwoPhaseCommittingSink+WithPreCommitTopology+to+alter+the+type+of+the+Committable)

Add a possibility to  the WithPreCommitTopology to transform not only the data, but the type of the data channelled through it.

Please only check the last commit. The previous commits have an open pull request. We can rebase once they are merged. 

## Brief change log

- Added `TwoPhaseCommittingSinkWithPreCommitTopology` to decouple the writer response type from the committer input type
- Updated `TwoPhaseCommittingSink` to be compatible with the previous implementation, but the interface is inherited from `TwoPhaseCommittingSinkWithPreCommitTopology`
- Changed `WithPostCommitTopology` and `WithPreCommitTopology` to be a mixin like interfaces (no inheritance from `TwoPhaseCommittingSink`)
- Changed the `SinkTransformationTranslator` to handle the new interfaces
- Updated old test to use the new `TwoPhaseCommittingSinkWithPreCommitTopology` where it was relevant
- Created new tests in `StreamingJobGraphGeneratorTest` to check if we can create sinks with `TwoPhaseCommittingSinkWithPreCommitTopology` and `TwoPhaseCommittingSink` too


## Verifying this change

Added new tests, and verified that the old tests are working

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented at the moment
