### PR TITLE
[hotfix][docs] Add SQL Gateway doc reference in the Chinese version of table overview

### DIFF
--- a/docs/content.zh/docs/dev/table/overview.md
+++ b/docs/content.zh/docs/dev/table/overview.md
@@ -52,6 +52,7 @@ and later use the DataStream API to build alerting based on the matched patterns
 * [SQL]({{< ref "docs/dev/table/sql/overview" >}}): SQL 支持的操作和语法。
 * [内置函数]({{< ref "docs/dev/table/functions/systemFunctions" >}}): Table API 和 SQL 中的内置函数。
 * [SQL Client]({{< ref "docs/dev/table/sqlClient" >}}): 不用编写代码就可以尝试 Flink SQL，可以直接提交 SQL 任务到集群上。
+* [SQL Gateway]({{< ref "docs/dev/table/sql-gateway/overview" >}}): SQL 提交服务，支持多个客户端从远端并发提交 SQL 任务。
 * [SQL Jdbc Driver]({{< ref "docs/dev/table/jdbcDriver" >}}): 标准JDBC Driver，可以提交Flink SQL作业到Sql Gateway。
 * [OLAP Quickstart]({{< ref "docs/dev/table/olap_quickstart" >}}): Flink OLAP服务搭建指南.
 


### PR DESCRIPTION
## What is the purpose of the change

 Add SQL Gateway doc reference in the Chinese version of table overview

## Brief change log

Add SQL Gateway doc reference in docs/content.zh/docs/dev/table/overview.md

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
