### PR TITLE
[FLINK-33402] Hybrid Source Concurrency Race Condition Fixes and Related Bugs Results in Data Loss

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Hybrid source reader that delegates to the actual source reader.
@@ -58,15 +60,18 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
     private int currentSourceIndex = -1;
     private boolean isFinalSource;
     private SourceReader<T, ? extends SourceSplit> currentReader;
+    private final ReadWriteLock currentReaderReadWriteLock;
     private CompletableFuture<Void> availabilityFuture = new CompletableFuture<>();
     private List<HybridSourceSplit> restoredSplits = new ArrayList<>();
 
     public HybridSourceReader(SourceReaderContext readerContext) {
         this.readerContext = readerContext;
+        this.currentReaderReadWriteLock = new ReentrantReadWriteLock();
     }
 
     @Override
     public void start() {
+        currentReaderReadWriteLock.readLock().lock();
         // underlying reader starts on demand with split assignment
         int initialSourceIndex = currentSourceIndex;
         if (!restoredSplits.isEmpty()) {
@@ -74,11 +79,14 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         }
         readerContext.sendSourceEventToCoordinator(
                 new SourceReaderFinishedEvent(initialSourceIndex));
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
     public InputStatus pollNext(ReaderOutput output) throws Exception {
+        currentReaderReadWriteLock.readLock().lock();
         if (currentReader == null) {
+            currentReaderReadWriteLock.readLock().unlock();
             return InputStatus.NOTHING_AVAILABLE;
         }
 
@@ -96,48 +104,57 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                     new SourceReaderFinishedEvent(currentSourceIndex));
             if (!isFinalSource) {
                 // More splits may arrive for a subsequent reader.
-                // InputStatus.NOTHING_AVAILABLE suspends poll, complete the
-                // availability future in the switchover to the next reader
+                // InputStatus.NOTHING_AVAILABLE suspends poll, requires completion of the
+                // availability future after receiving more splits to resume.
+                if (availabilityFuture.isDone()) {
+                    // reset to avoid continued polling
+                    availabilityFuture = new CompletableFuture();
+                }
+                currentReaderReadWriteLock.readLock().unlock();
                 return InputStatus.NOTHING_AVAILABLE;
             }
         }
