### PR TITLE
[FLINK-33171][table planner] Consistent implicit type coercion support for equal and non-equal comparisons for codegen

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
@@ -181,12 +181,21 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testSqlApi("'12:34:56' = f21", "TRUE")
     testSqlApi("'13:34:56' = f21", "FALSE")
 
+    testSqlApi("TYPEOF(f22)", "TIMESTAMP(6)")
     testSqlApi("f22 = '1996-11-10 12:34:56'", "TRUE")
     testSqlApi("f22 = '1996-11-10 12:34:57'", "FALSE")
     testSqlApi("f22 = cast(null as string)", "NULL")
     testSqlApi("'1996-11-10 12:34:56' = f22", "TRUE")
     testSqlApi("'1996-11-10 12:34:57' = f22", "FALSE")
     testSqlApi("cast(null as string) = f22", "NULL")
+
+    testSqlApi("TYPEOF(f23)", "TIMESTAMP_LTZ(6)")
+    testSqlApi("f23 = '1996-11-10 12:34:56'", "TRUE")
+    testSqlApi("f23 = '1996-11-10 12:34:57'", "FALSE")
+    testSqlApi("f23 = cast(null as string)", "NULL")
+    testSqlApi("'1996-11-10 12:34:56' = f23", "TRUE")
+    testSqlApi("'1996-11-10 12:34:57' = f23", "FALSE")
+    testSqlApi("cast(null as string) = f23", "NULL")
   }
 
   @Test
@@ -226,6 +235,223 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "date_format(f22 + interval '1' second, 'yyyy-MM-dd HH:mm:ss') = cast(f22 as timestamp_ltz)",
       "FALSE")
     testSqlApi("uuid() = cast(f22 as timestamp_ltz)", "NULL")
