### PR TITLE
[FLINK-33492][docs] Fix unavailable links in connector download page

### DIFF
--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -139,10 +139,10 @@ hbase:
     versions:
         - version: 1.4.x
           maven: flink-connector-hbase-1.4
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-1.4/$version/flink-sql-connector-hbase-1.4-$version.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-1.4/3.0.0-1.17/flink-sql-connector-hbase-1.4-3.0.0-1.17.jar
         - version: 2.2.x
           maven: flink-connector-hbase-2.2
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-2.2/$version/flink-sql-connector-hbase-2.2-$version.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase-2.2/3.0.0-1.17/flink-sql-connector-hbase-2.2-3.0.0-1.17.jar
 
 jdbc:
     name: JDBC
@@ -156,7 +156,7 @@ kafka:
     versions:
         - version: universal
           maven: flink-connector-kafka
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$version/flink-sql-connector-kafka-$version.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/3.0.1-1.18/flink-sql-connector-kafka-3.0.1-1.18.jar
 
 upsert-kafka:
     name: Upsert Kafka
@@ -164,7 +164,7 @@ upsert-kafka:
     versions:
         - version: universal
           maven: flink-connector-kafka
-          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$version/flink-sql-connector-kafka-$version.jar
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/3.0.1-1.18/flink-sql-connector-kafka-3.0.1-1.18.jar
 
 kinesis:
     name: Amazon Kinesis Data Streams

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -52,7 +52,7 @@ integrate_connector_docs rabbitmq v3.0
 integrate_connector_docs gcp-pubsub v3.0
 integrate_connector_docs mongodb v1.0
 integrate_connector_docs opensearch v1.0
-integrate_connector_docs kafka v3.0
+integrate_connector_docs kafka v3.0.1
 integrate_connector_docs hbase v3.0
 
 cd ..


### PR DESCRIPTION
## What is the purpose of the change

Fix unavailable links in connector download page to make it work for users

## Brief change log

* correct hbase, kafka, upsert-kafka connector download url

## Verifying this change

Docs only change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no