### PR TITLE
fixup! [FLINK-33060][state] Fix the javadoc of ListState interfaces about not allowing null value

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -58,8 +58,8 @@ public interface AppendingState<IN, OUT> extends State {
      * of values. The next time {@link #get()} is called (for the same state partition) the returned
      * state will represent the updated list.
      *
-     * <p>If null is passed in, the behaviour is undefined (implementation related).
-     * TODO: An unified behaviour across all sub-classes.
+     * <p>If null is passed in, the behaviour is undefined (implementation related). TODO: An
+     * unified behaviour across all sub-classes.
      *
      * @param value The new value for the state.
      * @throws Exception Thrown if the system cannot access the state.


### PR DESCRIPTION
## What is the purpose of the change

Fixing up the https://github.com/apache/flink/pull/23441 since the spotless check is broken.

## Brief change log

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