+
+    testSqlApi("f23 = date_format(f23, 'yyyy-MM-dd HH:mm:ss')", "TRUE")
+    testSqlApi("f23 = date_format(f23 + interval '1' second, 'yyyy-MM-dd HH:mm:ss')", "FALSE")
+    testSqlApi("f23 = uuid()", "NULL")
+    testSqlApi("date_format(f23, 'yyyy-MM-dd HH:mm:ss') = f23", "TRUE")
+    testSqlApi("date_format(f23 + interval '1' second, 'yyyy-MM-dd HH:mm:ss') = f23", "FALSE")
+    testSqlApi("uuid() = f23", "NULL")
+  }
+
+  @Test
+  def testTimePointTypeNotEqualsString(): Unit = {
+    testSqlApi("NOT(f15 = '1996-11-10')", "FALSE")
+    testSqlApi("NOT(f15 = '1996-11-11')", "TRUE")
+    testSqlApi("NOT('1996-11-10' = f15)", "FALSE")
+    testSqlApi("NOT('1996-11-11' = f15)", "TRUE")
+
+    testSqlApi("NOT(f21 = '12:34:56')", "FALSE")
+    testSqlApi("NOT(f21 = '13:34:56')", "TRUE")
+    testSqlApi("NOT('12:34:56' = f21)", "FALSE")
+    testSqlApi("NOT('13:34:56' = f21)", "TRUE")
+
+    testSqlApi("TYPEOF(f22)", "TIMESTAMP(6)")
+    testSqlApi("NOT(f22 = '1996-11-10 12:34:56')", "FALSE")
+    testSqlApi("NOT(f22 = '1996-11-10 12:34:57')", "TRUE")
+    testSqlApi("NOT(f22 = cast(null as string))", "NULL")
+    testSqlApi("NOT('1996-11-10 12:34:56' = f22)", "FALSE")
+    testSqlApi("NOT('1996-11-10 12:34:57' = f22)", "TRUE")
+    testSqlApi("NOT(cast(null as string) = f22)", "NULL")
+
+    testSqlApi("TYPEOF(f23)", "TIMESTAMP_LTZ(6)")
+    testSqlApi("f23 = '1996-11-10 12:34:56'", "TRUE")
+    testSqlApi("f23 = '1996-11-10 12:34:57'", "FALSE")
+    testSqlApi("f23 = cast(null as string)", "NULL")
+    testSqlApi("'1996-11-10 12:34:56' = f23", "TRUE")
+    testSqlApi("'1996-11-10 12:34:57' = f23", "FALSE")
+    testSqlApi("cast(null as string) = f23", "NULL")
+
+    testSqlApi("NOT(f15 = date_format(cast(f15 as timestamp), 'yyyy-MM-dd'))", "FALSE")
+    testSqlApi(
+      "NOT(f15 = date_format(cast(f15 as timestamp) + interval '1' day, 'yyyy-MM-dd'))",
+      "TRUE")
+    testSqlApi("NOT(f15 = uuid())", "NULL")
+    testSqlApi("NOT(date_format(cast(f15 as timestamp), 'yyyy-MM-dd') = f15)", "FALSE")
+    testSqlApi(
+      "NOT(date_format(cast(f15 as timestamp) + interval '1' day, 'yyyy-MM-dd')) = f15",
+      "TRUE")
+    testSqlApi("NOT(uuid() = f15)", "NULL")
+
+    testSqlApi("NOT(f21 = date_format(cast(f21 as timestamp), 'HH:mm:ss'))", "FALSE")
+    testSqlApi(
+      "NOT(f21 = date_format(cast(f21 as timestamp) + interval '1' hour, 'HH:mm:ss'))",
+      "TRUE")
+    testSqlApi("NOT(f21 = uuid())", "NULL")
+    testSqlApi("NOT(date_format(cast(f21 as timestamp), 'HH:mm:ss') = f21)", "FALSE")
+    testSqlApi(
+      "NOT(date_format(cast(f21 as timestamp) + interval '1' hour, 'HH:mm:ss') = f21)",
+      "TRUE")
+    testSqlApi("NOT(uuid() = f21)", "NULL")
+
+    testSqlApi("NOT(f22 = date_format(f22, 'yyyy-MM-dd HH:mm:ss'))", "FALSE")
+    testSqlApi("NOT(f22 = date_format(f22 + interval '1' second, 'yyyy-MM-dd HH:mm:ss'))", "TRUE")
+    testSqlApi("NOT(f22 = uuid())", "NULL")
+    testSqlApi("NOT(date_format(f22, 'yyyy-MM-dd HH:mm:ss') = f22)", "FALSE")
+    testSqlApi("NOT(date_format(f22 + interval '1' second, 'yyyy-MM-dd HH:mm:ss') = f22)", "TRUE")
+    testSqlApi("NOT(uuid() = f22)", "NULL")
+
+    testSqlApi("NOT(cast(f22 as timestamp_ltz) = date_format(f22, 'yyyy-MM-dd HH:mm:ss'))", "FALSE")
+    testSqlApi(
+      "NOT(cast(f22 as timestamp_ltz) = date_format(f22 + interval '1' second, 'yyyy-MM-dd HH:mm:ss'))",
+      "TRUE")
+    testSqlApi("NOT(cast(f22 as timestamp_ltz) = uuid())", "NULL")
+    testSqlApi("NOT(date_format(f22, 'yyyy-MM-dd HH:mm:ss') = cast(f22 as timestamp_ltz))", "FALSE")
+    testSqlApi(
+      "NOT(date_format(f22 + interval '1' second, 'yyyy-MM-dd HH:mm:ss') = cast(f22 as timestamp_ltz))",
+      "TRUE")
+    testSqlApi("NOT(uuid() = cast(f22 as timestamp_ltz))", "NULL")
+
+    testSqlApi("NOT(f23 = date_format(f23, 'yyyy-MM-dd HH:mm:ss'))", "FALSE")
+    testSqlApi("NOT(f23 = date_format(f23 + interval '1' second, 'yyyy-MM-dd HH:mm:ss'))", "TRUE")
+    testSqlApi("NOT(f23 = uuid())", "NULL")
+    testSqlApi("NOT(date_format(f23, 'yyyy-MM-dd HH:mm:ss') = f23)", "FALSE")
+    testSqlApi("NOT(date_format(f23 + interval '1' second, 'yyyy-MM-dd HH:mm:ss') = f23)", "TRUE")
+    testSqlApi("NOT(uuid() = f23)", "NULL")
+  }
+
+  @Test
+  def testMoreEqualAndNonEqual(): Unit = {
+    // character string
+    testSqlApi("f10 = 'String'", "TRUE")
+    testSqlApi("f10 = 'string'", "FALSE")
+    testSqlApi("f10 = NULL", "NULL")
+    testSqlApi("f10 = CAST(NULL AS STRING)", "NULL")
+    testSqlApi("'String' = f10", "TRUE")
+    testSqlApi("'string' = f10", "FALSE")
+    testSqlApi("NULL = f10", "NULL")
+    testSqlApi("CAST(NULL AS STRING) = f10", "NULL")
+
+    testSqlApi("NOT(f10 = 'String')", "FALSE")
+    testSqlApi("NOT(f10 = 'string')", "TRUE")
+    testSqlApi("NOT(f10 = NULL)", "NULL")
+    testSqlApi("NOT(f10 = CAST(NULL AS STRING))", "NULL")
+    testSqlApi("NOT('String' = f10)", "FALSE")
+    testSqlApi("NOT('string' = f10)", "TRUE")
+    testSqlApi("NOT(NULL = f10)", "NULL")
+    testSqlApi("NOT(CAST(NULL AS STRING) = f10)", "NULL")
+
+    // numeric types
+    testSqlApi("f2 = 1", "TRUE")
+    testSqlApi("f2 = 2", "FALSE")
+    testSqlApi("f2 = NULL", "NULL")
+    testSqlApi("f2 = CAST(NULL AS INT)", "NULL")
+    testSqlApi("1 = f2", "TRUE")
+    testSqlApi("2 = f2", "FALSE")
+    testSqlApi("NULL = f2", "NULL")
+    testSqlApi("CAST(NULL AS INT) = f2", "NULL")
+
+    testSqlApi("NOT(f2 = 1)", "FALSE")
+    testSqlApi("NOT(f2 = 2)", "TRUE")
+    testSqlApi("NOT(f2 = NULL)", "NULL")
+    testSqlApi("NOT(f2 = CAST(NULL AS INT))", "NULL")
+    testSqlApi("NOT(1 = f2)", "FALSE")
+    testSqlApi("NOT(2 = f2)", "TRUE")
+    testSqlApi("NOT(NULL = f2)", "NULL")
+    testSqlApi("NOT(CAST(NULL AS INT) = f2)", "NULL")
+
+    // array
+    testSqlApi("f24 = ARRAY['hello', 'world']", "TRUE")
+    testSqlApi("f24 = ARRAY['hello1', 'world']", "FALSE")
+    testSqlApi("f24 = NULL", "NULL")
+    testSqlApi("f24 = CAST(NULL AS ARRAY<STRING>)", "NULL")
+    testSqlApi("ARRAY['hello', 'world'] = f24", "TRUE")
+    testSqlApi("ARRAY['hello1', 'world'] = f24", "FALSE")
+    testSqlApi("NULL = f24", "NULL")
+    testSqlApi("CAST(NULL AS ARRAY<STRING>) = f24", "NULL")
+
+    testSqlApi("NOT(f24 = ARRAY['hello', 'world'])", "FALSE")
+    testSqlApi("NOT(f24 = ARRAY['hello1', 'world'])", "TRUE")
+    testSqlApi("NOT(f24 = NULL)", "NULL")
+    testSqlApi("NOT(f24 = CAST(NULL AS ARRAY<STRING>))", "NULL")
+    testSqlApi("NOT(ARRAY['hello', 'world'] = f24)", "FALSE")
+    testSqlApi("NOT(ARRAY['hello1', 'world'] = f24)", "TRUE")
+    testSqlApi("NOT(NULL = f24)", "NULL")
+    testSqlApi("NOT(CAST(NULL AS ARRAY<STRING>)) = f24", "NULL")
+
+    // map
+    testSqlApi("f25 = MAP['a', 1, 'b', 2]", "TRUE")
+    testSqlApi("f25 = MAP['a', 3, 'b', 2]", "FALSE")
+    testSqlApi("f25 = NULL", "NULL")
+    testSqlApi("f25 = CAST(NULL AS MAP<STRING, INT>)", "NULL")
+    testSqlApi("MAP['a', 1, 'b', 2] = f25", "TRUE")
+    testSqlApi("MAP['a', 3, 'b', 2] = f25", "FALSE")
+    testSqlApi("NULL = f25", "NULL")
+    testSqlApi("CAST(NULL AS MAP<STRING, INT>) = f25", "NULL")
+
+    testSqlApi("NOT(f25 = MAP['a', 1, 'b', 2])", "FALSE")
+    testSqlApi("NOT(f25 = MAP['a', 3, 'b', 2])", "TRUE")
+    testSqlApi("NOT(f25 = NULL)", "NULL")
+    testSqlApi("NOT(f25 = CAST(NULL AS MAP<STRING, INT>))", "NULL")
+    testSqlApi("NOT(MAP['a', 1, 'b', 2] = f25)", "FALSE")
+    testSqlApi("NOT(MAP['a', 3, 'b', 2] = f25)", "TRUE")
+    testSqlApi("NOT(NULL = f25)", "NULL")
+    testSqlApi("NOT(CAST(NULL AS MAP<STRING, INT>) = f25)", "NULL")
+
+    // raw
+    testSqlApi("f27 = f29", "TRUE")
+    testSqlApi("f27 = f28", "FALSE")
+    testSqlApi("f27 = NULL", "NULL")
+    testSqlApi("f29 = f27", "TRUE")
+    testSqlApi("f28 = f27", "FALSE")
+    testSqlApi("NULL = f27", "NULL")
+
+    testSqlApi("NOT(f27 = f29)", "FALSE")
+    testSqlApi("NOT(f27 = f28)", "TRUE")
+    testSqlApi("NOT(f27 = NULL)", "NULL")
+    testSqlApi("NOT(f29 = f27)", "FALSE")
+    testSqlApi("NOT(f28 = f27)", "TRUE")
+    testSqlApi("NOT(NULL = f27)", "NULL")
+
+    // non comparable types
+    testSqlApi("f30 = ROW('abc', 'def')", "TRUE")
+    testSqlApi("f30 = ROW('abc', 'xyz')", "FALSE")
+    testSqlApi("f30 = NULL", "NULL")
+    testSqlApi("f30 = CAST(NULL AS ROW<f0 STRING, f1 STRING>)", "NULL")
+    testSqlApi("ROW('abc', 'def') = f30", "TRUE")
+    testSqlApi("ROW('abc', 'xyz') = f30", "FALSE")
+    testSqlApi("CAST(NULL AS ROW<f0 STRING, f1 STRING>) = f30", "NULL")
+
+    testSqlApi("NOT(f30 = ROW('abc', 'def'))", "FALSE")
+    testSqlApi("NOT(f30 = ROW('abc', 'xyz'))", "TRUE")
+    testSqlApi("NOT(f30 = NULL)", "NULL")
+    testSqlApi("NOT(f30 = CAST(NULL AS ROW<f0 STRING, f1 STRING>))", "NULL")
+    testSqlApi("NOT(ROW('abc', 'def') = f30)", "FALSE")
+    testSqlApi("NOT(ROW('abc', 'xyz') = f30)", "TRUE")
+    testSqlApi("NOT(CAST(NULL AS ROW<f0 STRING, f1 STRING>) = f30)", "NULL")
+
+    // time interval, comparable
+    testSqlApi("f31 = f33", "TRUE")
+    testSqlApi("f31 = f32", "FALSE")
+    testSqlApi("f31 = NULL", "NULL")
+    testSqlApi("f31 = f34", "NULL")
+    testSqlApi("f31 = CAST(NULL AS INTERVAL DAY)", "NULL")
+    testSqlApi("f33 = f31", "TRUE")
+    testSqlApi("f32 = f31", "FALSE")
+    testSqlApi("NULL = f31", "NULL")
+    testSqlApi("f34 = f31", "NULL")
+    testSqlApi("CAST(NULL AS INTERVAL DAY) = f31", "NULL")
+
+    testSqlApi("NOT(f31 = f33)", "FALSE")
+    testSqlApi("NOT(f31 = f32)", "TRUE")
+    testSqlApi("NOT(f31 = NULL)", "NULL")
+    testSqlApi("NOT(f31 = f34)", "NULL")
+    testSqlApi("NOT(f31 = CAST(NULL AS INTERVAL DAY))", "NULL")
+    testSqlApi("NOT(f33 = f31)", "FALSE")
+    testSqlApi("NOT(f32 = f31)", "TRUE")
+    testSqlApi("NOT(NULL = f31)", "NULL")
+    testSqlApi("NOT(f34 = f31)", "NULL")
+    testSqlApi("NOT(CAST(NULL AS INTERVAL DAY) = f31)", "NULL")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -258,6 +258,7 @@ abstract class ExpressionTestBase(isStreaming: Boolean = true) {
       val converter = DataStructureConverters
         .getConverter(resolvedDataType)
         .asInstanceOf[DataStructureConverter[RowData, Row]]
+      converter.open(getClass.getClassLoader)
       converter.toInternalOrNull(testData)
     }
     try {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
@@ -21,13 +21,18 @@ import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.data.DecimalDataUtils
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
+import org.apache.flink.table.planner.utils.TableConfigUtils
 import org.apache.flink.table.types.AbstractDataType
 import org.apache.flink.types.Row
+
+import java.time.{DayOfWeek, Duration}
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val testData = new Row(23)
+    val testData = new Row(35)
     testData.setField(0, 1: Byte)
     testData.setField(1, 1: Short)
     testData.setField(2, 1)
@@ -51,6 +56,22 @@ abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
     testData.setField(20, "who".getBytes())
     testData.setField(21, localTime("12:34:56"))
     testData.setField(22, localDateTime("1996-11-10 12:34:56"))
+    testData.setField(
+      23,
+      localDateTime("1996-11-10 12:34:56")
+        .atZone(TableConfigUtils.getLocalTimeZone(tableConfig))
+        .toInstant)
+    testData.setField(24, Array("hello", "world"))
+    testData.setField(25, Map("a" -> 1, "b" -> 2).asJava)
+    testData.setField(26, Map("a" -> 1, "b" -> 2).asJava)
+    testData.setField(27, DayOfWeek.SUNDAY)
+    testData.setField(28, DayOfWeek.MONDAY)
+    testData.setField(29, DayOfWeek.SUNDAY)
+    testData.setField(30, Row.of("abc", "def"))
+    testData.setField(31, Duration.ofDays(2))
+    testData.setField(32, Duration.ofDays(3))
+    testData.setField(33, Duration.ofDays(2))
+    testData.setField(34, null)
     testData
   }
 
@@ -82,7 +103,23 @@ abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
       DataTypes.FIELD("f19", DataTypes.VARBINARY(200).notNull()),
       DataTypes.FIELD("f20", DataTypes.VARBINARY(200)),
       DataTypes.FIELD("f21", DataTypes.TIME()),
-      DataTypes.FIELD("f22", DataTypes.TIMESTAMP())
+      DataTypes.FIELD("f22", DataTypes.TIMESTAMP()),
+      DataTypes.FIELD("f23", DataTypes.TIMESTAMP_LTZ()),
+      DataTypes.FIELD("f24", DataTypes.ARRAY(DataTypes.STRING())),
+      DataTypes.FIELD("f25", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
+      DataTypes.FIELD("f26", DataTypes.MULTISET(DataTypes.STRING())),
+      DataTypes.FIELD("f27", DataTypes.RAW(classOf[DayOfWeek])),
+      DataTypes.FIELD("f28", DataTypes.RAW(classOf[DayOfWeek])),
+      DataTypes.FIELD("f29", DataTypes.RAW(classOf[DayOfWeek])),
+      DataTypes.FIELD(
+        "f30",
+        DataTypes.ROW(
+          DataTypes.FIELD("f0", DataTypes.STRING()),
+          DataTypes.FIELD("f1", DataTypes.STRING()))),
+      DataTypes.FIELD("f31", DataTypes.INTERVAL(DataTypes.DAY)),
+      DataTypes.FIELD("f32", DataTypes.INTERVAL(DataTypes.DAY)),
+      DataTypes.FIELD("f33", DataTypes.INTERVAL(DataTypes.DAY)),
+      DataTypes.FIELD("f34", DataTypes.INTERVAL(DataTypes.DAY))
     )
   }
 


