### PR TITLE
[FLINK-33428] Flink SQL CEP support 'followed','notNext' and 'notFollowedBy' semantics

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -111,6 +111,7 @@
     "org.apache.flink.sql.parser.validate.FlinkSqlConformance"
     "org.apache.flink.sql.parser.SqlProperty"
     "org.apache.flink.sql.parser.SqlPartitionSpecProperty"
+    "org.apache.flink.sql.parser.SqlOperatorPattern"
     "org.apache.calcite.sql.SqlAlienSystemTypeNameSpec"
     "org.apache.calcite.sql.SqlCreate"
     "org.apache.calcite.sql.SqlDrop"
@@ -557,6 +558,7 @@
     "SqlSet()"
     "SqlReset()"
     "SqlAnalyzeTable()"
+    "RichOrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlOperatorPattern.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlOperatorPattern.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
+
+/**
+ * Properties of sql pattern. Expanding new operators on the basis of {@link SqlStdOperatorTable}
+ */
+public class SqlOperatorPattern extends ReflectiveSqlOperatorTable {
+
+    public static final SqlSpecialOperator PATTERN_NEGATIVE =
+            new SqlSpecialOperator("PATTERN_NEGATIVE", SqlKind.OTHER, 100) {
+                @Override
+                public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+                    SqlWriter.Frame frame = writer.startList("[^", "]");
+                    SqlNode node = call.getOperandList().get(0);
+                    node.unparse(writer, 0, 0);
+                    writer.endList(frame);
+                }
+            };
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1950,6 +1950,18 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                                         "CREATE TABLE AS SELECT syntax does not support to create partitioned table yet."));
     }
 
