### PR TITLE
[FLINK-33532][rpc] Support configured akka remote dispatcher thread pool size

### DIFF
--- a/docs/layouts/shortcodes/generated/akka_configuration.html
+++ b/docs/layouts/shortcodes/generated/akka_configuration.html
@@ -57,6 +57,24 @@
             <td>Min number of threads to cap factor-based parallelism number to.</td>
         </tr>
         <tr>
+            <td><h5>pekko.remote-fork-join-executor.parallelism-factor</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>Double</td>
+            <td>The parallelism factor is used to determine thread pool size using the following formula: ceil(available processors * factor). Resulting size is then bounded by the parallelism-min and parallelism-max values.</td>
+        </tr>
+        <tr>
+            <td><h5>pekko.remote-fork-join-executor.parallelism-max</h5></td>
+            <td style="word-wrap: break-word;">16</td>
+            <td>Integer</td>
+            <td>Max number of threads to cap factor-based parallelism number to.</td>
+        </tr>
+        <tr>
+            <td><h5>pekko.remote-fork-join-executor.parallelism-min</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Integer</td>
+            <td>Min number of threads to cap factor-based parallelism number to.</td>
+        </tr>
+        <tr>
             <td><h5>pekko.framesize</h5></td>
             <td style="word-wrap: break-word;">"10485760b"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -237,6 +237,38 @@ public class AkkaOptions {
                                             "Max number of threads to cap factor-based parallelism number to.")
                                     .build());
 
+    public static final ConfigOption<Double> REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR =
+            ConfigOptions.key("pekko.remote-fork-join-executor.parallelism-factor")
+                    .doubleType()
+                    .defaultValue(2.0)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The parallelism factor is used to determine thread pool size using the"
+                                                    + " following formula: ceil(available processors * factor). Resulting size"
+                                                    + " is then bounded by the parallelism-min and parallelism-max values.")
+                                    .build());
+
+    public static final ConfigOption<Integer> REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MIN =
+            ConfigOptions.key("pekko.remote-fork-join-executor.parallelism-min")
+                    .intType()
+                    .defaultValue(8)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Min number of threads to cap factor-based parallelism number to.")
+                                    .build());
+
+    public static final ConfigOption<Integer> REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MAX =
+            ConfigOptions.key("pekko.remote-fork-join-executor.parallelism-max")
+                    .intType()
+                    .defaultValue(16)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Max number of threads to cap factor-based parallelism number to.")
+                                    .build());
+
     // ==================================================
     // Configurations for client-socket-work-pool.
     // ==================================================

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
@@ -273,4 +273,17 @@ public class ActorSystemBootstrapTools {
         return new RpcSystem.ForkJoinExecutorConfiguration(
                 parallelismFactor, minParallelism, maxParallelism);
     }