### PR DESCRIPTION
…t for equal and non-equal comparisons for codegen

This closes #23478

1.18 backport for parent PR https://github.com/apache/flink/pull/23478

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When executing the following SQL:

```
SELECT
    time1,
    time1 = '2023-09-30 18:22:42.123' AS eq1,
    NOT (time1 = '2023-09-30 18:22:42.123') AS notEq1
FROM table1;
```

the result is as follows:

```
+----+-------------------------+--------+--------+
| op |                   time1 |    eq1 | notEq1 |
+----+-------------------------+--------+--------+
| +I | 2023-09-30 18:22:42.123 |   TRUE |   TRUE |
| +I | 2023-09-30 18:22:42.124 |  FALSE |   TRUE |
+----+-------------------------+--------+--------+
2 rows in set
```

The "notEq1" in the first row should be FALSE.

```
import org.apache.flink.api.common.functions.RichMapFunction;
import org.apache.flink.api.common.typeinfo.TypeInformation;
import org.apache.flink.api.common.typeinfo.Types;
import org.apache.flink.api.java.typeutils.RowTypeInfo;
import org.apache.flink.configuration.Configuration;
import org.apache.flink.streaming.api.datastream.DataStreamSource;
import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
import org.apache.flink.table.api.DataTypes;
import org.apache.flink.table.api.Schema;
import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
import org.apache.flink.types.Row;

public class TimePointNotEqualTest {
    public static void main(String[] args) throws Exception {
        StreamExecutionEnvironment env =
                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
        env.setParallelism(1);

        DataStreamSource<Long> longDataStreamSource = env.fromSequence(0, 1);
        RowTypeInfo rowTypeInfo =
                new RowTypeInfo(new TypeInformation[] {Types.LONG}, new String[] {"time1"});
        SingleOutputStreamOperator<Row> map =
                longDataStreamSource.map(new RichMapFunction<Long, Row>() {
                    @Override
                    public Row map(Long value) {
                        Row row = new Row(1);
                        row.setField(0, 1696069362123L + value);
                        return row;
                    }
                }, rowTypeInfo);

        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
        Schema schema = Schema.newBuilder()
                .column("time1", DataTypes.TIMESTAMP_LTZ(3).bridgedTo(Long.class))
                .build();
        tableEnv.createTemporaryView("table1", map, schema);

        tableEnv.sqlQuery("SELECT "
                + "time1," // 2023-09-30 18:22:42.123
                + "time1 = '2023-09-30 18:22:42.123' AS eq1," // expect TRUE
                + "NOT (time1 = '2023-09-30 18:22:42.123') AS notEq1 " // expect FALSE but TRUE
                + "FROM table1").execute().print();
    }
}
```

## Brief change log

Add TimePoint not equalTo String code in ScalarOperatorGens 

## Verifying this change

Running the same SQL above will yield the correct result:

```
+----+-------------------------+--------+--------+
| op |                   time1 |    eq1 | notEq1 |
+----+-------------------------+--------+--------+
| +I | 2023-09-30 18:22:42.123 |   TRUE |  FALSE |
| +I | 2023-09-30 18:22:42.124 |  FALSE |   TRUE |
+----+-------------------------+--------+--------+
2 rows in set
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
