### PR TITLE
[FLINK-33524][ API / DataStream] fix IntervalJoinOperator 's judgment on isLate function bug

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -264,7 +264,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
 
     private boolean isLate(long timestamp) {
         long currentWatermark = internalTimerService.currentWatermark();
-        return timestamp < currentWatermark;
+        return timestamp <= currentWatermark;
     }
 
     /** Write skipped late arriving element to SideOutput. */


### PR DESCRIPTION
## What is the purpose of the change

*fix bug in isLast function*
*When data with an event time of 1000ms enters, the Watermark will be pushed to 999.*
*At this point, data with an event time of 999ms enters.Will be judged as non late data.*


## Brief change log

  - *Change judgment criteria*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)