### PR TITLE
[FLINK-25809][table] Improve readability of TableTestPrograms

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/SinkTestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/SinkTestStep.java
@@ -22,6 +22,7 @@ import org.apache.flink.types.Row;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -58,6 +59,11 @@ public final class SinkTestStep extends TableTestStep {
         this.expectedAfterRestoreStrings = expectedAfterRestoreStrings;
     }
 
+    /** Builder for creating a {@link SinkTestStep}. */
+    public static SinkTestStep.Builder newBuilder(String name) {
+        return new SinkTestStep.Builder(name);
+    }
+
     public List<String> getExpectedBeforeRestoreAsStrings() {
         if (expectedBeforeRestoreStrings != null) {
             return expectedBeforeRestoreStrings;
@@ -89,5 +95,59 @@ public final class SinkTestStep extends TableTestStep {
                 : expectedAfterRestore == null && expectedAfterRestoreStrings == null
                         ? TestKind.SINK_WITH_DATA
                         : TestKind.SINK_WITH_RESTORE_DATA;
+    }
+
+    /** Builder pattern for {@link SinkTestStep}. */
+    public static final class Builder extends AbstractBuilder<Builder> {
+
+        private List<Row> expectedBeforeRestore;
+        private List<Row> expectedAfterRestore;
+
+        private List<String> expectedBeforeRestoreStrings;
+        private List<String> expectedAfterRestoreStrings;
+
+        private Builder(String name) {
+            super(name);
+        }
+
+        public Builder consumedValues(Row... expectedRows) {
+            return consumedBeforeRestore(expectedRows);
+        }
+
+        public Builder consumedValues(String... expectedRows) {
+            return consumedBeforeRestore(expectedRows);
+        }
+
+        public Builder consumedBeforeRestore(Row... expectedRows) {
+            this.expectedBeforeRestore = Arrays.asList(expectedRows);
+            return this;
+        }
+
+        public Builder consumedBeforeRestore(String... expectedRows) {
+            this.expectedBeforeRestoreStrings = Arrays.asList(expectedRows);
+            return this;
+        }
+
+        public Builder consumedAfterRestore(Row... expectedRows) {
+            this.expectedAfterRestore = Arrays.asList(expectedRows);
+            return this;
+        }
+
+        public Builder consumedAfterRestore(String... expectedRows) {
+            this.expectedAfterRestoreStrings = Arrays.asList(expectedRows);
+            return this;
+        }
+
+        public SinkTestStep build() {
+            return new SinkTestStep(
+                    name,
+                    schemaComponents,
+                    partitionKeys,
+                    options,
+                    expectedBeforeRestore,
+                    expectedAfterRestore,
+                    expectedBeforeRestoreStrings,
+                    expectedAfterRestoreStrings);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/SourceTestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/SourceTestStep.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.test.program;
 
 import org.apache.flink.types.Row;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +43,11 @@ public final class SourceTestStep extends TableTestStep {
         this.dataAfterRestore = dataAfterRestore;
     }
 
+    /** Builder for creating a {@link SourceTestStep}. */
+    public static Builder newBuilder(String name) {
+        return new Builder(name);
+    }
+
     @Override
     public TestKind getKind() {
         return dataBeforeRestore.isEmpty()
@@ -48,5 +55,40 @@ public final class SourceTestStep extends TableTestStep {
                 : dataAfterRestore.isEmpty()
                         ? TestKind.SOURCE_WITH_DATA
                         : TestKind.SOURCE_WITH_RESTORE_DATA;
+    }
+
+    /** Builder pattern for {@link SourceTestStep}. */
+    public static final class Builder extends AbstractBuilder<Builder> {
+
+        private final List<Row> dataBeforeRestore = new ArrayList<>();
+        private final List<Row> dataAfterRestore = new ArrayList<>();
+
+        private Builder(String name) {
+            super(name);
+        }
+
+        public Builder producedValues(Row... data) {
+            return producedBeforeRestore(data);
+        }
+
+        public Builder producedBeforeRestore(Row... data) {
+            this.dataBeforeRestore.addAll(Arrays.asList(data));
+            return this;
+        }
+
+        public Builder producedAfterRestore(Row... data) {
+            this.dataAfterRestore.addAll(Arrays.asList(data));
+            return this;
+        }
+
+        public SourceTestStep build() {
+            return new SourceTestStep(
+                    name,
+                    schemaComponents,
+                    partitionKeys,
+                    options,
+                    dataBeforeRestore,
+                    dataAfterRestore);
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/CalcTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/CalcTestPrograms.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.exec.testutils;
 
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc;
+import org.apache.flink.table.test.program.SinkTestStep;
+import org.apache.flink.table.test.program.SourceTestStep;
 import org.apache.flink.table.test.program.TableTestProgram;
 import org.apache.flink.types.Row;
 
@@ -27,16 +29,18 @@ public class CalcTestPrograms {
 
     static final TableTestProgram SIMPLE_CALC =
             TableTestProgram.of("calc-simple", "validates basic calc node")
-                    .setupTableSource("t")
-                    .withSchema("a BIGINT", "b DOUBLE")
-                    .withValuesBeforeRestore(Row.of(420L, 42.0))
-                    .withValuesAfterRestore(Row.of(421L, 42.1))
-                    .complete()
-                    .setupTableSink("sink_t")
-                    .withSchema("a BIGINT", "b DOUBLE")
-                    .withValuesBeforeRestore(Row.of(421L, 42.0))
-                    .withValuesAfterRestore(Row.of(422L, 42.1))
-                    .complete()
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("a BIGINT", "b DOUBLE")
+                                    .producedBeforeRestore(Row.of(420L, 42.0))
+                                    .producedAfterRestore(Row.of(421L, 42.1))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("a BIGINT", "b DOUBLE")
+                                    .consumedBeforeRestore(Row.of(421L, 42.0))
+                                    .consumedAfterRestore(Row.of(422L, 42.1))
+                                    .build())
                     .runSql("INSERT INTO sink_t SELECT a + 1, b FROM t")
                     .build();
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/test/program/TableTestProgramRunnerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/test/program/TableTestProgramRunnerTest.java
@@ -97,14 +97,16 @@ public class TableTestProgramRunnerTest {
     void testTableStep() {
         final TableTestProgram program =
                 TableTestProgram.of(ID, DESCRIPTION)
-                        .setupTableSource("MyTableSource")
-                        .withSchema("i INT")
-                        .withOption("connector", "datagen")
-                        .complete()
-                        .setupTableSource("MyTableSink")
-                        .withSchema("i INT")
-                        .withOption("connector", "blackhole")
-                        .complete()
+                        .setupTableSource(
+                                SourceTestStep.newBuilder("MyTableSource")
+                                        .addSchema("i INT")
+                                        .addOption("connector", "datagen")
+                                        .build())
+                        .setupTableSink(
+                                SinkTestStep.newBuilder("MyTableSink")
+                                        .addSchema("i INT")
+                                        .addOption("connector", "blackhole")
+                                        .build())
                         .build();
 
         assertThat(program.setupSteps).hasSize(2);
@@ -127,8 +129,7 @@ public class TableTestProgramRunnerTest {
                         "CREATE TABLE `default_catalog`.`default_database`.`MyTableSink` (\n"
                                 + "  `i` INT\n"
                                 + ") WITH (\n"
-                                + "  'connector' = 'blackhole',\n"
-                                + "  'number-of-rows' = '3'\n"
+                                + "  'connector' = 'blackhole'\n"
                                 + ")\n");
     }
 


### PR DESCRIPTION
## What is the purpose of the change

From first feedback, this PR improves the readability of TableTestPrograms.

## Brief change log

- Use a proper builder pattern for `SourceTestStep` and `SinkTestStep`
- Give builder methods a better name (indicate when it `add` or sets, indicate whether data is `produced` or `consumed`)

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
