### PR TITLE
[FLINK-33598][k8s] Watch HA configmap via name instead of lables to reduce pressure on APIserver

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionHaServices.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.NAME_SEPARATOR;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -74,9 +73,7 @@ public class KubernetesLeaderElectionHaServices extends AbstractHaServices {
         this(
                 kubeClient,
                 kubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                configuration.get(KubernetesConfigOptions.CLUSTER_ID),
-                                LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY)),
+                        getClusterConfigMap(configuration.get(KubernetesConfigOptions.CLUSTER_ID))),
                 Executors.newCachedThreadPool(
                         new ExecutorThreadFactory("config-map-watch-handler")),
                 ioExecutor,
@@ -202,11 +199,7 @@ public class KubernetesLeaderElectionHaServices extends AbstractHaServices {
             exception = e;
         }
 
-        kubeClient
-                .deleteConfigMapsByLabels(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY))
-                .get();
+        kubeClient.deleteConfigMap(getClusterConfigMap()).get();
 
         ExceptionUtils.tryRethrowException(exception);
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -342,15 +342,6 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels) {
-        // the only time, the delete method returns false is due to a 404 HTTP status which is
-        // returned if the underlying resource doesn't exist
-        return CompletableFuture.runAsync(
-                () -> this.internalClient.configMaps().withLabels(labels).delete(),
-                kubeClientExecutorService);
-    }
-
-    @Override
     public CompletableFuture<Void> deleteConfigMap(String configMapName) {
         // the only time, the delete method returns false is due to a 404 HTTP status which is
         // returned if the underlying resource doesn't exist
@@ -360,9 +351,9 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(
-            Map<String, String> labels) {
-        return new KubernetesConfigMapSharedInformer(this.internalClient, labels);
+    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name) {
+        LOG.info("Creating configmap shared watcher for {}.", name);
+        return new KubernetesConfigMapSharedInformer(this.internalClient, name);
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -165,16 +165,6 @@ public interface FlinkKubeClient extends AutoCloseable {
             Function<KubernetesConfigMap, Optional<KubernetesConfigMap>> updateFunction);
 
     /**
-     * Delete the Kubernetes ConfigMaps by labels. This will be used by the HA service to clean up
-     * all data.
-     *
-     * @param labels labels to filter the resources. e.g. type: high-availability
-     * @return Return the delete future that only completes successfully, if the resources that are
-     *     subject to deletion are actually gone.
-     */
-    CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels);
-
-    /**
      * Delete a Kubernetes ConfigMap by name.
      *
      * @param configMapName ConfigMap name
@@ -183,13 +173,12 @@ public interface FlinkKubeClient extends AutoCloseable {
     CompletableFuture<Void> deleteConfigMap(String configMapName);
 
     /**
-     * Create a shared watcher for ConfigMaps with specified labels.
+     * Create a shared watcher for ConfigMaps with specified name.
      *
-     * @param labels labels to filter ConfigMaps. If the labels is null or empty, all ConfigMaps
-     *     will be taken in account, or it will be rejected if the implementation does not allow it.
+     * @param name name of the ConfigMap to watch.
      * @return Return a shared watcher.
      */
-    KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(Map<String, String> labels);
+    KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name);
 
     /** Close the Kubernetes client with no exception. */
     void close();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesConfigMapSharedInformer.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesConfigMapSharedInformer.java
