### PR TITLE
[FLINK-33418][test,ci] Uses getHost() to access HiveContainer (instead of hard-coded IP)

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainers.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainers.java
@@ -99,8 +99,8 @@ public class HiveContainers {
                             .post(new FormBody.Builder().build())
                             .url(
                                     String.format(
-                                            "http://127.0.0.1:%s",
-                                            getMappedPort(getNameNodeWebEndpointPort())))
+                                            "http://%s:%s",
+                                            getHost(), getMappedPort(getNameNodeWebEndpointPort())))
                             .build();
             OkHttpClient client = new OkHttpClient();
             try (Response response = client.newCall(request).execute()) {

--- a/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
@@ -80,7 +80,8 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
                         .post(new FormBody.Builder().build())
                         .url(
                                 String.format(
-                                        "http://127.0.0.1:%s", getMappedPort(NAME_NODE_WEB_PORT)))
+                                        "http://%s:%s",
+                                        getHost(), getMappedPort(NAME_NODE_WEB_PORT)))
                         .build();
         OkHttpClient client = new OkHttpClient();
         try (Response response = client.newCall(request).execute()) {


### PR DESCRIPTION
## What is the purpose of the change

The experiments on Github actions (FLINK-27075) revealed that the e2e tests that use `HiveContainer` would fail on Github Runners. Using `getHost()` instead to access the container works.

## Brief change log

* Utilize `getHost()` instead of `127.0.0.1` to access the container

## Verifying this change

* The two tests started to succeed in Github Actions
  * [Github Action Run](https://github.com/XComp/flink/actions/runs/6727253349/job/18285012233#step:15:13613) with `HiveITCase` failure 
  * [Github Action Run](https://github.com/XComp/flink/actions/runs/6719526710/job/18261920525#step:15:11508) with `SqlGatewayE2ECase` failure
  * [Github Action Run](https://github.com/XComp/flink/actions/runs/6729006580/job/18289544587) with fix [45f4473](https://github.com/XComp/flink/commit/45f4473408a88bb1a36458f13662ea3623af0410)
* The tests should succeed in AzureCI

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable