### PR TITLE
[FLINK-33520] Avoid using FLINK_HOME to find test scripts

### DIFF
--- a/flink-external-resources/flink-external-resource-gpu/src/test/java/org/apache/flink/externalresource/gpu/GPUDriverTest.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/test/java/org/apache/flink/externalresource/gpu/GPUDriverTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Set;
 import java.util.UUID;
 
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class GPUDriverTest {
 
     private static final String TESTING_DISCOVERY_SCRIPT_PATH =
-            "src/test/resources/testing-gpu-discovery.sh";
+            Paths.get("src/test/resources/testing-gpu-discovery.sh").toAbsolutePath().toString();
 
     @Test
     void testGPUDriverWithTestScript() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

This is a *very* minor change to avoid depending on the value of the `FLINK_HOME` environment variable when discovering the value of the gpu discovery test script (only used while testing).

Before this change, the following error occurs on the command line and IDE if the `FLINK_HOME` is set:

```
java.io.FileNotFoundException: The gpu discovery script does not exist in path /opt/asf/flink/src/test/resources/testing-gpu-discovery.sh.
	at org.apache.flink.externalresource.gpu.GPUDriver.<init>(GPUDriver.java:98)
	at org.apache.flink.externalresource.gpu.GPUDriverTest.testGPUDriverWithInvalidAmount(GPUDriverTest.java:64)
```

## Brief change log

During unit tests, use an absolute path to the modules `src/test/resources` directory instead of a path relative to `FLINK_HOME` (if it exists).

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
