### PR TITLE
[hotfix][docs] fix flink-table-api-java-bridge artifactId error…

### DIFF
--- a/docs/content/docs/dev/table/data_stream_api.md
+++ b/docs/content/docs/dev/table/data_stream_api.md
@@ -451,7 +451,7 @@ corresponding language-specific DataStream API module.
 ```xml
 <dependency>
   <groupId>org.apache.flink</groupId>
-  <artifactId>flink-table-api-java-bridge{{< scala_version >}}</artifactId>
+  <artifactId>flink-table-api-java-bridge</artifactId>
   <version>{{< version >}}</version>
   <scope>provided</scope>
 </dependency>


### PR DESCRIPTION
In data_stream_api.md. It's no need to add scala version in artifactId of flink-table-api-java-bridge dependency after flink 1.14.x.