+
+    public static RpcSystem.ForkJoinExecutorConfiguration getRemoteForkJoinExecutorConfiguration(
+            final Configuration configuration) {
+        final double parallelismFactor =
+                configuration.getDouble(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
+        final int minParallelism =
+                configuration.getInteger(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
+        final int maxParallelism =
+                configuration.getInteger(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
+
+        return new RpcSystem.ForkJoinExecutorConfiguration(
+                parallelismFactor, minParallelism, maxParallelism);
+    }
 }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
@@ -197,6 +197,9 @@ class PekkoUtils {
         addBaseRemoteConfig(builder, configuration, port, externalPort);
         addHostnameRemoteConfig(builder, bindAddress, externalHostname);
         addSslRemoteConfig(builder, configuration);
+        addRemoteForkJoinExecutorConfig(
+                builder,
+                ActorSystemBootstrapTools.getRemoteForkJoinExecutorConfiguration(configuration));
 
         return builder.build();
     }
@@ -382,6 +385,27 @@ class PekkoUtils {
                 .add("    }")
                 .add("  }")
                 .add("}");
+    }
+
+    private static Config addRemoteForkJoinExecutorConfig(
+            ConfigBuilder builder, RpcSystem.ForkJoinExecutorConfiguration configuration) {
+        final double parallelismFactor = configuration.getParallelismFactor();
+        final int minNumThreads = configuration.getMinParallelism();
+        final int maxNumThreads = configuration.getMaxParallelism();
+
+        return builder.add("pekko {")
+                .add("  remote {")
+                .add("    default-remote-dispatcher {")
+                .add("      executor = fork-join-executor")
+                .add("      fork-join-executor {")
+                .add("          parallelism-factor = " + parallelismFactor)
+                .add("          parallelism-min = " + minNumThreads)
+                .add("          parallelism-max = " + maxNumThreads)
+                .add("      }")
+                .add("    }")
+                .add("  }")
+                .add("}")
+                .build();
     }
 
     /**

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoUtilsTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoUtilsTest.java
@@ -175,6 +175,15 @@ class PekkoUtilsTest {
     }
 
     @Test
+    void getConfigDefaultsToRemoteForkJoinExecutor() {
+        final Config config =
+                PekkoUtils.getConfig(new Configuration(), new HostAndPort("localhost", 1234));
+
+        assertThat(config.getString("pekko.remote.default-remote-dispatcher.executor"))
+                .isEqualTo("fork-join-executor");
+    }
+
+    @Test
     void getConfigSetsExecutorWithThreadPriority() {
         final int threadPriority = 3;
         final int minThreads = 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/CachedShuffleDescriptors.java
@@ -87,7 +87,7 @@ public class CachedShuffleDescriptors {
                     new ShuffleDescriptorGroup(
                             toBeSerialized.toArray(new ShuffleDescriptorAndIndex[0]));
             MaybeOffloaded<ShuffleDescriptorGroup> serializedShuffleDescriptorGroup =
-                    shuffleDescriptorSerializer.serializeAndTryOffloadShuffleDescriptor(
+                    shuffleDescriptorSerializer.trySerializeAndOffloadShuffleDescriptor(
                             shuffleDescriptorGroup, numConsumers);
 
             toBeSerialized.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloadedRaw;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
@@ -98,9 +98,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
                 new IndexRange(consumedSubpartitionIndex, consumedSubpartitionIndex),
                 inputChannels.length,
                 Collections.singletonList(
-                        new NonOffloaded<>(
-                                CompressedSerializedValue.fromObject(
-                                        new ShuffleDescriptorGroup(inputChannels)))));
+                        new NonOffloadedRaw<>(new ShuffleDescriptorGroup(inputChannels))));
     }
 
     public InputGateDeploymentDescriptor(
@@ -147,18 +145,14 @@ public class InputGateDeploymentDescriptor implements Serializable {
             // This is only for testing scenarios, in a production environment we always call
             // tryLoadAndDeserializeShuffleDescriptors to deserialize ShuffleDescriptors first.
             inputChannels = new ShuffleDescriptor[numberOfInputChannels];
-            try {
-                for (MaybeOffloaded<ShuffleDescriptorGroup> serializedShuffleDescriptors :
-                        serializedInputChannels) {
-                    checkState(
-                            serializedShuffleDescriptors instanceof NonOffloaded,
-                            "Trying to work with offloaded serialized shuffle descriptors.");
-                    NonOffloaded<ShuffleDescriptorGroup> nonOffloadedSerializedValue =
-                            (NonOffloaded<ShuffleDescriptorGroup>) serializedShuffleDescriptors;
-                    tryDeserializeShuffleDescriptorGroup(nonOffloadedSerializedValue);
-                }
-            } catch (ClassNotFoundException | IOException e) {
-                throw new RuntimeException("Could not deserialize shuffle descriptors.", e);
+            for (MaybeOffloaded<ShuffleDescriptorGroup> rawShuffleDescriptors :
+                    serializedInputChannels) {
+                checkState(
+                        rawShuffleDescriptors instanceof NonOffloadedRaw,
+                        "Trying to work with offloaded serialized shuffle descriptors.");
+                NonOffloadedRaw<ShuffleDescriptorGroup> nonOffloadedRawValue =
+                        (NonOffloadedRaw<ShuffleDescriptorGroup>) rawShuffleDescriptors;
+                putOrReplaceShuffleDescriptors(nonOffloadedRawValue.value);
             }
         }
         return inputChannels;
@@ -213,19 +207,10 @@ public class InputGateDeploymentDescriptor implements Serializable {
             }
             putOrReplaceShuffleDescriptors(shuffleDescriptorGroup);
         } else {
-            NonOffloaded<ShuffleDescriptorGroup> nonOffloadedSerializedValue =
-                    (NonOffloaded<ShuffleDescriptorGroup>) serializedShuffleDescriptors;
-            tryDeserializeShuffleDescriptorGroup(nonOffloadedSerializedValue);
+            NonOffloadedRaw<ShuffleDescriptorGroup> nonOffloadedSerializedValue =
+                    (NonOffloadedRaw<ShuffleDescriptorGroup>) serializedShuffleDescriptors;
+            putOrReplaceShuffleDescriptors(nonOffloadedSerializedValue.value);
         }
-    }
-
-    private void tryDeserializeShuffleDescriptorGroup(
-            NonOffloaded<ShuffleDescriptorGroup> nonOffloadedShuffleDescriptorGroup)
-            throws IOException, ClassNotFoundException {
-        ShuffleDescriptorGroup shuffleDescriptorGroup =
-                nonOffloadedShuffleDescriptorGroup.serializedValue.deserializeValue(
-                        getClass().getClassLoader());
-        putOrReplaceShuffleDescriptors(shuffleDescriptorGroup);
     }
 
     private void putOrReplaceShuffleDescriptors(ShuffleDescriptorGroup shuffleDescriptorGroup) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -81,6 +81,25 @@ public final class TaskDeploymentDescriptor implements Serializable {
     }
 
     /**
+     * The raw value that is not offloaded to the {@link org.apache.flink.runtime.blob.BlobServer}.
+     *
+     * @param <T> type of the raw value
+     */
+    public static class NonOffloadedRaw<T> extends MaybeOffloaded<T> {
+        private static final long serialVersionUID = 1L;
+
+        /** The raw value. */
+        public T value;
+
+        @SuppressWarnings("unused")
+        public NonOffloadedRaw() {}
+
+        public NonOffloadedRaw(T value) {
+            this.value = Preconditions.checkNotNull(value);
+        }
+    }
+
+    /**
      * Reference to a serialized value that was offloaded to the {@link
      * org.apache.flink.runtime.blob.BlobServer}.
      *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTestUtils.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.deployment;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.TestingBlobWriter;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffloaded;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloaded;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.NonOffloadedRaw;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.Offloaded;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorAndIndex;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.ShuffleDescriptorGroup;
@@ -47,11 +47,8 @@ public class TaskDeploymentDescriptorTestUtils {
         int maxIndex = 0;
         for (MaybeOffloaded<ShuffleDescriptorGroup> sd : maybeOffloaded) {
             ShuffleDescriptorGroup shuffleDescriptorGroup;
-            if (sd instanceof NonOffloaded) {
-                shuffleDescriptorGroup =
-                        ((NonOffloaded<ShuffleDescriptorGroup>) sd)
-                                .serializedValue.deserializeValue(
-                                        ClassLoader.getSystemClassLoader());
+            if (sd instanceof NonOffloadedRaw) {
+                shuffleDescriptorGroup = ((NonOffloadedRaw<ShuffleDescriptorGroup>) sd).value;
 
             } else {
                 final CompressedSerializedValue<ShuffleDescriptorGroup> compressedSerializedValue =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -70,7 +70,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
-import org.apache.flink.util.CompressedSerializedValue;
 
 import org.apache.flink.shaded.guava31.com.google.common.io.Closer;
 
@@ -1337,9 +1336,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                         subpartitionIndexRange,
                         channelDescs.length,
                         Collections.singletonList(
-                                new TaskDeploymentDescriptor.NonOffloaded<>(
-                                        CompressedSerializedValue.fromObject(
-                                                new ShuffleDescriptorGroup(channelDescs)))));
+                                new TaskDeploymentDescriptor.NonOffloadedRaw<>(
+                                        new ShuffleDescriptorGroup(channelDescs))));
 
         final TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();


### PR DESCRIPTION
## What is the purpose of the change

 - Support configured akka remote dispatcher thread pool size.
 - Move the serialization of ShuffleDescriptorGroup out of the RPC main thread

## Brief change log

- Add config `akka.remote-fork-join-executor.parallelism-factor`,`akka.remote-fork-join-executor.parallelism-max` and `akka.remote-fork-join-executor.parallelism-min`
- Move the serialization logic of ShuffleDescriptorGroup to akka's default-remote-dispatcher thread instead of the default-dispatcher thread.

## Verifying this change
- Add `getConfigDefaultsToRemoteForkJoinExecutor` in `PekkoUtilsTest`.
- The tests related to `ShuffleDescriptorGroup` have already been covered by existing tests, such as `TaskDeploymentDescriptorFactoryTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
