### PR TITLE
[FLINK-33508] [HistoryServer] Support for wildcard paths in Flink History Server for multi cluster environment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -670,6 +670,23 @@ public abstract class FileSystem {
     public abstract FileStatus[] listStatus(Path f) throws IOException;
 
     /**
+     * Returns an array of paths that match given path pattern.
+     *
+     * <p>This method is optional on file systems and various file system implementations may not
+     * support this method, throwing an {@code UnsupportedOperationException}.
+     *
+     * @param pathPattern path pattern to match
+     * @return the statuses of the files/directories that matches given path
+     * @throws IOException Thrown, if given path can not be found/resolved by filesystem
+     */
+    public FileStatus[] globStatus(Path pathPattern) throws IOException {
+        // UnsupportedOperationException if not implemented in subclass. GlobStatus is currently
+        // supported only for Hadoop File Systems. It is not supported for Local File System.
+        throw new UnsupportedOperationException(
+                "This file system does not support file paths with regular expression.");
+    }
+
+    /**
      * Check if exists.
      *
      * @param f source file
@@ -780,6 +797,17 @@ public abstract class FileSystem {
      * @return True, if this is a distributed file system, false otherwise.
      */
     public abstract boolean isDistributedFS();
+
+    /**
+     * Returns true if this is a file system with globPattern support. As of now, globPattern is
+     * supported only for Hadoop based file systems. Ex: Google Cloud Storage, Hadoop Distributed
+     * File System.
+     *
+     * @return True, when file system supports globStatus(globPattern) operation, false otherwise.
+     */
+    public boolean isGlobStatusSupported() {
+        return false;
+    }
 
     /**
      * Gets a description of the characteristics of this file system.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -329,6 +329,11 @@ public class LimitedConnectionsFileSystem extends FileSystem {
     }
 
     @Override
+    public boolean isGlobStatusSupported() {
+        return originalFs.isGlobStatusSupported();
+    }
+
+    @Override
     public Path getWorkingDirectory() {
         return originalFs.getWorkingDirectory();
     }
@@ -357,6 +362,11 @@ public class LimitedConnectionsFileSystem extends FileSystem {
     @Override
     public FileStatus[] listStatus(Path f) throws IOException {
         return originalFs.listStatus(f);
+    }
+
+    @Override
+    public FileStatus[] globStatus(Path f) throws IOException {
+        return originalFs.globStatus(f);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
@@ -143,6 +143,13 @@ public class PluginFileSystemFactory implements FileSystemFactory {
         }
 
         @Override
+        public FileStatus[] globStatus(final Path f) throws IOException {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                return inner.globStatus(f);
+            }
+        }
+
+        @Override
         public boolean exists(final Path f) throws IOException {
             try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
                 return inner.exists(f);
@@ -175,6 +182,13 @@ public class PluginFileSystemFactory implements FileSystemFactory {
         public boolean isDistributedFS() {
             try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
                 return inner.isDistributedFS();
+            }
+        }
+
+        @Override
+        public boolean isGlobStatusSupported() {
+            try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
+                return inner.isGlobStatusSupported();
             }
         }
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -100,6 +100,11 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
     }
 
     @Override
+    public FileStatus[] globStatus(Path f) throws IOException {
+        return unsafeFileSystem.globStatus(f);
+    }
+
+    @Override
     public boolean exists(Path f) throws IOException {
         return unsafeFileSystem.exists(f);
     }
@@ -151,6 +156,11 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
     @Override
     public boolean isDistributedFS() {
         return unsafeFileSystem.isDistributedFS();
+    }
+
+    @Override
+    public boolean isGlobStatusSupported() {
+        return unsafeFileSystem.isGlobStatusSupported();
     }
 
     @Override

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -179,6 +179,25 @@ public class HadoopFileSystem extends FileSystem {
     }
 
     @Override
+    public FileStatus[] globStatus(Path pathPattern) throws IOException {
+        final org.apache.hadoop.fs.FileStatus[] hadoopFiles =
+                this.fs.globStatus(toHadoopPath(pathPattern));
+
+        if (hadoopFiles == null) {
+            return null;
+        }
+
+        final FileStatus[] files = new FileStatus[hadoopFiles.length];
+
+        // Convert types
+        for (int i = 0; i < files.length; i++) {
+            files[i] = HadoopFileStatus.fromHadoopStatus(hadoopFiles[i]);
+        }
+
+        return files;
+    }
+
+    @Override
     public boolean mkdirs(final Path f) throws IOException {
         return this.fs.mkdirs(toHadoopPath(f));
     }
@@ -196,6 +215,11 @@ public class HadoopFileSystem extends FileSystem {
 
     @Override
     public boolean isDistributedFS() {
+        return true;
+    }
+
+    @Override
+    public boolean isGlobStatusSupported() {
         return true;
     }
 

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystemGlobTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystemGlobTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+/** Test for {@link org.apache.hadoop.fs.FileSystem} globStatus API support. */
+public class HadoopFileSystemGlobTest {
+
+    private FileSystem mockHadoopFileSystem;
+    private HadoopFileSystem testFileSystem;
+
+    @Before
+    public void setUp() throws Exception {
+        mockHadoopFileSystem = Mockito.mock(FileSystem.class);
+        testFileSystem = new HadoopFileSystem(mockHadoopFileSystem);
+    }
+
+    @Test
+    public void testGlobStatusSupported() {
+        assertEquals(testFileSystem.isGlobStatusSupported(), true);
+    }
+
+    @Test
+    public void testGlobStatusWhenMatchingFilesFound() throws IOException {
+        final String globPattern = "hdfs://abc/*";
+        final String absFilePath = "hdfs://abc/a";
+
+        org.apache.hadoop.fs.FileStatus mockFileStatusHadoop =
+                new org.apache.hadoop.fs.FileStatus();
+        mockFileStatusHadoop.setPath(new org.apache.hadoop.fs.Path(absFilePath));
+        org.apache.hadoop.fs.FileStatus[] mockFileStatusResult =
+                new org.apache.hadoop.fs.FileStatus[] {mockFileStatusHadoop};
+        when(mockHadoopFileSystem.globStatus(new org.apache.hadoop.fs.Path(globPattern)))
+                .thenReturn(mockFileStatusResult);
+
+        FileStatus[] fileStatusResult = testFileSystem.globStatus(new Path(globPattern));
+        assertEquals(fileStatusResult.length, 1);
+        assertEquals(fileStatusResult[0].getPath(), new Path(absFilePath));
+    }
+
+    @Test
+    public void testGlobStatusWhenNoMatchingFilesFound() throws IOException {
+        when(mockHadoopFileSystem.globStatus(any())).thenReturn(null);
+
+        FileStatus[] fileStatusResult = testFileSystem.globStatus(new Path("hdfs://abc/*"));
+        assertNull(fileStatusResult);
+    }
+
+    @Test(expected = IOException.class)
+    public void testGlobStatusWhenException() throws IOException {
+        when(mockHadoopFileSystem.globStatus(any(org.apache.hadoop.fs.Path.class)))
+                .thenThrow(IOException.class);
+        testFileSystem.globStatus(new Path("hdfs://abc/*"));
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This pull request updates Flink's History Server logic to enable getting logs and data from multiple directories at a time by using a path with wildcards (i.e glob pattern) from HadoopFileSystem locations. The feature can be very useful for cloud based use cases where users wish to setup history server in multi cluster environment.

## Brief change log

- Enhance the Flink's FileSystem API by adding a function that exposes the Hadoop's file system API GlobStatus feature.
- Flink's HistoryServerArchiveFetcher currently uses the HadoopFileSystem's listStatus API method to read files from the location specified in 'historyserver.archive.fs.dir' property which by design does not resolve patterns/wildcards in the history server file path.
- We enhance the Flink's FileSystem API by introducing a new method similar to Hadoop's `globStatus(Path pathPattern)` as below:
```
public FileStatus[] globStatus(Path pathPattern) throws IOException
```
- This new method is now implemented in Flink's HadoopFileSystem class such that it uses the Hadoop's internal globStatus implementation.

```
public FileStatus[] globStatus(final Path pathPattern) throws IOException {
    final FileStatus[] hadoopFiles = this.fs.globStatus(toHadoopPath(pathPattern));
    // rest of the code
}
```
- Finally, HistoryServerArchiveFetcher.java will call the new globStatus() API instead of listStatus() for HadoopFileSystem.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added unit tests to test the functionality of the new globSatus API in Flink's HadoopFileSystem class
  - Manually verified the change by running two 3-node clusters (GCP Dataproc) with logs storage on object store (Google Cloud Storage) and reading their logs from another single node cluster's history server UI Interface.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
