### PR TITLE
[hotfix] Add missing import to fix build

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.plan.rules.physical.stream.IncrementalAggr
 import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, StreamTableTestUtil, TableTestBase}
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 
-import org.junit.jupiter.api.{BeforeEach, Test, TestTemplate}
+import org.junit.jupiter.api.{BeforeEach, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util
@@ -217,7 +217,7 @@ class DistinctAggregateTest(
     util.verifyRelPlan(sqlQuery, ExplainDetail.CHANGELOG_MODE)
   }
 
-  @Test
+  @TestTemplate
   def testListAggWithDistinctMultiArgs(): Unit = {
     util.verifyExecPlan("SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.plan.rules.physical.stream.IncrementalAggr
 import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, StreamTableTestUtil, TableTestBase}
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 
-import org.junit.jupiter.api.{BeforeEach, TestTemplate}
+import org.junit.jupiter.api.{BeforeEach, Test, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.util


### PR DESCRIPTION
The PR is aiming to fix build failure 
https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=54581&view=logs&j=52b61abe-a3cc-5bde-cc35-1bbe89bb7df5&t=54421a62-0c80-5aad-3319-094ff69180bb
```
11:58:02.126 [ERROR] /__w/1/s/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala:220: error: not found: type Test
11:58:02.126 [ERROR]   @Test
11:58:02.126 [ERROR]    ^

```
