### PR TITLE
[FLINK-33449][table]Support array_contains_seq function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -844,6 +844,9 @@ collection:
   - sql: ARRAY_MIN(array)
     table: array.arrayMin()
     description: Returns the minimum value from the array, if array itself is null, the function returns null.
+  - sql: ARRAY_CONTAINS_SEQ(array1, array2)
+    table: array1.array_contains_seq(array2)
+    description: Return true if array1 contains all of array2 as a subsequence (all values in the same consecutive order).
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: Returns the keys of the map as array. No order guaranteed.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -971,6 +971,9 @@ collection:
   - sql: ARRAY_JOIN(array, delimiter[, nullReplacement])
     table: array.arrayJoin(delimiter[, nullReplacement])
     description: 返回一个字符串，表示给定数组中元素的串联，并且给定数组中元素的数据类型为字符串。 分隔符 delimiter 是一个字符串，用于分隔数组的每对连续元素。 可选的参数 nullReplacement 是一个字符串，用于替换数组中的 null 元素。 如果未指定 nullReplacement，则结果字符串中将从数组中省略 null 元素。 如果输入数组或分隔符或 nullReplacement 为 null，则返回 null。
+  - sql: ARRAY_CONTAINS_SEQ(array1, array2)
+    table: array1.array_contains_seq(array2)
+    description: Return true if array1 contains all of array2 as a subsequence (all values in the same consecutive order).
   - sql: MAP_KEYS(map)
     table: MAP.mapKeys()
     description: 以数组形式返回 map 中的所有 key，不保证顺序。

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -253,6 +253,7 @@ advanced type helper functions
     Expression.array_min
     Expression.array_sort
     Expression.array_union
+    Expression.array_contains_seq
     Expression.map_entries
     Expression.map_keys
     Expression.map_union

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -8,6 +8,7 @@
 #  with the License.  You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
@@ -1710,6 +1711,12 @@ class Expression(Generic[T]):
         if necessary.
         """
         return _binary_op("arrayContains")(self, needle)
+
+    def array_contains_seq(self, array) -> 'Expression':
+        """
+        Return true if array1 contains all of array2 as a subsequence (all values in the same consecutive order).
+        """
+        return _binary_op("arrayContainsSeq")(self, array)
 
     def array_distinct(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -56,6 +56,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_APPEND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONCAT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_CONTAINS_SEQ;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_EXCEPT;
@@ -1756,6 +1757,15 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayUnion(InType array) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_UNION, toExpr(), objectToExpression(array)));
+    }
+
+    /**
+     * Return true if array array1 contains all of array2 as a subsequence (all values in the same
+     * consecutive order).
+     */
+    public OutType arrayContainsSeq(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_CONTAINS_SEQ, toExpr(), objectToExpression(array)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -376,6 +376,17 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayUnionFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_CONTAINS_SEQ =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_CONTAINS_SEQ")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(
+                            nullableIfArgs(
+                                    ConstantArgumentCount.of(0), explicit(DataTypes.BOOLEAN())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayContainsSeqFunction")
+                    .build();
     public static final BuiltInFunctionDefinition ARRAY_CONCAT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("ARRAY_CONCAT")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -1886,7 +1886,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS_SEQ)
                         .onFieldsWithData(
                                 new Integer[] {1, 2, null},
-                                new Integer[] {1},
+                                new Integer[] {1, 2, 3, 4},
                                 new Integer[] {1, 2, null, 3},
                                 new Integer[] {1, 2, null, 3},
                                 1)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsSeqFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsSeqFunction.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_CONTAINS_SEQ}. */
+@Internal
+public class ArrayContainsSeqFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+
+    private final SpecializedFunction.ExpressionEvaluator equalityEvaluator;
+    private transient MethodHandle equalityHandle;
+
+    public ArrayContainsSeqFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_CONTAINS_SEQ, context);
+
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(1))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(dataType.getLogicalType());
+        equalityEvaluator =
+                context.createEvaluator(
+                        $("element1").isEqual($("element2")),
+                        DataTypes.BOOLEAN(),
+                        DataTypes.FIELD("element1", dataType.notNull().toInternal()),
+                        DataTypes.FIELD("element2", dataType.notNull().toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityHandle = equalityEvaluator.open(context);
+    }
+
+    public @Nullable Boolean eval(ArrayData array1, ArrayData array2) {
+        try {
+            if (array1.size() < array2.size()) {
+                return false;
+            }
+            int i = 0;
+            int j = 0;
+            boolean isEqual = false;
+            while (i < array1.size()) {
+                int k = i;
+                int l = 0;
+                while (j < array2.size()) {
+                    final Object element1 = elementGetter.getElementOrNull(array1, k);
+                    final Object element2 = elementGetter.getElementOrNull(array2, j);
+                    // handle nullability before to avoid SQL three-value logic for equality
+                    // because in SQL `NULL == NULL` would return `NULL` and not `TRUE`
+                    if (element1 == null && element2 == null) {
+                        isEqual = true;
+                    } else if (element1 != null && element2 != null) {
+                        isEqual = (boolean) equalityHandle.invoke(element1, element2);
+                    }
+                    if (isEqual) {
+                        k++;
+                        l++;
+                    }
+                    j++;
+                }
+                if (l == array2.size()) {
+                    return true;
+                }
+                j = 0;
+                i++;
+            }
+            return false;
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityEvaluator.close();
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsSeqFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsSeqFunction.java
@@ -68,11 +68,13 @@ public class ArrayContainsSeqFunction extends BuiltInScalarFunction {
                 return false;
             }
             int i = 0;
-            int j = 0;
             boolean isEqual = false;
             while (i < array1.size()) {
+                if (array1.size() - i < array2.size()) {
+                    return false;
+                }
                 int k = i;
-                int l = 0;
+                int j = 0;
                 while (j < array2.size()) {
                     final Object element1 = elementGetter.getElementOrNull(array1, k);
                     final Object element2 = elementGetter.getElementOrNull(array2, j);
@@ -85,14 +87,14 @@ public class ArrayContainsSeqFunction extends BuiltInScalarFunction {
                     }
                     if (isEqual) {
                         k++;
-                        l++;
+                        j++;
+                    } else {
+                        break;
                     }
-                    j++;
                 }
-                if (l == array2.size()) {
+                if (j == array2.size()) {
                     return true;
                 }
-                j = 0;
                 i++;
             }
             return false;


### PR DESCRIPTION
<!--


This is an implementation of ARRAY_Contains_seq

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*
This is an implementation of ARRAY_Contains_seq

## Brief change log
ARRAY_CONTAINS_SEQ for Table API and SQL

Syntax:
ARRAY_CONTAINS_SEQ (arr1, arr2) 

Returns:
The function returns boolean

Examples:
*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*
Flink SQL> select array_contains_seq(array[1,1,2,3],array[1,2]);

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