+        currentReaderReadWriteLock.readLock().unlock();
         return status;
     }
 
     @Override
     public List<HybridSourceSplit> snapshotState(long checkpointId) {
+        currentReaderReadWriteLock.readLock().lock();
         List<? extends SourceSplit> state =
                 currentReader != null
                         ? currentReader.snapshotState(checkpointId)
                         : Collections.emptyList();
+        currentReaderReadWriteLock.readLock().unlock();
         return HybridSourceSplit.wrapSplits(state, currentSourceIndex, switchedSources);
     }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        currentReaderReadWriteLock.readLock().lock();
         if (currentReader != null) {
             currentReader.notifyCheckpointComplete(checkpointId);
         }
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
     public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        currentReaderReadWriteLock.readLock().lock();
         if (currentReader != null) {
             currentReader.notifyCheckpointAborted(checkpointId);
         }
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
-    public CompletableFuture<Void> isAvailable() {
-        if (availabilityFuture.isDone()) {
-            availabilityFuture = currentReader.isAvailable();
-        }
-
+    public  CompletableFuture<Void> isAvailable() {
         return availabilityFuture;
     }
 
     @Override
     public void addSplits(List<HybridSourceSplit> splits) {
+        currentReaderReadWriteLock.readLock().lock();
         LOG.info(
                 "Adding splits subtask={} sourceIndex={} currentReader={} {}",
                 readerContext.getIndexOfSubtask(),
@@ -159,10 +176,12 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
             }
             currentReader.addSplits((List) realSplits);
         }
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
     public void notifyNoMoreSplits() {
+        currentReaderReadWriteLock.readLock().lock();
         if (currentReader != null) {
             currentReader.notifyNoMoreSplits();
         }
@@ -171,10 +190,12 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                 readerContext.getIndexOfSubtask(),
                 currentSourceIndex,
                 currentReader);
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
     public void handleSourceEvents(SourceEvent sourceEvent) {
+        currentReaderReadWriteLock.readLock().lock();
         if (sourceEvent instanceof SwitchSourceEvent) {
             SwitchSourceEvent sse = (SwitchSourceEvent) sourceEvent;
             LOG.info(
@@ -183,15 +204,23 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                     sse.sourceIndex(),
                     sse.source());
             switchedSources.put(sse.sourceIndex(), sse.source());
+            currentReaderReadWriteLock.readLock().unlock();
             setCurrentReader(sse.sourceIndex());
+            currentReaderReadWriteLock.readLock().lock();
             isFinalSource = sse.isFinalSource();
+            if (!availabilityFuture.isDone()) {
+                // continue polling
+                availabilityFuture.complete(null);
+            }
         } else {
             currentReader.handleSourceEvents(sourceEvent);
         }
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     @Override
     public void close() throws Exception {
+        currentReaderReadWriteLock.readLock().lock();
         if (currentReader != null) {
             currentReader.close();
         }
@@ -200,14 +229,17 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                 readerContext.getIndexOfSubtask(),
                 currentSourceIndex,
                 currentReader);
+        currentReaderReadWriteLock.readLock().unlock();
     }
 
     private void setCurrentReader(int index) {
+        currentReaderReadWriteLock.writeLock().lock();
         Preconditions.checkArgument(index != currentSourceIndex);
         if (currentReader != null) {
             try {
                 currentReader.close();
             } catch (Exception e) {
+                currentReaderReadWriteLock.writeLock().unlock();
                 throw new RuntimeException("Failed to close current reader", e);
             }
             LOG.debug(
@@ -222,12 +254,22 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         try {
             reader = source.createReader(readerContext);
         } catch (Exception e) {
+            currentReaderReadWriteLock.writeLock().unlock();
             throw new RuntimeException("Failed tp create reader", e);
         }
         reader.start();
         currentSourceIndex = index;
         currentReader = reader;
-        availabilityFuture.complete(null);
+        currentReader
+                .isAvailable()
+                .whenComplete(
+                        (result, ex) -> {
+                            if (ex == null) {
+                                availabilityFuture.complete(result);
+                            } else {
+                                availabilityFuture.completeExceptionally(ex);
+                            }
+                        });
         LOG.debug(
                 "Reader started: subtask={} sourceIndex={} {}",
                 readerContext.getIndexOfSubtask(),
@@ -244,7 +286,10 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
                     it.remove();
                 }
             }
+            currentReaderReadWriteLock.writeLock().unlock();
             addSplits(splits);
+            return;
         }
+        currentReaderReadWriteLock.writeLock().unlock();
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -77,7 +77,7 @@ public class HybridSourceSplitEnumerator
     private final SwitchedSources switchedSources = new SwitchedSources();
     // Splits that have been returned due to subtask reset
     private final Map<Integer, TreeMap<Integer, List<HybridSourceSplit>>> pendingSplits;
-    private Set<Integer> finishedReaders;
+    private final Set<Integer> finishedReaders;
     private final Map<Integer, Integer> readerSourceIndex;
     private int currentSourceIndex;
     private HybridSourceEnumeratorState restoredEnumeratorState;
@@ -284,11 +284,11 @@ public class HybridSourceSplitEnumerator
 
     private void switchEnumerator() {
         currentEnumeratorReadWriteLock.writeLock().lock();
-        finishedReaders = new HashSet<>();
         SplitEnumerator<SourceSplit, Object> previousEnumerator = currentEnumerator;
         if (currentEnumerator != null) {
             try {
                 currentEnumerator.close();
+                finishedReaders.clear();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable
