### PR TITLE
[FLINK-33485][table] Optimize exists subqueries by looking at metadata rowcount

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
@@ -216,14 +216,14 @@ class FlinkSubQueryRemoveRule(
 
       // EXISTS and NOT EXISTS
       case SqlKind.EXISTS =>
-        // If the sub-query is guaranteed to produce at least one row, just return TRUE.
-        // If the sub-query is guaranteed to produce no rows then return FALSE.
         val mq = subQuery.rel.getCluster.getMetadataQuery
         val minRowCount = mq.getMinRowCount(subQuery.rel)
+        // If the sub-query is guaranteed to produce at least one row, just return TRUE.
         if (minRowCount != null && minRowCount >= 1d) {
           return Option.apply(relBuilder.literal(!withNot))
         }
         val maxRowCount = mq.getMaxRowCount(subQuery.rel)
+        // If the sub-query is guaranteed to produce no rows then return FALSE.
         if (maxRowCount != null && maxRowCount < 1d) {
           return Option.apply(relBuilder.literal(withNot))
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
@@ -216,9 +216,8 @@ class FlinkSubQueryRemoveRule(
 
       // EXISTS and NOT EXISTS
       case SqlKind.EXISTS =>
-        // If the sub-query is guaranteed to produce at least one row, just return// If the sub-query is guaranteed to produce at least one row, just return
-
-        // TRUE.
+        // If the sub-query is guaranteed to produce at least one row, just return TRUE.
+        // If the sub-query is guaranteed to produce no rows then return FALSE.
         val mq = subQuery.rel.getCluster.getMetadataQuery
         val minRowCount = mq.getMinRowCount(subQuery.rel)
         if (minRowCount != null && minRowCount >= 1d) {
@@ -228,6 +227,7 @@ class FlinkSubQueryRemoveRule(
         if (maxRowCount != null && maxRowCount < 1d) {
           return Option.apply(relBuilder.literal(withNot))
         }
+
         val joinCondition = if (equivalent != null) {
           // EXISTS has correlation variables
           relBuilder.push(equivalent.getKey) // push join right

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPruneAggregateCallRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPruneAggregateCallRuleTest.xml
@@ -54,14 +54,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $condition=[$t1])
-   +- LogicalAggregate(group=[{}], m=[MIN($0)])
-      +- LogicalCalc(expr#0=[{inputs}], expr#1=[true], i=[$t1])
-         +- LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-            +- LogicalCalc(expr#0..3=[{inputs}], a1=[$t0])
-               +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -83,13 +76,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $condition=[$t1])
-   +- LogicalAggregate(group=[{}], m=[MIN($0)])
-      +- LogicalCalc(expr#0=[{inputs}], expr#1=[true], i=[$t1])
-         +- LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-            +- LogicalValues(tuples=[[]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -131,14 +118,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $condition=[$t1])
-   +- LogicalAggregate(group=[{}], m=[MIN($0)])
-      +- LogicalCalc(expr#0=[{inputs}], expr#1=[true], i=[$t1])
-         +- LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-            +- LogicalCalc(expr#0..3=[{inputs}], expr#4=[0], $f0=[$t4])
-               +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -160,13 +140,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalCalc(expr#0=[{inputs}], expr#1=[IS NOT NULL($t0)], $condition=[$t1])
-   +- LogicalAggregate(group=[{}], m=[MIN($0)])
-      +- LogicalCalc(expr#0=[{inputs}], expr#1=[true], i=[$t1])
-         +- LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-            +- LogicalValues(tuples=[[]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRuleTest.xml
@@ -493,14 +493,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, c])
-+- FlinkLogicalJoin(condition=[$3], joinType=[semi])
-   :- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-   +- FlinkLogicalCalc(select=[IS NOT NULL(m) AS $f0])
-      +- FlinkLogicalAggregate(group=[{}], m=[MIN($0)])
-         +- FlinkLogicalCalc(select=[true AS i])
-            +- FlinkLogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-               +- FlinkLogicalCalc(select=[a])
-                  +- FlinkLogicalValues(tuples=[[]])
++- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkLimit0RemoveRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/FlinkLimit0RemoveRuleTest.xml
@@ -34,12 +34,7 @@ LogicalSort(fetch=[0])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalJoin(condition=[$3], joinType=[semi])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-   +- LogicalProject($f0=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalValues(tuples=[[]])
++- LogicalValues(tuples=[[]])
 ]]>
     </Resource>
   </TestCase>
@@ -93,7 +88,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
   </TestCase>
   <TestCase name="testLimitZeroWithJoin">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable INNER JOIN (SELECT * FROM MyTable Limit 0) ON TRUE]]>
+      <![CDATA[SELECT * FROM MyTable INNER JOIN (SELECT * FROM MyTable LIMIT 0) ON TRUE]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -132,12 +127,7 @@ LogicalSort(fetch=[0])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalJoin(condition=[$3], joinType=[anti])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-   +- LogicalProject($f0=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalValues(tuples=[[]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectPruneAggregateCallRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectPruneAggregateCallRuleTest.xml
@@ -54,15 +54,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalProject
-   +- LogicalFilter(condition=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-               +- LogicalProject(a1=[$0])
-                  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -84,14 +76,7 @@ LogicalAggregate(group=[{}], EXPR$0=[SUM($0)], EXPR$1=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalProject
-   +- LogicalFilter(condition=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
-               +- LogicalValues(tuples=[[]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -133,15 +118,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalProject
-   +- LogicalFilter(condition=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-               +- LogicalProject($f0=[0])
-                  +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>
@@ -163,14 +140,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalJoin(condition=[true], joinType=[semi])
-:- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
-+- LogicalProject
-   +- LogicalFilter(condition=[IS NOT NULL($0)])
-      +- LogicalAggregate(group=[{}], m=[MIN($0)])
-         +- LogicalProject(i=[true])
-            +- LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-               +- LogicalValues(tuples=[[]])
+LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRuleTest.scala
@@ -131,7 +131,6 @@ class FlinkAggregateRemoveRuleTest extends TableTestBase {
 
   @Test
   def testAggRemove_WithoutGroupBy3(): Unit = {
-    // can not remove agg
     util.verifyRelPlan(
       "SELECT * FROM MyTable2 WHERE EXISTS (SELECT SUM(a) FROM MyTable1 WHERE 1=2)")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLimit0RemoveRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkLimit0RemoveRuleTest.scala
@@ -89,6 +89,6 @@ class FlinkLimit0RemoveRuleTest extends TableTestBase {
 
   @Test
   def testLimitZeroWithJoin(): Unit = {
-    util.verifyRelPlan("SELECT * FROM MyTable INNER JOIN (SELECT * FROM MyTable Limit 0) ON TRUE")
+    util.verifyRelPlan("SELECT * FROM MyTable INNER JOIN (SELECT * FROM MyTable LIMIT 0) ON TRUE")
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

The idea is to look at metadata rowcount for `EXISTS` subqueries and based on this take a decision whether it could be optimized to `TRUE`/`FALSE`

## Brief change log

FlinkSubQueryRemoveRule.java
adopted tests, since optimization changed execution plans

## Verifying this change

This change is already covered by existing tests, such as 
CalcPruneAggregateCallRuleTest
ProjectPruneAggregateCallRuleTest
FlinkAggregateRemoveRuleTest
FlinkLimit0RemoveRuleTest
ProjectPruneAggregateCallRuleTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
