### PR TITLE
[FLINK-33210] Introduce lineage graph relevant interfaces

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetConfigFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetConfigFacet.java
@@ -21,14 +21,10 @@ package org.apache.flink.streaming.api.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.List;
+import java.util.Map;
 
-/**
- * Lineage vertex represents the connectors in lineage graph, including source {@link
- * SourceLineageVertex} and sink.
- */
+/** Builtin config facet for dataset. */
 @PublicEvolving
-public interface LineageVertex {
-    /* List of input (for source) or output (for sink) datasets interacted with by the connector */
-    List<LineageDataset> datasets();
+public interface DatasetConfigFacet extends LineageDatasetFacet {
+    Map<String, String> config();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaFacet.java
@@ -21,14 +21,10 @@ package org.apache.flink.streaming.api.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.List;
+import java.util.Map;
 
-/**
- * Lineage vertex represents the connectors in lineage graph, including source {@link
- * SourceLineageVertex} and sink.
- */
+/** Builtin schema facet for dataset. */
 @PublicEvolving
-public interface LineageVertex {
-    /* List of input (for source) or output (for sink) datasets interacted with by the connector */
-    List<LineageDataset> datasets();
+public interface DatasetSchemaFacet extends LineageDatasetFacet {
+    <T> Map<String, DatasetSchemaField<T>> fields();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
@@ -23,6 +23,7 @@ package org.apache.flink.streaming.api.lineage;
 public interface DatasetSchemaField<T> {
     /** The name of the field. */
     String name();
+
     /** The type of the field. */
     T type();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
@@ -19,7 +19,10 @@
 
 package org.apache.flink.streaming.api.lineage;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 /** Field for schema in dataset. */
+@PublicEvolving
 public interface DatasetSchemaField<T> {
     /** The name of the field. */
     String name();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
@@ -19,16 +19,10 @@
 
 package org.apache.flink.streaming.api.lineage;
 
-import org.apache.flink.annotation.PublicEvolving;
-
-import java.util.List;
-
-/**
- * Lineage vertex represents the connectors in lineage graph, including source {@link
- * SourceLineageVertex} and sink.
- */
-@PublicEvolving
-public interface LineageVertex {
-    /* List of input (for source) or output (for sink) datasets interacted with by the connector */
-    List<LineageDataset> datasets();
+/** Field for schema in dataset. */
+public interface DatasetSchemaField<T> {
+    /** The name of the field. */
+    String name();
+    /** The type of the field. */
+    T type();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Default implementation for {@link LineageGraph}. */
+public class DefaultLineageGraph implements LineageGraph {
+    private final List<LineageEdge> lineageEdges;
+    private final List<SourceLineageVertex> sources;
+    private final List<LineageVertex> sinks;
+
+    private DefaultLineageGraph(List<LineageEdge> lineageEdges) {
+        this.lineageEdges = lineageEdges;
+
+        Set<SourceLineageVertex> srcs = new HashSet<>();
+        Set<LineageVertex> targets = new HashSet<>();
+        for (LineageEdge lineageEdge : lineageEdges) {
+            srcs.add(lineageEdge.source());
+            targets.add(lineageEdge.sink());
+        }
+        this.sources = new ArrayList<>(srcs);
+        this.sinks = new ArrayList<>(targets);
+    }
+
+    @Override
+    public List<SourceLineageVertex> sources() {
+        return sources;
+    }
+
+    @Override
+    public List<LineageVertex> sinks() {
+        return sinks;
+    }
+
+    @Override
+    public List<LineageEdge> relations() {
+        return lineageEdges;
+    }
+
+    public static LineageGraphBuilder builder() {
+        return new LineageGraphBuilder();
+    }
+
+    /** Build the default lineage graph from {@link LineageEdge}. */
+    public static class LineageGraphBuilder {
+        private final List<LineageEdge> lineageEdges;
+
+        private LineageGraphBuilder() {
+            this.lineageEdges = new ArrayList<>();
+        }
+
+        public LineageGraphBuilder addLineageEdge(LineageEdge lineageEdge) {
+            this.lineageEdges.add(lineageEdge);
+            return this;
+        }
+
+        public LineageGraphBuilder addLineageEdges(LineageEdge... lineageEdges) {
+            this.lineageEdges.addAll(Arrays.asList(lineageEdges));
+            return this;
+        }
+
+        public LineageGraph build() {
+            return new DefaultLineageGraph(lineageEdges);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.streaming.api.lineage;
 
+import org.apache.flink.annotation.Internal;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 /** Default implementation for {@link LineageGraph}. */
+@Internal
 public class DefaultLineageGraph implements LineageGraph {
     private final List<LineageEdge> lineageEdges;
     private final List<SourceLineageVertex> sources;
@@ -64,6 +67,7 @@ public class DefaultLineageGraph implements LineageGraph {
     }
 
     /** Build the default lineage graph from {@link LineageEdge}. */
+    @Internal
     public static class LineageGraphBuilder {
         private final List<LineageEdge> lineageEdges;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
@@ -37,14 +37,14 @@ public class DefaultLineageGraph implements LineageGraph {
     private DefaultLineageGraph(List<LineageEdge> lineageEdges) {
         this.lineageEdges = lineageEdges;
 
-        Set<SourceLineageVertex> srcs = new HashSet<>();
-        Set<LineageVertex> targets = new HashSet<>();
+        Set<SourceLineageVertex> deduplicatedSources = new HashSet<>();
+        Set<LineageVertex> deduplicatedSinks = new HashSet<>();
         for (LineageEdge lineageEdge : lineageEdges) {
-            srcs.add(lineageEdge.source());
-            targets.add(lineageEdge.sink());
+            deduplicatedSources.add(lineageEdge.source());
+            deduplicatedSinks.add(lineageEdge.sink());
         }
-        this.sources = new ArrayList<>(srcs);
-        this.sinks = new ArrayList<>(targets);
+        this.sources = new ArrayList<>(deduplicatedSources);
+        this.sinks = new ArrayList<>(deduplicatedSinks);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.lineage;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,17 +46,17 @@ public class DefaultLineageGraph implements LineageGraph {
 
     @Override
     public List<SourceLineageVertex> sources() {
-        return sources;
+        return Collections.unmodifiableList(sources);
     }
 
     @Override
     public List<LineageVertex> sinks() {
-        return sinks;
+        return Collections.unmodifiableList(sinks);
     }
 
     @Override
     public List<LineageEdge> relations() {
-        return lineageEdges;
+        return Collections.unmodifiableList(lineageEdges);
     }
 
     public static LineageGraphBuilder builder() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDataset.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDataset.java
@@ -21,14 +21,17 @@ package org.apache.flink.streaming.api.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.List;
+import java.util.Map;
 
-/**
- * Lineage vertex represents the connectors in lineage graph, including source {@link
- * SourceLineageVertex} and sink.
- */
+/** Lineage dataset represents the source or sink in the job. */
 @PublicEvolving
-public interface LineageVertex {
-    /* List of input (for source) or output (for sink) datasets interacted with by the connector */
-    List<LineageDataset> datasets();
+public interface LineageDataset {
+    /* Name for this particular dataset. */
+    String name();
+
+    /* Unique name for this dataset's storage, for example, url for jdbc connector and location for lakehouse connector. */
+    String namespace();
+
+    /* Facets for the lineage vertex to describe the particular information of dataset, such as schema and config. */
+    Map<String, LineageDatasetFacet> facets();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDatasetFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDatasetFacet.java
@@ -21,14 +21,9 @@ package org.apache.flink.streaming.api.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.List;
-
-/**
- * Lineage vertex represents the connectors in lineage graph, including source {@link
- * SourceLineageVertex} and sink.
- */
+/** Facet interface for dataset. */
 @PublicEvolving
-public interface LineageVertex {
-    /* List of input (for source) or output (for sink) datasets interacted with by the connector */
-    List<LineageDataset> datasets();
+public interface LineageDatasetFacet {
+    /** Name for the facet which will be used as key in facets of LineageDataset. */
+    String name();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageEdge.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Lineage edge from source to sink. */
+@PublicEvolving
+public interface LineageEdge {
+    SourceLineageVertex source();
+
+    LineageVertex sink();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraph.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+
+import java.util.List;
+
+/**
+ * Job lineage is built according to {@link StreamGraph}, users can get sources, sinks and
+ * relationships from lineage and manage the relationship between jobs and tables.
+ */
+@PublicEvolving
+public interface LineageGraph {
+    /* Source lineage vertex list. */
+    List<SourceLineageVertex> sources();
+
+    /* Sink lineage vertex list. */
+    List<LineageVertex> sinks();
+
+    /* lineage edges from sources to sinks. */
+    List<LineageEdge> relations();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertex.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Map;
+
+/**
+ * Lineage vertex represents the connectors in lineage graph, including source {@link
+ * SourceLineageVertex} and sink.
+ */
+@PublicEvolving
+public interface LineageVertex {
+    /* Config for the lineage vertex contains all the options for the connector. */
+    Map<String, String> config();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+
+/**
+ * Lineage vertex for source which has {@link Boundedness} to indicate whether the data for the
+ * source is bounded.
+ */
+public interface SourceLineageVertex extends LineageVertex {
+    /**
+     * The boundedness for the source connector, users can get boundedness for each sources in the
+     * lineage and determine the job execution mode with RuntimeExecutionMode.
+     */
+    Boundedness boundedness();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
@@ -19,12 +19,14 @@
 
 package org.apache.flink.streaming.api.lineage;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.Boundedness;
 
 /**
  * Lineage vertex for source which has {@link Boundedness} to indicate whether the data for the
  * source is bounded.
  */
+@PublicEvolving
 public interface SourceLineageVertex extends LineageVertex {
     /**
      * The boundedness for the source connector, users can get boundedness for each sources in the

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
@@ -46,7 +46,7 @@ class DefaultLineageGraphTest {
                         .build();
         assertThat(lineageGraph.sources()).containsExactlyInAnyOrder(source1, source2, source3);
         assertThat(lineageGraph.sinks()).containsExactlyInAnyOrder(sink1, sink2);
-        assertThat(lineageGraph.relations().size()).isEqualTo(4);
+        assertThat(lineageGraph.relations()).hasSize(4);
     }
 
     /** Testing sink lineage vertex. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.connector.source.Boundedness;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,8 +62,8 @@ class DefaultLineageGraphTest {
         }
 
         @Override
-        public Map<String, String> config() {
-            return new HashMap<>();
+        public List<LineageDataset> datasets() {
+            return new ArrayList<>();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraphTest.java
@@ -22,14 +22,13 @@ import org.apache.flink.api.connector.source.Boundedness;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Testing for lineage graph. */
-class LineageGraphTest {
+class DefaultLineageGraphTest {
     @Test
     void testLineageGraph() {
         SourceLineageVertex source1 = new TestingSourceLineageVertex("source1");
@@ -45,8 +44,8 @@ class LineageGraphTest {
                                 new TestingLineageEdge(source3, sink1),
                                 new TestingLineageEdge(source1, sink2))
                         .build();
-        assertThat(lineageGraph.sources()).isEqualTo(Arrays.asList(source1, source2, source3));
-        assertThat(lineageGraph.sinks()).isEqualTo(Arrays.asList(sink1, sink2));
+        assertThat(lineageGraph.sources()).containsExactlyInAnyOrder(source1, source2, source3);
+        assertThat(lineageGraph.sinks()).containsExactlyInAnyOrder(sink1, sink2);
         assertThat(lineageGraph.relations().size()).isEqualTo(4);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/LineageGraphTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/lineage/LineageGraphTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Testing for lineage graph. */
+class LineageGraphTest {
+    @Test
+    void testLineageGraph() {
+        SourceLineageVertex source1 = new TestingSourceLineageVertex("source1");
+        SourceLineageVertex source2 = new TestingSourceLineageVertex("source2");
+        SourceLineageVertex source3 = new TestingSourceLineageVertex("source3");
+        LineageVertex sink1 = new TestingLineageVertex("sink1");
+        LineageVertex sink2 = new TestingLineageVertex("sink2");
+        LineageGraph lineageGraph =
+                DefaultLineageGraph.builder()
+                        .addLineageEdge(new TestingLineageEdge(source1, sink1))
+                        .addLineageEdges(
+                                new TestingLineageEdge(source2, sink2),
+                                new TestingLineageEdge(source3, sink1),
+                                new TestingLineageEdge(source1, sink2))
+                        .build();
+        assertThat(lineageGraph.sources()).isEqualTo(Arrays.asList(source1, source2, source3));
+        assertThat(lineageGraph.sinks()).isEqualTo(Arrays.asList(sink1, sink2));
+        assertThat(lineageGraph.relations().size()).isEqualTo(4);
+    }
+
+    /** Testing sink lineage vertex. */
+    static class TestingLineageVertex implements LineageVertex {
+        private final String id;
+
+        private TestingLineageVertex(String id) {
+            this.id = id;
+        }
+
+        private String id() {
+            return id;
+        }
+
+        @Override
+        public Map<String, String> config() {
+            return new HashMap<>();
+        }
+    }
+
+    /** Testing source lineage vertex. */
+    static class TestingSourceLineageVertex extends TestingLineageVertex
+            implements SourceLineageVertex {
+
+        private TestingSourceLineageVertex(String id) {
+            super(id);
+        }
+
+        @Override
+        public Boundedness boundedness() {
+            return Boundedness.BOUNDED;
+        }
+    }
+
+    /** Testing lineage edge. */
+    static class TestingLineageEdge implements LineageEdge {
+        private final SourceLineageVertex source;
+        private final LineageVertex sink;
+
+        private TestingLineageEdge(SourceLineageVertex source, LineageVertex sink) {
+            this.source = source;
+            this.sink = sink;
+        }
+
+        @Override
+        public SourceLineageVertex source() {
+            return source;
+        }
+
+        @Override
+        public LineageVertex sink() {
+            return sink;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add lineage graph relevant interfaces such as `LineageGraph`, `LineageVertex`, `SourceLineageVertex` and `LineageEdge`

## Brief change log
  - Add lineage graph relevant interfaces
  - Add default lineage graph implementation


## Verifying this change

This change added tests and can be verified as follows:

  - Added test `LineageGraphTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
