### PR TITLE
[FLINK-33567] Only display connector download links if its available

### DIFF
--- a/docs/layouts/shortcodes/connector_artifact.html
+++ b/docs/layouts/shortcodes/connector_artifact.html
@@ -27,17 +27,35 @@ under the License.
 {{ $version := $connector.version  }}
 {{ $path := .Page.Path }}
 
+{{ $connector := index .Site.Data $name }}
+{{ $flink_compatibility := $connector.flink_compatibility  }}
+{{ $flink_version := .Site.Params.VersionTitle }}
+
 {{ $hash := md5 now }}
 
+{{ $containsVersion := false }}
+{{ range $flink_compatibility }}
+    {{ if in . $flink_version }}
+        {{ $containsVersion = true }}
+        {{ printf "Fine" }}
+        {{ break }}
+    {{ end }}
+{{ end }}
+
+
 {{ if $.Site.Params.IsStable }}
-<div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
-    <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
-    <span class="nt">&ltartifactId&gt</span>{{- $artifactId -}}<span class="nt">&lt/artifactId&gt</span>
-    <span class="nt">&ltversion&gt</span>{{- $version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
-<span class="nt">&lt/dependency&gt</span></code></pre></div>
-<div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
-  Copied to clipboard!
-</div>
+    {{ if $containsVersion }}
+    <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+        <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
+        <span class="nt">&ltartifactId&gt</span>{{- $artifactId -}}<span class="nt">&lt/artifactId&gt</span>
+        <span class="nt">&ltversion&gt</span>{{- $version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
+    <span class="nt">&lt/dependency&gt</span></code></pre></div>
+    <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+      Copied to clipboard!
+    </div>
+    {{ else }}
+    <p style="font-weight: bold">There is no connector (yet) available for Flink version {{ printf $flink_version }}.</p>
+    {{ end }}
 {{ else }}
-Only available for stable versions.
+    <p style="font-weight: bold">Only available for stable versions.</p>
 {{ end }}

--- a/docs/layouts/shortcodes/py_connector_download_link.html
+++ b/docs/layouts/shortcodes/py_connector_download_link.html
@@ -21,8 +21,17 @@ Generates an XML snippet for the externalized connector python download table.
 {{ $name := .Get 0 }}
 {{ $connector := index .Site.Data $name }}
 {{ $connector_version := $connector.version  }}
+{{ $flink_compatibility := $connector.flink_compatibility  }}
 {{ $flink_version := .Site.Params.VersionTitle }}
 {{ $full_version := printf "%s-%s" $connector_version $flink_version }}
+
+{{ $containsVersion := false }}
+{{ range $flink_compatibility }}
+    {{ if in . $flink_version }}
+        {{ $containsVersion = true }}
+        {{ break }}
+    {{ end }}
+{{ end }}
 
 <p>
 {{ if eq $.Site.Language.Lang "en" }}
@@ -41,11 +50,15 @@ dependencies are required:
     <tr>
         <td style="text-align: left">{{- .maven -}}</td>
         {{ if $.Site.Params.IsStable }}
-        {{ if eq .sql_url nil}}
-        <td style="text-align:left">There is no sql jar available yet.</td>
-        {{ else }}
-        <td style="text-align:left"><a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a></td>
-        {{ end }}
+            {{ if $containsVersion }}
+                {{ if eq .sql_url nil}}
+                <td style="text-align:left">There is no SQL jar (yet) available.</td>
+                {{ else }}
+                <td style="text-align:left"><a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a></td>
+                {{ end }}
+            {{ else }}
+            <td>There is no SQL jar (yet) available for Flink version {{ printf $flink_version }}.</td>
+            {{ end }}
         {{ else }}
         <td>Only available for stable releases.</td>
         {{ end }}

--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -24,42 +24,55 @@
   {{ $name := .Get 0 }}
   {{ $connector := index .Site.Data $name }}
   {{ $connector_version := $connector.version  }}
+  {{ $flink_compatibility := $connector.flink_compatibility  }}
   {{ $flink_version := .Site.Params.VersionTitle }}
   {{ $full_version := printf "%s-%s" $connector_version $flink_version }}
   
   {{ $path := .Page.Path }}
   
   {{ $hash := md5 now }}
-  
+
+{{ $containsVersion := false }}
+{{ range $flink_compatibility }}
+    {{ if in . $flink_version }}
+        {{ $containsVersion = true }}
+        {{ break }}
+    {{ end }}
+{{ end }}
+
   {{ if $.Site.Params.IsStable }}
-  <table style="display:table;margin-left:auto;margin-right:auto" id="download-table">
-    <thead>
-      <th style="text-align:left">Maven dependency</th>
-      <th style="text-align:left">SQL Client</th>
-    </thead>
-    <tbody>
-      {{ range $connector.variants }}
-      <tr>
-        <td style="text-align: left">
-          <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight">
-<pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
-  <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
-  <span class="nt">&ltartifactId&gt</span>{{- .maven -}}<span class="nt">&lt/artifactId&gt</span>
-  <span class="nt">&ltversion&gt</span>{{- $full_version -}}<span class="nt">&lt/version&gt</span>
-<span class="nt">&lt/dependency&gt</span></code></pre></div>
-          <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
-            Copied to clipboard!
-          </div> 
-        </td>
-        <td style="text-align: left">
-          <a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a>
-        </td>
-      </tr>
-      {{ end }}
-    </tbody>
-  </table>
+    {{ if $containsVersion }}
+      <table style="display:table;margin-left:auto;margin-right:auto" id="download-table">
+        <thead>
+          <th style="text-align:left">Maven dependency</th>
+          <th style="text-align:left">SQL Client</th>
+        </thead>
+        <tbody>
+          {{ range $connector.variants }}
+          <tr>
+            <td style="text-align: left">
+              <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight">
+    <pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+      <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
+      <span class="nt">&ltartifactId&gt</span>{{- .maven -}}<span class="nt">&lt/artifactId&gt</span>
+      <span class="nt">&ltversion&gt</span>{{- $full_version -}}<span class="nt">&lt/version&gt</span>
+    <span class="nt">&lt/dependency&gt</span></code></pre></div>
+              <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+                Copied to clipboard!
+              </div>
+            </td>
+            <td style="text-align: left">
+              <a href="{{ replace .sql_url "$full_version" $full_version}}">Download</a>
+            </td>
+          </tr>
+          {{ end }}
+        </tbody>
+      </table>
+    {{ else }}
+        <p style="font-weight: bold">There is no connector (yet) available for Flink version {{ printf $flink_version }}.</p>
+    {{ end }}
   {{ else }}
-  Only available for stable versions.
+    <p style="font-weight: bold">Only available for stable versions.</p>
   {{ end }}
 
-  
+


### PR DESCRIPTION
## What is the purpose of the change

For all download displays, this performs an additional check if there's a connector release available for that specific Flink release. If not, it will display that there's no connector release yet available for that Flink version.

## Brief change log

* Checks if value in connector's `flink_compatibility` exists (See https://github.com/apache/flink-connector-kafka/blob/v3.0/docs/data/kafka.yml#L20 as an example) and if that matches with the Flink main version. If yes, then display the download link. If not, then display a message that there's no connector version yet available

## Verifying this change

Can be verified locally by building the documentation locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
