### PR TITLE
[FLINK-33316][runtime] Using SERIALIZED_UDF_CLASS instead of SERIALIZED_UDF_CLASS_NAME

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -641,7 +641,10 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     @Nullable
     private Counter getOperatorRecordsOutCounter(
             StreamTask<?, ?> containingTask, StreamConfig operatorConfig) {
-        String streamOperatorFactoryClassName = operatorConfig.getStreamOperatorFactoryClassName();
+        ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
+        Class<StreamOperatorFactory<?>> streamOperatorFactoryClass =
+                operatorConfig.getStreamOperatorFactoryClass(userCodeClassloader);
+
         // Do not use the numRecordsOut counter on output if this operator is SinkWriterOperator.
         //
         // Metric "numRecordsOut" is defined as the total number of records written to the
@@ -649,8 +652,15 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         // number of records sent to downstream operators, which is number of Committable batches
         // sent to SinkCommitter. So we skip registering this metric on output and leave this metric
         // to sink writer implementations to report.
-        if (SinkWriterOperatorFactory.class.getName().equals(streamOperatorFactoryClassName)) {
-            return null;
+        try {
+            Class<?> sinkWriterFactoryClass =
+                    userCodeClassloader.loadClass(SinkWriterOperatorFactory.class.getName());
+            if (sinkWriterFactoryClass.isAssignableFrom(streamOperatorFactoryClass)) {
+                return null;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new StreamTaskException(
+                    "Could not load SinkWriterOperatorFactory class from userCodeClassloader.", e);
         }
 
         InternalOperatorMetricGroup operatorMetricGroup =


### PR DESCRIPTION
## What is the purpose of the change

See this https://github.com/apache/flink/pull/23550#discussion_r1368508673, Using the SERIALIZED_UDF_CLASS can support adding a subclass for SinkWriterOperatorFactory in the future.


## Brief change log

Using SERIALIZED_UDF_CLASS instead of SERIALIZED_UDF_CLASS_NAME.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?no
