### PR TITLE
[hotfix][table-planner] fix the failed cases caused by junit5

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -217,7 +217,7 @@ class DistinctAggregateTest(
     util.verifyRelPlan(sqlQuery, ExplainDetail.CHANGELOG_MODE)
   }
 
-  @Test
+  @TestTemplate
   def testListAggWithDistinctMultiArgs(): Unit = {
     util.verifyExecPlan("SELECT a, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY a")
   }


### PR DESCRIPTION
## What is the purpose of the change

Fix the failed case in DistinctAggregateTest.

## Brief change log

  - *Fix the failed case*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no