### PR TITLE
[FLINK-33568] Fix NullpointerException in SinkV2MetricsITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -42,6 +42,7 @@ import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -227,37 +228,22 @@ public class SinkV2MetricsITCase extends TestLogger {
                 continue;
             }
 
-            Counter successCounter = (Counter) metrics.get(MetricNames.SUCCESSFUL_COMMITTABLES);
-            Counter committedCounter =
-                    (Counter) metrics.get(MetricNames.ALREADY_COMMITTED_COMMITTABLES);
-            Counter retriedCounter = (Counter) metrics.get(MetricNames.RETRIED_COMMITTABLES);
-            Counter failedCounter = (Counter) metrics.get(MetricNames.FAILED_COMMITTABLES);
-            Counter totalCounter = (Counter) metrics.get(MetricNames.TOTAL_COMMITTABLES);
             Gauge<Integer> pendingMetrics =
                     (Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES);
 
-            if (successCounter != null) {
-                aggregated.merge(
-                        MetricNames.SUCCESSFUL_COMMITTABLES, successCounter.getCount(), Long::sum);
+            for (String metricName :
+                    Arrays.asList(
+                            MetricNames.SUCCESSFUL_COMMITTABLES,
+                            MetricNames.ALREADY_COMMITTED_COMMITTABLES,
+                            MetricNames.RETRIED_COMMITTABLES,
+                            MetricNames.FAILED_COMMITTABLES,
+                            MetricNames.TOTAL_COMMITTABLES)) {
+                final Counter counter = (Counter) metrics.get(metricName);
+                if (counter != null) {
+                    aggregated.merge(metricName, counter.getCount(), Long::sum);
+                }
             }
-            if (successCounter != null) {
-                aggregated.merge(
-                        MetricNames.ALREADY_COMMITTED_COMMITTABLES,
-                        committedCounter.getCount(),
-                        Long::sum);
-            }
-            if (successCounter != null) {
-                aggregated.merge(
-                        MetricNames.RETRIED_COMMITTABLES, retriedCounter.getCount(), Long::sum);
-            }
-            if (successCounter != null) {
-                aggregated.merge(
-                        MetricNames.FAILED_COMMITTABLES, failedCounter.getCount(), Long::sum);
-            }
-            if (successCounter != null) {
-                aggregated.merge(
-                        MetricNames.TOTAL_COMMITTABLES, totalCounter.getCount(), Long::sum);
-            }
+
             if (pendingMetrics != null && pendingMetrics.getValue() != null) {
                 aggregated.merge(
                         MetricNames.PENDING_COMMITTABLES,

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -57,6 +57,7 @@ import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGaug
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 
 /** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
 public class SinkV2MetricsITCase extends TestLogger {
@@ -224,13 +225,6 @@ public class SinkV2MetricsITCase extends TestLogger {
         for (OperatorMetricGroup group : groups) {
             Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
 
-            if (metrics == null) {
-                continue;
-            }
-
-            Gauge<Integer> pendingMetrics =
-                    (Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES);
-
             for (String metricName :
                     Arrays.asList(
                             MetricNames.SUCCESSFUL_COMMITTABLES,
@@ -244,6 +238,8 @@ public class SinkV2MetricsITCase extends TestLogger {
                 }
             }
 
+            Gauge<Integer> pendingMetrics =
+                    (Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES);
             if (pendingMetrics != null && pendingMetrics.getValue() != null) {
                 aggregated.merge(
                         MetricNames.PENDING_COMMITTABLES,

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -57,7 +57,6 @@ import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGaug
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 
 /** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
 public class SinkV2MetricsITCase extends TestLogger {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -56,7 +56,6 @@ import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGaug
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 
 /** Tests whether all provided metrics of a {@link Sink} are of the expected values (FLIP-33). */
 public class SinkV2MetricsITCase extends TestLogger {
@@ -115,11 +114,11 @@ public class SinkV2MetricsITCase extends TestLogger {
         final JobID jobId = jobClient.getJobID();
 
         beforeBarrier.get().await();
-        assertSinkMetrics(jobId, stopAtRecord1, env.getParallelism(), numSplits);
+        assertSinkMetrics(jobId, stopAtRecord1, numSplits);
         afterBarrier.get().await();
 
         beforeBarrier.get().await();
-        assertSinkMetrics(jobId, stopAtRecord2, env.getParallelism(), numSplits);
+        assertSinkMetrics(jobId, stopAtRecord2, numSplits);
         afterBarrier.get().await();
 
         jobClient.getJobExecutionResult().get();
@@ -152,7 +151,6 @@ public class SinkV2MetricsITCase extends TestLogger {
         beforeLatch.get().await();
         assertSinkCommitterMetrics(
                 jobId,
-                env.getParallelism(),
                 ImmutableMap.of(
                         MetricNames.ALREADY_COMMITTED_COMMITTABLES, 0L,
                         MetricNames.FAILED_COMMITTABLES, 0L,
@@ -166,7 +164,6 @@ public class SinkV2MetricsITCase extends TestLogger {
         jobClient.getJobExecutionResult().get();
         assertSinkCommitterMetrics(
                 jobId,
-                env.getParallelism(),
                 ImmutableMap.of(
                         MetricNames.ALREADY_COMMITTED_COMMITTABLES, 1L,
                         MetricNames.FAILED_COMMITTABLES, 2L,
@@ -177,18 +174,18 @@ public class SinkV2MetricsITCase extends TestLogger {
     }
 
     @SuppressWarnings("checkstyle:WhitespaceAfter")
-    private void assertSinkMetrics(
-            JobID jobId, long processedRecordsPerSubtask, int parallelism, int numSplits) {
+    private void assertSinkMetrics(JobID jobId, long processedRecordsPerSubtask, int numSplits) {
         List<OperatorMetricGroup> groups =
                 reporter.findOperatorMetricGroups(
                         jobId, TEST_SINK_NAME + ": " + DEFAULT_WRITER_NAME);
-        assertThat(groups, hasSize(parallelism));
 
         int subtaskWithMetrics = 0;
         for (OperatorMetricGroup group : groups) {
             Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
             // There are only 2 splits assigned; so two groups will not update metrics.
-            if (group.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
+            if (group.getIOMetricGroup() == null
+                    || group.getIOMetricGroup().getNumRecordsOutCounter() == null
+                    || group.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
                 continue;
             }
             subtaskWithMetrics++;
@@ -217,43 +214,56 @@ public class SinkV2MetricsITCase extends TestLogger {
         assertThat(subtaskWithMetrics, equalTo(numSplits));
     }
 
-    private void assertSinkCommitterMetrics(
-            JobID jobId, int parallelism, Map<String, Long> expected) {
+    private void assertSinkCommitterMetrics(JobID jobId, Map<String, Long> expected) {
         List<OperatorMetricGroup> groups =
                 reporter.findOperatorMetricGroups(
                         jobId, TEST_SINK_NAME + ": " + DEFAULT_COMMITTER_NAME);
-        assertThat(groups, hasSize(parallelism));
 
         Map<String, Long> aggregated = new HashMap<>(6);
         for (OperatorMetricGroup group : groups) {
             Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
 
-            aggregated.merge(
-                    MetricNames.SUCCESSFUL_COMMITTABLES,
-                    ((Counter) metrics.get(MetricNames.SUCCESSFUL_COMMITTABLES)).getCount(),
-                    Long::sum);
-            aggregated.merge(
-                    MetricNames.ALREADY_COMMITTED_COMMITTABLES,
-                    ((Counter) metrics.get(MetricNames.ALREADY_COMMITTED_COMMITTABLES)).getCount(),
-                    Long::sum);
-            aggregated.merge(
-                    MetricNames.RETRIED_COMMITTABLES,
-                    ((Counter) metrics.get(MetricNames.RETRIED_COMMITTABLES)).getCount(),
-                    Long::sum);
-            aggregated.merge(
-                    MetricNames.FAILED_COMMITTABLES,
-                    ((Counter) metrics.get(MetricNames.FAILED_COMMITTABLES)).getCount(),
-                    Long::sum);
-            aggregated.merge(
-                    MetricNames.TOTAL_COMMITTABLES,
-                    ((Counter) metrics.get(MetricNames.TOTAL_COMMITTABLES)).getCount(),
-                    Long::sum);
-            aggregated.merge(
-                    MetricNames.PENDING_COMMITTABLES,
-                    ((Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES))
-                            .getValue()
-                            .longValue(),
-                    Long::sum);
+            if (metrics == null) {
+                continue;
+            }
+
+            Counter successCounter = (Counter) metrics.get(MetricNames.SUCCESSFUL_COMMITTABLES);
+            Counter committedCounter =
+                    (Counter) metrics.get(MetricNames.ALREADY_COMMITTED_COMMITTABLES);
+            Counter retriedCounter = (Counter) metrics.get(MetricNames.RETRIED_COMMITTABLES);
+            Counter failedCounter = (Counter) metrics.get(MetricNames.FAILED_COMMITTABLES);
+            Counter totalCounter = (Counter) metrics.get(MetricNames.TOTAL_COMMITTABLES);
+            Gauge<Integer> pendingMetrics =
+                    (Gauge<Integer>) metrics.get(MetricNames.PENDING_COMMITTABLES);
+
+            if (successCounter != null) {
+                aggregated.merge(
+                        MetricNames.SUCCESSFUL_COMMITTABLES, successCounter.getCount(), Long::sum);
+            }
+            if (successCounter != null) {
+                aggregated.merge(
+                        MetricNames.ALREADY_COMMITTED_COMMITTABLES,
+                        committedCounter.getCount(),
+                        Long::sum);
+            }
+            if (successCounter != null) {
+                aggregated.merge(
+                        MetricNames.RETRIED_COMMITTABLES, retriedCounter.getCount(), Long::sum);
+            }
+            if (successCounter != null) {
+                aggregated.merge(
+                        MetricNames.FAILED_COMMITTABLES, failedCounter.getCount(), Long::sum);
+            }
+            if (successCounter != null) {
+                aggregated.merge(
+                        MetricNames.TOTAL_COMMITTABLES, totalCounter.getCount(), Long::sum);
+            }
+            if (pendingMetrics != null && pendingMetrics.getValue() != null) {
+                aggregated.merge(
+                        MetricNames.PENDING_COMMITTABLES,
+                        pendingMetrics.getValue().longValue(),
+                        Long::sum);
+            }
         }
 
         expected.entrySet()


### PR DESCRIPTION
## What is the purpose of the change

Fix the NullpointerException found by the tests: https://issues.apache.org/jira/browse/FLINK-33568?focusedCommentId=17786726&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17786726


## Brief change log

Add Null checks

## Verifying this change

I was not able to repro the case, I think we might have an intermittent issue where the operator is not initialized when we try to fetch the metrics. This could happen when the specific task does not get any committables.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
