### PR TITLE
[FLINK-6755][CLI] Support manual checkpoints triggering

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -153,6 +153,35 @@ $ ./bin/flink savepoint \
 Triggering the savepoint disposal through the `savepoint` action does not only remove the data from 
 the storage but makes Flink clean up the savepoint-related metadata as well.
 
+### Creating a Checkpoint
+[Checkpoints]({{< ref "docs/ops/state/checkpoints" >}}) can also be manually created to save the
+current state. To get the difference between checkpoint and savepoint, please refer to
+[Checkpoints vs. Savepoints]({{< ref "docs/ops/state/checkpoints_vs_savepoints" >}}). All that's
+needed to trigger a checkpoint manually is the JobID:
+```bash
+$ ./bin/flink checkpoint \
+      $JOB_ID
+```
+```
+Triggering checkpoint for job 99c59fead08c613763944f533bf90c0f.
+Waiting for response...
+Checkpoint(CONFIGURED) 26 for job 99c59fead08c613763944f533bf90c0f completed.
+You can resume your program from this checkpoint with the run command.
+```
+If you want to trigger a full checkpoint while the job periodically triggering incremental checkpoints,
+please use the `--full` option.
+```bash
+$ ./bin/flink checkpoint \
+      $JOB_ID \
+      --full
+```
+```
+Triggering checkpoint for job 99c59fead08c613763944f533bf90c0f.
+Waiting for response...
+Checkpoint(FULL) 78 for job 99c59fead08c613763944f533bf90c0f completed.
+You can resume your program from this checkpoint with the run command.
+```
+
 ### Terminating a Job
 
 #### Stopping a Job Gracefully Creating a Final Savepoint
@@ -299,6 +328,13 @@ Here's an overview of actions supported by Flink's CLI tool:
                 necessary to specify a savepoint directory besides the JobID, if the 
                 <a href="{{< ref "docs/deployment/config" >}}#state-savepoints-dir">state.savepoints.dir</a> 
                 parameter was not specified in <code class="highlighter-rouge">conf/flink-conf.yaml</code>.
+            </td>
+        </tr>
+        <tr>
+            <td><code class="highlighter-rouge">checkpoint</code></td>
+            <td>
+                This action can be used to create checkpoints for a given job. The checkpoint type
+                (full or incremental) can be specified.
             </td>
         </tr>
         <tr>

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -151,6 +151,35 @@ $ ./bin/flink savepoint \
 Triggering the savepoint disposal through the `savepoint` action does not only remove the data from 
 the storage but makes Flink clean up the savepoint-related metadata as well.
 
+### Creating a Checkpoint
+[Checkpoints]({{< ref "docs/ops/state/checkpoints" >}}) can also be manually created to save the 
+current state. To get the difference between checkpoint and savepoint, please refer to 
+[Checkpoints vs. Savepoints]({{< ref "docs/ops/state/checkpoints_vs_savepoints" >}}). All that's 
+needed to trigger a checkpoint manually is the JobID:
+```bash
+$ ./bin/flink checkpoint \
+      $JOB_ID
+```
+```
+Triggering checkpoint for job 99c59fead08c613763944f533bf90c0f.
+Waiting for response...
+Checkpoint(CONFIGURED) 26 for job 99c59fead08c613763944f533bf90c0f completed.
+You can resume your program from this checkpoint with the run command.
+```
+If you want to trigger a full checkpoint while the job periodically triggering incremental checkpoints, 
+please use the `--full` option.
+```bash
+$ ./bin/flink checkpoint \
+      $JOB_ID \
+      --full
+```
+```
+Triggering checkpoint for job 99c59fead08c613763944f533bf90c0f.
+Waiting for response...
+Checkpoint(FULL) 78 for job 99c59fead08c613763944f533bf90c0f completed.
+You can resume your program from this checkpoint with the run command.
+```
+
 ### Terminating a Job
 
 #### Stopping a Job Gracefully Creating a Final Savepoint
