### PR TITLE
[FLINK-33311] `surefire.module.config` args should be before entry point classname to work with java 21

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterUncaughtExceptionHandlerITCase.java
@@ -130,7 +130,7 @@ public class ClusterUncaughtExceptionHandlerITCase extends TestLogger {
         }
 
         @Override
-        public String[] getJvmArgs() {
+        public String[] getMainMethodArgs() {
             return new String[0];
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -185,7 +185,7 @@ class FileChannelManagerImplTest {
         }
 
         @Override
-        public String[] getJvmArgs() {
+        public String[] getMainMethodArgs() {
             return new String[] {Boolean.toString(callerHasHook), tmpDirectories, signalFilePath};
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
@@ -78,7 +78,7 @@ public class DispatcherProcess extends TestJvmProcess {
     }
 
     @Override
-    public String[] getJvmArgs() {
+    public String[] getMainMethodArgs() {
         return jvmArgs;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -101,12 +101,12 @@ public abstract class TestJvmProcess {
      *
      * <p>These can be parsed by the main method of the entry point class.
      */
-    public abstract String[] getJvmArgs();
+    public abstract String[] getMainMethodArgs();
 
     /**
      * Returns the name of the class to run.
      *
-     * <p>Arguments to the main method can be specified via {@link #getJvmArgs()}.
+     * <p>Arguments to the main method can be specified via {@link #getMainMethodArgs()}.
      */
     public abstract String getEntryPointClassName();
 
@@ -151,10 +151,10 @@ public abstract class TestJvmProcess {
 
         cmd = ArrayUtils.add(cmd, getEntryPointClassName());
 
-        String[] jvmArgs = getJvmArgs();
+        String[] mainMethodArgs = getMainMethodArgs();
 
-        if (jvmArgs != null && jvmArgs.length > 0) {
-            cmd = ArrayUtils.addAll(cmd, jvmArgs);
+        if (mainMethodArgs != null && mainMethodArgs.length > 0) {
+            cmd = ArrayUtils.addAll(cmd, mainMethodArgs);
         }
 
         synchronized (createDestroyLock) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -141,19 +141,20 @@ public abstract class TestJvmProcess {
                     "-Xmx" + jvmMemoryInMb + "m",
                     "-classpath",
                     getCurrentClasspath(),
-                    "-XX:+IgnoreUnrecognizedVMOptions",
-                    getEntryPointClassName()
+                    "-XX:+IgnoreUnrecognizedVMOptions"
                 };
+
+        final String moduleConfig = System.getProperty("surefire.module.config");
+        if (moduleConfig != null) {
+            cmd = ArrayUtils.addAll(cmd, moduleConfig.trim().split("\\s+"));
+        }
+
+        cmd = ArrayUtils.add(cmd, getEntryPointClassName());
 
         String[] jvmArgs = getJvmArgs();
 
         if (jvmArgs != null && jvmArgs.length > 0) {
             cmd = ArrayUtils.addAll(cmd, jvmArgs);
-        }
-
-        final String moduleConfig = System.getProperty("surefire.module.config");
-        if (moduleConfig != null) {
-            cmd = ArrayUtils.addAll(cmd, moduleConfig.split(" "));
         }
 
         synchronized (createDestroyLock) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
@@ -55,7 +55,7 @@ public class TestingClusterEntrypointProcess extends TestJvmProcess {
     }
 
     @Override
-    public String[] getJvmArgs() {
+    public String[] getMainMethodArgs() {
         return new String[] {markerFile.getAbsolutePath()};
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockingShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockingShutdownTest.java
@@ -164,7 +164,7 @@ class BlockingShutdownTest {
         }
 
         @Override
-        public String[] getJvmArgs() {
+        public String[] getMainMethodArgs() {
             return new String[] {
                 tempFilePath, String.valueOf(installSignalHandler), String.valueOf(selfKillDelay)
             };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/FlinkSecurityManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/FlinkSecurityManagerITCase.java
@@ -82,7 +82,7 @@ class FlinkSecurityManagerITCase {
         }
 
         @Override
-        public String[] getJvmArgs() {
+        public String[] getMainMethodArgs() {
             return new String[0];
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -131,7 +131,7 @@ class JvmExitOnFatalErrorTest {
         }
 
         @Override
-        public String[] getJvmArgs() {
+        public String[] getMainMethodArgs() {
             return new String[] {temporaryFolder.getAbsolutePath()};
         }
 


### PR DESCRIPTION
The issue with `TestJvmProccess` is that properties from `surefire.module.config` are putting in a command line after entry point class name and as a result will be ignored that leads to `FlinkSecurityManagerITCase` failure for jdk21 for instance.

The PR moves these properties before the class name

Also there is a separate commit to rename `getJvmArg` to `getMainMethodArgs` since `getJvmArg` could lead to some misunderstandings.


## Verifying this change

The change is test itself

to reproduce the issue: compile code with java 21 and then execute test FlinkSecurityManagerITCase
without this fix it fails as mentioned in jira

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
