### PR TITLE
[FLINK-33578][ci] Removes scala-2.12 system property

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
             vmImage: 'ubuntu-20.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8
@@ -96,5 +96,5 @@ stages:
       - template: tools/azure-pipelines/build-python-wheels.yml
         parameters:
           stage_name: cron_python_wheels
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           container: flink-build-container

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -128,7 +128,7 @@ Flink 有使用 [Scala](http://scala-lang.org) 来写的 API，库和运行时�
 
 要针对特定的二进制 Scala 版本进行构建，可以使用
 ```bash
-mvn clean install -DskipTests -Dscala-2.12 -Dscala.version=<scala version>
+mvn clean install -DskipTests -Dscala.version=<scala version>
 ```
 
 {{< top >}}

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -125,7 +125,7 @@ Since version 1.15 Flink dropped the support of Scala 2.11 and it will use Scala
 
 To build against a specific binary Scala version you can use:
 ```bash
-mvn clean install -DskipTests -Dscala-2.12 -Dscala.version=<scala version>
+mvn clean install -DskipTests -Dscala.version=<scala version>
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -965,9 +965,7 @@ under the License.
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
-				<property>
-					<name>!old-and-unsupported-scala-version</name>
-				</property>
+				<activeByDefault>true</activeByDefault>
 			</activation>
 			<build>
 				<plugins>

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -69,7 +69,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8
@@ -113,7 +113,7 @@ stages:
             vmImage: 'ubuntu-20.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: true
           container: flink-build-container
           jdk: 8
@@ -135,7 +135,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12 -Djdk11 -Pjava11-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Pjava11-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 11
@@ -146,7 +146,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12 -Djdk11 -Djdk17 -Pjava17-target"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Pjava17-target"
           run_end_to_end: true
           container: flink-build-container
           jdk: 17
@@ -157,7 +157,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12 -Penable-adaptive-scheduler"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Penable-adaptive-scheduler"
           run_end_to_end: true
           container: flink-build-container
           jdk: 8
@@ -172,5 +172,5 @@ stages:
       - template: build-python-wheels.yml
         parameters:
           stage_name: cron_python_wheels
-          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           container: flink-build-container

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -20,7 +20,6 @@
 ##
 ## Variables with defaults (if not overwritten by environment)
 ##
-SCALA_VERSION=${SCALA_VERSION:-none}
 SKIP_GPG=${SKIP_GPG:-false}
 MVN=${MVN:-mvn}
 
@@ -58,20 +57,14 @@ mkdir -p ${PYTHON_RELEASE_DIR}
 
 # build maven package, create Flink distribution, generate signature
 make_binary_release() {
-  FLAGS=""
-  SCALA_VERSION=$1
-
-  echo "Creating binary release, SCALA_VERSION: ${SCALA_VERSION}"
-  dir_name="flink-$RELEASE_VERSION-bin-scala_${SCALA_VERSION}"
-
-  if [ $SCALA_VERSION = "2.12" ]; then
-      FLAGS="-Dscala-2.12"
-  else
-      echo "Invalid Scala version ${SCALA_VERSION}"
-  fi
+  local DEFAULT_SCALA_VERSION
+  DEFAULT_SCALA_VERSION="2.12"
+  echo "Creating binary release"
+  # the scala version is still included in the name to not break "backwards-compatibility" of the naming scheme
+  dir_name="flink-$RELEASE_VERSION-bin-scala_${DEFAULT_SCALA_VERSION}"
 
   # enable release profile here (to check for the maven version)
-  $MVN clean package $FLAGS -Prelease -pl flink-dist -am -Dgpg.skip -Dcheckstyle.skip=true -DskipTests
+  $MVN clean package -Prelease -pl flink-dist -am -Dgpg.skip -Dcheckstyle.skip=true -DskipTests
 
   cd flink-dist/target/flink-${RELEASE_VERSION}-bin
   ${FLINK_DIR}/tools/releasing/collect_license_files.sh ./flink-${RELEASE_VERSION} ./flink-${RELEASE_VERSION}
@@ -165,10 +158,5 @@ make_python_release() {
   cd ${FLINK_DIR}
 }
 
-if [ "$SCALA_VERSION" == "none" ]; then
-  make_binary_release "2.12"
-  make_python_release
-else
-  make_binary_release "$SCALA_VERSION"
-  make_python_release
-fi
+make_binary_release
+make_python_release

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -43,5 +43,4 @@ echo "Deploying to repository.apache.org"
 
 COMMON_OPTIONS="-Prelease,docs-and-source -DskipTests -DretryFailedDeploymentCount=10 $CUSTOM_OPTIONS"
 
-echo "Deploying Scala 2.12 version"
-$MVN clean deploy $COMMON_OPTIONS -Dscala-2.12
+$MVN clean deploy $COMMON_OPTIONS


### PR DESCRIPTION
## What is the purpose of the change

We're only relying on Scala 2.12 (and the plan is to drop it entirely for 2.x). The Scala prefix is still present in CI, though. This commit cleans it up entirely. 

This clean up step helps reduce the noise in the GHA workflow change (FLINK-27075). There's no need to label workflows with the scala version. Therefore, we can remove the scala version from the build parameters entirely.

## Brief change log

* Removed `scala-2.12` system variable from release scripts and azure workflow

## Verifying this change

* The nightly deployment should still look the same (related to the `tools/releasing/deploy_staging_jars.sh` change)
* The binary release artifacts shouldn't have changed (related to the `tools/releasing/create_binary_release.sh` change)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable