### PR TITLE
[BP-1.18][FLINK-33418][test] Uses getHost()

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainers.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hive/src/test/java/org/apache/flink/tests/hive/containers/HiveContainers.java
@@ -99,8 +99,8 @@ public class HiveContainers {
                             .post(new FormBody.Builder().build())
                             .url(
                                     String.format(
-                                            "http://127.0.0.1:%s",
-                                            getMappedPort(getNameNodeWebEndpointPort())))
+                                            "http://%s:%s",
+                                            getHost(), getMappedPort(getNameNodeWebEndpointPort())))
                             .build();
             OkHttpClient client = new OkHttpClient();
             try (Response response = client.newCall(request).execute()) {

--- a/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/containers/HiveContainer.java
@@ -80,7 +80,8 @@ public class HiveContainer extends GenericContainer<HiveContainer> {
                         .post(new FormBody.Builder().build())
                         .url(
                                 String.format(
-                                        "http://127.0.0.1:%s", getMappedPort(NAME_NODE_WEB_PORT)))
+                                        "http://%s:%s",
+                                        getHost(), getMappedPort(NAME_NODE_WEB_PORT)))
                         .build();
         OkHttpClient client = new OkHttpClient();
         try (Response response = client.newCall(request).execute()) {


### PR DESCRIPTION
1.18 backport for parent PR #23649