### PR TITLE
[FLINK-33588][Flink-Runtime] Fix NullArgumentException in DescriptiveStatisticsHistogramStatistics

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -174,6 +174,8 @@ public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistic
             }
             if (data != null) {
                 percentilesImpl.setData(data);
+            } else {
+                percentilesImpl.setData(new double[]{0.0});
             }
         }
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix NullArgumentException of getQuantile method in DescriptiveStatisticsHistogramStatistics

## Brief change log

This DescriptiveStatisticsHistogramStatistics class has added null initialization
1、DescriptiveStatisticsHistogramStatistics.java

## Verifying this change

<img width="845" alt="3799e5aae7fa3cc0500aa1cd0b06856" src="https://github.com/apache/flink/assets/28818582/f498c368-0766-4cb1-adff-bb77abf5cda9">

During the verification process, the task was submitted to Yarn and run in Yarn cluster mode. After multiple stops and restarts, it was found that the NullArgumentException exception had disappeared. This fully verified the correctness of the modification, improved the stability of program operation, and also improved the accuracy of displaying statistical information in the web UI interface of the Flink task (as shown in the above figure).
The highlighted log section in the above figure is the log I printed to assist in troubleshooting, which can be ignored.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
