### PR TITLE
 [FLINK-33317][runtime] Add cleaning mechanism for initial configs to reduce the memory usage

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -743,6 +743,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
         // task specific initialization
         init();
+        configuration.clearInitialConfigs();
 
         // save the work of reloading state, etc, if the task is already canceled
         ensureNotCanceled();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamConfigTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.graph;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.util.MockStreamConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link StreamConfig}. */
+class StreamConfigTest {
+
+    @Test
+    void testClearInitialConfigs() {
+        int chainedTaskId = 3456;
+        MockStreamConfig streamConfig =
+                new MockStreamConfig(
+                        new Configuration(),
+                        1,
+                        Collections.singletonMap(
+                                chainedTaskId, new MockStreamConfig(new Configuration(), 1)));
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        StreamOperatorFactory<?> streamOperatorFactory =
+                streamConfig.getStreamOperatorFactory(classLoader);
+        assertThat(streamOperatorFactory).isNotNull();
+        assertThat(streamConfig.getStreamOperatorFactoryClass(classLoader)).isNotNull();
+        assertThat(streamConfig.getTransitiveChainedTaskConfigs(classLoader))
+                .hasSize(1)
+                .containsKey(chainedTaskId);
+
+        // StreamOperatorFactory and ChainedTaskConfigs should be cleared after clearInitialConfigs,
+        // but the factory class shouldn't be cleared.
+        streamConfig.clearInitialConfigs();
+        assertThatThrownBy(() -> streamConfig.getStreamOperatorFactory(classLoader))
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("serializedUDF has been removed.");
+        assertThat(streamConfig.getStreamOperatorFactoryClass(classLoader)).isNotNull();
+        assertThatThrownBy(() -> streamConfig.getTransitiveChainedTaskConfigs(classLoader))
+                .hasCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("chainedTaskConfig_ has been removed.");
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
@@ -30,13 +30,24 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.tasks.SourceStreamTask;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /** A dummy stream config implementation for specifying the number of outputs in tests. */
 public class MockStreamConfig extends StreamConfig {
 
     public MockStreamConfig(Configuration configuration, int numberOfOutputs) {
+        this(configuration, numberOfOutputs, null);
+    }
+
+    public MockStreamConfig(
+            Configuration configuration,
+            int numberOfOutputs,
+            @Nullable Map<Integer, StreamConfig> chainedTaskConfigs) {
+
         super(configuration);
 
         setChainStart();
@@ -71,6 +82,9 @@ public class MockStreamConfig extends StreamConfig {
         }
         setVertexNonChainedOutputs(streamOutputs);
         setOperatorNonChainedOutputs(streamOutputs);
+        if (chainedTaskConfigs != null) {
+            setAndSerializeTransitiveChainedTaskConfigs(chainedTaskConfigs);
+        }
         serializeAllConfigs();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is FLINK-33317, it's a subtask of FLINK-33315. See FLINK-33315 and FLINK-33317 for details.

## Brief change log

Clean up the StreamConfig#SERIALIZEDUDF after getStreamOperatorFactory.

## Verifying this change

This change added tests and can be verified as follows:

  - Added StreamConfigTest#cleanSerializedUDF

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
