### PR TITLE
[hotfix] Update docs build CI image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Build documentation
         run: |
-          docker run  --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
+          docker run  --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_maven_386_v2 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:


### PR DESCRIPTION
The docs CI build is failing because its using an old docker image that still uses maven 3.2.5. Upgrade to the current CI image.