@@ -297,6 +326,13 @@ Here's an overview of actions supported by Flink's CLI tool:
                 necessary to specify a savepoint directory besides the JobID, if the 
                 <a href="{{< ref "docs/deployment/config" >}}#state-savepoints-dir">state.savepoints.dir</a> 
                 parameter was not specified in <code class="highlighter-rouge">conf/flink-conf.yaml</code>.
+            </td>
+        </tr>
+        <tr>
+            <td><code class="highlighter-rouge">checkpoint</code></td>
+            <td>
+                This action can be used to create checkpoints for a given job. The checkpoint type
+                (full or incremental) can be specified.
             </td>
         </tr>
         <tr>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CheckpointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CheckpointOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.core.execution.CheckpointType;
+
+import org.apache.commons.cli.CommandLine;
+
+import static org.apache.flink.client.cli.CliFrontendParser.CHECKPOINT_FULL_OPTION;
+
+/** Command line options for the CHECKPOINT command. */
+public class CheckpointOptions extends CommandLineOptions {
+
+    private final String[] args;
+
+    private CheckpointType checkpointType;
+
+    public CheckpointOptions(CommandLine line) throws CliArgsException {
+        super(line);
+        args = line.getArgs();
+        // TODO: Support type INCREMENTAL
+        if (line.hasOption(CHECKPOINT_FULL_OPTION.getOpt())) {
+            checkpointType = CheckpointType.FULL;
+        } else {
+            checkpointType = CheckpointType.CONFIGURED;
+        }
+    }
+
+    public String[] getArgs() {
+        return args == null ? new String[0] : args;
+    }
+
+    public CheckpointType getCheckpointType() {
+        return checkpointType;
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -157,6 +157,13 @@ public class CliFrontendParser {
                             + " for changing state backends, native = a specific format for the"
                             + " chosen state backend, might be faster to take and restore from.");
 
+    static final Option CHECKPOINT_FULL_OPTION =
+            new Option(
+                    "full",
+                    "full",
+                    false,
+                    "Defines whether to trigger this checkpoint as a full one.");
+
     // list specific options
     static final Option RUNNING_OPTION =
             new Option("r", "running", false, "Show only running programs and their JobIDs");
@@ -442,6 +449,10 @@ public class CliFrontendParser {
                 .addOption(SAVEPOINT_FORMAT_OPTION);
     }
 
+    static Options getCheckpointCommandOptions() {
+        return buildGeneralOptions(new Options()).addOption(CHECKPOINT_FULL_OPTION);
+    }
+
     // --------------------------------------------------------------------------------------------
     //  Help
     // --------------------------------------------------------------------------------------------
@@ -482,6 +493,10 @@ public class CliFrontendParser {
                 .addOption(JAR_OPTION);
     }
 
+    private static Options getCheckpointOptionsWithoutDeprecatedOptions(Options options) {
+        return options.addOption(CHECKPOINT_FULL_OPTION);
+    }
+
     /** Prints the help for the client. */
     public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
         System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
@@ -495,6 +510,7 @@ public class CliFrontendParser {
         printHelpForStop(customCommandLines);
         printHelpForCancel(customCommandLines);
         printHelpForSavepoint(customCommandLines);
+        printHelpForCheckpoint(customCommandLines);
 
         System.out.println();
     }
@@ -605,6 +621,21 @@ public class CliFrontendParser {
         System.out.println("\n  Syntax: savepoint [OPTIONS] <Job ID> [<target directory>]");
         formatter.setSyntaxPrefix("  \"savepoint\" action options:");
         formatter.printHelp(" ", getSavepointOptionsWithoutDeprecatedOptions(new Options()));
+
+        printCustomCliOptions(customCommandLines, formatter, false);
+
+        System.out.println();
+    }
+
+    public static void printHelpForCheckpoint(Collection<CustomCommandLine> customCommandLines) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.setLeftPadding(5);
+        formatter.setWidth(80);
+
+        System.out.println("\nAction \"checkpoint\" triggers checkpoints for a running job.");
+        System.out.println("\n  Syntax: checkpoint [OPTIONS] <Job ID>");
+        formatter.setSyntaxPrefix("  \"checkpoint\" action options:");
+        formatter.printHelp(" ", getCheckpointOptionsWithoutDeprecatedOptions(new Options()));
 
         printCustomCliOptions(customCommandLines, formatter, false);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -177,6 +178,15 @@ public interface ClusterClient<T> extends AutoCloseable {
      */
     CompletableFuture<String> triggerSavepoint(
             JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType);
+
+    /**
+     * Triggers a checkpoint for the job identified by the job id. The checkpoint will be written to
+     * the checkpoint directory for the job.
+     *
+     * @param jobId job id
+     * @param checkpointType the checkpoint type (configured / full / incremental)
+     */
+    CompletableFuture<Long> triggerCheckpoint(JobID jobId, CheckpointType checkpointType);
 
     /**
      * Sends out a request to a specified coordinator and return the response.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -107,6 +108,11 @@ public class MiniClusterClient implements ClusterClient<MiniClusterClient.MiniCl
     public CompletableFuture<String> triggerSavepoint(
             JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType) {
         return miniCluster.triggerSavepoint(jobId, savepointDirectory, false, formatType);
+    }
+
+    @Override
+    public CompletableFuture<Long> triggerCheckpoint(JobID jobId, CheckpointType checkpointType) {
+        return miniCluster.triggerCheckpoint(jobId, checkpointType);
     }
 
     @Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCheckpointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCheckpointTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.cli.util.MockedCliFrontend;
+import org.apache.flink.client.program.TestingClusterClient;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the CHECKPOINT command. */
+class CliFrontendCheckpointTest extends CliFrontendTestBase {
+
+    @Test
+    void testTriggerCheckpointSuccess() throws Exception {
+        JobID jobId = new JobID();
+        long checkpointId = 15L;
+        String[] parameters = {jobId.toString()};
+
+        TestingClusterClient<String> clusterClient = new TestingClusterClient<>();
+
+        try {
+            clusterClient.setTriggerCheckpointFunction(
+                    (ignore, checkpointType) -> {
+                        return CompletableFuture.completedFuture(checkpointId);
+                    });
+
+            MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+            testFrontend.checkpoint(parameters);
+        } finally {
+            clusterClient.close();
+        }
+    }
+
+    @Test
+    void testMissingJobId() {
+        assertThatThrownBy(
+                        () -> {
+                            String[] parameters = {};
+                            Configuration configuration = getConfiguration();
+                            CliFrontend testFrontend =
+                                    new CliFrontend(
+                                            configuration, Collections.singletonList(getCli()));
+                            testFrontend.checkpoint(parameters);
+                        })
+                .isInstanceOf(CliArgsException.class);
+    }
+
+    @Test
+    void testFullCheckpoint() throws Exception {
+        JobID jobId = new JobID();
+        long checkpointId = 15L;
+        String[] parameters = {"-full", jobId.toString()};
+
+        TestingClusterClient<String> clusterClient = new TestingClusterClient<>();
+
+        try {
+            clusterClient.setTriggerCheckpointFunction(
+                    (ignore, checkpointType) -> {
+                        return CompletableFuture.completedFuture(checkpointId);
+                    });
+
+            MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+            testFrontend.checkpoint(parameters);
+        } finally {
+            clusterClient.close();
+        }
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.deployment.StandaloneClusterId;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
+import org.apache.flink.core.execution.CheckpointType;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.RestServerEndpoint;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationResult;
+import org.apache.flink.runtime.rest.handler.async.TriggerResponse;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointInfo;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatusHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatusMessageParameters;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointTriggerHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointTriggerMessageParameters;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointTriggerRequestBody;
+import org.apache.flink.runtime.rest.util.TestRestServerEndpoint;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link RestClusterClient} for operations that trigger checkpoints.
+ *
+ * <p>These tests verify that the client uses the appropriate headers for each request, properly
+ * constructs the request bodies/parameters and processes the responses correctly.
+ */
+class RestClusterClientCheckpointTriggerTest {
+
+    private static final DispatcherGateway mockRestfulGateway =
+            TestingDispatcherGateway.newBuilder().build();
+
+    private static final GatewayRetriever<DispatcherGateway> mockGatewayRetriever =
+            () -> CompletableFuture.completedFuture(mockRestfulGateway);
+
+    private static ExecutorService executor;
+
+    private static final Configuration REST_CONFIG;
+
+    static {
+        final Configuration config = new Configuration();
+        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
+        config.setLong(RestOptions.RETRY_DELAY, 0);
+        config.setInteger(RestOptions.PORT, 0);
+
+        REST_CONFIG = new UnmodifiableConfiguration(config);
+    }
+
+    @BeforeAll
+    static void setUp() {
+        executor =
+                Executors.newSingleThreadExecutor(
+                        new ExecutorThreadFactory(
+                                RestClusterClientCheckpointTriggerTest.class.getSimpleName()));
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(CheckpointType.class)
+    void testTriggerCheckpointWithType(CheckpointType type) throws Exception {
+        final TriggerId triggerId = new TriggerId();
+        final long expectedCheckpointId = 5L;
+
+        try (final RestServerEndpoint restServerEndpoint =
+                createRestServerEndpoint(
+                        request -> {
+                            assertThat(request.getCheckpointType()).isEqualTo(type);
+                            return triggerId;
+                        },
+                        trigger -> {
+                            assertThat(triggerId).isEqualTo(trigger);
+                            return new CheckpointInfo(expectedCheckpointId, null);
+                        })) {
+
+            final RestClusterClient<?> restClusterClient =
+                    createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
+
+            final long checkpointId = restClusterClient.triggerCheckpoint(new JobID(), type).get();
+            assertThat(checkpointId).isEqualTo(expectedCheckpointId);
+        }
+    }
+
+    private static RestServerEndpoint createRestServerEndpoint(
+            final FunctionWithException<
+                            CheckpointTriggerRequestBody, TriggerId, RestHandlerException>
+                    triggerHandlerLogic,
+            final FunctionWithException<TriggerId, CheckpointInfo, RestHandlerException>
+                    checkpointHandlerLogic)
+            throws Exception {
+        return TestRestServerEndpoint.builder(REST_CONFIG)
+                .withHandler(new TestCheckpointTriggerHandler(triggerHandlerLogic))
+                .withHandler(new TestCheckpointHandler(checkpointHandlerLogic))
+                .buildAndStart();
+    }
+
+    private static final class TestCheckpointTriggerHandler
+            extends TestHandler<
+                    CheckpointTriggerRequestBody,
+                    TriggerResponse,
+                    CheckpointTriggerMessageParameters> {
+
+        private final FunctionWithException<
+                        CheckpointTriggerRequestBody, TriggerId, RestHandlerException>
+                triggerHandlerLogic;
+
+        TestCheckpointTriggerHandler(
+                final FunctionWithException<
+                                CheckpointTriggerRequestBody, TriggerId, RestHandlerException>
+                        triggerHandlerLogic) {
+            super(CheckpointTriggerHeaders.getInstance());
+            this.triggerHandlerLogic = triggerHandlerLogic;
+        }
+
+        @Override
+        protected CompletableFuture<TriggerResponse> handleRequest(
+                @Nonnull HandlerRequest<CheckpointTriggerRequestBody> request,
+                @Nonnull DispatcherGateway gateway)
+                throws RestHandlerException {
+
+            return CompletableFuture.completedFuture(
+                    new TriggerResponse(triggerHandlerLogic.apply(request.getRequestBody())));
+        }
+    }
+
+    private static class TestCheckpointHandler
+            extends TestHandler<
+                    EmptyRequestBody,
+                    AsynchronousOperationResult<CheckpointInfo>,
+                    CheckpointStatusMessageParameters> {
+
+        private final FunctionWithException<TriggerId, CheckpointInfo, RestHandlerException>
+                checkpointHandlerLogic;
+
+        TestCheckpointHandler(
+                final FunctionWithException<TriggerId, CheckpointInfo, RestHandlerException>
+                        checkpointHandlerLogic) {
+            super(CheckpointStatusHeaders.getInstance());
+            this.checkpointHandlerLogic = checkpointHandlerLogic;
+        }
+
+        @Override
+        protected CompletableFuture<AsynchronousOperationResult<CheckpointInfo>> handleRequest(
+                @Nonnull HandlerRequest<EmptyRequestBody> request,
+                @Nonnull DispatcherGateway gateway)
+                throws RestHandlerException {
+
+            final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
+            return CompletableFuture.completedFuture(
+                    AsynchronousOperationResult.completed(checkpointHandlerLogic.apply(triggerId)));
+        }
+    }
+
+    private abstract static class TestHandler<
+                    R extends RequestBody, P extends ResponseBody, M extends MessageParameters>
+            extends AbstractRestHandler<DispatcherGateway, R, P, M> {
+
+        private TestHandler(MessageHeaders<R, P, M> headers) {
+            super(mockGatewayRetriever, RpcUtils.INF_TIMEOUT, Collections.emptyMap(), headers);
+        }
+    }
+
+    private RestClusterClient<StandaloneClusterId> createRestClusterClient(final int port)
+            throws Exception {
+        final Configuration clientConfig = new Configuration(REST_CONFIG);
+        clientConfig.setInteger(RestOptions.PORT, port);
+        return new RestClusterClient<>(
+                clientConfig,
+                new RestClient(REST_CONFIG, executor),
+                StandaloneClusterId.getInstance(),
+                (attempt) -> 0);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -1002,7 +1002,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         return dispatcherCachedOperationsHandler.getCheckpointStatus(operationKey);
     }
 
-    private CompletableFuture<Long> triggerCheckpointAndGetCheckpointID(
+    @Override
+    public CompletableFuture<Long> triggerCheckpointAndGetCheckpointID(
             final JobID jobID, final CheckpointType checkpointType, final Time timeout) {
         return performOperationOnJobMasterGateway(
                 jobID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -106,6 +107,20 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
             SavepointFormatType formatType,
             TriggerSavepointMode savepointMode,
             @RpcTimeout final Time timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Triggers a checkpoint, returning a future that completes with the checkpoint id when it is
+     * complete.
+     *
+     * @param jobId the job id
+     * @param checkpointType checkpoint type of this checkpoint (configured / full / incremental)
+     * @param timeout Timeout for the asynchronous operation
+     * @return Future which is completed once the operation is triggered successfully
+     */
+    default CompletableFuture<Long> triggerCheckpointAndGetCheckpointID(
+            final JobID jobId, final CheckpointType checkpointType, final Time timeout) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobClient;
@@ -892,6 +893,13 @@ public class MiniCluster implements AutoCloseableAsync {
     public CompletableFuture<String> triggerCheckpoint(JobID jobID) {
         return runDispatcherCommand(
                 dispatcherGateway -> dispatcherGateway.triggerCheckpoint(jobID, rpcTimeout));
+    }
+
+    public CompletableFuture<Long> triggerCheckpoint(JobID jobID, CheckpointType checkpointType) {
+        return runDispatcherCommand(
+                dispatcherGateway ->
+                        dispatcherGateway.triggerCheckpointAndGetCheckpointID(
+                                jobID, checkpointType, rpcTimeout));
     }
 
     public CompletableFuture<String> stopWithSavepoint(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.client.deployment.ClusterClientJobClientAdapter;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
@@ -271,6 +272,12 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
         @Override
         public CompletableFuture<String> triggerSavepoint(
                 JobID jobId, @Nullable String savepointDirectory, SavepointFormatType formatType) {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<Long> triggerCheckpoint(
+                JobID jobId, CheckpointType checkpointType) {
             return null;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

Since FLINK-24280, we have supported manual checkpoint triggering from REST API. This PR wire command-line interface and rest endpoint, supporting manual checkpoints triggering from CLI.

## Brief change log

 - Add an action "checkpoint" in CLI, and related parameters parsing logic.
 - Wire this action with rest endpoint.
 - Documentation about this feature.

## Verifying this change

This change added tests and can be verified as follows:
  - Unit tests for newly added checkpoint cli action
  - Manually verified triggering checkpoint using command line interface on sample wordcout job deployed on a yarn cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation
  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented?  **docs**
