### PR TITLE
[FLINK-33447][table-planner] Avoid CompiledPlan recompilation during loading

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/ExecNodeGraphInternalPlan.java
@@ -34,17 +34,21 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /** Implementation of {@link CompiledPlan} backed by an {@link ExecNodeGraph}. */
 @Internal
 public class ExecNodeGraphInternalPlan implements InternalPlan {
 
-    private final String serializedPlan;
+    private final Supplier<String> serializedPlanSupplier;
     private final ExecNodeGraph execNodeGraph;
 
-    public ExecNodeGraphInternalPlan(String serializedPlan, ExecNodeGraph execNodeGraph) {
-        this.serializedPlan = serializedPlan;
+    private String serializedPlan;
+
+    public ExecNodeGraphInternalPlan(
+            Supplier<String> serializedPlanSupplier, ExecNodeGraph execNodeGraph) {
+        this.serializedPlanSupplier = serializedPlanSupplier;
         this.execNodeGraph = execNodeGraph;
     }
 
@@ -54,6 +58,9 @@ public class ExecNodeGraphInternalPlan implements InternalPlan {
 
     @Override
     public String asJsonString() {
+        if (serializedPlan == null) {
+            serializedPlan = serializedPlanSupplier.get();
+        }
         return serializedPlan;
     }
 
@@ -78,7 +85,7 @@ public class ExecNodeGraphInternalPlan implements InternalPlan {
             Files.createDirectories(file.toPath().getParent());
             Files.write(
                     file.toPath(),
-                    serializedPlan.getBytes(StandardCharsets.UTF_8),
+                    asJsonString().getBytes(StandardCharsets.UTF_8),
                     StandardOpenOption.CREATE,
                     StandardOpenOption.TRUNCATE_EXISTING,
                     StandardOpenOption.WRITE);


### PR DESCRIPTION
## What is the purpose of the change

Avoids re-serializing of JSON during the load operation. The re-serialization makes still sense to retrieve a normalized JSON but this is a rather uncommon case.

## Brief change log

- Introduce a supplier pattern

## Verifying this change

This change is already covered by existing tests, such as `CompiledPlanITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
