### PR TITLE
[FLINK-33430] Fix `testSerializerTree` test failures

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/GenericTypeInfoTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/GenericTypeInfoTest.java
@@ -26,7 +26,9 @@ import org.apache.flink.test.operators.util.CollectionDataSets;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.core.IsEqual.equalTo;
+import java.util.Arrays;
+
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 
 /** Test TypeInfo serializer tree. */
 public class GenericTypeInfoTest {
@@ -51,22 +53,25 @@ public class GenericTypeInfoTest {
                                 "( {8}[a-zA-Z]+:java\\.math\\.BigInteger\\R)( {12}\\S*\\R)+", "$1");
 
         Assert.assertThat(
-                serTree,
-                equalTo(
-                        "GenericTypeInfo (PojoWithCollectionGeneric)\n"
-                                + "    pojos:java.util.List\n"
-                                + "    key:int\n"
-                                + "    sqlDate:java.sql.Date\n"
-                                + "    bigInt:java.math.BigInteger\n"
-                                + "    bigDecimalKeepItNull:java.math.BigDecimal\n"
-                                + "        intVal:java.math.BigInteger\n"
-                                + "        scale:int\n"
-                                + "    scalaBigInt:scala.math.BigInt\n"
-                                + "        bigInteger:java.math.BigInteger\n"
-                                + "    mixed:java.util.List\n"
-                                + "    makeMeGeneric:org.apache.flink.test.operators.util.CollectionDataSets$PojoWithDateAndEnum\n"
-                                + "        group:java.lang.String\n"
-                                + "        date:java.util.Date\n"
-                                + "        cat:org.apache.flink.test.operators.util.CollectionDataSets$Category (is enum)\n"));
+                Arrays.asList(serTree.split("\n")),
+                containsInAnyOrder(
+                        Arrays.asList(
+                                        ("GenericTypeInfo (PojoWithCollectionGeneric)\n"
+                                                        + "    pojos:java.util.List\n"
+                                                        + "    key:int\n"
+                                                        + "    sqlDate:java.sql.Date\n"
+                                                        + "    bigInt:java.math.BigInteger\n"
+                                                        + "    bigDecimalKeepItNull:java.math.BigDecimal\n"
+                                                        + "        intVal:java.math.BigInteger\n"
+                                                        + "        scale:int\n"
+                                                        + "    scalaBigInt:scala.math.BigInt\n"
+                                                        + "        bigInteger:java.math.BigInteger\n"
+                                                        + "    mixed:java.util.List\n"
+                                                        + "    makeMeGeneric:org.apache.flink.test.operators.util.CollectionDataSets$PojoWithDateAndEnum\n"
+                                                        + "        group:java.lang.String\n"
+                                                        + "        date:java.util.Date\n"
+                                                        + "        cat:org.apache.flink.test.operators.util.CollectionDataSets$Category (is enum)\n")
+                                                .split("\n"))
+                                .toArray()));
     }
 }


### PR DESCRIPTION
<!--
## Contribution Checklist
  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. 
-->

## What is the purpose of the change
This PR is to fix a flaky test `org.apache.flink.test.misc.GenericTypeInfoTest#testSerializerTree` in module `flink-tests`. **Please let me know if you prefer other fix, thanks!**

**Reproduce test failures:**
- Run the following commands
```
mvn -pl flink-tests edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.flink.test.misc.GenericTypeInfoTest#testSerializerTree
```
- Then we found the following test failures:
```
[ERROR]   GenericTypeInfoTest.testSerializerTree:53 
Expected: "GenericTypeInfo (PojoWithCollectionGeneric)\n    pojos:java.util.List\n    key:int\n    sqlDate:java.sql.Date\n    bigInt:java.math.BigInteger\n    bigDecimalKeepItNull:java.math.BigDecimal\n        intVal:java.math.BigInteger\n        scale:int\n    scalaBigInt:scala.math.BigInt\n        bigInteger:java.math.BigInteger\n    mixed:java.util.List\n    makeMeGeneric:org.apache.flink.test.operators.util.CollectionDataSets$PojoWithDateAndEnum\n        group:java.lang.String\n        date:java.util.Date\n        cat:org.apache.flink.test.operators.util.CollectionDataSets$Category (is enum)\n"
     but: was "GenericTypeInfo (PojoWithCollectionGeneric)\n    key:int\n    bigDecimalKeepItNull:java.math.BigDecimal\n        intVal:java.math.BigInteger\n        scale:int\n    bigInt:java.math.BigInteger\n    sqlDate:java.sql.Date\n    pojos:java.util.List\n    scalaBigInt:scala.math.BigInt\n        bigInteger:java.math.BigInteger\n    makeMeGeneric:org.apache.flink.test.operators.util.CollectionDataSets$PojoWithDateAndEnum\n        date:java.util.Date\n        cat:org.apache.flink.test.operators.util.CollectionDataSets$Category (is enum)\n        group:java.lang.String\n    mixed:java.util.List\n"
```
## Brief change log
The root cause of the test failure is due to assuming a consistent order of `serTree`, but the elements of it is actually not consistent (in the implementation of `getSerializerTree()`, it calls a method`getGenericTypeTree()`, during which it uses `getDeclaredFields()` to iterate an array containing the names of field objects reflecting all the accessible fields, however the elements in the array returned are not sorted and are not in any particular order, which causes the flakiness), to fix the test failure:
  - *change the assertion to compare two lists, which can ignore the orders of elements*
## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
