### PR TITLE
[FLINK-33456] Upgrade maven-shade-plugin to 3.5.1 to support jdk20+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2207,7 +2207,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.4.1</version>
+					<version>3.5.1</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION

## What is the purpose of the change

The issue with current shade plugin is that it does not support jdk 20, 21
The support was added at 3.5.1 within https://issues.apache.org/jira/browse/MSHADE-454
The PR bumps to that version


## Brief change log

pom.xml


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
