### PR TITLE
[BP-1.17][FLINK-32426][table-runtime] Fix adaptive local hash can't work when auxGrouping exists

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -28,7 +28,6 @@ import org.apache.flink.table.planner.functions.aggfunctions._
 import org.apache.flink.table.planner.plan.utils.AggregateInfo
 import org.apache.flink.table.runtime.generated.{GeneratedProjection, Projection}
 import org.apache.flink.table.types.logical.{BigIntType, LogicalType, RowType}
-import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldTypes
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -161,7 +160,7 @@ object ProjectionCodeGenerator {
               sumAggFunction.getResultType.getLogicalType,
               aggInfo.agg.getArgList.get(0))
           case _: MaxAggFunction | _: MinAggFunction =>
-            fieldExprs += GenerateUtils.generateFieldAccess(
+            fieldExprs += reuseFieldExprForAggFunc(
               ctx,
               inputType,
               inputTerm,
@@ -231,25 +230,23 @@ object ProjectionCodeGenerator {
       inputTerm: String,
       targetType: LogicalType,
       index: Int): GeneratedExpression = {
-    val fieldType = getFieldTypes(inputType).get(index)
-    val resultTypeTerm = primitiveTypeTermForType(fieldType)
-    val defaultValue = primitiveDefaultValue(fieldType)
-    val readCode = rowFieldReadAccess(index.toString, inputTerm, fieldType)
-    val Seq(fieldTerm, nullTerm) =
-      ctx.addReusableLocalVariables((resultTypeTerm, "field"), ("boolean", "isNull"))
-
-    val inputCode =
-      s"""
-         |$nullTerm = $inputTerm.isNullAt($index);
-         |$fieldTerm = $defaultValue;
-         |if (!$nullTerm) {
-         |  $fieldTerm = $readCode;
-         |}
-           """.stripMargin.trim
-
-    val expression = GeneratedExpression(fieldTerm, nullTerm, inputCode, fieldType)
+    val fieldExpr = reuseFieldExprForAggFunc(ctx, inputType, inputTerm, index)
     // Convert the projected value type to sum agg func target type.
-    ScalarOperatorGens.generateCast(ctx, expression, targetType, true)
+    ScalarOperatorGens.generateCast(ctx, fieldExpr, targetType, nullOnFailure = true)
+  }
+
+  /** Get reuse field expr if it has been evaluated before for adaptive local hash aggregation. */
+  def reuseFieldExprForAggFunc(
+      ctx: CodeGeneratorContext,
+      inputType: LogicalType,
+      inputTerm: String,
+      index: Int): GeneratedExpression = {
+    // Reuse the field access code if it has been evaluated before
+    ctx.getReusableInputUnboxingExprs(inputTerm, index) match {
+      case None => GenerateUtils.generateFieldAccess(ctx, inputType, inputTerm, index)
+      case Some(expr) =>
+        GeneratedExpression(expr.resultTerm, expr.nullTerm, NO_CODE, expr.resultType)
+    }
   }
 
   /**
@@ -260,13 +257,17 @@ object ProjectionCodeGenerator {
       ctx: CodeGeneratorContext,
       inputTerm: String,
       index: Int): GeneratedExpression = {
+    val fieldNullCode = ctx.getReusableInputUnboxingExprs(inputTerm, index) match {
+      case None => s"$inputTerm.isNullAt($index)"
+      case Some(expr) => expr.nullTerm
+    }
+
     val Seq(fieldTerm, nullTerm) =
       ctx.addReusableLocalVariables(("long", "field"), ("boolean", "isNull"))
-
     val inputCode =
       s"""
          |$fieldTerm = 0L;
-         |if (!$inputTerm.isNullAt($index)) {
+         |if (!$fieldNullCode) {
          |  $fieldTerm = 1L;
          |}
            """.stripMargin.trim

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ProjectionCodeGenerator.scala
@@ -146,9 +146,13 @@ object ProjectionCodeGenerator {
       outClass: Class[_ <: RowData] = classOf[BinaryRowData],
       inputTerm: String = DEFAULT_INPUT1_TERM,
       aggInfos: Array[AggregateInfo],
+      auxGrouping: Array[Int],
       outRecordTerm: String = DEFAULT_OUT_RECORD_TERM,
       outRecordWriterTerm: String = DEFAULT_OUT_RECORD_WRITER_TERM): String = {
     val fieldExprs: ArrayBuffer[GeneratedExpression] = ArrayBuffer()
+    // The auxGrouping also need to consider which is aggBuffer field
+    auxGrouping.foreach(i => fieldExprs += reuseFieldExprForAggFunc(ctx, inputType, inputTerm, i))
+
     aggInfos.map {
       aggInfo =>
         aggInfo.function match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -257,6 +257,7 @@ object HashAggCodeGenerator {
           classOf[BinaryRowData],
           inputTerm = inputTerm,
           aggInfos,
+          auxGrouping,
           outRecordTerm = currentValueTerm,
           outRecordWriterTerm = currentValueWriterTerm
         )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -142,21 +142,6 @@ object HashAggCodeGenerator {
         outRecordWriterTerm = currentKeyWriterTerm)
       .code
 
-    val valueProjectionCode =
-      if (!isFinal && supportAdaptiveLocalHashAgg) {
-        ProjectionCodeGenerator.genAdaptiveLocalHashAggValueProjectionCode(
-          ctx,
-          inputType,
-          classOf[BinaryRowData],
-          inputTerm = inputTerm,
-          aggInfos,
-          outRecordTerm = currentValueTerm,
-          outRecordWriterTerm = currentValueWriterTerm
-        )
-      } else {
-        ""
-      }
-
     // gen code to create groupKey, aggBuffer Type array
     // it will be used in BytesHashMap and BufferedKVExternalSorter if enable fallback
     val groupKeyTypesTerm = CodeGenUtils.newName("groupKeyTypes")
@@ -264,6 +249,21 @@ object HashAggCodeGenerator {
     }
     val localAggSuppressedTerm = CodeGenUtils.newName("localAggSuppressed")
     ctx.addReusableMember(s"private transient boolean $localAggSuppressedTerm = false;")
+    val valueProjectionCode =
+      if (!isFinal && supportAdaptiveLocalHashAgg) {
+        ProjectionCodeGenerator.genAdaptiveLocalHashAggValueProjectionCode(
+          ctx,
+          inputType,
+          classOf[BinaryRowData],
+          inputTerm = inputTerm,
+          aggInfos,
+          outRecordTerm = currentValueTerm,
+          outRecordWriterTerm = currentValueWriterTerm
+        )
+      } else {
+        ""
+      }
+
     val (
       distinctCountIncCode,
       totalCountIncCode,


### PR DESCRIPTION
## What is the purpose of the change

*Fix adaptive local hash can't work when auxGrouping exists*

## Brief change log

  - *Fix adaptive local hash can't work when auxGrouping exists*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in HashAggITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
