### PR TITLE
[FLINK-33210][core] Introduce job status changed listener for lineage

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -78,6 +78,14 @@ public class DeploymentOptions {
                             "Custom JobListeners to be registered with the execution environment."
                                     + " The registered listeners cannot have constructors with arguments.");
 
+    public static final ConfigOption<List<String>> JOB_STATUS_CHANGED_LISTENERS =
+            key("execution.job-status-changed-listeners")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When job is created or its status is changed, Flink will generate job event and notify job status changed listener.");
+
     public static final ConfigOption<Boolean> SHUTDOWN_ON_APPLICATION_FINISH =
             ConfigOptions.key("execution.shutdown-on-application-finish")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultJobExecutionStatusEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultJobExecutionStatusEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+
+import javax.annotation.Nullable;
+
+/** Default implementation for {@link JobExecutionStatusEvent}. */
+@Internal
+public class DefaultJobExecutionStatusEvent implements JobExecutionStatusEvent {
+    private final JobID jobId;
+    private final String jobName;
+    private final JobStatus oldStatus;
+    private final JobStatus newStatus;
+    @Nullable private final Throwable cause;
+
+    public DefaultJobExecutionStatusEvent(
+            JobID jobId,
+            String jobName,
+            JobStatus oldStatus,
+            JobStatus newStatus,
+            @Nullable Throwable cause) {
+        this.jobId = jobId;
+        this.jobName = jobName;
+        this.oldStatus = oldStatus;
+        this.newStatus = newStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public JobStatus oldStatus() {
+        return oldStatus;
+    }
+
+    @Override
+    public JobStatus newStatus() {
+        return newStatus;
+    }
+
+    @Nullable
+    @Override
+    public Throwable exception() {
+        return cause;
+    }
+
+    @Override
+    public JobID jobId() {
+        return jobId;
+    }
+
+    @Override
+    public String jobName() {
+        return jobName;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobExecutionStatusEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobExecutionStatusEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobStatus;
+
+import javax.annotation.Nullable;
+
+/** Job execution status event. */
+@PublicEvolving
+public interface JobExecutionStatusEvent extends JobStatusChangedEvent {
+    /** Old status for job. */
+    JobStatus oldStatus();
+
+    /** New status for job. */
+    JobStatus newStatus();
+
+    /** Exception for job. */
+    @Nullable
+    Throwable exception();
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
+
+/** Basic job status event. */
+@PublicEvolving
+public interface JobStatusChangedEvent {
+    /** Job id for the event. */
+    JobID jobId();
+
+    /** Job name for the event. */
+    String jobName();
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListener.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * When job is created or its status is changed, Flink will generate job event and notify job status
+ * changed listener.
+ */
+@PublicEvolving
+public interface JobStatusChangedListener {
+    /* Event will be fired when job status is changed. */
+    void onEvent(JobStatusChangedEvent event);
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.concurrent.Executor;
+
+/** Factory for job status changed listener. */
+@PublicEvolving
+public interface JobStatusChangedListenerFactory {
+
+    JobStatusChangedListener createListener(Context context);
+
+    /** Context for factory to create {@link JobStatusChangedListener}. */
+    @PublicEvolving
+    interface Context {
+        /*
+         * Configuration for the factory to create listener, users can add customized options to flink and get them here to create the listener. For
+         * example, users can add rest address for datahub to the configuration, and get it when they need to create http client for the listener.
+         */
+        Configuration getConfiguration();
+
+        /** User class loader for the factory. */
+        ClassLoader getUserClassLoader();
+
+        /*
+         * Get an Executor pool for the listener to run async operations that can potentially be IO-heavy. `JobMaster` will provide an independent executor
+         * for io operations and it won't block the main-thread. All tasks submitted to the executor will be executed in parallel, and when the job ends,
+         * previously submitted tasks will be executed, but no new tasks will be accepted.
+         */
+        Executor getIOExecutor();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.DeploymentOptions.JOB_STATUS_CHANGED_LISTENERS;
+
+/** Util class for {@link JobStatusChangedListener}. */
+@Internal
+public final class JobStatusChangedListenerUtils {
+    /**
+     * Create job status changed listeners from configuration for job.
+     *
+     * @param configuration The job configuration.
+     * @return the job status changed listeners.
+     */
+    public static List<JobStatusChangedListener> createJobStatusChangedListeners(
+            ClassLoader userClassLoader, Configuration configuration, Executor ioExecutor) {
+        List<String> jobStatusChangedListeners = configuration.get(JOB_STATUS_CHANGED_LISTENERS);
+        if (jobStatusChangedListeners == null || jobStatusChangedListeners.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return jobStatusChangedListeners.stream()
+                .map(
+                        fac -> {
+                            try {
+                                return InstantiationUtil.instantiate(
+                                                fac,
+                                                JobStatusChangedListenerFactory.class,
+                                                userClassLoader)
+                                        .createListener(
+                                                new JobStatusChangedListenerFactory.Context() {
+                                                    @Override
+                                                    public Configuration getConfiguration() {
+                                                        return configuration;
+                                                    }
+
+                                                    @Override
+                                                    public ClassLoader getUserClassLoader() {
+                                                        return userClassLoader;
+                                                    }
+
+                                                    @Override
+                                                    public Executor getIOExecutor() {
+                                                        return ioExecutor;
+                                                    }
+                                                });
+                            } catch (FlinkException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerUtils;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -138,6 +140,10 @@ public class DefaultExecutionGraphBuilder {
             throw new JobException("Could not create the TaskDeploymentDescriptorFactory.", e);
         }
 
+        final List<JobStatusChangedListener> jobStatusChangedListeners =
+                JobStatusChangedListenerUtils.createJobStatusChangedListeners(
+                        classLoader, jobManagerConfig, ioExecutor);
+
         // create a new execution graph, if none exists so far
         final DefaultExecutionGraph executionGraph =
                 new DefaultExecutionGraph(
@@ -160,7 +166,8 @@ public class DefaultExecutionGraphBuilder {
                         executionJobVertexFactory,
                         jobGraph.getJobStatusHooks(),
                         markPartitionFinishedStrategy,
-                        taskDeploymentDescriptorFactory);
+                        taskDeploymentDescriptorFactory,
+                        jobStatusChangedListeners);
 
         // set the basic properties
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobStatusChangedListenerTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobStatusChangedListenerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobExecutionStatusEvent;
+import org.apache.flink.core.execution.JobStatusChangedEvent;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerFactory;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.configuration.DeploymentOptions.JOB_STATUS_CHANGED_LISTENERS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for job status changed listener. */
+public class JobStatusChangedListenerTest {
+    private static List<JobStatusChangedEvent> statusChangedEvents = new ArrayList<>();
+
+    @Test
+    void testJobStatusChanged() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                JOB_STATUS_CHANGED_LISTENERS,
+                Collections.singletonList(TestingJobStatusChangedListenerFactory.class.getName()));
+        try (StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration)) {
+            List<String> sourceValues = Arrays.asList("a", "b", "c");
+            List<String> resultValues = new ArrayList<>();
+            try (CloseableIterator<String> iterator =
+                    env.fromCollection(sourceValues).executeAndCollect()) {
+                while (iterator.hasNext()) {
+                    resultValues.add(iterator.next());
+                }
+            }
+            assertThat(resultValues).containsExactlyInAnyOrder(sourceValues.toArray(new String[0]));
+        }
+        assertThat(statusChangedEvents.size()).isEqualTo(2);
+        assertThat(statusChangedEvents.get(0).jobId())
+                .isEqualTo(statusChangedEvents.get(1).jobId());
+        assertThat(statusChangedEvents.get(0).jobName())
+                .isEqualTo(statusChangedEvents.get(1).jobName());
+
+        statusChangedEvents.forEach(
+                event -> {
+                    JobExecutionStatusEvent status = (JobExecutionStatusEvent) event;
+                    assertThat(
+                                    (status.oldStatus() == JobStatus.CREATED
+                                                    && status.newStatus() == JobStatus.RUNNING)
+                                            || (status.oldStatus() == JobStatus.RUNNING
+                                                    && status.newStatus() == JobStatus.FINISHED))
+                            .isTrue();
+                });
+    }
+
+    /** Testing job status changed listener factory. */
+    public static class TestingJobStatusChangedListenerFactory
+            implements JobStatusChangedListenerFactory {
+
+        @Override
+        public JobStatusChangedListener createListener(Context context) {
+            return new TestingJobStatusChangedListener();
+        }
+    }
+
+    /** Testing job status changed listener. */
+    private static class TestingJobStatusChangedListener implements JobStatusChangedListener {
+
+        @Override
+        public void onEvent(JobStatusChangedEvent event) {
+            statusChangedEvents.add(event);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to introduce job status changed listener for lineage.

## Brief change log

  - Introduce JobStatusChangedListener and JobStatusChangedListenerFactory for flink
  - Introduce JobStatusChangedEvent for listener
  - Create listener in execution graph and notify listener when job status changes

## Verifying this change

This change added tests and can be verified as follows:

  - Added JobStatusChangedListenerTest to validate job status changed events

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