+    @Test
+    void testSelectList4() {
+        sql("select ^from^ emp").fails("(?s).*Encountered \"from emp\" at line .*");
+    }
+
+    @Test
+    void testMinusIsReserved() {
+        sql("select ^minus^ from t").fails("(?s).*Encountered \"minus from\" at .*");
+        sql("select ^minus^ select").fails("(?s).*Encountered \"minus select\" at .*");
+        sql("select * from t as ^minus^ where x < y").fails("(?s).*Encountered \"minus\" at .*");
+    }
+
     public static BaseMatcher<SqlNode> validated(String validatedSql) {
         return new TypeSafeDiagnosingMatcher<SqlNode>() {
             @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
@@ -227,11 +227,30 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
         final Pattern<RowData, RowData> cepPattern;
         if (matchSpec.getInterval().isPresent()) {
             Time interval = translateTimeBound(matchSpec.getInterval().get());
-            cepPattern = matchSpec.getPattern().accept(patternVisitor).within(interval);
+            PatternWithStrategy resultPatternWithStrategy =
+                    matchSpec.getPattern().accept(patternVisitor);
+            cepPattern = resultPatternWithStrategy.getPattern().within(interval);
+            checkPatternReasonableEnding(resultPatternWithStrategy);
         } else {
-            cepPattern = matchSpec.getPattern().accept(patternVisitor);
+            PatternWithStrategy resultPatternWithStrategy =
+                    matchSpec.getPattern().accept(patternVisitor);
+            cepPattern = resultPatternWithStrategy.getPattern();
+            checkPatternReasonableEnding(resultPatternWithStrategy);
         }
         return new Tuple2<>(cepPattern, new ArrayList<>(patternVisitor.names));
+    }
+
+    private static void checkPatternReasonableEnding(PatternWithStrategy patternWithStrategy) {
+        if (patternWithStrategy == null) {
+            throw new TableException("This should not happen.");
+        }
+        Quantifier.ConsumingStrategy lastConsumingStrategy =
+                patternWithStrategy.getNextConsumingStrategy();
+        if (lastConsumingStrategy.equals(Quantifier.ConsumingStrategy.SKIP_TILL_NEXT)
+                || lastConsumingStrategy.equals(Quantifier.ConsumingStrategy.SKIP_TILL_ANY)) {
+            throw new TableException(
+                    "Currently, CEP doesn't support {- -} patterns at the ending.");
+        }
     }
 
     private static Time translateTimeBound(RexNode interval) {
@@ -248,14 +267,14 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
     public abstract boolean isProcTime(RowType inputRowType);
 
     /** The visitor to traverse the pattern RexNode. */
-    private static class PatternVisitor extends RexDefaultVisitor<Pattern<RowData, RowData>> {
+    private static class PatternVisitor extends RexDefaultVisitor<PatternWithStrategy> {
         private final ReadableConfig config;
         private final ClassLoader classLoader;
         private final RelBuilder relBuilder;
         private final RowType inputRowType;
         private final MatchSpec matchSpec;
         private final LinkedHashSet<String> names;
-        private Pattern<RowData, RowData> pattern;
+        private PatternWithStrategy patternWithStrategy;
 
         public PatternVisitor(
                 ReadableConfig config,
@@ -272,10 +291,9 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
         }
 
         @Override
-        public Pattern<RowData, RowData> visitLiteral(RexLiteral literal) {
+        public PatternWithStrategy visitLiteral(RexLiteral literal) {
             String patternName = literal.getValueAs(String.class);
-            pattern = translateSingleVariable(pattern, patternName);
-
+            patternWithStrategy = translateSingleVariable(patternWithStrategy, patternName);
             RexNode patternDefinition = matchSpec.getPatternDefinitions().get(patternName);
             if (patternDefinition != null) {
                 MatchCodeGenerator generator =
@@ -292,19 +310,22 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                         JavaScalaConversionUtil.toScala(Optional.empty()));
                 IterativeCondition<RowData> condition =
                         generator.generateIterativeCondition(patternDefinition);
-                return pattern.where(condition);
+                patternWithStrategy.setPattern(patternWithStrategy.getPattern().where(condition));
+                return patternWithStrategy;
             } else {
-                return pattern.where(BooleanConditions.trueFunction());
+                patternWithStrategy.setPattern(
+                        patternWithStrategy.getPattern().where(BooleanConditions.trueFunction()));
+                return patternWithStrategy;
             }
         }
 
         @Override
-        public Pattern<RowData, RowData> visitCall(RexCall call) {
+        public PatternWithStrategy visitCall(RexCall call) {
             SqlOperator operator = call.getOperator();
             if (operator == SqlStdOperatorTable.PATTERN_CONCAT) {
-                pattern = call.operands.get(0).accept(this);
-                pattern = call.operands.get(1).accept(this);
-                return pattern;
+                patternWithStrategy = call.operands.get(0).accept(this);
+                patternWithStrategy = call.operands.get(1).accept(this);
+                return patternWithStrategy;
             } else if (operator == SqlStdOperatorTable.PATTERN_QUANTIFIER) {
                 final RexLiteral name;
                 if (call.operands.get(0) instanceof RexLiteral) {
@@ -315,8 +336,6 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                                     "Expression not supported: %s Group patterns are not supported yet.",
                                     call.operands.get(0)));
                 }
-
-                pattern = name.accept(this);
                 int startNum =
                         MathUtils.checkedDownCast(
                                 ((RexLiteral) call.operands.get(1)).getValueAs(Long.class));
@@ -325,7 +344,13 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                                 ((RexLiteral) call.operands.get(2)).getValueAs(Long.class));
                 boolean isGreedy = !((RexLiteral) call.operands.get(3)).getValueAs(Boolean.class);
 
-                return applyQuantifier(pattern, startNum, endNum, isGreedy);
+                if (patternWithStrategy != null && patternWithStrategy.isExcluded()) {
+                    return decideNextConsumingStrategyByExcludePattern(
+                            patternWithStrategy, startNum, endNum, isGreedy);
+                } else {
+                    patternWithStrategy = name.accept(this);
+                    return applyQuantifier(patternWithStrategy, startNum, endNum, isGreedy);
+                }
             } else if (operator == SqlStdOperatorTable.PATTERN_ALTER) {
                 throw new TableException(
                         String.format(
@@ -337,35 +362,75 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                                 "Expression not supported: %s. Currently, CEP doesn't support PERMUTE patterns.",
                                 call));
             } else if (operator == SqlStdOperatorTable.PATTERN_EXCLUDE) {
-                throw new TableException(
-                        String.format(
-                                "Expression not supported: %s. Currently, CEP doesn't support '{-' '-}' patterns.",
-                                call));
+                if (patternWithStrategy == null || patternWithStrategy.getPattern() == null) {
+                    throw new TableException(
+                            String.format(
+                                    "Expression not supported: %s. Currently, CEP doesn't support {- -} patterns at the beginning.",
+                                    call));
+                }
+                if (call.operands.get(0) instanceof RexCall) {
+                    patternWithStrategy.setNextConsumingStrategy(
+                            Quantifier.ConsumingStrategy.SKIP_TILL_NEXT);
+                    RexCall name = (RexCall) call.operands.get(0);
+                    patternWithStrategy.setExcluded(true);
+                    patternWithStrategy = name.accept(this);
+                    return patternWithStrategy;
+                } else {
+                    throw new TableException(
+                            String.format(
+                                    "Expression not supported: %s. Currently, CEP doesn't support {- -} patterns without quantifier.",
+                                    call));
+                }
             } else {
                 throw new TableException("This should not happen.");
             }
         }
 
         @Override
-        public Pattern<RowData, RowData> visitNode(RexNode rexNode) {
+        public PatternWithStrategy visitNode(RexNode rexNode) {
             throw new TableException(
                     String.format("Unsupported expression within Pattern: [%s]", rexNode));
         }
 
-        private Pattern<RowData, RowData> translateSingleVariable(
-                Pattern<RowData, RowData> previousPattern, String patternName) {
+        private PatternWithStrategy translateSingleVariable(
+                PatternWithStrategy patternWithStrategy, String patternName) {
+            Pattern<RowData, RowData> newPattern;
             if (names.contains(patternName)) {
                 throw new TableException(
                         "Pattern variables must be unique. That might change in the future.");
             } else {
                 names.add(patternName);
             }
-
-            if (previousPattern != null) {
-                return previousPattern.next(patternName);
+            if (patternWithStrategy != null
+                    && patternWithStrategy.getPattern() != null
+                    && patternWithStrategy.getNextConsumingStrategy() != null) {
+                Pattern<RowData, RowData> previousPattern = patternWithStrategy.getPattern();
+                switch (patternWithStrategy.getNextConsumingStrategy()) {
+                    case STRICT:
+                        newPattern = previousPattern.next(patternName);
+                        break;
+                    case NOT_NEXT:
+                        newPattern = previousPattern.notNext(patternName);
+                        break;
+                    case SKIP_TILL_NEXT:
+                        newPattern = previousPattern.followedBy(patternName);
+                        break;
+                    case SKIP_TILL_ANY:
+                        newPattern = previousPattern.followedByAny(patternName);
+                        break;
+                    case NOT_FOLLOW:
+                        newPattern = previousPattern.notFollowedBy(patternName);
+                        break;
+                    default:
+                        throw new TableException(
+                                "Pattern ConsumingStrategy must be <STRICT, SKIP_TILL_NEXT, SKIP_TILL_ANY, NOT_FOLLOW, NOT_NEXT>");
+                }
             } else {
-                return Pattern.begin(patternName, translateSkipStrategy());
+                newPattern = Pattern.begin(patternName, translateSkipStrategy());
             }
+            PatternWithStrategy newPatternWithStrategy = new PatternWithStrategy();
+            newPatternWithStrategy.setPattern(newPattern);
+            return newPatternWithStrategy;
         }
 
         private AfterMatchSkipStrategy translateSkipStrategy() {
@@ -401,32 +466,82 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                     .getValueAs(String.class);
         }
 
-        private Pattern<RowData, RowData> applyQuantifier(
-                Pattern<RowData, RowData> pattern, int startNum, int endNum, boolean greedy) {
+        private PatternWithStrategy applyQuantifier(
+                PatternWithStrategy patternWithStrategy, int startNum, int endNum, boolean greedy) {
             boolean isOptional = startNum == 0 && endNum == 1;
 
             final Pattern<RowData, RowData> newPattern;
             if (startNum == 0 && endNum == -1) { // zero or more
-                newPattern = pattern.oneOrMore().optional().consecutive();
+                newPattern = patternWithStrategy.getPattern().oneOrMore().optional().consecutive();
             } else if (startNum == 1 && endNum == -1) { // one or more
-                newPattern = pattern.oneOrMore().consecutive();
+                newPattern = patternWithStrategy.getPattern().oneOrMore().consecutive();
             } else if (isOptional) { // optional
-                newPattern = pattern.optional();
+                newPattern = patternWithStrategy.getPattern().optional();
             } else if (endNum != -1) { // times
-                newPattern = pattern.times(startNum, endNum).consecutive();
+                newPattern = patternWithStrategy.getPattern().times(startNum, endNum).consecutive();
             } else { // times or more
-                newPattern = pattern.timesOrMore(startNum).consecutive();
+                newPattern = patternWithStrategy.getPattern().timesOrMore(startNum).consecutive();
             }
 
             if (greedy && (isOptional || startNum == endNum)) {
-                return newPattern;
+                patternWithStrategy.setPattern(newPattern);
+                return patternWithStrategy;
             } else if (greedy) {
-                return newPattern.greedy();
+                patternWithStrategy.setPattern(newPattern.greedy());
+                return patternWithStrategy;
             } else if (isOptional) {
                 throw new TableException("Reluctant optional variables are not supported yet.");
             } else {
-                return newPattern;
+                patternWithStrategy.setPattern(newPattern);
+                return patternWithStrategy;
             }
+        }
+
+        private PatternWithStrategy decideNextConsumingStrategyByExcludePattern(
+                PatternWithStrategy patternWithStrategy, int startNum, int endNum, boolean greedy) {
+            if (startNum == 0 && endNum == -1) {
+                patternWithStrategy.setNextConsumingStrategy(
+                        greedy
+                                ? Quantifier.ConsumingStrategy.SKIP_TILL_ANY
+                                : Quantifier.ConsumingStrategy.SKIP_TILL_NEXT);
+            } else {
+                throw new TableException("Pattern excluded quantifier must be <*?, *>.");
+            }
+            return patternWithStrategy;
+        }
+    }
+
+    /**
+     * This info is used to temporarily store pattern information and next connection information.
+     */
+    private static class PatternWithStrategy {
+        private Pattern<RowData, RowData> pattern;
+        private Quantifier.ConsumingStrategy nextConsumingStrategy =
+                Quantifier.ConsumingStrategy.STRICT;
+        private boolean isExcluded = false;
+
+        public Pattern<RowData, RowData> getPattern() {
+            return pattern;
+        }
+
+        public void setPattern(Pattern<RowData, RowData> pattern) {
+            this.pattern = pattern;
+        }
+
+        public Quantifier.ConsumingStrategy getNextConsumingStrategy() {
+            return nextConsumingStrategy;
+        }
+
+        public void setNextConsumingStrategy(Quantifier.ConsumingStrategy nextConsumingStrategy) {
+            this.nextConsumingStrategy = nextConsumingStrategy;
+        }
+
+        public boolean isExcluded() {
+            return isExcluded;
+        }
+
+        public void setExcluded(boolean excluded) {
+            isExcluded = excluded;
         }
     }
 }


### PR DESCRIPTION
1.Use the {- -} extension to expand the follow semantics.
2.add the "[^ ]" extension to expand the notNext and notFollowedBy semantics.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
