### PR TITLE
[#FLINK-33596][Connectors/Hive]] Fold expression before transfer function to RexNode.

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.module.hive.udf.generic.HiveGenericUDFToDecimal;
 import org.apache.flink.util.StringUtils;
 
 import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFFirstValue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -138,6 +139,7 @@ public class HiveModule implements Module {
             functionNames.add(GenericUDFLegacyGroupingID.NAME);
             functionNames.add(HiveGenericUDFArrayAccessStructField.NAME);
             functionNames.add(HiveGenericUDFToDecimal.NAME);
+            functionNames.add("first");
         }
         return functionNames;
     }
@@ -159,6 +161,11 @@ public class HiveModule implements Module {
             return Optional.of(
                     factory.createFunctionDefinitionFromHiveFunction(
                             name, HiveGenericUDFGrouping.class.getName(), context));
+        }
+        if (name.equalsIgnoreCase("first")) {
+            return Optional.of(
+                    factory.createFunctionDefinitionFromHiveFunction(
+                            name, GenericUDAFFirstValue.class.getName(), context));
         }
 
         // this function is used to generate legacy GROUPING__ID value for old hive versions

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -70,6 +70,8 @@ import org.apache.hadoop.hive.conf.VariableSubstitution;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.processors.HiveCommand;
 import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFCollectList;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFFirstValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,6 +238,7 @@ public class HiveParser implements Parser {
             HiveSessionState.startSessionState(hiveConfCopy, catalogRegistry);
             // We override Hive's grouping function. Refer to the implementation for more details.
             hiveShim.registerTemporaryFunction("grouping", HiveGenericUDFGrouping.class);
+            hiveShim.registerTemporaryFunction("first", GenericUDAFFirstValue.class);
             return processCmd(statement, hiveConfCopy, hiveShim, currentCatalog);
         } finally {
             HiveSessionState.clearSessionState();

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -164,6 +164,8 @@ public class HiveDialectQueryITCase {
         tableEnv.executeSql(
                 "create function hiveudf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFAbs'");
         tableEnv.executeSql(
+                "create function hiveudaf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDAFCollectList'");
+        tableEnv.executeSql(
                 "create function hiveudtf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDTFExplode'");
         tableEnv.executeSql("create function myudtf as '" + MyUDTF.class.getName() + "'");
 
@@ -178,6 +180,13 @@ public class HiveDialectQueryITCase {
         for (File qfile : qfiles) {
             runQFile(qfile);
         }
+    }
+
+    @Test
+    public void testCommonTest() throws Exception {
+        tableEnv.executeSql("select first_value(id, true) over (partition by name order by dep) from employee")
+                .collect().forEachRemaining(
+                r -> System.out.println(r.toString()));
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/group_by.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/group_by.q
@@ -31,3 +31,7 @@ select dep,count(1) from employee where salary<5000 and age>=38 and dep='Sales' 
 select x,null as n from foo group by x,'a',null;
 
 [+I[1, null], +I[2, null], +I[3, null], +I[4, null], +I[5, null]]
+
+select dep, sum(salary) from employee group by dep, UNIX_TIMESTAMP();
+
+[+I[Management, 12900], +I[Production, 18600], +I[Sales, 8400], +I[Service, 4100]]


### PR DESCRIPTION
## What is the purpose of the change
Fold expression before transfer function to RexNode.
Hive will fold expression in optimization stage. 
But flink-hive-parser use flink optimization.
And flink can't know some hive function can be constant value.

Some hive code reference:

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRexExecutorImpl.java#L62

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java#L1776

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java#L1069

## Brief change log
Try to transfer to constant before function transfer to rexNode.

## Verifying this change
This change is verified by added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

