### PR TITLE
[hotfix] Prepare StatefulSequenceSource for removal in 2.0

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/StatefulSequenceSource.java
@@ -42,6 +42,9 @@ import java.util.Deque;
  * <p>This strategy guarantees that each element will be emitted exactly-once, but elements will not
  * necessarily be emitted in ascending order, even for the same tasks.
  *
+ * <p>NOTE: this source will be removed together with the deprecated
+ * StreamExecutionEnvironmetn#generateSequence() method.
+ *
  * @deprecated This class is based on the {@link
  *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -21,7 +21,6 @@ package org.apache.flink.connector.datagen.table;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.connector.datagen.table.types.RowDataGenerator;
-import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -33,10 +32,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.types.DataType;
 
-/**
- * A {@link StreamTableSource} that emits each number from a given interval exactly once, possibly
- * in parallel. See {@link StatefulSequenceSource}.
- */
+/** A {@link StreamTableSource} that emits generated data rows. */
 @Internal
 public class DataGenTableSource implements ScanTableSource, SupportsLimitPushDown {
 


### PR DESCRIPTION
This a simple fix for an erroneous reference to `StatefulSequenceSource` in `DataGenTableSource` and preparation for its removal in 2.0