@@ -19,29 +19,26 @@
 package org.apache.flink.kubernetes.kubeclient.resources;
 
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Informable;
-
-import java.util.Map;
 
 /** The shared informer for {@link ConfigMap}, it can be used as a shared watcher. */
 public class KubernetesConfigMapSharedInformer
         extends KubernetesSharedInformer<ConfigMap, KubernetesConfigMap>
         implements KubernetesConfigMapSharedWatcher {
 
-    public KubernetesConfigMapSharedInformer(
-            NamespacedKubernetesClient client, Map<String, String> labels) {
-        super(client, getInformableConfigMaps(client, labels), KubernetesConfigMap::new);
+    public KubernetesConfigMapSharedInformer(NamespacedKubernetesClient client, String name) {
+        super(client, getInformabaleConfigMaps(client, name), KubernetesConfigMap::new);
     }
 
-    private static Informable<ConfigMap> getInformableConfigMaps(
-            NamespacedKubernetesClient client, Map<String, String> labels) {
+    private static Informable<ConfigMap> getInformabaleConfigMaps(
+            NamespacedKubernetesClient client, String name) {
         Preconditions.checkArgument(
-                !CollectionUtil.isNullOrEmpty(labels), "Labels must not be null or empty");
-        return client.configMaps().withLabels(labels);
+                !StringUtils.isNullOrWhitespaceOnly(name), "Name must not be null or empty");
+        return client.configMaps().withName(name);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -62,7 +62,18 @@ public class Constants {
     public static final String LABEL_COMPONENT_KEY = "component";
     public static final String LABEL_COMPONENT_JOB_MANAGER = "jobmanager";
     public static final String LABEL_COMPONENT_TASK_MANAGER = "taskmanager";
-    public static final String LABEL_CONFIGMAP_TYPE_KEY = "configmap-type";
+
+    /**
+     * This constant is deprecated since we do not use it for deletion currently. We still keep the
+     * constants here for backward compatibility.
+     */
+    @Deprecated public static final String LABEL_CONFIGMAP_TYPE_KEY = "configmap-type";
+
+    /**
+     * This constant is deprecated since we do not use it for deletion currently. We still keep the
+     * constants here for backward compatibility.
+     */
+    @Deprecated
     public static final String LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY = "high-availability";
 
     // Use fixed port in kubernetes, it needs to be exposed.

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -38,7 +38,6 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -89,7 +88,6 @@ class KubernetesHighAvailabilityTestBase {
         final Configuration configuration;
 
         final CompletableFuture<Void> closeKubeClientFuture;
-        final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture;
 
         Context() throws Exception {
             kubernetesTestFixture =
@@ -102,8 +100,6 @@ class KubernetesHighAvailabilityTestBase {
             flinkKubeClient = kubernetesTestFixture.getFlinkKubeClient();
             configuration = kubernetesTestFixture.getConfiguration();
             closeKubeClientFuture = kubernetesTestFixture.getCloseKubeClientFuture();
-            deleteConfigMapByLabelsFuture =
-                    kubernetesTestFixture.getDeleteConfigMapByLabelsFuture();
             electionEventHandler = new TestingLeaderElectionListener();
             leaderElectionDriver = createLeaderElectionDriver();
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -25,7 +25,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesHighAvailabilityOptio
 import org.apache.flink.kubernetes.configuration.KubernetesLeaderElectionConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubernetesConfigMapSharedWatcher;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.leaderelection.LeaderElectionEvent;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionListener;
@@ -43,7 +42,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -87,9 +85,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
         final List<AutoCloseable> closeables = new ArrayList<>();
 
         final KubernetesConfigMapSharedWatcher configMapSharedWatcher =
-                flinkKubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+                flinkKubeClient.createConfigMapSharedWatcher(configMapName);
         closeables.add(configMapSharedWatcher);
 
         final TestingLeaderElectionListener electionEventHandler =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -26,7 +26,6 @@ import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector.LEADER_ANNOTATION_KEY;
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test fixture for Kubernetes tests that sets up a mock {@link FlinkKubeClient}. */
@@ -58,8 +56,6 @@ class KubernetesTestFixture {
     private final List<TestingFlinkKubeClient.MockKubernetesWatch> configMapWatches =
             new ArrayList<>();
 
-    private final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture =
-            new CompletableFuture<>();
     private final CompletableFuture<Void> closeKubeClientFuture = new CompletableFuture<>();
 
     private final CompletableFuture<KubernetesLeaderElector.LeaderCallbackHandler>
@@ -76,10 +72,7 @@ class KubernetesTestFixture {
         configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
 
         flinkKubeClient = createFlinkKubeClient();
-        configMapSharedWatcher =
-                flinkKubeClient.createConfigMapSharedWatcher(
-                        KubernetesUtils.getConfigMapLabels(
-                                clusterId, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+        configMapSharedWatcher = flinkKubeClient.createConfigMapSharedWatcher(leaderConfigmapName);
     }
 
     void close() {
@@ -92,10 +85,6 @@ class KubernetesTestFixture {
 
     CompletableFuture<Void> getCloseKubeClientFuture() {
         return closeKubeClientFuture;
-    }
-
-    CompletableFuture<Map<String, String>> getDeleteConfigMapByLabelsFuture() {
-        return deleteConfigMapByLabelsFuture;
     }
 
     KubernetesConfigMapSharedWatcher getConfigMapSharedWatcher() {
@@ -178,19 +167,6 @@ class KubernetesTestFixture {
                             configMapStore.remove(name);
                             return FutureUtils.completedVoidFuture();
                         })
-                .setDeleteConfigMapByLabelFunction(
-                        labels -> {
-                            if (deleteConfigMapByLabelsFuture.isDone()) {
-                                return FutureUtils.completedExceptionally(
-                                        new KubernetesException(
-                                                "ConfigMap with labels "
-                                                        + labels
-                                                        + " has already be deleted."));
-                            } else {
-                                deleteConfigMapByLabelsFuture.complete(labels);
-                                return FutureUtils.completedVoidFuture();
-                            }
-                        })
                 .setCloseConsumer(closeKubeClientFuture::complete)
                 .setCreateLeaderElectorFunction(
                         (leaderConfig, callbackHandler) -> {
@@ -199,12 +175,11 @@ class KubernetesTestFixture {
                                     leaderConfig, callbackHandler);
                         })
                 .setCreateConfigMapSharedWatcherFunction(
-                        (labels) -> {
+                        name -> {
                             final TestingFlinkKubeClient.TestingKubernetesConfigMapSharedWatcher
                                     watcher =
                                             new TestingFlinkKubeClient
-                                                    .TestingKubernetesConfigMapSharedWatcher(
-                                                    labels);
+                                                    .TestingKubernetesConfigMapSharedWatcher(name);
                             watcher.setWatchFunction(
                                     (ignore, handler) -> {
                                         final CompletableFuture<

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -491,21 +491,6 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     }
 
     @Test
-    void testDeleteConfigMapByLabels() throws Exception {
-        this.flinkKubeClient.createConfigMap(buildTestingConfigMap()).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isPresent();
-        this.flinkKubeClient.deleteConfigMapsByLabels(TESTING_LABELS).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-    }
-
-    @Test
-    void testDeleteNotExistingConfigMapByLabels() throws Exception {
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-        this.flinkKubeClient.deleteConfigMapsByLabels(TESTING_LABELS).get();
-        assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isNotPresent();
-    }
-
-    @Test
     void testDeleteConfigMapByName() throws Exception {
         this.flinkKubeClient.createConfigMap(buildTestingConfigMap()).get();
         assertThat(this.flinkKubeClient.getConfigMap(TESTING_CONFIG_MAP_NAME)).isPresent();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -61,8 +61,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>,
                     CompletableFuture<Boolean>>
             checkAndUpdateConfigMapFunction;
-    private final Function<Map<String, String>, CompletableFuture<Void>>
-            deleteConfigMapByLabelFunction;
     private final Function<String, CompletableFuture<Void>> deleteConfigMapFunction;
     private final Consumer<Void> closeConsumer;
     private final BiFunction<
@@ -71,7 +69,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     KubernetesLeaderElector>
             createLeaderElectorFunction;
 
-    private final Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+    private final Function<String, KubernetesConfigMapSharedWatcher>
             createConfigMapSharedWatcherFunction;
 
     private TestingFlinkKubeClient(
@@ -88,7 +86,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             Function<KubernetesConfigMap, Optional<KubernetesConfigMap>>,
                             CompletableFuture<Boolean>>
                     checkAndUpdateConfigMapFunction,
-            Function<Map<String, String>, CompletableFuture<Void>> deleteConfigMapByLabelFunction,
             Function<String, CompletableFuture<Void>> deleteConfigMapFunction,
             Consumer<Void> closeConsumer,
             BiFunction<
@@ -96,7 +93,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             KubernetesLeaderElector.LeaderCallbackHandler,
                             KubernetesLeaderElector>
                     createLeaderElectorFunction,
-            Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+            Function<String, KubernetesConfigMapSharedWatcher>
                     createConfigMapSharedWatcherFunction) {
 
         this.createTaskManagerPodFunction = createTaskManagerPodFunction;
@@ -108,7 +105,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         this.createConfigMapFunction = createConfigMapFunction;
         this.getConfigMapFunction = getConfigMapFunction;
         this.checkAndUpdateConfigMapFunction = checkAndUpdateConfigMapFunction;
-        this.deleteConfigMapByLabelFunction = deleteConfigMapByLabelFunction;
         this.deleteConfigMapFunction = deleteConfigMapFunction;
 
         this.closeConsumer = closeConsumer;
@@ -183,19 +179,13 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public CompletableFuture<Void> deleteConfigMapsByLabels(Map<String, String> labels) {
-        return deleteConfigMapByLabelFunction.apply(labels);
-    }
-
-    @Override
     public CompletableFuture<Void> deleteConfigMap(String configMapName) {
         return deleteConfigMapFunction.apply(configMapName);
     }
 
     @Override
-    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(
-            Map<String, String> labels) {
-        return createConfigMapSharedWatcherFunction.apply(labels);
+    public KubernetesConfigMapSharedWatcher createConfigMapSharedWatcher(String name) {
+        return createConfigMapSharedWatcherFunction.apply(name);
     }
 
     @Override
@@ -241,8 +231,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                         CompletableFuture<Boolean>>
                 checkAndUpdateConfigMapFunction =
                         (ignore1, ignore2) -> CompletableFuture.completedFuture(true);
-        private Function<Map<String, String>, CompletableFuture<Void>>
-                deleteConfigMapByLabelFunction = (ignore) -> FutureUtils.completedVoidFuture();
         private Function<String, CompletableFuture<Void>> deleteConfigMapFunction =
                 (ignore) -> FutureUtils.completedVoidFuture();
 
@@ -254,7 +242,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                         KubernetesLeaderElector>
                 createLeaderElectorFunction = TestingKubernetesLeaderElector::new;
 
-        private Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+        private Function<String, KubernetesConfigMapSharedWatcher>
                 createConfigMapSharedWatcherFunction = TestingKubernetesConfigMapSharedWatcher::new;
 
         private Builder() {}
@@ -318,13 +306,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
             return this;
         }
 
-        public Builder setDeleteConfigMapByLabelFunction(
-                Function<Map<String, String>, CompletableFuture<Void>>
-                        deleteConfigMapByLabelFunction) {
-            this.deleteConfigMapByLabelFunction = deleteConfigMapByLabelFunction;
-            return this;
-        }
-
         public Builder setDeleteConfigMapFunction(
                 Function<String, CompletableFuture<Void>> deleteConfigMapFunction) {
             this.deleteConfigMapFunction = deleteConfigMapFunction;
@@ -347,7 +328,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         }
 
         public Builder setCreateConfigMapSharedWatcherFunction(
-                Function<Map<String, String>, KubernetesConfigMapSharedWatcher>
+                Function<String, KubernetesConfigMapSharedWatcher>
                         createConfigMapSharedWatcherFunction) {
             this.createConfigMapSharedWatcherFunction = createConfigMapSharedWatcherFunction;
             return this;
@@ -363,7 +344,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     createConfigMapFunction,
                     getConfigMapFunction,
                     checkAndUpdateConfigMapFunction,
-                    deleteConfigMapByLabelFunction,
                     deleteConfigMapFunction,
                     closeConsumer,
                     createLeaderElectorFunction,
@@ -454,7 +434,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         private BiFunction<String, WatchCallbackHandler<KubernetesConfigMap>, Watch> watchFunction =
                 (ignore1, ignore2) -> new MockKubernetesWatch();
 
-        public TestingKubernetesConfigMapSharedWatcher(Map<String, String> labels) {}
+        public TestingKubernetesConfigMapSharedWatcher(String name) {}
 
         public void setWatchFunction(
                 BiFunction<String, WatchCallbackHandler<KubernetesConfigMap>, Watch>


### PR DESCRIPTION
## What is the purpose of the change

As [FLINK-24819](https://issues.apache.org/jira/browse/FLINK-24819) described, the k8s API server would receive more pressure when HA is enabled, due to the configmap watching being achieved via filter with labels instead of just querying the configmap name. This could be done after [FLINK-24038](https://issues.apache.org/jira/browse/FLINK-24038), which reduced the number of configmaps to only one as `<clusterId>-cluster-config-map`.

This PR would not touch `<clusterId>-<jobId>-config-map`, which stores the checkpoint information, as that configmap is directly accessed by JM and not watched by taskmanagers.


## Brief change log

  - Introduce new API named `FlinkKubeClient#createConfigMapSharedWatcher(String)` and use this API to create watcher.
  - Delete useless `FlinkKubeClient#createConfigMapSharedWatcher(Map<String, String> labels)` and `FlinkKubeClient#deleteConfigMapsByLabels` APIs.


## Verifying this change

This change added tests and can be verified as follows:

  - Modified test `KubernetesLeaderElectionAndRetrievalITCase`
  - Modified test `KubernetesTestFixture`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
