### PR TITLE
[FLINK-33610][runtime] Fix unstable test CoGroupTaskTest.testCancelCoGroupTaskWhileCoGrouping

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CoGroupTaskTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.RichCoGroupFunction;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.operators.CoGroupTaskExternalITCase.MockCoGroupStub;
 import org.apache.flink.runtime.operators.testutils.DelayingInfinitiveInputIterator;
 import org.apache.flink.runtime.operators.testutils.DriverTestBase;
@@ -36,11 +38,8 @@ import org.apache.flink.util.Collector;
 
 import org.junit.jupiter.api.TestTemplate;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Record>> {
     private static final long SORT_MEM = 3 * 1024 * 1024;
@@ -62,7 +61,7 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
     }
 
     @TestTemplate
-    void testSortBoth1CoGroupTask() {
+    void testSortBoth1CoGroupTask() throws Exception {
         int keyCnt1 = 100;
         int valCnt1 = 2;
 
@@ -81,21 +80,13 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt1, valCnt1, false),
-                    this.comparator1.duplicate());
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt2, valCnt2, false),
-                    this.comparator2.duplicate());
-            testDriver(testTask, MockCoGroupStub.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
+        testDriver(testTask, MockCoGroupStub.class);
 
         assertThat(this.output.getNumberOfRecords())
                 .withFailMessage("Wrong result set size.")
@@ -103,7 +94,7 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
     }
 
     @TestTemplate
-    void testSortBoth2CoGroupTask() {
+    void testSortBoth2CoGroupTask() throws Exception {
         int keyCnt1 = 200;
         int valCnt1 = 2;
 
@@ -122,21 +113,13 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt1, valCnt1, false),
-                    this.comparator1.duplicate());
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt2, valCnt2, false),
-                    this.comparator2.duplicate());
-            testDriver(testTask, MockCoGroupStub.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
+        testDriver(testTask, MockCoGroupStub.class);
 
         assertThat(this.output.getNumberOfRecords())
                 .withFailMessage("Wrong result set size.")
@@ -144,7 +127,7 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
     }
 
     @TestTemplate
-    void testSortFirstCoGroupTask() {
+    void testSortFirstCoGroupTask() throws Exception {
         int keyCnt1 = 200;
         int valCnt1 = 2;
 
@@ -163,19 +146,12 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt1, valCnt1, false),
-                    this.comparator1.duplicate());
-            addInput(new UniformRecordGenerator(keyCnt2, valCnt2, true));
-            testDriver(testTask, MockCoGroupStub.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt1, valCnt1, false), this.comparator1.duplicate());
+        addInput(new UniformRecordGenerator(keyCnt2, valCnt2, true));
+        testDriver(testTask, MockCoGroupStub.class);
 
         assertThat(this.output.getNumberOfRecords())
                 .withFailMessage("Wrong result set size.")
@@ -183,7 +159,7 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
     }
 
     @TestTemplate
