### PR TITLE
[BP-1.17][FLINK-18356] Update CI image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Build documentation
         run: |
-          docker run  --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
+          docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_maven_325 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -37,9 +37,12 @@ trigger:
 resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
-  # see https://github.com/flink-ci/flink-ci-docker
+  # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
+  # The Docker image was customized for 1.17 to cover the changes of FLINK-18356
+  # (Docker images with updated Maven binaries are used in branches for Flink 1.18+)
+  # but still use Maven 3.2.5 (to avoid backporting FLINK-28016)
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17
+    image: chesnay/flink-ci:java_8_11_17_maven_325
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
## What is the purpose of the change

1.17 backport PR for parent PR #23717

## Brief change log

I also backport the change for the docs build for the sake of consistency even though it's not necessary to fix FLINK-18356.

This backport required the upgrade of Maven to 3.8.6 (FLINK-28203).

## Verifying this change

CI should pass without problems and should include the optional check

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable