### PR TITLE
[FLINK-33276][ci] Merges connect_1 and connect_2 stages into a single one

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -95,10 +95,8 @@ jobs:
         module: python
       table:
         module: table
-      connect_1:
-        module: connect_1
-      connect_2:
-        module: connect_2
+      connect:
+        module: connect
       tests:
         module: tests
       misc:

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -21,8 +21,7 @@ STAGE_COMPILE="compile"
 STAGE_CORE="core"
 STAGE_PYTHON="python"
 STAGE_TABLE="table"
-STAGE_CONNECTORS_1="connect_1"
-STAGE_CONNECTORS_2="connect_2"
+STAGE_CONNECTORS="connect"
 STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
@@ -84,7 +83,7 @@ flink-table/flink-table-code-splitter,\
 flink-table/flink-table-test-utils,\
 "
 
-MODULES_CONNECTORS_1="\
+MODULES_CONNECTORS="\
 flink-contrib/flink-connector-wikiedits,\
 flink-filesystems,\
 flink-filesystems/flink-azure-fs-hadoop,\
@@ -124,9 +123,6 @@ flink-metrics/flink-metrics-prometheus,\
 flink-metrics/flink-metrics-statsd,\
 flink-metrics/flink-metrics-datadog,\
 flink-metrics/flink-metrics-slf4j,\
-"
-
-MODULES_CONNECTORS_2="\
 flink-connectors/flink-connector-base,\
 "
 
@@ -144,11 +140,8 @@ function get_compile_modules_for_stage() {
         (${STAGE_TABLE})
             echo "-pl $MODULES_TABLE -am"
         ;;
-        (${STAGE_CONNECTORS_1})
-            echo "-pl $MODULES_CONNECTORS_1 -am"
-        ;;
-        (${STAGE_CONNECTORS_2})
-            echo "-pl $MODULES_CONNECTORS_2 -am"
+        (${STAGE_CONNECTORS})
+            echo "-pl $MODULES_CONNECTORS -am"
         ;;
         (${STAGE_TESTS})
             echo "-pl $MODULES_TESTS -am"
@@ -170,15 +163,13 @@ function get_test_modules_for_stage() {
 
     local modules_core=$MODULES_CORE
     local modules_table=$MODULES_TABLE
-    local modules_connectors_2=$MODULES_CONNECTORS_2
-    local modules_connectors_1=$MODULES_CONNECTORS_1
+    local modules_connectors=$MODULES_CONNECTORS
     local modules_tests=$MODULES_TESTS
     local negated_core=\!${MODULES_CORE//,/,\!}
     local negated_table=\!${MODULES_TABLE//,/,\!}
-    local negated_connectors_2=\!${MODULES_CONNECTORS_2//,/,\!}
-    local negated_connectors_1=\!${MODULES_CONNECTORS_1//,/,\!}
+    local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
-    local modules_misc="$negated_core,$negated_table,$negated_connectors_1,$negated_connectors_2,$negated_tests"
+    local modules_misc="$negated_core,$negated_table,$negated_connectors,$negated_tests"
 
     case ${stage} in
         (${STAGE_CORE})
@@ -187,11 +178,8 @@ function get_test_modules_for_stage() {
         (${STAGE_TABLE})
             echo "-pl $modules_table"
         ;;
-        (${STAGE_CONNECTORS_1})
-            echo "-pl $modules_connectors_1"
-        ;;
-        (${STAGE_CONNECTORS_2})
-            echo "-pl $modules_connectors_2"
+        (${STAGE_CONNECTORS})
+            echo "-pl $modules_connectors"
         ;;
         (${STAGE_TESTS})
             echo "-pl $modules_tests"


### PR DESCRIPTION
## What is the purpose of the change

* Merged `connect_2` stage into `connect_1` and renamed it into `connect`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable