### PR TITLE
[FLINK-20539][table-planner] Fix type mismatch when using ROW in comp…

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -236,6 +236,24 @@ Calc(select=[timestamp, metadata_timestamp, other, UPPER(other) AS computed_othe
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDDLWithRowTypeComputedColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM t1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalProject(a=[$0], b=[$1], c=[ROW($0, $1)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, ROW(a, b) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDDLWithWatermarkComputedColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM t1]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -79,6 +79,20 @@ class TableScanTest extends TableTestBase {
   }
 
   @Test
+  def testDDLWithRowTypeComputedColumn(): Unit = {
+    util.addTable(s"""
+                     |create table t1(
+                     |  a int,
+                     |  b varchar,
+                     |  c as row(a, b)
+                     |) with (
+                     |  'connector' = 'values'
+                     |)
+       """.stripMargin)
+    util.verifyExecPlan("SELECT * FROM t1")
+  }
+
+  @Test
   def testDDLWithMetadataColumn(): Unit = {
     // tests reordering, skipping, and casting of metadata
     util.addTable(


### PR DESCRIPTION
## What is the purpose of the change

This pr is cherry-picked from master. See more here: https://github.com/apache/flink/pull/23519

When using row as a computed column and select the computed column as a query, an exception will be thrown by calcite because of the type mismatch about ROW.

The cause is that in Flink, we always treat the ROW as a struct type PEEK_FIELDS_NO_EXPAND (refs to LogicalRelDataTypeConverter and FlinkTypeFactory), but in calcite, the struct type about ROW is FULLY_QUALIFIED (refs to SqlRowOperator#inferReturnType). And when selecting the column, the difference causes this bug.

## Brief change log

  - *Modify the SqlRowOperator to return the true struct type about ROW*
  - *Add tests about this pr*


## Verifying this change

Necessary tests have been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