-    void testSortSecondCoGroupTask() {
+    void testSortSecondCoGroupTask() throws Exception {
         int keyCnt1 = 200;
         int valCnt1 = 2;
 
@@ -202,19 +178,12 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInput(new UniformRecordGenerator(keyCnt1, valCnt1, true));
-            addInputSorted(
-                    new UniformRecordGenerator(keyCnt2, valCnt2, false),
-                    this.comparator2.duplicate());
-            testDriver(testTask, MockCoGroupStub.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInput(new UniformRecordGenerator(keyCnt1, valCnt1, true));
+        addInputSorted(
+                new UniformRecordGenerator(keyCnt2, valCnt2, false), this.comparator2.duplicate());
+        testDriver(testTask, MockCoGroupStub.class);
 
         assertThat(this.output.getNumberOfRecords())
                 .withFailMessage("Wrong result set size.")
@@ -222,7 +191,7 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
     }
 
     @TestTemplate
-    void testMergeCoGroupTask() {
+    void testMergeCoGroupTask() throws Exception {
         int keyCnt1 = 200;
         int valCnt1 = 2;
 
@@ -245,15 +214,9 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            testDriver(testTask, MockCoGroupStub.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        testDriver(testTask, MockCoGroupStub.class);
 
         assertThat(this.output.getNumberOfRecords())
                 .withFailMessage("Wrong result set size.")
@@ -278,15 +241,14 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
         assertThatThrownBy(() -> testDriver(testTask, MockFailingCoGroupStub.class))
                 .isInstanceOf(ExpectedTestException.class);
     }
 
     @TestTemplate
-    void testCancelCoGroupTaskWhileSorting1() {
+    void testCancelCoGroupTaskWhileSorting1() throws Exception {
         int keyCnt = 10;
         int valCnt = 2;
 
@@ -298,29 +260,16 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInputSorted(new DelayingInfinitiveInputIterator(1000), this.comparator1.duplicate());
-            addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInputSorted(new DelayingInfinitiveInputIterator(1000), this.comparator1.duplicate());
+        addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
 
-        final AtomicBoolean success = new AtomicBoolean(false);
-
-        Thread taskRunner =
-                new Thread() {
+        CheckedThread taskRunner =
+                new CheckedThread() {
                     @Override
-                    public void run() {
-                        try {
-                            testDriver(testTask, MockCoGroupStub.class);
-                            success.set(true);
-                        } catch (Exception ie) {
-                            ie.printStackTrace();
-                        }
+                    public void go() throws Exception {
+                        testDriver(testTask, MockCoGroupStub.class);
                     }
                 };
         taskRunner.start();
@@ -328,18 +277,12 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         TaskCancelThread tct = new TaskCancelThread(1, taskRunner, this);
         tct.start();
 
-        try {
-            tct.join();
-            taskRunner.join();
-        } catch (InterruptedException ie) {
-            fail("Joining threads failed");
-        }
-
-        assertThat(success).withFailMessage("The test task was not properly canceled.").isTrue();
+        tct.join();
+        taskRunner.sync();
     }
 
     @TestTemplate
-    void testCancelCoGroupTaskWhileSorting2() {
+    void testCancelCoGroupTaskWhileSorting2() throws Exception {
         int keyCnt = 10;
         int valCnt = 2;
 
@@ -351,29 +294,16 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
-            addInputSorted(new DelayingInfinitiveInputIterator(1000), this.comparator2.duplicate());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
+        addInputSorted(new DelayingInfinitiveInputIterator(1000), this.comparator2.duplicate());
 
-        final AtomicBoolean success = new AtomicBoolean(false);
-
-        Thread taskRunner =
-                new Thread() {
+        CheckedThread taskRunner =
+                new CheckedThread() {
                     @Override
-                    public void run() {
-                        try {
-                            testDriver(testTask, MockCoGroupStub.class);
-                            success.set(true);
-                        } catch (Exception ie) {
-                            ie.printStackTrace();
-                        }
+                    public void go() throws Exception {
+                        testDriver(testTask, MockCoGroupStub.class);
                     }
                 };
         taskRunner.start();
@@ -381,20 +311,12 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         TaskCancelThread tct = new TaskCancelThread(1, taskRunner, this);
         tct.start();
 
-        try {
-            tct.join();
-            taskRunner.join();
-        } catch (InterruptedException ie) {
-            fail("Joining threads failed");
-        }
-
-        assertThat(success)
-                .withFailMessage("Test threw an exception even though it was properly canceled.")
-                .isTrue();
+        tct.join();
+        taskRunner.sync();
     }
 
     @TestTemplate
-    void testCancelCoGroupTaskWhileCoGrouping() {
+    void testCancelCoGroupTaskWhileCoGrouping() throws Exception {
         int keyCnt = 100;
         int valCnt = 5;
 
@@ -406,29 +328,18 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         getTaskConfig().setDriverPairComparator(RecordPairComparatorFactory.get());
         getTaskConfig().setDriverStrategy(DriverStrategy.CO_GROUP);
 
-        final CoGroupDriver<Record, Record, Record> testTask =
-                new CoGroupDriver<Record, Record, Record>();
+        final CoGroupDriver<Record, Record, Record> testTask = new CoGroupDriver<>();
 
-        try {
-            addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
-            addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("The test caused an exception.");
-        }
+        addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
+        addInput(new UniformRecordGenerator(keyCnt, valCnt, true));
 
-        final AtomicBoolean success = new AtomicBoolean(false);
+        final OneShotLatch closeLatch = new OneShotLatch();
 
-        Thread taskRunner =
-                new Thread() {
+        CheckedThread taskRunner =
+                new CheckedThread() {
                     @Override
-                    public void run() {
-                        try {
-                            testDriver(testTask, MockDelayingCoGroupStub.class);
-                            success.set(true);
-                        } catch (Exception ie) {
-                            ie.printStackTrace();
-                        }
+                    public void go() throws Exception {
+                        testDriver(testTask, new MockDelayingCoGroupStub(closeLatch));
                     }
                 };
         taskRunner.start();
@@ -436,16 +347,9 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
         TaskCancelThread tct = new TaskCancelThread(1, taskRunner, this);
         tct.start();
 
-        try {
-            tct.join();
-            taskRunner.join();
-        } catch (InterruptedException ie) {
-            fail("Joining threads failed");
-        }
-
-        assertThat(success)
-                .withFailMessage("Test threw an exception even though it was properly canceled.")
-                .isTrue();
+        tct.join();
+        closeLatch.trigger();
+        taskRunner.sync();
     }
 
     public static class MockFailingCoGroupStub extends RichCoGroupFunction<Record, Record, Record> {
@@ -488,24 +392,19 @@ class CoGroupTaskTest extends DriverTestBase<CoGroupFunction<Record, Record, Rec
             extends RichCoGroupFunction<Record, Record, Record> {
         private static final long serialVersionUID = 1L;
 
-        @SuppressWarnings("unused")
+        private final OneShotLatch closeLatch;
+
+        public MockDelayingCoGroupStub(OneShotLatch closeLatch) {
+            this.closeLatch = closeLatch;
+        }
+
         @Override
         public void coGroup(
-                Iterable<Record> records1, Iterable<Record> records2, Collector<Record> out) {
+                Iterable<Record> records1, Iterable<Record> records2, Collector<Record> out) {}
 
-            for (Record r : records1) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                }
-            }
-
-            for (Record r : records2) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                }
-            }
+        @Override
+        public void close() throws InterruptedException {
+            closeLatch.await();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/CombineTaskExternalITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
-import org.apache.flink.api.common.functions.RichGroupReduceFunction;
 import org.apache.flink.runtime.operators.testutils.DriverTestBase;
 import org.apache.flink.runtime.operators.testutils.UniformRecordGenerator;
 import org.apache.flink.runtime.testutils.recordutils.RecordComparator;
@@ -38,7 +37,7 @@ import java.util.HashMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-class CombineTaskExternalITCase extends DriverTestBase<RichGroupReduceFunction<Record, ?>> {
+class CombineTaskExternalITCase extends DriverTestBase<GroupReduceFunction<Record, ?>> {
 
     private static final long COMBINE_MEM = 3 * 1024 * 1024;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskExternalITCase.java
@@ -44,7 +44,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-class ReduceTaskExternalITCase extends DriverTestBase<RichGroupReduceFunction<Record, Record>> {
+class ReduceTaskExternalITCase extends DriverTestBase<GroupReduceFunction<Record, Record>> {
     private static final Logger LOG = LoggerFactory.getLogger(ReduceTaskExternalITCase.class);
 
     @SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/ReduceTaskTest.java
@@ -50,7 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
-public class ReduceTaskTest extends DriverTestBase<RichGroupReduceFunction<Record, Record>> {
+public class ReduceTaskTest extends DriverTestBase<GroupReduceFunction<Record, Record>> {
     private static final Logger LOG = LoggerFactory.getLogger(ReduceTaskTest.class);
 
     @SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -190,18 +190,18 @@ public abstract class DriverTestBase<S extends Function> implements TaskContext<
         this.numFileHandles = numFileHandles;
     }
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "unchecked"})
     protected void testDriver(Driver driver, Class stubClass) throws Exception {
-        testDriverInternal(driver, stubClass);
+        testDriver(driver, (S) stubClass.newInstance());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected void testDriverInternal(Driver driver, Class stubClass) throws Exception {
+    protected void testDriver(Driver driver, S stub) throws Exception {
 
         this.driver = driver;
         driver.setup(this);
 
-        this.stub = (S) stubClass.newInstance();
+        this.stub = stub;
 
         // regular running logic
         boolean stubOpen = false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -190,9 +190,11 @@ public abstract class DriverTestBase<S extends Function> implements TaskContext<
         this.numFileHandles = numFileHandles;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    protected void testDriver(Driver driver, Class stubClass) throws Exception {
-        testDriver(driver, (S) stubClass.newInstance());
+    /** @deprecated Use {@link #testDriver(Driver, Function)} instead. */
+    @Deprecated
+    @SuppressWarnings({"rawtypes"})
+    protected void testDriver(Driver driver, Class<? extends S> stubClass) throws Exception {
+        testDriver(driver, stubClass.getDeclaredConstructor().newInstance());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33610][runtime] Fix unstable test CoGroupTaskTest.testCancelCoGroupTaskWhileCoGrouping

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=54741&view=logs&j=675bf62c-8558-587e-2555-dcad13acefb5&t=5878eed3-cc1e-5b12-1ed0-9e7139ce0992&l=7675
```
java.lang.NullPointerException: Cannot invoke "org.apache.flink.runtime.operators.util.CoGroupTaskIterator.close()" because "this.coGroupIterator" is null
at org.apache.flink.runtime.operators.CoGroupDriver.cleanup(CoGroupDriver.java:185)
at org.apache.flink.runtime.operators.testutils.DriverTestBase.testDriverInternal(DriverTestBase.java:270)
at org.apache.flink.runtime.operators.testutils.DriverTestBase.testDriver(DriverTestBase.java:195)
at org.apache.flink.runtime.operators.CoGroupTaskTest.access$200(CoGroupTaskTest.java:45)
at org.apache.flink.runtime.operators.CoGroupTaskTest$3.run(CoGroupTaskTest.java:427)
```

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
