### PR TITLE
[FLINK-33608][test-utils] UpsertTestDynamicTableSink's keySerializationSchama should extract and serialize the primary key fields from RowData

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/sink/UpsertTestFileUtil.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/sink/UpsertTestFileUtil.java
@@ -140,9 +140,10 @@ public class UpsertTestFileUtil {
             DeserializationSchema<V> valueDeserializationSchema)
             throws IOException {
         checkNotNull(file);
-        FileInputStream fs = new FileInputStream(file);
-        BufferedInputStream bis = new BufferedInputStream(fs);
-        return readRecords(bis, keyDeserializationSchema, valueDeserializationSchema);
+        try (FileInputStream fs = new FileInputStream(file);
+                BufferedInputStream bis = new BufferedInputStream(fs)) {
+            return readRecords(bis, keyDeserializationSchema, valueDeserializationSchema);
+        }
     }
 
     /**

--- a/flink-tests/src/test/java/org/apache/flink/connector/upserttest/table/UpsertTestDynamicTableSinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/connector/upserttest/table/UpsertTestDynamicTableSinkITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.upserttest.table;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.upserttest.sink.UpsertTestFileUtil;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -31,6 +33,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -92,5 +96,17 @@ class UpsertTestDynamicTableSinkITCase {
 
         int numberOfResultRecords = UpsertTestFileUtil.getNumberOfRecords(outputFile);
         assertThat(numberOfResultRecords).isEqualTo(3);
+
+        DeserializationSchema<String> deserializationSchema = new SimpleStringSchema();
+        Map<String, String> records =
+                UpsertTestFileUtil.readRecords(
+                        outputFile, deserializationSchema, deserializationSchema);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("{\"user_id\":1}", "{\"user_id\":1,\"user_name\":\"Bob\",\"user_count\":2}");
+        expected.put("{\"user_id\":22}", "{\"user_id\":22,\"user_name\":\"Tom\",\"user_count\":1}");
+        expected.put("{\"user_id\":42}", "{\"user_id\":42,\"user_name\":\"Kim\",\"user_count\":3}");
+
+        assertThat(records).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33608][test-utils] UpsertTestDynamicTableSink's keySerializationSchama should extract and serialize the primary key fields from RowData

```sql
CREATE TABLE UpsertFileSinkTable (
  user_id INT,
  user_name STRING,
  user_count BIGINT,
  PRIMARY KEY (user_id) NOT ENFORCED
) WITH (
  'connector' = 'upsert-files',
  'key.format' = 'json',
  'value.format' = 'json',
  'output-filepath' = '..'
);


INSERT INTO UpsertFileSinkTable
SELECT user_id, user_name, COUNT(*) AS user_count
FROM (VALUES (1, 'Bob'), (22, 'Tom'), (42, 'Kim'), (42, 'Kim'), (42, 'Kim'), (1, 'Bob'))
  AS UserCountTable(user_id, user_name)
GROUP BY user_id, user_name;
```

Results:
| Key | Value |
|:-:|:-:|
| {"user_id":1,"user_name":"Bob","user_count":2} | {"user_id":1,"user_name":"Bob","user_count":2} |
| {"user_id":22,"user_name":"Tom","user_count":1} | {"user_id":22,"user_name":"Tom","user_count":1} |
| {"user_id":42,"user_name":"Kim","user_count":3} | {"user_id":42,"user_name":"Kim","user_count":3} |

Expected:
| Key | Value |
|:-:|:-:|
| {"user_id":1} | {"user_id":1,"user_name":"Bob","user_count":2} |
| {"user_id":22} | {"user_id":22,"user_name":"Tom","user_count":1} |
| {"user_id":42} | {"user_id":42,"user_name":"Kim","user_count":3} |


## Verifying this change

This change is already covered by existing tests `UpsertTestDynamicTableSinkITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
