### PR TITLE
[FLINK-31481][table] Support enhanced show databases syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -507,7 +507,7 @@ SHOW CURRENT CATALOG
 ## SHOW DATABASES
 
 ```sql
-SHOW DATABASES
+SHOW DATABASES [ ( FROM | IN ) catalog_name] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
 展示当前 catalog 中所有的 database。

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -507,10 +507,22 @@ Show current catalog.
 ## SHOW DATABASES
 
 ```sql
-SHOW DATABASES
+SHOW DATABASES [ ( FROM | IN ) catalog_name] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
 ```
 
-Show all databases in the current catalog.
+Show all databases within optionally specified catalog. 
+If no catalog is specified, then the default catalog is used. 
+Additionally, a `<sql_like_pattern>` can be used to filter the databases.
+
+**LIKE**
+Show all databases with a `LIKE` clause, whose name is similar to the `<sql_like_pattern>`.
+
+The syntax of the SQL pattern in the `LIKE` clause is the same as that of the `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, and `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
+
+**ILIKE**
+The same behavior as `LIKE` but the SQL pattern is case-insensitive.
 
 ## SHOW CURRENT DATABASE
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -110,6 +110,70 @@ show databases;
 2 rows in set
 !ok
 
+create database db2;
+[INFO] Execute statement succeed.
+!info
+
+show databases like 'db%';
++---------------+
+| database name |
++---------------+
+|           db1 |
+|           db2 |
++---------------+
+2 rows in set
+!ok
+
+show databases ilike 'db%';
++---------------+
+| database name |
++---------------+
+|           db1 |
+|           db2 |
++---------------+
+2 rows in set
+!ok
+
+show databases like 'db1%';
++---------------+
+| database name |
++---------------+
+|           db1 |
++---------------+
+1 row in set
+!ok
+
+show databases ilike 'db1%';
++---------------+
+| database name |
++---------------+
+|           db1 |
++---------------+
+1 row in set
+!ok
+
+show databases like 'db2%';
++---------------+
+| database name |
++---------------+
+|           db2 |
++---------------+
+1 row in set
+!ok
+
+show databases ilike 'db2%';
++---------------+
+| database name |
++---------------+
+|           db2 |
++---------------+
+1 row in set
+!ok
+
+drop database db2;
+[INFO] Execute statement succeed.
+!info
+
 show current database;
 +-----------------------+
 | current database name |
@@ -152,6 +216,101 @@ show databases;
 +---------------+
 3 rows in set
 !ok
+
+create catalog `c0` with ('type'='generic_in_memory');
+[INFO] Execute statement succeed.
+!info
+
+create database c0.db0a;
+[INFO] Execute statement succeed.
+!info
+
+create database c0.db0b;
+[INFO] Execute statement succeed.
+!info
+
+show databases from c0;
++---------------+
+| database name |
++---------------+
+|          db0a |
+|          db0b |
+|       default |
++---------------+
+3 rows in set
+!ok
+
+show databases from c0 like 'db0a%';
++---------------+
+| database name |
++---------------+
+|          db0a |
++---------------+
+1 row in set
+!ok
+
+show databases from c0 ilike 'db0a%';
++---------------+
+| database name |
++---------------+
+|          db0a |
++---------------+
+1 row in set
+!ok
+
+show databases from c0 not like 'db0a%';
++---------------+
+| database name |
++---------------+
+|          db0b |
+|       default |
++---------------+
+2 rows in set
+!ok
+
+show databases from c0 not ilike 'db0a%';
++---------------+
+| database name |
++---------------+
+|          db0b |
+|       default |
++---------------+
+2 rows in set
+!ok
+
+show databases from c0 like 'db%';
++---------------+
+| database name |
++---------------+
+|          db0a |
+|          db0b |
++---------------+
+2 rows in set
+!ok
+
+show databases from c0 ilike 'db%';
++---------------+
+| database name |
++---------------+
+|          db0a |
+|          db0b |
++---------------+
+2 rows in set
+!ok
+
+show databases in c0.t;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.sql.parser.impl.ParseException: Show databases from/in identifier [ c0.t ] format error, catalog must be a single part identifier.
+!error
+
+drop catalog `c0`;
+[INFO] Execute statement succeed.
+!info
+
+show databases from c0;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.ValidationException: Catalog c0 does not exist
+!error
 
 drop database if exists db2;
 [INFO] Execute statement succeed.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -146,11 +146,50 @@ SqlDrop SqlDropCatalog(Span s, boolean replace) :
 */
 SqlShowDatabases SqlShowDatabases() :
 {
+    SqlParserPos pos;
+    String prep = null;
+    SqlIdentifier catalogName = null;
+    String likeType = null;
+    SqlCharStringLiteral likeLiteral = null;
+    boolean notLike = false;
 }
 {
-    <SHOW> <DATABASES>
+    <SHOW>
     {
-        return new SqlShowDatabases(getPos());
+        pos = getPos();
+    }
+    <DATABASES>
+    [
+        ( <FROM> { prep = "FROM"; } | <IN> { prep = "IN"; } )
+        { pos = getPos(); }
+        catalogName = CompoundIdentifier()
+    ]
+    [
+        [
+            <NOT>
+            {
+                notLike = true;
+            }
+        ]
+        (
+            <LIKE>
+            {
+                likeType = "LIKE";
+            }
+        |
+            <ILIKE>
+            {
+                likeType = "ILIKE";
+            }
+        )
+        <QUOTED_STRING>
+        {
+            String likeCondition = SqlParserUtil.parseString(token.image);
+            likeLiteral = SqlLiteral.createCharString(likeCondition, getPos());
+        }
+    ]
+    {
+        return new SqlShowDatabases(pos, prep, catalogName, likeType, likeLiteral, notLike);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.flink.sql.parser.impl.ParseException;
+
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -29,14 +33,64 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import java.util.Collections;
 import java.util.List;
 
-/** SHOW Databases sql call. */
+import static java.util.Objects.requireNonNull;
+
+/**
+ * SHOW Databases sql call. The full syntax for show databases is as followings:
+ *
+ * <pre>{@code
+ * SHOW DATABASES [ ( FROM | IN ) catalog_name] [ [NOT] (LIKE | ILIKE)
+ * <sql_like_pattern> ] statement
+ * }</pre>
+ */
 public class SqlShowDatabases extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("SHOW DATABASES", SqlKind.OTHER);
 
-    public SqlShowDatabases(SqlParserPos pos) {
+    private final String preposition;
+    private final SqlIdentifier catalogName;
+    private final String likeType;
+    private final SqlCharStringLiteral likeLiteral;
+    private final boolean notLike;
+
+    public String[] getCatalog() {
+        return catalogName == null || catalogName.names.isEmpty()
+                ? new String[] {}
+                : catalogName.names.toArray(new String[0]);
+    }
+
+    public SqlShowDatabases(
+            SqlParserPos pos,
+            String preposition,
+            SqlIdentifier catalogName,
+            String likeType,
+            SqlCharStringLiteral likeLiteral,
+            boolean notLike)
+            throws ParseException {
         super(pos);
+        this.preposition = preposition;
+
+        this.catalogName =
+                preposition != null
+                        ? requireNonNull(catalogName, "Catalog name must not be null.")
+                        : null;
+        if (this.catalogName != null && this.catalogName.names.size() > 1) {
+            throw new ParseException(
+                    String.format(
+                            "Show databases from/in identifier [ %s ] format error, catalog must be a single part identifier.",
+                            String.join(".", this.catalogName.names)));
+        }
+
+        if (likeType != null) {
+            this.likeType = likeType;
+            this.likeLiteral = requireNonNull(likeLiteral, "Like pattern must not be null");
+            this.notLike = notLike;
+        } else {
+            this.likeType = null;
+            this.likeLiteral = null;
+            this.notLike = false;
+        }
     }
 
     @Override
@@ -46,11 +100,39 @@ public class SqlShowDatabases extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.EMPTY_LIST;
+        return catalogName == null
+                ? Collections.emptyList()
+                : Collections.singletonList(catalogName);
     }
 
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         writer.keyword("SHOW DATABASES");
+        if (preposition != null) {
+            writer.keyword(preposition);
+            catalogName.unparse(writer, leftPrec, rightPrec);
+        }
+        if (likeType != null) {
+            writer.keyword(
+                    isNotLike()
+                            ? String.format("NOT %s '%s'", likeType, getLikeSqlPattern())
+                            : String.format("%s '%s'", likeType, getLikeSqlPattern()));
+        }
+    }
+
+    public String getLikeSqlPattern() {
+        return likeLiteral == null ? null : likeLiteral.getValueAs(String.class);
+    }
+
+    public boolean isNotLike() {
+        return notLike;
+    }
+
+    public String getPreposition() {
+        return preposition;
+    }
+
+    public String getLikeType() {
+        return likeType;
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -124,6 +124,31 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testShowDataBases() {
         sql("show databases").ok("SHOW DATABASES");
+
+        sql("show databases like '%'").ok("SHOW DATABASES LIKE '%'");
+        sql("show databases not like '%'").ok("SHOW DATABASES NOT LIKE '%'");
+
+        sql("show databases from c1").ok("SHOW DATABASES FROM `C1`");
+        sql("show databases in c1").ok("SHOW DATABASES IN `C1`");
+
+        sql("show databases from c1 like '%'").ok("SHOW DATABASES FROM `C1` LIKE '%'");
+        sql("show databases from c1 ilike '%'").ok("SHOW DATABASES FROM `C1` ILIKE '%'");
+        sql("show databases in c1 like '%'").ok("SHOW DATABASES IN `C1` LIKE '%'");
+        sql("show databases in c1 ilike '%'").ok("SHOW DATABASES IN `C1` ILIKE '%'");
+
+        sql("show databases from c1 not like '%'").ok("SHOW DATABASES FROM `C1` NOT LIKE '%'");
+        sql("show databases from c1 not ilike '%'").ok("SHOW DATABASES FROM `C1` NOT ILIKE '%'");
+        sql("show databases in c1 not like '%'").ok("SHOW DATABASES IN `C1` NOT LIKE '%'");
+        sql("show databases in c1 not ilike '%'").ok("SHOW DATABASES IN `C1` NOT ILIKE '%'");
+
+        sql("show databases ^likes^")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 16.\n.*");
+        sql("show databases not ^likes^")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 20" + ".\n" + ".*");
+        sql("show databases ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 16.\n.*");
+        sql("show databases not ^ilikes^")
+                .fails("(?s).*Encountered \"ilikes\" at line 1, column 20" + ".\n" + ".*");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
@@ -20,26 +20,82 @@ package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.functions.SqlLikeUtils;
 
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
 import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
 
 /** Operation to describe a SHOW DATABASES statement. */
 @Internal
 public class ShowDatabasesOperation implements ShowOperation {
 
+    private final String catalogName;
+    private final LikeType likeType;
+    private final String likePattern;
+    private final boolean notLike;
+
+    public ShowDatabasesOperation() {
+        // "SHOW DATABASES" command with all options being default
+        this(null, null, null, false);
+    }
+
+    public ShowDatabasesOperation(String likeType, String likePattern, boolean notLike) {
+        this(null, likeType, likePattern, notLike);
+    }
+
+    public ShowDatabasesOperation(
+            String catalogName, String likeType, String likePattern, boolean notLike) {
+        this.catalogName = catalogName;
+        if (likeType != null) {
+            this.likeType = LikeType.of(likeType);
+            this.likePattern = requireNonNull(likePattern, "Like pattern must not be null");
+            this.notLike = notLike;
+        } else {
+            this.likeType = null;
+            this.likePattern = null;
+            this.notLike = false;
+        }
+    }
+
     @Override
     public String asSummaryString() {
-        return "SHOW DATABASES";
+        StringBuilder builder = new StringBuilder();
+        builder.append("SHOW DATABASES");
+        if (catalogName != null) {
+            builder.append(String.format(" FROM/IN %s", catalogName));
+        }
+        if (likeType != null) {
+            if (notLike) {
+                builder.append(String.format(" NOT %s '%s'", likeType.name(), likePattern));
+            } else {
+                builder.append(String.format(" %s '%s'", likeType.name(), likePattern));
+            }
+        }
+        return builder.toString();
     }
 
     @Override
     public TableResultInternal execute(Context ctx) {
-        String[] databases =
-                ctx.getCatalogManager()
-                        .getCatalogOrThrowException(ctx.getCatalogManager().getCurrentCatalog())
-                        .listDatabases().stream()
-                        .sorted()
-                        .toArray(String[]::new);
-        return buildStringArrayResult("database name", databases);
+        String cName =
+                catalogName == null ? ctx.getCatalogManager().getCurrentCatalog() : catalogName;
+        Stream<String> databases =
+                ctx.getCatalogManager().getCatalogOrThrowException(cName).listDatabases().stream();
+
+        if (likeType != null) {
+            databases =
+                    databases.filter(
+                            row -> {
+                                if (likeType == LikeType.ILIKE) {
+                                    return notLike != SqlLikeUtils.ilike(row, likePattern, "\\");
+                                } else if (likeType == LikeType.LIKE) {
+                                    return notLike != SqlLikeUtils.like(row, likePattern, "\\");
+                                }
+                                return false;
+                            });
+        }
+
+        return buildStringArrayResult("database name", databases.sorted().toArray(String[]::new));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -69,7 +69,6 @@ import org.apache.flink.sql.parser.dql.SqlShowCreateTable;
 import org.apache.flink.sql.parser.dql.SqlShowCreateView;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentCatalog;
 import org.apache.flink.sql.parser.dql.SqlShowCurrentDatabase;
-import org.apache.flink.sql.parser.dql.SqlShowDatabases;
 import org.apache.flink.sql.parser.dql.SqlShowJars;
 import org.apache.flink.sql.parser.dql.SqlShowJobs;
 import org.apache.flink.sql.parser.dql.SqlShowModules;
@@ -131,7 +130,6 @@ import org.apache.flink.table.operations.ShowCreateTableOperation;
 import org.apache.flink.table.operations.ShowCreateViewOperation;
 import org.apache.flink.table.operations.ShowCurrentCatalogOperation;
 import org.apache.flink.table.operations.ShowCurrentDatabaseOperation;
-import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowModulesOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.ShowViewsOperation;
@@ -300,8 +298,6 @@ public class SqlNodeToOperationConversion {
             return Optional.of(converter.convertDropDatabase((SqlDropDatabase) validated));
         } else if (validated instanceof SqlAlterDatabase) {
             return Optional.of(converter.convertAlterDatabase((SqlAlterDatabase) validated));
-        } else if (validated instanceof SqlShowDatabases) {
-            return Optional.of(converter.convertShowDatabases((SqlShowDatabases) validated));
         } else if (validated instanceof SqlShowCurrentDatabase) {
             return Optional.of(
                     converter.convertShowCurrentDatabase((SqlShowCurrentDatabase) validated));
@@ -894,11 +890,6 @@ public class SqlNodeToOperationConversion {
     /** Convert SHOW CURRENT CATALOG statement. */
     private Operation convertShowCurrentCatalog(SqlShowCurrentCatalog sqlShowCurrentCatalog) {
         return new ShowCurrentCatalogOperation();
-    }
-
-    /** Convert SHOW DATABASES statement. */
-    private Operation convertShowDatabases(SqlShowDatabases sqlShowDatabases) {
-        return new ShowDatabasesOperation();
     }
 
     /** Convert SHOW CURRENT DATABASE statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -52,6 +52,7 @@ public class SqlNodeConverters {
         register(new SqlShowProcedureConverter());
         register(new SqlReplaceTableAsConverter());
         register(new SqlProcedureCallConverter());
+        register(new SqlShowDatabasesConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowDatabasesConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowDatabasesConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowDatabases;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowDatabasesOperation;
+
+/** A converter for {@link SqlShowDatabases}. */
+public class SqlShowDatabasesConverter implements SqlNodeConverter<SqlShowDatabases> {
+
+    @Override
+    public Operation convertSqlNode(SqlShowDatabases sqlShowDatabases, ConvertContext context) {
+        if (sqlShowDatabases.getPreposition() == null) {
+            return new ShowDatabasesOperation(
+                    sqlShowDatabases.getLikeType(),
+                    sqlShowDatabases.getLikeSqlPattern(),
+                    sqlShowDatabases.isNotLike());
+        } else {
+            return new ShowDatabasesOperation(
+                    sqlShowDatabases.getCatalog()[0],
+                    sqlShowDatabases.getLikeType(),
+                    sqlShowDatabases.getLikeSqlPattern(),
+                    sqlShowDatabases.isNotLike());
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support enhanced show functions syntax described in [FLIP-297](https://cwiki.apache.org/confluence/display/FLINK/FLIP-297%3A+Improve+Auxiliary+Sql+Statements)


## Brief change log

Changelog from:
```
SHOW DATABASES
```

to:

```
SHOW DATABASES [ ( FROM | IN ) catalog_name] [ [NOT] (LIKE | ILIKE) <sql_like_pattern> ]
```



## Verifying this change

  - Extended integration tests `flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q`
  - Extended unit test `flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java -> testShowDataBases()`
  - Added unit tests in `flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java -> testShowDatabases()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
