### PR TITLE
[FLINK-33489][table-planner] forbid generating partial-final agg with LISTAGG to avoid wrong result

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -953,9 +953,10 @@ object AggregateUtil extends Enumeration {
         aggCall.getAggregation match {
           case _: SqlCountAggFunction | _: SqlAvgAggFunction | _: SqlMinMaxAggFunction |
               _: SqlSumAggFunction | _: SqlSumEmptyIsZeroAggFunction |
-              _: SqlSingleValueAggFunction | _: SqlListAggFunction =>
+              _: SqlSingleValueAggFunction =>
             true
-          case _: SqlFirstLastValueAggFunction => aggCall.getArgList.size() == 1
+          case _: SqlFirstLastValueAggFunction | _: SqlListAggFunction =>
+            aggCall.getArgList.size() == 1
           case _ => false
         }
     }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
@@ -290,6 +290,92 @@ GroupAggregate(groupBy=[b], partialFinalType=[FINAL], select=[b, FIRST_VALUE_RET
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testListAggWithDistinctMultiArgs[splitDistinctAggEnabled=false, aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1, $2)])
++- LogicalProject(a=[$0], c=[$2], $f2=[_UTF-16LE'#'])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[a], select=[a, LISTAGG(DISTINCT c, $f2) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a, c, '#' AS $f2])
+      +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testListAggWithDistinctMultiArgs[splitDistinctAggEnabled=false, aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1, $2)])
++- LogicalProject(a=[$0], c=[$2], $f2=[_UTF-16LE'#'])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GlobalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 (accDelimiter$0, concatAcc$1)) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- LocalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 c, $f2) AS (accDelimiter$0, concatAcc$1), DISTINCT(c, $f2) AS distinct$0])
+      +- Calc(select=[a, c, '#' AS $f2])
+         +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testListAggWithDistinctMultiArgs[splitDistinctAggEnabled=true, aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1, $2)])
++- LogicalProject(a=[$0], c=[$2], $f2=[_UTF-16LE'#'])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[a], select=[a, LISTAGG(DISTINCT c, $f2) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a, c, '#' AS $f2])
+      +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testListAggWithDistinctMultiArgs[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1, $2)])
++- LogicalProject(a=[$0], c=[$2], $f2=[_UTF-16LE'#'])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GlobalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 (accDelimiter$0, concatAcc$1)) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- LocalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 c, $f2) AS (accDelimiter$0, concatAcc$1), DISTINCT(c, $f2) AS distinct$0])
+      +- Calc(select=[a, c, '#' AS $f2])
+         +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMinMaxWithRetraction[splitDistinctAggEnabled=false, aggPhaseEnforcer=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/IncrementalAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/IncrementalAggregateTest.xml
@@ -88,6 +88,28 @@ GroupAggregate(groupBy=[b], partialFinalType=[FINAL], select=[b, FIRST_VALUE_RET
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testListAggWithDistinctMultiArgs[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[LISTAGG(DISTINCT $1, $2)])
++- LogicalProject(a=[$0], c=[$2], $f2=[_UTF-16LE'#'])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GlobalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 (accDelimiter$0, concatAcc$1)) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- LocalGroupAggregate(groupBy=[a], select=[a, LISTAGG(distinct$0 c, $f2) AS (accDelimiter$0, concatAcc$1), DISTINCT(c, $f2) AS distinct$0])
+      +- Calc(select=[a, c, '#' AS $f2])
+         +- MiniBatchAssigner(interval=[1000ms], mode=[ProcTime])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMinMaxWithRetraction[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -216,6 +216,11 @@ class DistinctAggregateTest(
        """.stripMargin
     util.verifyRelPlan(sqlQuery, ExplainDetail.CHANGELOG_MODE)
   }
+
+  @Test
+  def testListAggWithDistinctMultiArgs(): Unit = {
+    util.verifyExecPlan("SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a")
+  }
 }
 
 object DistinctAggregateTest {


### PR DESCRIPTION
## What is the purpose of the change

Currently LISTAGG with splitting original agg to final-partial agg will cause wrong result. This pr is for a quick fix to avoid splitting with it.

## Brief change log

  - *Avoid splitting LISTAGG when SplitAggregateRule*
  - *Add UT and IT*

## Verifying this change

Some tests are added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no