### PR TITLE
[FLINK-26624][Runtime] 1.18 backport Running HA (hashmap, async) end-to-end test failed on azu

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ha.sh
@@ -49,7 +49,7 @@ function verify_num_occurences_in_logs() {
     local text="$2"
     local expected_no="$3"
 
-    local actual_no=$(grep -r --include "*${log_pattern}*.log*" -e "${text}" "$FLINK_LOG_DIR/" | cut -d ":" -f 1 | sed "s/\.[0-9]\{1,\}$//g" | uniq | wc -l)
+    local actual_no=$(grep -r --include "*${log_pattern}*.log*" -e "${text}" "$FLINK_LOG_DIR/" | cut -d ":" -f 1 | sed "s/\.[0-9]\{1,\}$//g" | sort -u | wc -l)
     [[ "${expected_no}" -eq "${actual_no}" ]]
 }
 


### PR DESCRIPTION
1.18 backport for PR https://github.com/apache/flink/pull/23614

## What is the purpose of the change

*(Running HA (hashmap, async) end-to-end test failed on azure due to unable to find master logs.)*


## Brief change log

  - *1.18 backport PR, modify  verify_num_occurences_in_logs.sh, Changed `uniq `to `sort -u`*

## Verifying this change
  - *This change is already covered by existing test.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? no)
  - If yes, how is the feature documented? (not applicable)
