### PR TITLE
[FLINK-33371] Make TestValues sinks return results as Rows

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputView;
@@ -46,13 +45,14 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.LookupFunction;
 import org.apache.flink.table.runtime.generated.GeneratedProjection;
 import org.apache.flink.table.runtime.generated.Projection;
+import org.apache.flink.table.runtime.typeutils.ExternalSerializer;
 import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.RowUtils;
-import org.apache.flink.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -70,6 +70,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.planner.factories.TestValuesTableFactory.RESOURCE_COUNTER;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -82,29 +83,40 @@ final class TestValuesRuntimeFunctions {
     static final Object LOCK = TestValuesTableFactory.class;
 
     // [table_name, [task_id, List[value]]]
-    private static final Map<String, Map<Integer, List<String>>> globalRawResult = new HashMap<>();
+    private static final Map<String, Map<Integer, List<Row>>> globalRawResult = new HashMap<>();
     // [table_name, [task_id, Map[key, value]]]
-    private static final Map<String, Map<Integer, Map<String, String>>> globalUpsertResult =
+    private static final Map<String, Map<Integer, Map<Row, Row>>> globalUpsertResult =
             new HashMap<>();
     // [table_name, [task_id, List[value]]]
-    private static final Map<String, Map<Integer, List<String>>> globalRetractResult =
-            new HashMap<>();
+    private static final Map<String, Map<Integer, List<Row>>> globalRetractResult = new HashMap<>();
     // [table_name, [watermark]]
     private static final Map<String, List<Watermark>> watermarkHistory = new HashMap<>();
 
-    static List<String> getRawResults(String tableName) {
-        List<String> result = new ArrayList<>();
+    static List<String> getRawResultsAsStrings(String tableName) {
+        return getRawResults(tableName).stream()
+                .map(TestValuesRuntimeFunctions::rowToString)
+                .collect(Collectors.toList());
+    }
+
+    static List<Row> getRawResults(String tableName) {
         synchronized (LOCK) {
             if (globalRawResult.containsKey(tableName)) {
-                globalRawResult.get(tableName).values().forEach(result::addAll);
+                return globalRawResult.get(tableName).values().stream()
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList());
             }
         }
-        return result;
+        return Collections.emptyList();
     }
 
     /** Returns raw results if there was only one table with results, throws otherwise. */
-    static List<String> getOnlyRawResults() {
-        List<String> result = new ArrayList<>();
+    static List<String> getOnlyRawResultsAsStrings() {
+        return getOnlyRawResults().stream()
+                .map(TestValuesRuntimeFunctions::rowToString)
+                .collect(Collectors.toList());
+    }
+
+    static List<Row> getOnlyRawResults() {
         synchronized (LOCK) {
             if (globalRawResult.size() != 1) {
                 throw new IllegalStateException(
@@ -112,9 +124,10 @@ final class TestValuesRuntimeFunctions {
                                 + globalRawResult.size());
             }
 
-            globalRawResult.values().iterator().next().values().forEach(result::addAll);
+            return globalRawResult.values().iterator().next().values().stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
         }
-        return result;
     }
 
     static List<Watermark> getWatermarks(String tableName) {
@@ -127,23 +140,25 @@ final class TestValuesRuntimeFunctions {
         }
     }
 
-    static List<String> getResults(String tableName) {
-        List<String> result = new ArrayList<>();
+    static List<String> getResultsAsStrings(String tableName) {
+        return getResults(tableName).stream().map(Row::toString).collect(Collectors.toList());
+    }
+
+    static List<Row> getResults(String tableName) {
         synchronized (LOCK) {
             if (globalUpsertResult.containsKey(tableName)) {
-                globalUpsertResult
-                        .get(tableName)
-                        .values()
-                        .forEach(map -> result.addAll(map.values()));
+                return globalUpsertResult.get(tableName).values().stream()
+                        .flatMap(map -> map.values().stream())
+                        .collect(Collectors.toList());
             } else if (globalRetractResult.containsKey(tableName)) {
-                globalRetractResult.get(tableName).values().forEach(result::addAll);
+                return globalRetractResult.get(tableName).values().stream()
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
             } else if (globalRawResult.containsKey(tableName)) {
-                getRawResults(tableName).stream()
-                        .map(s -> s.substring(3, s.length() - 1)) // removes the +I(...) wrapper
-                        .forEach(result::add);
+                return getRawResults(tableName);
             }
         }
-        return result;
+        return Collections.emptyList();
     }
 
     static void clearResults() {
@@ -152,6 +167,14 @@ final class TestValuesRuntimeFunctions {
             globalUpsertResult.clear();
             globalRetractResult.clear();
             watermarkHistory.clear();
+        }
+    }
+
+    private static String rowToString(Row row) {
+        if (RowUtils.USE_LEGACY_TO_STRING) {
+            return String.format("%s(%s)", row.getKind().shortString(), row);
+        } else {
+            return row.toString();
         }
     }
 
@@ -178,7 +201,7 @@ final class TestValuesRuntimeFunctions {
 
         private volatile boolean isRunning = true;
 
-        private String tableName;
+        private final String tableName;
 
         public FromElementSourceFunctionWithWatermark(
                 String tableName,
@@ -283,22 +306,29 @@ final class TestValuesRuntimeFunctions {
         private static final long serialVersionUID = 1L;
 
         protected final String tableName;
+        protected final DataType consumedDataType;
+        protected final DataStructureConverter converter;
+        protected transient ListState<Row> rawResultState;
+        protected transient List<Row> localRawResult;
 
-        protected transient ListState<String> rawResultState;
-        protected transient List<String> localRawResult;
-
-        protected AbstractExactlyOnceSink(String tableName) {
+        protected AbstractExactlyOnceSink(
+                String tableName, DataType consumedDataType, DataStructureConverter converter) {
             this.tableName = tableName;
+            this.consumedDataType = consumedDataType;
+            this.converter = converter;
         }
 
         @Override
         public void initializeState(FunctionInitializationContext context) throws Exception {
             this.rawResultState =
                     context.getOperatorStateStore()
-                            .getListState(new ListStateDescriptor<>("sink-results", Types.STRING));
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "sink-results",
+                                            ExternalSerializer.of(consumedDataType)));
             this.localRawResult = new ArrayList<>();
             if (context.isRestored()) {
-                for (String value : rawResultState.get()) {
+                for (Row value : rawResultState.get()) {
                     localRawResult.add(value);
                 }
             }
@@ -321,22 +351,20 @@ final class TestValuesRuntimeFunctions {
     static class AppendingSinkFunction extends AbstractExactlyOnceSink {
 
         private static final long serialVersionUID = 1L;
-        private final DataStructureConverter converter;
         private final int rowtimeIndex;
 
         protected AppendingSinkFunction(
-                String tableName, DataStructureConverter converter, int rowtimeIndex) {
-            super(tableName);
-            this.converter = converter;
+                String tableName,
+                DataType consumedDataType,
+                DataStructureConverter converter,
+                int rowtimeIndex) {
+            super(tableName, consumedDataType, converter);
             this.rowtimeIndex = rowtimeIndex;
         }
 
         @Override
         public void invoke(RowData value, Context context) throws Exception {
-            RowKind kind = value.getRowKind();
             if (value.getRowKind() == RowKind.INSERT) {
-                Row row = (Row) converter.toExternal(value);
-                assertThat(row).isNotNull();
                 if (rowtimeIndex >= 0) {
                     // currently, rowtime attribute always uses 3 precision
                     TimestampData rowtime = value.getTimestamp(rowtimeIndex, 3);
@@ -347,7 +375,7 @@ final class TestValuesRuntimeFunctions {
                     }
                 }
                 synchronized (LOCK) {
-                    localRawResult.add(kind.shortString() + "(" + row.toString() + ")");
+                    localRawResult.add((Row) converter.toExternal(value));
                 }
             } else {
                 throw new RuntimeException(
@@ -362,25 +390,24 @@ final class TestValuesRuntimeFunctions {
      */
     static class KeyedUpsertingSinkFunction extends AbstractExactlyOnceSink {
         private static final long serialVersionUID = 1L;
-        private final DataStructureConverter converter;
         private final int[] keyIndices;
         private final int[] targetColumnIndices;
         private final int expectedSize;
         private final int totalColumns;
 
         // [key, value] map result
-        private transient Map<String, String> localUpsertResult;
+        private transient Map<Row, Row> localUpsertResult;
         private transient int receivedNum;
 
         protected KeyedUpsertingSinkFunction(
                 String tableName,
+                DataType consumedDataType,
                 DataStructureConverter converter,
                 int[] keyIndices,
                 int[] targetColumnIndices,
                 int expectedSize,
                 int totalColumns) {
-            super(tableName);
-            this.converter = converter;
+            super(tableName, consumedDataType, converter);
             this.keyIndices = keyIndices;
             this.targetColumnIndices = targetColumnIndices;
             this.expectedSize = expectedSize;
@@ -408,29 +435,27 @@ final class TestValuesRuntimeFunctions {
             assertThat(row).isNotNull();
 
             synchronized (LOCK) {
-                if (RowUtils.USE_LEGACY_TO_STRING) {
-                    localRawResult.add(kind.shortString() + "(" + row + ")");
-                } else {
-                    localRawResult.add(row.toString());
-                }
+                localRawResult.add(row);
 
-                row.setKind(RowKind.INSERT);
                 Row key = Row.project(row, keyIndices);
+                key.setKind(RowKind.INSERT);
+
+                final Row upsertRow = Row.copy(row);
+                upsertRow.setKind(RowKind.INSERT);
 
                 if (kind == RowKind.INSERT || kind == RowKind.UPDATE_AFTER) {
                     if (targetColumnIndices.length > 0) {
                         // perform partial insert
-                        localUpsertResult.put(
-                                key.toString(),
-                                updateRowValue(
-                                        localUpsertResult.get(key.toString()),
-                                        row,
-                                        targetColumnIndices));
+                        localUpsertResult.compute(
+                                key,
+                                (entryKey, currentValue) ->
+                                        updateRowValue(
+                                                currentValue, upsertRow, targetColumnIndices));
                     } else {
-                        localUpsertResult.put(key.toString(), row.toString());
+                        localUpsertResult.put(key, upsertRow);
                     }
                 } else {
-                    String oldValue = localUpsertResult.remove(key.toString());
+                    Row oldValue = localUpsertResult.remove(key);
                     if (oldValue == null) {
                         throw new RuntimeException(
                                 "Tried to delete a value that wasn't inserted first. "
@@ -446,27 +471,17 @@ final class TestValuesRuntimeFunctions {
             }
         }
 
-        private String updateRowValue(String old, Row newRow, int[] targetColumnIndices) {
-            if (StringUtils.isNullOrWhitespaceOnly(old)) {
+        private Row updateRowValue(Row old, Row newRow, int[] targetColumnIndices) {
+            if (old == null) {
                 // no old value, just return current
-                return newRow.toString();
+                return newRow;
             } else {
-                String[] oldCols =
-                        org.apache.commons.lang3.StringUtils.splitByWholeSeparatorPreserveAllTokens(
-                                old, ", ");
-                assert oldCols.length == totalColumns;
+                assert old.getArity() == totalColumns;
                 // exist old value, simply simulate an update
-                for (int i = 0; i < targetColumnIndices.length; i++) {
-                    int idx = targetColumnIndices[i];
-                    if (idx == 0) {
-                        oldCols[idx] = String.format("+I[%s", newRow.getField(idx));
-                    } else if (idx == totalColumns - 1) {
-                        oldCols[idx] = String.format("%s]", newRow.getField(idx));
-                    } else {
-                        oldCols[idx] = (String) newRow.getField(idx);
-                    }
+                for (int idx : targetColumnIndices) {
+                    old.setField(idx, newRow.getField(idx));
                 }
-                return String.join(", ", oldCols);
+                return old;
             }
         }
     }
@@ -474,14 +489,12 @@ final class TestValuesRuntimeFunctions {
     static class RetractingSinkFunction extends AbstractExactlyOnceSink {
         private static final long serialVersionUID = 1L;
 
-        private final DataStructureConverter converter;
+        protected transient ListState<Row> retractResultState;
+        protected transient List<Row> localRetractResult;
 
-        protected transient ListState<String> retractResultState;
-        protected transient List<String> localRetractResult;
-
-        protected RetractingSinkFunction(String tableName, DataStructureConverter converter) {
-            super(tableName);
-            this.converter = converter;
+        protected RetractingSinkFunction(
+                String tableName, DataType consumedDataType, DataStructureConverter converter) {
+            super(tableName, consumedDataType, converter);
         }
 
         @Override
@@ -491,11 +504,12 @@ final class TestValuesRuntimeFunctions {
                     context.getOperatorStateStore()
                             .getListState(
                                     new ListStateDescriptor<>(
-                                            "sink-retract-results", Types.STRING));
+                                            "sink-retract-results",
+                                            ExternalSerializer.of(consumedDataType)));
             this.localRetractResult = new ArrayList<>();
 
             if (context.isRestored()) {
-                for (String value : retractResultState.get()) {
+                for (Row value : retractResultState.get()) {
                     localRetractResult.add(value);
                 }
             }
@@ -523,13 +537,13 @@ final class TestValuesRuntimeFunctions {
             Row row = (Row) converter.toExternal(value);
             assertThat(row).isNotNull();
             synchronized (LOCK) {
-                localRawResult.add(kind.shortString() + "(" + row.toString() + ")");
+                localRawResult.add(row);
+                final Row retractRow = Row.copy(row);
+                retractRow.setKind(RowKind.INSERT);
                 if (kind == RowKind.INSERT || kind == RowKind.UPDATE_AFTER) {
-                    row.setKind(RowKind.INSERT);
-                    localRetractResult.add(row.toString());
+                    localRetractResult.add(retractRow);
                 } else {
-                    row.setKind(RowKind.INSERT);
-                    boolean contains = localRetractResult.remove(row.toString());
+                    boolean contains = localRetractResult.remove(retractRow);
                     if (!contains) {
                         throw new RuntimeException(
                                 "Tried to retract a value that wasn't inserted first. "
@@ -546,7 +560,7 @@ final class TestValuesRuntimeFunctions {
         private final String tableName;
         private final DataStructureConverter converter;
 
-        protected transient List<String> localRawResult;
+        protected transient List<Row> localRawResult;
 
         protected AppendingOutputFormat(String tableName, DataStructureConverter converter) {
             this.tableName = tableName;
@@ -570,12 +584,11 @@ final class TestValuesRuntimeFunctions {
 
         @Override
         public void writeRecord(RowData value) throws IOException {
-            RowKind kind = value.getRowKind();
             if (value.getRowKind() == RowKind.INSERT) {
                 Row row = (Row) converter.toExternal(value);
                 assertThat(row).isNotNull();
                 synchronized (LOCK) {
-                    localRawResult.add(kind.shortString() + "(" + row.toString() + ")");
+                    localRawResult.add(row);
                 }
             } else {
                 throw new RuntimeException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
@@ -65,7 +65,7 @@ class RTASITCase extends BatchTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
                 .isEqualTo("[+I[1, 1, Hi], +I[2, 2, Hello], +I[3, 2, Hello world]]");
 
         // verify the table after replacing
@@ -96,7 +96,7 @@ class RTASITCase extends BatchTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
                 .isEqualTo("[+I[1, Hi], +I[2, Hello], +I[3, Hello world]]");
 
         // verify the table after replacing
@@ -116,7 +116,7 @@ class RTASITCase extends BatchTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("not_exist_target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("not_exist_target").toString())
                 .isEqualTo("[+I[1, Hi], +I[2, Hello], +I[3, Hello world]]");
 
         // verify the table after replacing

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
@@ -168,7 +168,7 @@ public class AdaptiveHashJoinITCase extends TestLogger {
 
     private void asserResult(String sinkTableName, int resultSize) {
         // Due to concern OOM and record value is same, here just assert result size
-        List<String> result = TestValuesTableFactory.getResults(sinkTableName);
+        List<String> result = TestValuesTableFactory.getResultsAsStrings(sinkTableName);
         assertThat(result.size()).isEqualTo(resultSize);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ChangelogSourceJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ChangelogSourceJsonPlanITCase.java
@@ -52,7 +52,7 @@ class ChangelogSourceJsonPlanITCase extends JsonPlanTestBase {
                         "+I[user1, Tom, tom123@gmail.com, 8.10, 16.20]",
                         "+I[user3, Bailey, bailey@qq.com, 9.99, 19.98]",
                         "+I[user4, Tina, tina@gmail.com, 11.30, 22.60]");
-        assertResult(expected, TestValuesTableFactory.getResults("user_sink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("user_sink"));
     }
 
     @Test
@@ -74,7 +74,7 @@ class ChangelogSourceJsonPlanITCase extends JsonPlanTestBase {
                         "+I[user1, Tom, tom123@gmail.com, 8.10, 16.20]",
                         "+I[user3, Bailey, bailey@qq.com, 9.99, 19.98]",
                         "+I[user4, Tina, tina@gmail.com, 11.30, 22.60]");
-        assertResult(expected, TestValuesTableFactory.getResults("user_sink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("user_sink"));
     }
 
     // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ConfigureOperatorLevelStateTtlJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ConfigureOperatorLevelStateTtlJsonITCase.java
@@ -113,7 +113,7 @@ class ConfigureOperatorLevelStateTtlJsonITCase extends JsonPlanTestBase {
                         "+I[Jerry, 1, 2, 99.9]",
                         "+I[Olivia, 2, 4, 1100.0]",
                         "+I[Michael, 1, 3, 599.9]");
-        assertResult(expected, TestValuesTableFactory.getResults("OrdersStats"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("OrdersStats"));
     }
 
     @Test
@@ -187,7 +187,7 @@ class ConfigureOperatorLevelStateTtlJsonITCase extends JsonPlanTestBase {
         List<String> expected =
                 Arrays.asList(
                         "+I[1, 1000002, TRUCK]", "+I[1, 1000004, RAIL]", "+I[1, 1000005, AIR]");
-        assertResult(expected, TestValuesTableFactory.getResults("OrdersShipInfo"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("OrdersShipInfo"));
     }
 
     private static Map<String, String> getProperties(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
@@ -49,7 +49,7 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -61,7 +61,7 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -73,7 +73,7 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -85,7 +85,7 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                 "insert into MySink SELECT a, v FROM MyTable, lateral table(STRING_SPLIT(a, ',')) as T(v)";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]", "+I[1,1,hi, hi]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -99,7 +99,7 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                         + "where try_cast(v as int) > 0";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -114,6 +114,6 @@ class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                 "INSERT INTO MySink SELECT name, nested FROM MyNestedTable CROSS JOIN UNNEST(arr) AS t (nested)";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[Bob, 1]", "+I[Bob, 2]", "+I[Bob, 3]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
@@ -74,6 +74,6 @@ class DeduplicationJsonPlanITCase extends JsonPlanTestBase {
 
         assertResult(
                 Arrays.asList("+I[1, terry, pen, 1000]", "+I[4, bob, apple, 4000]"),
-                TestValuesTableFactory.getRawResults("MySink"));
+                TestValuesTableFactory.getRawResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ExpandJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ExpandJsonPlanITCase.java
@@ -58,7 +58,7 @@ class ExpandJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by b")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(Arrays.asList("+I[1, 1, Hi]", "+I[2, 2, Hello world]"), result);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupAggregateJsonPlanITCase.java
@@ -89,7 +89,7 @@ class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by b")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(Arrays.asList("+I[1, 1, null, Hi]", "+I[2, 2, 2.0, Hello]"), result);
     }
 
@@ -124,7 +124,7 @@ class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by e")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[1, 1, 4, 12, 32, 6.0, 5]",
@@ -164,7 +164,7 @@ class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by e")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList("+I[1, 77, 0, 1]", "+I[2, 120, 0, 2]", "+I[3, 58, 0, 3]"), result);
     }
@@ -194,7 +194,7 @@ class GroupAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by e")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[1, 1, Hallo Welt wie|Hallo|GHI|EFG|DEF]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupWindowAggregateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/GroupWindowAggregateJsonITCase.java
@@ -81,7 +81,7 @@ class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, TUMBLE(rowtime, INTERVAL '5' SECOND)")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 2020-10-10T00:00, 2020-10-10T00:00:05, 4, 10, 2]",
@@ -104,7 +104,7 @@ class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, HOP(rowtime, INTERVAL '5' SECOND, INTERVAL '10' SECOND)")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 1]",
@@ -132,7 +132,7 @@ class GroupWindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, Session(rowtime, INTERVAL '3' SECOND)")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 1]", "+I[a, 4]", "+I[b, 1]", "+I[b, 1]", "+I[b, 2]", "+I[null, 1]"),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IncrementalAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IncrementalAggregateJsonPlanITCase.java
@@ -72,7 +72,7 @@ class IncrementalAggregateJsonPlanITCase extends JsonPlanTestBase {
                                 + "from MyTable group by b")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(Arrays.asList("+I[1, 1]", "+I[2, 2]"), result);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IntervalJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/IntervalJoinJsonPlanITCase.java
@@ -65,7 +65,7 @@ class IntervalJoinJsonPlanITCase extends JsonPlanTestBase {
                         "+I[1, HiHi, Hi6]",
                         "+I[1, HiHi, Hi8]",
                         "+I[2, HeHe, Hi5]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -112,6 +112,6 @@ class IntervalJoinJsonPlanITCase extends JsonPlanTestBase {
                         "+I[1, HiHi, Hi2]",
                         "+I[1, HiHi, Hi3]",
                         "+I[2, HeHe, Hi5]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/JoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/JoinJsonPlanITCase.java
@@ -121,7 +121,7 @@ class JoinJsonPlanITCase extends JsonPlanTestBase {
                         "+I[1, HiHi, Hi8]",
                         "+I[2, HeHe, Hi5]",
                         "+I[null, HeHe, Hi9]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -132,7 +132,7 @@ class JoinJsonPlanITCase extends JsonPlanTestBase {
         List<String> expected =
                 Arrays.asList(
                         "+I[Hello world, Hallo Welt]", "+I[Hello, Hallo Welt]", "+I[Hi, Hallo]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -141,7 +141,7 @@ class JoinJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan("insert into MySink \n" + "SELECT a1, b1 FROM A JOIN B ON a1 = b1")
                 .await();
         List<String> expected = Arrays.asList("+I[1, 1]", "+I[2, 2]", "+I[2, 2]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -152,7 +152,7 @@ class JoinJsonPlanITCase extends JsonPlanTestBase {
                                 + "SELECT a3, b4 FROM A, B where a2 = b2 and a2 < 2")
                 .await();
         List<String> expected = Arrays.asList("+I[Hi, Hallo]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -163,6 +163,6 @@ class JoinJsonPlanITCase extends JsonPlanTestBase {
                                 + "SELECT a1, b1, b3 FROM A JOIN B ON a1 = b1 AND a1 = b3")
                 .await();
         List<String> expected = Arrays.asList("+I[2, 2, 2]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
@@ -45,6 +45,6 @@ class LimitJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[2, a, 6]", "+I[4, b, 8]", "+I[6, c, 10]");
-        assertResult(expected, TestValuesTableFactory.getResults("result"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("result"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
@@ -79,7 +79,7 @@ class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
                         "+I[1, 12, Julian, Julian]",
                         "+I[2, 15, Hello, Jark]",
                         "+I[3, 15, Fabian, Fabian]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -91,7 +91,7 @@ class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
                 .await();
         List<String> expected =
                 Arrays.asList("+I[2, 15, Hello, Jark]", "+I[3, 15, Fabian, Fabian]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -108,6 +108,6 @@ class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
                         "+I[3, 15, Fabian, null]",
                         "+I[8, 11, Hello world, null]",
                         "+I[9, 12, Hello world!, null]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
@@ -66,7 +66,7 @@ class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Collections.singletonList("+I[6, 7, 8]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -104,6 +104,6 @@ class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Collections.singletonList("+I[19, 13, null]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/OverAggregateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/OverAggregateJsonPlanITCase.java
@@ -75,7 +75,7 @@ class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
                         "+I[5, 33, 10]",
                         "+I[5, 46, 10]",
                         "+I[5, 60, 10]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -120,7 +120,7 @@ class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
                         "+I[Hello, 4, null]",
                         "+I[Hello, 5, null]",
                         "+I[Hello, 6, null]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -197,6 +197,6 @@ class OverAggregateJsonPlanITCase extends JsonPlanTestBase {
                         "+I[Hello World, 18, 1, 1, 7]",
                         "+I[Hello World, 8, 2, 2, 15]",
                         "+I[Hello World, 20, 1, 1, 20]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -48,7 +48,7 @@ class RankJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[1, a, 1]", "+I[3, b, 1]", "+I[5, c, 1]");
-        assertResult(expected, TestValuesTableFactory.getResults("result"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("result"));
     }
 
     @Test
@@ -70,6 +70,6 @@ class RankJsonPlanITCase extends JsonPlanTestBase {
         List<String> expected =
                 Arrays.asList(
                         "+I[book, 1, 1]", "+I[book, 2, 2]", "+I[fruit, 4, 1]", "+I[fruit, 3, 2]");
-        assertResult(expected, TestValuesTableFactory.getResults("result1"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("result1"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SargJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SargJsonPlanITCase.java
@@ -41,6 +41,6 @@ class SargJsonPlanITCase extends JsonPlanTestBase {
                         + "FROM MyTable WHERE a = 1 OR a = 2 OR a IS NULL";
         compileSqlAndExecutePlan(sql).await();
         List<String> expected = Arrays.asList("+I[1]", "+I[2]", "+I[null]");
-        assertResult(expected, TestValuesTableFactory.getResults("result"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("result"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
@@ -45,6 +45,6 @@ class SortLimitJsonPlanITCase extends JsonPlanTestBase {
         compileSqlAndExecutePlan(sql).await();
 
         List<String> expected = Arrays.asList("+I[1, a, 5]", "+I[2, a, 6]", "+I[3, b, 7]");
-        assertResult(expected, TestValuesTableFactory.getResults("result"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("result"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSinkJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TableSinkJsonPlanITCase.java
@@ -68,7 +68,7 @@ class TableSinkJsonPlanITCase extends JsonPlanTestBase {
 
         compileSqlAndExecutePlan("insert into MySink select * from MyTable").await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList("+I[1, 1, hi]", "+I[2, 1, hello]", "+I[3, 2, hello world]"), result);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalJoinJsonPlanITCase.java
@@ -89,7 +89,7 @@ class TemporalJoinJsonPlanITCase extends JsonPlanTestBase {
                                 + "WHERE o.currency = r.currency ")
                 .await();
         List<String> expected = Arrays.asList("+I[102]", "+I[228]", "+I[348]", "+I[50]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -102,6 +102,6 @@ class TemporalJoinJsonPlanITCase extends JsonPlanTestBase {
                                 + "ON o.currency = r.currency ")
                 .await();
         List<String> expected = Arrays.asList("+I[102]", "+I[228]", "+I[348]", "+I[50]");
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalSortJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/TemporalSortJsonITCase.java
@@ -48,7 +48,7 @@ class TemporalSortJsonITCase extends JsonPlanTestBase {
 
         assertResult(
                 Arrays.asList("+I[1]", "+I[2]", "+I[3]"),
-                TestValuesTableFactory.getResults("MySink"));
+                TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 
     @Test
@@ -78,7 +78,7 @@ class TemporalSortJsonITCase extends JsonPlanTestBase {
                         "insert into MySink SELECT `int` FROM MyTable order by rowtime, `double`")
                 .await();
 
-        assertThat(TestValuesTableFactory.getResults("MySink"))
+        assertThat(TestValuesTableFactory.getResultsAsStrings("MySink"))
                 .isEqualTo(
                         Arrays.asList(
                                 "+I[1]", "+I[2]", "+I[2]", "+I[5]", "+I[6]", "+I[3]", "+I[3]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/UnionJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/UnionJsonPlanITCase.java
@@ -61,6 +61,6 @@ class UnionJsonPlanITCase extends JsonPlanTestBase {
                         "+I[5, c, 9]",
                         "+I[3, b, 7]" // a=3 need to be doubled
                         );
-        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+        assertResult(expected, TestValuesTableFactory.getResultsAsStrings("MySink"));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
@@ -36,7 +36,7 @@ class ValuesJsonPlanITCase extends JsonPlanTestBase {
                         "INSERT INTO MySink SELECT * from (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(Arrays.asList("+I[1, 2, Hi]", "+I[3, 4, Hello]"), result);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowAggregateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowAggregateJsonITCase.java
@@ -103,7 +103,7 @@ class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, window_start, window_end")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 2020-10-10T00:00, 2020-10-10T00:00:05, 4, 10, 2]",
@@ -127,7 +127,7 @@ class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, window_start, window_end")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 1]",
@@ -160,7 +160,7 @@ class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, window_start, window_end")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 4]",
@@ -200,7 +200,7 @@ class WindowAggregateJsonITCase extends JsonPlanTestBase {
                                 + "GROUP BY name, window_start, window_end")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[a, 5.0, 3]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowDeduplicateJsonITCase.java
@@ -96,7 +96,7 @@ class WindowDeduplicateJsonITCase extends JsonPlanTestBase {
                                 + "WHERE rownum <= 1")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[2020-10-10 00:00:04, 5, 5.0, 5.0, 5.55, null, a, 2020-10-10 00:00:04.000, 2020-10-10T00:00, 2020-10-10T00:00:05, 2020-10-10T00:00:04.999]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowJoinJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowJoinJsonITCase.java
@@ -119,7 +119,7 @@ class WindowJoinJsonITCase extends JsonPlanTestBase {
                                 + "ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.name = R.name")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[b, 2020-10-10T00:00:05, 2020-10-10T00:00:10, 2, 2]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowTableFunctionJsonITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/WindowTableFunctionJsonITCase.java
@@ -90,7 +90,7 @@ class WindowTableFunctionJsonITCase extends JsonPlanTestBase {
                                 + "FROM TABLE(TUMBLE(TABLE MyTable, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))")
                 .await();
 
-        List<String> result = TestValuesTableFactory.getResults("MySink");
+        List<String> result = TestValuesTableFactory.getResultsAsStrings("MySink");
         assertResult(
                 Arrays.asList(
                         "+I[2020-10-10 00:00:01, 1, 1.0, 1.0, 1.11, Hi, a, 2020-10-10 00:00:01.000, 2020-10-10T00:00, 2020-10-10T00:00:05, 2020-10-10T00:00:04.999]",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -735,10 +735,10 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         // submits all source-to-sink pipelines
         testResult(env.fromElements(3, 4, 5), 3, 4, 5);
 
-        assertThat(TestValuesTableFactory.getResults("OutputTable1"))
+        assertThat(TestValuesTableFactory.getResultsAsStrings("OutputTable1"))
                 .containsExactlyInAnyOrder("+I[1, a]", "+I[2, b]");
 
-        assertThat(TestValuesTableFactory.getResults("OutputTable2"))
+        assertThat(TestValuesTableFactory.getResultsAsStrings("OutputTable2"))
                 .containsExactlyInAnyOrder("+I[1]", "+I[2]", "+I[3]");
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RTASITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RTASITCase.java
@@ -66,7 +66,7 @@ public class RTASITCase extends StreamingTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
                 .isEqualTo("[+I[1, 1, Hi], +I[2, 2, Hello], +I[3, 2, Hello world]]");
 
         // verify the table after replacing
@@ -97,7 +97,7 @@ public class RTASITCase extends StreamingTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
                 .isEqualTo("[+I[1, Hi], +I[2, Hello], +I[3, Hello world]]");
 
         // verify the table after replacing
@@ -117,7 +117,7 @@ public class RTASITCase extends StreamingTestBase {
                 .await();
 
         // verify written rows
-        assertThat(TestValuesTableFactory.getResults("not_exist_target").toString())
+        assertThat(TestValuesTableFactory.getResultsAsStrings("not_exist_target").toString())
                 .isEqualTo("[+I[1, Hi], +I[2, Hello], +I[3, Hello world]]");
 
         // verify the table after replacing

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CodeSplitITCase.scala
@@ -117,7 +117,7 @@ class CodeSplitITCase extends BatchTestBase {
     for (i <- 0 until 100) {
       expected.add(s"+I[${Range(0, 100).map(_ => s"$i").mkString(", ")}]")
     }
-    assertThatIterable(TestValuesTableFactory.getResults("test_many_values"))
+    assertThatIterable(TestValuesTableFactory.getResultsAsStrings("test_many_values"))
       .containsExactlyElementsOf(expected)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -58,7 +58,7 @@ class TableSinkITCase extends BatchTestBase {
       .select("12345", 55.cast(DataTypes.DECIMAL(10, 0)), "12345".cast(DataTypes.CHAR(5)))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     val expected = Seq("12345,55,12345")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
@@ -84,7 +84,7 @@ class TableSinkITCase extends BatchTestBase {
       .select("12345", 55.cast(DataTypes.DECIMAL(10, 0)), "12345".cast(DataTypes.CHAR(5)))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     val expected = Seq("12345,55,12345")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
@@ -110,7 +110,7 @@ class TableSinkITCase extends BatchTestBase {
       .select('a, 'b.sum())
     table.executeInsert("testSink").await()
 
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     val expected = List("1,0.1", "2,0.4", "3,1.0", "4,2.2", "5,3.9")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
@@ -135,7 +135,7 @@ class TableSinkITCase extends BatchTestBase {
       .select('a, 'b.sum())
     table.executeInsert("testSink").await()
 
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     val expected = List("1,0.1", "2,0.4", "3,1.0", "4,2.2", "5,3.9")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
@@ -167,7 +167,7 @@ class TableSinkITCase extends BatchTestBase {
       .await()
     val expected =
       List("1,2021,1,0.1", "2,2021,1,0.4", "3,2021,1,1.0", "4,2021,1,2.2", "5,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -193,7 +193,7 @@ class TableSinkITCase extends BatchTestBase {
                      |""".stripMargin)
       .await()
     val expected = List("null,0.1", "null,0.4", "null,1.0", "null,2.2", "null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -228,7 +228,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -259,7 +259,7 @@ class TableSinkITCase extends BatchTestBase {
       .await()
     val expected =
       List("1,2021,1,0.1", "2,2021,1,0.4", "3,2021,1,1.0", "4,2021,1,2.2", "5,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -294,7 +294,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,null,null,1.0",
       "null,null,null,2.2",
       "null,null,null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -329,7 +329,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -364,7 +364,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -399,7 +399,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 
@@ -434,7 +434,7 @@ class TableSinkITCase extends BatchTestBase {
       "null,2021,null,1.0",
       "null,2021,null,2.2",
       "null,2021,null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertThat(result.sorted).isEqualTo(expected.sorted)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
@@ -115,13 +115,13 @@ class ChangelogSourceITCase(
       "user1,Tom,tom123@gmail.com,8.10,16.20",
       "user3,Bailey,bailey@qq.com,9.99,19.98",
       "user4,Tina,tina@gmail.com,11.30,22.60")
-    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+    assertEquals(expected.sorted, TestValuesTableFactory.getResultsAsStrings("user_sink").sorted)
 
     sourceMode match {
       // verify the update_before messages haven been filtered when scanning changelog source
       // the CHANGELOG_SOURCE has I,UA,UB,D but no primary key, so we can not omit UB
       case CHANGELOG_SOURCE_WITH_EVENTS_DUPLICATE =>
-        val rawResult = TestValuesTableFactory.getRawResults("user_sink")
+        val rawResult = TestValuesTableFactory.getRawResultsAsStrings("user_sink")
         val hasUB = rawResult.exists(r => r.startsWith("-U"))
         assertFalse(
           s"Sink result shouldn't contain UPDATE_BEFORE, but is:\n ${rawResult.mkString("\n")}",
@@ -173,7 +173,7 @@ class ChangelogSourceITCase(
     tEnv.executeSql(dml).await()
 
     val expected = Seq("ALL,3,29.39,tom123@gmail.com")
-    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+    assertEquals(expected.sorted, TestValuesTableFactory.getResultsAsStrings("user_sink").sorted)
   }
 
   @Test
@@ -202,7 +202,7 @@ class ChangelogSourceITCase(
 
     val expected =
       Seq("16.20,1,tom123@gmail.com", "19.98,1,bailey@qq.com", "22.60,1,tina@gmail.com")
-    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+    assertEquals(expected.sorted, TestValuesTableFactory.getResultsAsStrings("user_sink").sorted)
   }
 
   @Test
@@ -233,7 +233,7 @@ class ChangelogSourceITCase(
 
     val expected =
       Seq("user3,Bailey,bailey@qq.com,9.99,19.98", "user4,Tina,tina@gmail.com,11.30,22.60")
-    assertEquals(expected.sorted, TestValuesTableFactory.getResults("user_sink").sorted)
+    assertEquals(expected.sorted, TestValuesTableFactory.getResultsAsStrings("user_sink").sorted)
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
@@ -198,7 +198,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("rowtime_sink")
 
     val expected = List(
       "+I(1,1,Hi,1970-01-01T00:00:00.001)",
@@ -237,7 +237,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("rowtime_sink")
 
     val expected = List(
       "+I(1,1,Hi,1970-01-01T00:00:00.001)",
@@ -279,7 +279,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
     """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getResultsAsStrings("rowtime_sink")
     val expected = List("6")
     assertEquals(expected.sorted, rawResult.sorted)
   }
@@ -306,7 +306,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("rowtime_sink")
 
     val expected = List(
       "+I(1,1,Hi,1970-01-01T00:00:00.001)",
@@ -349,7 +349,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getRawResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("rowtime_sink")
 
     val expected = List(
       "+I(1,1,Hi,1970-01-01T00:00:00.001)",
@@ -393,7 +393,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
     """.stripMargin
 
     tEnv.executeSql(sql).await()
-    val rawResult = TestValuesTableFactory.getResults("rowtime_sink")
+    val rawResult = TestValuesTableFactory.getResultsAsStrings("rowtime_sink")
     val expected = List("6")
     assertEquals(expected.sorted, rawResult.sorted)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -114,7 +114,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("JoinDisorderChangeLog")
+    val result = TestValuesTableFactory.getResultsAsStrings("JoinDisorderChangeLog")
     val expected = List("+I[jason, 4, 22.5, 22]")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -139,7 +139,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("SinkDisorderChangeLog")
+    val result = TestValuesTableFactory.getResultsAsStrings("SinkDisorderChangeLog")
     val expected = List("+I[jason, 4, 22.5]")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -168,7 +168,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
           |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("SinkRankChangeLog")
+    val result = TestValuesTableFactory.getResultsAsStrings("SinkRankChangeLog")
     val expected = List("+I[jason, 4]")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -197,14 +197,14 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                      |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("sink_with_pk")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink_with_pk")
     val expected = List(
       "+I[user1, Tom, tom123@gmail.com, 8.10]",
       "+I[user3, Bailey, bailey@qq.com, 9.99]",
       "+I[user4, Tina, tina@gmail.com, 11.30]")
     assertEquals(expected.sorted, result.sorted)
 
-    val rawResult = TestValuesTableFactory.getRawResults("sink_with_pk")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("sink_with_pk")
     val expectedRaw = List(
       "+I[user1, Tom, tom@gmail.com, 10.02]",
       "+I[user2, Jack, jack@hotmail.com, 71.20]",
@@ -246,7 +246,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("zm_test")
+    val result = TestValuesTableFactory.getResultsAsStrings("zm_test")
     val expected = List(
       "+I[jason, 1, null, null, null, null]",
       "+I[jason, 1, null, null, null, null]",
@@ -272,7 +272,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |    src
                     |""".stripMargin)
       .await()
-    val actual = TestValuesTableFactory.getResults("MyCtasTable")
+    val actual = TestValuesTableFactory.getResultsAsStrings("MyCtasTable")
     val expected = List(
       "+I[jason, 1]",
       "+I[jason, 1]",
@@ -295,7 +295,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                                 |    src
                                 |""".stripMargin)
     statementSet.execute().await()
-    val actualUseStatement = TestValuesTableFactory.getResults("MyCtasTableUseStatement")
+    val actualUseStatement = TestValuesTableFactory.getResultsAsStrings("MyCtasTableUseStatement")
     Assertions.assertThat(actualUseStatement.sorted).isEqualTo(expected.sorted)
   }
 
@@ -359,7 +359,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("test_sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("test_sink")
     val expected = List(
       "+I[1, jason, 3, null, null]",
       "+I[2, andy, 2, null, null]",
@@ -378,7 +378,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
                     |""".stripMargin)
       .await()
 
-    val result2 = TestValuesTableFactory.getResults("test_sink")
+    val result2 = TestValuesTableFactory.getResultsAsStrings("test_sink")
     val expected2 =
       List("+I[1, jason, 3, X, 43]", "+I[2, andy, 2, Y, 32]", "+I[3, clark, 1, Z, 29]")
     assertEquals(expected2.sorted, result2.sorted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.runtime.stream.sql
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.factories.TestValuesTableFactory.{getResults, registerData}
+import org.apache.flink.table.planner.factories.TestValuesTableFactory.{getResultsAsStrings, registerData}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.utils.LegacyRowResource
@@ -477,7 +477,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -495,7 +495,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -513,7 +513,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
     val expected = List(
       "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
       "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02")
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -532,7 +532,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,null,null"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -553,7 +553,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,null,null"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -574,7 +574,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,null,null"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -592,7 +592,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -609,7 +609,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -625,7 +625,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -663,7 +663,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,null,null,null,null"
     )
-    assertEquals(expected.sorted, getResults("rowtime_sink1").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_sink1").sorted)
   }
 
   @Test
@@ -683,7 +683,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,114,2020-08-15T00:00:01",
       "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -703,7 +703,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -723,7 +723,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,null,null",
       "5,RMB,40,2020-08-16T00:03,null,null"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -750,7 +750,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
       "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
       "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04"
     )
-    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
+    assertEquals(expected.sorted, getResultsAsStrings("rowtime_default_sink").sorted)
   }
 
   private def createSinkTable(tableName: String, columns: Option[String]): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -75,7 +75,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('w.end.as('t), 'id.count.as('icnt), 'num.sum.as('nsum))
     table.executeInsert("appendSink").await()
 
-    val result = TestValuesTableFactory.getResults("appendSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("appendSink")
     val expected = List(
       "1970-01-01T00:00:00.005,4,8",
       "1970-01-01T00:00:00.010,5,18",
@@ -108,7 +108,7 @@ class TableSinkITCase extends StreamingTestBase {
         "INSERT INTO appendSink /*+ OPTIONS('sink.parallelism' = '1') */(t, num, text) SELECT id, num, text FROM src")
       .await()
 
-    val result = TestValuesTableFactory.getResults("appendSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("appendSink")
     val expected = List("1,1,Hi", "2,2,Hello", "3,2,Hello world")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -131,7 +131,7 @@ class TableSinkITCase extends StreamingTestBase {
                        |""".stripMargin)
     tEnv.executeSql("INSERT INTO appendSink SELECT id, ROW(num, text) FROM src").await()
 
-    val result = TestValuesTableFactory.getResults("appendSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("appendSink")
     val expected = List("1,1,Hi", "2,2,Hello", "3,2,Hello world")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -157,7 +157,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('c, 'g)
     table.executeInsert("appendSink").await()
 
-    val result = TestValuesTableFactory.getResults("appendSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("appendSink")
     val expected = List("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -186,7 +186,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('len, 'id.count.as('icnt), 'num.sum.as('nsum))
     table.executeInsert("retractSink").await()
 
-    val result = TestValuesTableFactory.getResults("retractSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("retractSink")
     val expected = List("2,1,1", "5,1,2", "11,1,2", "25,1,3", "10,7,39", "14,1,3", "9,9,41")
     assertEquals(expected.sorted, result.sorted)
 
@@ -216,13 +216,13 @@ class TableSinkITCase extends StreamingTestBase {
       .select('w.end.as('t), 'id.count.as('icnt), 'num.sum.as('nsum))
     table.executeInsert("retractSink").await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("retractSink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("retractSink")
     assertFalse(
       "Received retraction messages for append only table",
       rawResult.exists(_.startsWith("-"))
     ) // maybe -U or -D
 
-    val result = TestValuesTableFactory.getResults("retractSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("retractSink")
     val expected = List(
       "1970-01-01T00:00:00.005,4,8",
       "1970-01-01T00:00:00.010,5,18",
@@ -261,10 +261,10 @@ class TableSinkITCase extends StreamingTestBase {
       .select('count, 'len.count.as('lencnt), 'cTrue)
     table.executeInsert("upsertSink").await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("upsertSink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("upsertSink")
     assertTrue("Results must include delete messages", rawResult.exists(_.startsWith("-D(")))
 
-    val result = TestValuesTableFactory.getResults("upsertSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("upsertSink")
     val expected = List("1,5,true", "7,1,true", "9,1,true")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -295,13 +295,13 @@ class TableSinkITCase extends StreamingTestBase {
       .select('num, 'w.end.as('window_end), 'id.count.as('icnt))
     table.executeInsert("upsertSink").await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("upsertSink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("upsertSink")
     assertFalse(
       "Received retraction messages for append only table",
       rawResult.exists(_.startsWith("-"))
     ) // maybe -D or -U
 
-    val result = TestValuesTableFactory.getResults("upsertSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("upsertSink")
     val expected = List(
       "1,1970-01-01T00:00:00.005,1",
       "2,1970-01-01T00:00:00.005,2",
@@ -341,7 +341,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('w.end.as('wend), 'id.count.as('cnt))
     table.executeInsert("upsertSink").await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("upsertSink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("upsertSink")
     assertFalse(
       "Received retraction messages for append only table",
       rawResult.exists(_.startsWith("-"))
@@ -386,7 +386,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('num, 'id.count.as('cnt))
     table.executeInsert("upsertSink").await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("upsertSink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("upsertSink")
     assertFalse(
       "Received retraction messages for append only table",
       rawResult.exists(_.startsWith("-"))
@@ -438,7 +438,7 @@ class TableSinkITCase extends StreamingTestBase {
       .where('cnt <= 3)
     table.executeInsert("upsertSink").await()
 
-    val result = TestValuesTableFactory.getResults("upsertSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("upsertSink")
     val expected = List("1,1", "2,2", "3,3")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -502,7 +502,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('num, 'w.rowtime.as('rowtime1), 'w.rowtime.as('rowtime2))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     assertEquals(result.size(), 10)
 
     // clean up
@@ -532,7 +532,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select("12345", 55.cast(DataTypes.DECIMAL(10, 0)), "12345".cast(DataTypes.CHAR(5)))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     val expected = Seq("12345,55,12345")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -558,7 +558,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select("12345", 55.cast(DataTypes.DECIMAL(10, 0)), "12345".cast(DataTypes.CHAR(5)))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     val expected = Seq("12345,55,12345")
     assertEquals(expected.sorted, result.sorted)
   }
@@ -608,7 +608,7 @@ class TableSinkITCase extends StreamingTestBase {
                     |""".stripMargin)
       .await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("changelog_sink")
+    val rawResult = TestValuesTableFactory.getRawResultsAsStrings("changelog_sink")
     val expected = List(
       "+I(1,user2,71.20)",
       "+I(1,user1,10.02)",
@@ -659,7 +659,7 @@ class TableSinkITCase extends StreamingTestBase {
                     |GROUP BY user_name
                     |""".stripMargin)
       .await()
-    val finalResult = TestValuesTableFactory.getResults("final_sink")
+    val finalResult = TestValuesTableFactory.getResultsAsStrings("final_sink")
     val finalExpected = List("user1,28.12", "user2,71.20", "user3,32.33", "user4,9.99")
     assertEquals(finalExpected.sorted, finalResult.sorted)
   }
@@ -701,7 +701,7 @@ class TableSinkITCase extends StreamingTestBase {
                      |""".stripMargin)
       .await()
 
-    val result = TestValuesTableFactory.getResults("MetadataSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("MetadataSink")
     val expected =
       List("1,book,12", "2,book,null", "3,fruit,44", "4,book,11", "4,fruit,null", "5,fruit,null")
     assertEquals(expected.sorted, result.sorted)
@@ -815,7 +815,7 @@ class TableSinkITCase extends StreamingTestBase {
                      |""".stripMargin)
       .await()
     val expected = List("null,0.1", "null,0.4", "null,1.0", "null,2.2", "null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -851,7 +851,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -883,7 +883,7 @@ class TableSinkITCase extends StreamingTestBase {
       .await()
     val expected =
       List("1,2021,1,0.1", "2,2021,1,0.4", "3,2021,1,1.0", "4,2021,1,2.2", "5,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -919,7 +919,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,null,null,1.0",
       "null,null,null,2.2",
       "null,null,null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -958,7 +958,7 @@ class TableSinkITCase extends StreamingTestBase {
       "1,c,c1,c2,33333,12,1.0",
       "1,c,c1,c2,33333,12,2.2",
       "1,c,c1,c2,33333,12,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -995,7 +995,7 @@ class TableSinkITCase extends StreamingTestBase {
       "1,c,c1,c2,33333,12,1.0",
       "1,c,c1,c2,33333,12,2.2",
       "1,c,c1,c2,33333,12,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -1031,7 +1031,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -1068,7 +1068,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -1104,7 +1104,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,2021,1,1.0",
       "null,2021,1,2.2",
       "null,2021,1,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -1140,7 +1140,7 @@ class TableSinkITCase extends StreamingTestBase {
       "null,2021,null,1.0",
       "null,2021,null,2.2",
       "null,2021,null,3.9")
-    val result = TestValuesTableFactory.getResults("testSink")
+    val result = TestValuesTableFactory.getResultsAsStrings("testSink")
     assertEquals(expected.sorted, result.sorted)
   }
 
@@ -1235,7 +1235,7 @@ class TableSinkITCase extends StreamingTestBase {
               .build())
           .build())
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
 
     // Derived schema
 
@@ -1247,7 +1247,7 @@ class TableSinkITCase extends StreamingTestBase {
       .from("T2")
       .executeInsert(TableDescriptor.forConnector("values").build())
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
 
     // Enriched schema
 
@@ -1269,7 +1269,7 @@ class TableSinkITCase extends StreamingTestBase {
               .build())
           .build())
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
     TestValuesTableFactory.clearAllData()
   }
 
@@ -1303,7 +1303,7 @@ class TableSinkITCase extends StreamingTestBase {
       )
       .execute()
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
 
     // Derived schema
 
@@ -1319,7 +1319,7 @@ class TableSinkITCase extends StreamingTestBase {
       )
       .execute()
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
 
     // Enriched schema
 
@@ -1344,7 +1344,7 @@ class TableSinkITCase extends StreamingTestBase {
       )
       .execute()
       .await()
-    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResults.toList)
+    assertEquals(Seq("+I(42)"), TestValuesTableFactory.getOnlyRawResultsAsStrings.toList)
   }
 
   @Test
@@ -1375,7 +1375,7 @@ class TableSinkITCase extends StreamingTestBase {
       .select('w.end.as('t), 'id.count.as('icnt), 'num.sum.as('nsum))
     table.executeInsert("sink").await()
 
-    val result = TestValuesTableFactory.getResults("sink")
+    val result = TestValuesTableFactory.getResultsAsStrings("sink")
     val expected = List(
       "1970-01-01T00:00:00.005,4,8",
       "1970-01-01T00:00:00.010,5,18",


### PR DESCRIPTION
## What is the purpose of the change

If we want to use the predicates from https://github.com/apache/flink/pull/23584 in restore tests we need to make testing sinks return Rows instead of Strings

## Verifying this change

All existing tests still work.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
