### PR TITLE
[FLINK-32182][build] Use original japicmp plugin

### DIFF
--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -343,7 +343,7 @@ under the License.
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.github.zentol.japicmp</groupId>
+						<groupId>com.github.siom79.japicmp</groupId>
 						<artifactId>japicmp-maven-plugin</artifactId>
 						<configuration>
 							<!-- version bump broke the checks -->

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -263,7 +263,7 @@ under the License.
 			</plugin>
 
 			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
+				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<parameter>
@@ -305,7 +305,7 @@ under the License.
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.github.zentol.japicmp</groupId>
+						<groupId>com.github.siom79.japicmp</groupId>
 						<artifactId>japicmp-maven-plugin</artifactId>
 						<configuration>
 							<!-- version bump broke the checks -->

--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -84,7 +84,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
+				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -1199,7 +1199,7 @@ under the License.
 							</configuration>
 						</plugin>
 						<plugin>
-							<groupId>io.github.zentol.japicmp</groupId>
+							<groupId>com.github.siom79.japicmp</groupId>
 							<artifactId>japicmp-maven-plugin</artifactId>
 							<configuration>
 								<skip>true</skip>
@@ -1470,7 +1470,7 @@ under the License.
 
 			<plugin>
 				<!-- activate API compatibility checks -->
-				<groupId>io.github.zentol.japicmp</groupId>
+				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 
@@ -2240,9 +2240,9 @@ under the License.
 
 				<!-- Configuration for the binary compatibility checker -->
 				<plugin>
-					<groupId>io.github.zentol.japicmp</groupId>
+					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.17.1.1_m325</version>
+					<version>0.17.1</version>
 					<configuration>
 						<oldVersion>
 							<dependency>


### PR DESCRIPTION
Based on https://github.com/apache/flink/pull/23609

Move us back to the original japicmp plugin.