### PR TITLE
[FLINK-27681] RocksdbStatebackend verify incremental sst file checksum during checkpoint

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
@@ -15,7 +15,7 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enable</h5></td>
+            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set. RocksDBStateBackend will verify the Checksum of the incremental sst file during Checkpoint. If the Checksum fails, the Checkpoint will fail. This process may cause some overhead, but it can improve the availability of Checkpoint.</td>

--- a/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rocksdb_section.html
@@ -15,6 +15,12 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enable</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If set. RocksDBStateBackend will verify the Checksum of the incremental sst file during Checkpoint. If the Checksum fails, the Checkpoint will fail. This process may cause some overhead, but it can improve the availability of Checkpoint.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -15,7 +15,7 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enable</h5></td>
+            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set. RocksDBStateBackend will verify the Checksum of the incremental sst file during Checkpoint. If the Checksum fails, the Checkpoint will fail. This process may cause some overhead, but it can improve the availability of Checkpoint.</td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -15,6 +15,12 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.checkpoint.verify.checksum.enable</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If set. RocksDBStateBackend will verify the Checksum of the incremental sst file during Checkpoint. If the Checksum fails, the Checkpoint will fail. This process may cause some overhead, but it can improve the availability of Checkpoint.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -82,7 +82,7 @@ import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBOptions.CHECKPOINT_TRANSFER_THREAD_NUM;
-import static org.apache.flink.contrib.streaming.state.RocksDBOptions.CHECKPOINT_VERIFY_CHECKSUM_ENABLE;
+import static org.apache.flink.contrib.streaming.state.RocksDBOptions.CHECKPOINT_VERIFY_CHECKSUM_ENABLED;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -243,7 +243,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
 
         this.enableVerifySstFileChecksum =
                 original.enableVerifySstFileChecksum.resolveUndefined(
-                        config.get(CHECKPOINT_VERIFY_CHECKSUM_ENABLE));
+                        config.get(CHECKPOINT_VERIFY_CHECKSUM_ENABLED));
 
         if (original.writeBatchSize == UNDEFINED_WRITE_BATCH_SIZE) {
             this.writeBatchSize = config.get(WRITE_BATCH_SIZE).getBytes();
@@ -827,7 +827,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     /** Whether to verify the Checksum of the incremental sst file during Checkpoint. */
     public boolean getEnableSstFileChecksum() {
         return enableVerifySstFileChecksum.getOrDefault(
-                CHECKPOINT_VERIFY_CHECKSUM_ENABLE.defaultValue());
+                CHECKPOINT_VERIFY_CHECKSUM_ENABLED.defaultValue());
     }
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -96,7 +96,7 @@ public class RocksDBOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to verify the Checksum of the incremental sst file during Checkpoint in RocksDBStateBackend");
+                            "If set. RocksDBStateBackend will verify the Checksum of the incremental sst file during Checkpoint. If the Checksum fails, the Checkpoint will fail. This process may cause some overhead, but it can improve the availability of Checkpoint.");
 
     /** The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. */
     @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -86,6 +86,18 @@ public class RocksDBOptions {
                     .withDescription(
                             "The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.");
 
+    /**
+     * Whether to verify the Checksum of the incremental sst file during Checkpoint in
+     * RocksDBStateBackend.
+     */
+    @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)
+    public static final ConfigOption<Boolean> CHECKPOINT_VERIFY_CHECKSUM_ENABLE =
+            ConfigOptions.key("state.backend.rocksdb.checkpoint.verify.checksum.enable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to verify the Checksum of the incremental sst file during Checkpoint in RocksDBStateBackend");
+
     /** The predefined settings for RocksDB DBOptions and ColumnFamilyOptions by Flink community. */
     @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)
     public static final ConfigOption<String> PREDEFINED_OPTIONS =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -91,8 +91,8 @@ public class RocksDBOptions {
      * RocksDBStateBackend.
      */
     @Documentation.Section(Documentation.Sections.EXPERT_ROCKSDB)
-    public static final ConfigOption<Boolean> CHECKPOINT_VERIFY_CHECKSUM_ENABLE =
-            ConfigOptions.key("state.backend.rocksdb.checkpoint.verify.checksum.enable")
+    public static final ConfigOption<Boolean> CHECKPOINT_VERIFY_CHECKSUM_ENABLED =
+            ConfigOptions.key("state.backend.rocksdb.checkpoint.verify.checksum.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -33,6 +33,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Filter;
 import org.rocksdb.IndexType;
+import org.rocksdb.Options;
 import org.rocksdb.PlainTableConfig;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.Statistics;
@@ -240,6 +241,12 @@ public final class RocksDBResourceContainer implements AutoCloseable {
             opt = optionsFactory.createReadOptions(opt, handlesToClose);
         }
 
+        return opt;
+    }
+
+    public Options getSstFileReaderOptions() {
+        Options opt = new Options(getDbOptions(), getColumnOptions());
+        handlesToClose.add(opt);
         return opt;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateFileVerifier.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateFileVerifier.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileReader;
+
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Help class for verify Checksum RocksDB state files. */
+public class RocksDBStateFileVerifier implements Closeable {
+
+    private final SstFileReader sstFileReader;
+
+    public RocksDBStateFileVerifier(Options sstFileReaderOptions) {
+        this.sstFileReader = new SstFileReader(sstFileReaderOptions);
+    }
+
+    public void verifySstFilesChecksum(@Nonnull List<Path> files) throws IOException {
+        for (Path file : files) {
+            try {
+                sstFileReader.open(file.toString());
+                sstFileReader.verifyChecksum();
+            } catch (RocksDBException e) {
+                throw new IOException(
+                        "Error while verifying Checksum of Sst File : " + file.toString() + ". ",
+                        e);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        sstFileReader.close();
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateFileVerifier.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateFileVerifier.java
@@ -24,13 +24,12 @@ import org.rocksdb.SstFileReader;
 
 import javax.annotation.Nonnull;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
 /** Help class for verify Checksum RocksDB state files. */
-public class RocksDBStateFileVerifier implements Closeable {
+public class RocksDBStateFileVerifier implements AutoCloseable {
 
     private final SstFileReader sstFileReader;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -105,7 +106,7 @@ public class RocksIncrementalSnapshotStrategy<K>
             @Nonnull UUID backendUID,
             @Nonnull SortedMap<Long, Collection<HandleAndLocalPath>> uploadedStateHandles,
             @Nonnull RocksDBStateUploader rocksDBStateUploader,
-            RocksDBStateFileVerifier stateFileVerifier,
+            @Nullable RocksDBStateFileVerifier stateFileVerifier,
             long lastCompletedCheckpointId) {
 
         super(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksNativeFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksNativeFullSnapshotStrategy.java
@@ -43,6 +43,7 @@ import org.rocksdb.RocksDB;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -87,7 +88,7 @@ public class RocksNativeFullSnapshotStrategy<K>
             @Nonnull File instanceBasePath,
             @Nonnull UUID backendUID,
             @Nonnull RocksDBStateUploader rocksDBStateUploader,
-            RocksDBStateFileVerifier stateFileVerifier) {
+            @Nullable RocksDBStateFileVerifier stateFileVerifier) {
         super(
                 DESCRIPTION,
                 db,
@@ -145,7 +146,9 @@ public class RocksNativeFullSnapshotStrategy<K>
     @Override
     public void close() {
         stateUploader.close();
-        stateFileVerifier.close();
+        if (stateFileVerifier != null) {
+            stateFileVerifier.close();
+        }
     }
 
     /** Encapsulates the process to perform a full snapshot of a RocksDBKeyedStateBackend. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBExtension.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBExtension.java
@@ -30,6 +30,7 @@ import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.InfoLogLevel;
+import org.rocksdb.Options;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Statistics;
@@ -77,6 +78,9 @@ public class RocksDBExtension implements BeforeEachCallback, AfterEachCallback {
 
     /** Wrapper for batched writes to the RocksDB instance. */
     private RocksDBWriteBatchWrapper batchWrapper;
+
+    /** The options for SstFileReader. */
+    private Options sstFileReaderOptions;
 
     /** Resources to close. */
     private final ArrayList<AutoCloseable> handlesToClose = new ArrayList<>();
@@ -151,6 +155,10 @@ public class RocksDBExtension implements BeforeEachCallback, AfterEachCallback {
         return dbOptions;
     }
 
+    public Options getSstFileReaderOptions() {
+        return sstFileReaderOptions;
+    }
+
     public RocksDBWriteBatchWrapper getBatchWrapper() {
         return batchWrapper;
     }
@@ -192,6 +200,7 @@ public class RocksDBExtension implements BeforeEachCallback, AfterEachCallback {
         this.writeOptions.disableWAL();
         this.readOptions = new ReadOptions();
         this.columnFamilyHandles = new ArrayList<>(1);
+        this.sstFileReaderOptions = new Options(dbOptions, columnFamilyOptions);
         this.rocksDB =
                 RocksDB.open(
                         dbOptions,
@@ -214,6 +223,7 @@ public class RocksDBExtension implements BeforeEachCallback, AfterEachCallback {
         IOUtils.closeQuietly(this.writeOptions);
         IOUtils.closeQuietly(this.columnFamilyOptions);
         IOUtils.closeQuietly(this.dbOptions);
+        IOUtils.closeQuietly(this.sstFileReaderOptions);
         handlesToClose.forEach(IOUtils::closeQuietly);
         temporaryFolder.delete();
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
@@ -21,10 +21,9 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.util.FileUtils;
 
 import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
@@ -48,12 +47,12 @@ import static org.junit.Assert.fail;
 /** {@link RocksDBStateFileVerifier} test. */
 public class RocksdbStateFileVerifierTest {
 
-    @Rule public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir java.nio.file.Path folder;
 
     @Test
     public void rocksdbStateFileVerifierTest() throws Exception {
         List columnFamilyHandles = new ArrayList<>(1);
-        String rootPath = folder.newFolder().getAbsolutePath();
+        String rootPath = folder.toAbsolutePath().toString();
         File dbPath = new File(rootPath, "db");
         File cpPath = new File(rootPath, "cp");
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.Checkpoint;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.SST_FILE_SUFFIX;
+import static org.junit.Assert.fail;
+
+/** {@link RocksDBStateFileVerifier} test. */
+public class RocksdbStateFileVerifierTest {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void rocksdbStateFileVerifierTest() throws Exception {
+        ArrayList columnFamilyHandles = new ArrayList<>(1);
+        String rootPath = folder.newFolder().getAbsolutePath();
+        File dbPath = new File(rootPath, "db");
+        File cpPath = new File(rootPath, "cp");
+
+        try (DBOptions dbOptions = new DBOptions().setCreateIfMissing(true);
+                ColumnFamilyOptions colOptions = new ColumnFamilyOptions();
+                Options sstFileReaderOptions = new Options(dbOptions, colOptions);
+                WriteOptions writeOptions = new WriteOptions().setDisableWAL(true);
+                RocksDB db =
+                        RocksDB.open(
+                                dbOptions,
+                                dbPath.toString(),
+                                Collections.singletonList(
+                                        new ColumnFamilyDescriptor(
+                                                "default".getBytes(), colOptions)),
+                                columnFamilyHandles);
+                RocksDBStateFileVerifier rocksDBStateFileVerifier =
+                        new RocksDBStateFileVerifier(sstFileReaderOptions)) {
+
+            byte[] key = "checkpoint".getBytes();
+            byte[] val = "incrementalTest".getBytes();
+            db.put(writeOptions, key, val);
+
+            try (Checkpoint checkpoint = Checkpoint.create(db)) {
+                checkpoint.createCheckpoint(cpPath.toString());
+            }
+
+            List<Path> sstFiles =
+                    Arrays.stream(FileUtils.listDirectory(cpPath.toPath()))
+                            .filter(file -> file.getFileName().toString().endsWith(SST_FILE_SUFFIX))
+                            .collect(Collectors.toList());
+
+            Assert.assertEquals(sstFiles.isEmpty(), false);
+
+            try {
+                rocksDBStateFileVerifier.verifySstFilesChecksum(sstFiles);
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+            // corrupt sst file.
+            Path chosenSstFile = sstFiles.get(0);
+            File corruptedSstFile =
+                    new File(
+                            chosenSstFile.getParent().toString(),
+                            "corrupted_" + chosenSstFile.getFileName().toString());
+            corruptSstFile(chosenSstFile, corruptedSstFile.toPath());
+            sstFiles.add(corruptedSstFile.toPath());
+            try {
+                rocksDBStateFileVerifier.verifySstFilesChecksum(sstFiles);
+                // corrupted sst file would verify failed
+                fail("verifySstFilesChecksum should failed");
+            } catch (IOException e) {
+                Assertions.assertTrue(
+                        e.getMessage().contains("Error while verifying Checksum of Sst File"));
+            }
+        }
+    }
+
+    public static void corruptSstFile(Path originalFile, Path corruptedFile) throws IOException {
+        byte[] sstData = FileUtils.readAllBytes(originalFile);
+        byte[] corruptedSstData = sstData.clone();
+        int startIndex = corruptedSstData.length / 4;
+        int endIndex = (corruptedSstData.length / 4) * 3;
+        for (int i = startIndex; i < endIndex; i++) {
+            corruptedSstData[i] ^= 0x80;
+        }
+        org.apache.commons.io.FileUtils.writeByteArrayToFile(
+                corruptedFile.toFile(), corruptedSstData);
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksdbStateFileVerifierTest.java
@@ -52,7 +52,7 @@ public class RocksdbStateFileVerifierTest {
 
     @Test
     public void rocksdbStateFileVerifierTest() throws Exception {
-        ArrayList columnFamilyHandles = new ArrayList<>(1);
+        List columnFamilyHandles = new ArrayList<>(1);
         String rootPath = folder.newFolder().getAbsolutePath();
         File dbPath = new File(rootPath, "db");
         File cpPath = new File(rootPath, "cp");
@@ -85,7 +85,7 @@ public class RocksdbStateFileVerifierTest {
                             .filter(file -> file.getFileName().toString().endsWith(SST_FILE_SUFFIX))
                             .collect(Collectors.toList());
 
-            Assert.assertEquals(sstFiles.isEmpty(), false);
+            Assert.assertFalse(sstFiles.isEmpty());
 
             try {
                 rocksDBStateFileVerifier.verifySstFilesChecksum(sstFiles);


### PR DESCRIPTION

## What is the purpose of the change

RocksdbStatebackend verify incremental sst file checksum during checkpoint

## Brief change log

- Add the configuration **state.backend.rocksdb.checkpoint.verify.checksum.enable** in RocksDBStateBackend to determine whether the checksum of SST needs to be verified when making Checkpoint.

- Introduce `RocksDBStateFileVerifier` into SnapshotStrategy to verify the Checksum of sst during snapshots

## Verifying this change

- add unit test RocksdbStateFileVerifierTest#rocksdbStateFileVerifierTest
- add unit test RocksIncrementalSnapshotStrategyTest#testCheckpointFailIfSstFileCorrupted

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
