### PR TITLE
[FLINK-33478][hive] Enable foldExpr by default in filter condition

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -896,7 +896,7 @@ public class HiveParserCalcitePlanner {
             throws SemanticException {
         ExprNodeDesc filterCond =
                 semanticAnalyzer.genExprNodeDesc(
-                        filterExpr, relToRowResolver.get(srcRel), outerRR, null, useCaching);
+                        filterExpr, relToRowResolver.get(srcRel), outerRR, null, useCaching, true);
         if (filterCond instanceof ExprNodeConstantDesc
                 && !filterCond.getTypeString().equals(serdeConstants.BOOLEAN_TYPE_NAME)) {
             throw new SemanticException("Filter expression with non-boolean return type.");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
@@ -2233,9 +2233,20 @@ public class HiveParserSemanticAnalyzer {
             Map<HiveParserASTNode, RelNode> subqueryToRelNode,
             boolean useCaching)
             throws SemanticException {
+        return genExprNodeDesc(expr, input, outerRR, subqueryToRelNode, useCaching, false);
+    }
+
+    public ExprNodeDesc genExprNodeDesc(
+            HiveParserASTNode expr,
+            HiveParserRowResolver input,
+            HiveParserRowResolver outerRR,
+            Map<HiveParserASTNode, RelNode> subqueryToRelNode,
+            boolean useCaching,
+            boolean foldExpr)
+            throws SemanticException {
 
         HiveParserTypeCheckCtx tcCtx =
-                new HiveParserTypeCheckCtx(input, useCaching, false, frameworkConfig, cluster);
+                new HiveParserTypeCheckCtx(input, useCaching, foldExpr, frameworkConfig, cluster);
         tcCtx.setOuterRR(outerRR);
         tcCtx.setSubqueryToRelNode(subqueryToRelNode);
         return genExprNodeDesc(expr, input, tcCtx);

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/udf.q
@@ -15,3 +15,7 @@ select round(123.45, -2);
 select sha2('ABC', cast(null as int));
 
 [+I[null]]
+
+select x from foo where cast(unix_timestamp() as int) > 0;
+
+[+I[1], +I[2], +I[3], +I[4], +I[5]]


### PR DESCRIPTION
## What is the purpose of the change
Use foldExpr config as default to fix NPE problem when use unix_timestamp() in filter condition.
And it is already the default value in hive project.


## Brief change log
Change foldExpr config default as true in filter condition

## Verifying this change
This change is verified by added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

