### PR TITLE
[FLINK-33531][python] Remove cython upper bounds

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -16,7 +16,7 @@ pip>=20.3
 setuptools>=18.0
 wheel
 apache-beam>=2.43.0,<2.49.0
-cython>=0.29.24,<3
+cython>=0.29.24
 py4j==0.10.9.7
 python-dateutil>=2.8.0,<3
 cloudpickle~=2.2.0

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -22,7 +22,7 @@ requires = [
     "setuptools>=18.0",
     "wheel",
     "apache-beam>=2.43.0,<2.49.0",
-    "cython>=0.29.24,<3",
+    "cython>=0.29.24",
     "fastavro>=1.1.0,!=1.8.0"
 ]
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will remove cython upper bounds*


## Brief change log

  - *remove cython upper bounds*

## Verifying this change
 - *original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
