### PR TITLE
[FLINK-20672] Catch throwable when sending checkpoint aborted messages from JM to TM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1597,8 +1597,17 @@ public class CheckpointCoordinator {
                     for (ExecutionVertex ev : tasksToAbort) {
                         Execution ee = ev.getCurrentExecutionAttempt();
                         if (ee != null) {
-                            ee.notifyCheckpointAborted(
-                                    checkpointId, latestCompletedCheckpointId, timeStamp);
+                            try {
+                                ee.notifyCheckpointAborted(
+                                        checkpointId, latestCompletedCheckpointId, timeStamp);
+                            } catch (Throwable e) {
+                                LOG.warn(
+                                        "Could not send aborted message of checkpoint {} to task {} belonging to job {}.",
+                                        checkpointId,
+                                        ee.getAttemptId(),
+                                        ee.getVertex().getJobId(),
+                                        e);
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
## What is the purpose of the change

Avoid the RPC failure from JM to TM causing JM exit.

## Brief change log

Use try catch to protect the sending logic in async executor when sending checkpoint aborted messages.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
