### PR TITLE
[FLINK-33507][json]Support zero-timestamp.behavior option for JSON fo…

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/json.md
+++ b/docs/content.zh/docs/connectors/table/formats/json.md
@@ -55,7 +55,8 @@ CREATE TABLE user_behavior (
  'properties.group.id' = 'testGroup',
  'format' = 'json',
  'json.fail-on-missing-field' = 'false',
- 'json.ignore-parse-errors' = 'true'
+ 'json.ignore-parse-errors' = 'true' ,
+ 'json.zero-timestamp.behavior' = 'CONVERT_TO_NULL'
 )
 ```
 
@@ -105,6 +106,18 @@ Format 参数
         以 "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP_LTZ, 例如 "2020-12-30 12:13:14.123Z" 且会以相同的格式输出。</li>
         <li>可选参数 <code>'ISO-8601'</code> 将会以 "yyyy-MM-ddTHH:mm:ss.s{precision}" 的格式解析输入 TIMESTAMP, 例如 "2020-12-30T12:13:14.123" ，
         以 "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP_LTZ, 例如 "2020-12-30T12:13:14.123Z" 且会以相同的格式输出。</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><h5>json.zero-timestamp.behavior</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+      <td>String</td>
+      <td>指定如何反序列化JSON中出现的<code>TIMESTAMP</code>类型的零值，例如 "0000-00-00 00:00:00" 和 "0000-00-00"。当前支持的选项有<code>'FAIL'</code> 以及 <code>'CONVERT_TO_NULL'</code>：
+      <ul>
+        <li>可选参数 <code>'FAIL'</code> 将会抛出异常当遇到零值。</li>
+        <li>可选参数 <code>'CONVERT_TO_NULL'</code> 遇到零值时，会将字段值转换为<code>null</code>并返回。</li>
       </ul>
       </td>
     </tr>

--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -57,7 +57,8 @@ CREATE TABLE user_behavior (
  'properties.group.id' = 'testGroup',
  'format' = 'json',
  'json.fail-on-missing-field' = 'false',
- 'json.ignore-parse-errors' = 'true'
+ 'json.ignore-parse-errors' = 'true' ,
+ 'json.zero-timestamp.behavior' = 'CONVERT_TO_NULL'
 )
 ```
 
@@ -113,6 +114,19 @@ Format Options
         parse input TIMESTAMP_LTZ values in "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30 12:13:14.123Z" and output timestamp in the same format.</li>
         <li>Option <code>'ISO-8601'</code>will parse input TIMESTAMP in "yyyy-MM-ddTHH:mm:ss.s{precision}" format, e.g "2020-12-30T12:13:14.123" 
         parse input TIMESTAMP_LTZ in "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30T12:13:14.123Z" and output timestamp in the same format.</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><h5>json.zero-timestamp.behavior</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+      <td>String</td>
+      <td>Specify how to deserialize zero timestamp data of type <code>TIMESTAMP</code> in json, such as "0000-00-00 00:00:00" and "0000-00-00". Currently supported values are <code>'FAIL'</code> and <code>'CONVERT_TO_NULL'</code>:
+      <ul>
+        <li>Option <code>'FAIL'</code> will throw exception when encountering zero timestamp.</li>
+        <li>Option <code>'CONVERT_TO_NULL'</code> will set field value to null when encountering zero timestamp.</li>
       </ul>
       </td>
     </tr>

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonFormatOptions.ZeroTimestampBehavior;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
@@ -51,6 +52,7 @@ import static org.apache.flink.formats.json.JsonFormatOptions.IGNORE_PARSE_ERROR
 import static org.apache.flink.formats.json.JsonFormatOptions.MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.JsonFormatOptions.MAP_NULL_KEY_MODE;
 import static org.apache.flink.formats.json.JsonFormatOptions.TIMESTAMP_FORMAT;
+import static org.apache.flink.formats.json.JsonFormatOptions.ZERO_TIMESTAMP_BEHAVIOR;
 
 /**
  * Table format factory for providing configured instances of JSON to RowData {@link
@@ -66,11 +68,14 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
             DynamicTableFactory.Context context, ReadableConfig formatOptions) {
         FactoryUtil.validateFactoryOptions(this, formatOptions);
         JsonFormatOptionsUtil.validateDecodingFormatOptions(formatOptions);
+        JsonFormatOptionsUtil.validateZeroTimestampBehavior(formatOptions);
 
         final boolean failOnMissingField = formatOptions.get(FAIL_ON_MISSING_FIELD);
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
         final boolean jsonParserEnabled = formatOptions.get(DECODE_JSON_PARSER_ENABLED);
         TimestampFormat timestampOption = JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
+        ZeroTimestampBehavior zeroTimestampBehavior =
+                JsonFormatOptionsUtil.getZeroTimestampBehavior(formatOptions);
 
         return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
             @Override
@@ -90,6 +95,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                             failOnMissingField,
                             ignoreParseErrors,
                             timestampOption,
+                            zeroTimestampBehavior,
                             toProjectedNames(
                                     (RowType) physicalDataType.getLogicalType(), projections));
                 } else {
@@ -98,7 +104,8 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                             rowDataTypeInfo,
                             failOnMissingField,
                             ignoreParseErrors,
-                            timestampOption);
+                            timestampOption,
+                            zeroTimestampBehavior);
                 }
             }
 
@@ -184,6 +191,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(FAIL_ON_MISSING_FIELD);
         options.add(IGNORE_PARSE_ERRORS);
         options.add(TIMESTAMP_FORMAT);
+        options.add(ZERO_TIMESTAMP_BEHAVIOR);
         options.add(MAP_NULL_KEY_MODE);
         options.add(MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
@@ -194,6 +202,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
     public Set<ConfigOption<?>> forwardOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(TIMESTAMP_FORMAT);
+        options.add(ZERO_TIMESTAMP_BEHAVIOR);
         options.add(MAP_NULL_KEY_MODE);
         options.add(MAP_NULL_KEY_LITERAL);
         options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
@@ -66,6 +66,14 @@ public class JsonFormatOptions {
                                     + " Option ISO-8601 will parse input timestamp in \"yyyy-MM-ddTHH:mm:ss.s{precision}\" format and output timestamp in the same format."
                                     + " Option SQL will parse input timestamp in \"yyyy-MM-dd HH:mm:ss.s{precision}\" format and output timestamp in the same format.");
 
+    public static final ConfigOption<String> ZERO_TIMESTAMP_BEHAVIOR =
+            ConfigOptions.key("zero-timestamp.behavior")
+                    .stringType()
+                    .defaultValue("FAIL")
+                    .withDescription(
+                            "Optional flag to specify behavior when parsing zero timestamp, FAIL by default."
+                                    + " Option CONVERT_TO_NULL will convert zero timestamp to null.");
+
     public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER =
             ConfigOptions.key("encode.decimal-as-plain-number")
                     .booleanType()
@@ -83,6 +91,12 @@ public class JsonFormatOptions {
     // --------------------------------------------------------------------------------------------
     // Enums
     // --------------------------------------------------------------------------------------------
+
+    /** Behavior mode for zero timestamp. */
+    public enum ZeroTimestampBehavior {
+        FAIL,
+        CONVERT_TO_NULL
+    }
 
     /** Handling mode for map data with null key. */
     public enum MapNullKeyMode {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.json;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonFormatOptions.ZeroTimestampBehavior;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -54,7 +55,14 @@ public class JsonParserRowDataDeserializationSchema extends AbstractJsonDeserial
             boolean failOnMissingField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat) {
-        this(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat, null);
+        this(
+                rowType,
+                resultTypeInfo,
+                failOnMissingField,
+                ignoreParseErrors,
+                timestampFormat,
+                ZeroTimestampBehavior.FAIL,
+                null);
     }
 
     public JsonParserRowDataDeserializationSchema(
@@ -63,11 +71,15 @@ public class JsonParserRowDataDeserializationSchema extends AbstractJsonDeserial
             boolean failOnMissingField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat,
+            ZeroTimestampBehavior zeroTimestampBehavior,
             @Nullable String[][] projectedFields) {
         super(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat);
         this.runtimeConverter =
                 new JsonParserToRowDataConverters(
-                                failOnMissingField, ignoreParseErrors, timestampFormat)
+                                failOnMissingField,
+                                ignoreParseErrors,
+                                timestampFormat,
+                                zeroTimestampBehavior)
                         .createConverter(projectedFields, checkNotNull(rowType));
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.json;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonFormatOptions.ZeroTimestampBehavior;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -56,9 +57,29 @@ public class JsonRowDataDeserializationSchema extends AbstractJsonDeserializatio
             boolean failOnMissingField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat) {
+        this(
+                rowType,
+                resultTypeInfo,
+                failOnMissingField,
+                ignoreParseErrors,
+                timestampFormat,
+                ZeroTimestampBehavior.FAIL);
+    }
+
+    public JsonRowDataDeserializationSchema(
+            RowType rowType,
+            TypeInformation<RowData> resultTypeInfo,
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            TimestampFormat timestampFormat,
+            ZeroTimestampBehavior zeroTimestampBehavior) {
         super(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat);
         this.runtimeConverter =
-                new JsonToRowDataConverters(failOnMissingField, ignoreParseErrors, timestampFormat)
+                new JsonToRowDataConverters(
+                                failOnMissingField,
+                                ignoreParseErrors,
+                                timestampFormat,
+                                zeroTimestampBehavior)
                         .createConverter(checkNotNull(rowType));
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -106,6 +106,31 @@ class JsonFormatFactoryTest {
     }
 
     @Test
+    void testInvalidOptionForZeroTimestampBehavior() {
+        final Map<String, String> tableOptions =
+                getModifyOptions(options -> options.put("json.zero-timestamp.behavior", "test"));
+
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'test' for zero-timestamp.behavior. Supported values are [FAIL, CONVERT_TO_NULL]."));
+    }
+
+    @Test
+    void testLowerCaseOptionForZeroTimestampBehavior() {
+        final Map<String, String> tableOptions =
+                getModifyOptions(
+                        options -> options.put("json.zero-timestamp.behavior", "convert_to_null"));
+
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "Unsupported value 'convert_to_null' for zero-timestamp.behavior. Supported values are [FAIL, CONVERT_TO_NULL]."));
+    }
+
+    @Test
     void testInvalidOptionForMapNullKeyMode() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.map-null-key.mode", "invalid"));
@@ -224,6 +249,7 @@ class JsonFormatFactoryTest {
         options.put("json.fail-on-missing-field", "false");
         options.put("json.ignore-parse-errors", "true");
         options.put("json.timestamp-format.standard", "ISO-8601");
+        options.put("json.zero-timestamp.behavior", "FAIL");
         options.put("json.map-null-key.mode", "LITERAL");
         options.put("json.map-null-key.literal", "null");
         options.put("json.encode.decimal-as-plain-number", "true");

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.json;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonFormatOptions.ZeroTimestampBehavior;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -169,6 +170,7 @@ public class JsonParserRowDataDeSerSchemaTest {
                         false,
                         false,
                         TimestampFormat.ISO_8601,
+                        ZeroTimestampBehavior.FAIL,
                         new String[][] {
                             new String[] {"f1"},
                             new String[] {"f4"},
@@ -262,6 +264,7 @@ public class JsonParserRowDataDeSerSchemaTest {
                         false,
                         false,
                         TimestampFormat.ISO_8601,
+                        ZeroTimestampBehavior.FAIL,
                         new String[][] {
                             new String[] {"f1"},
                             new String[] {"f3", "f1"},
@@ -329,6 +332,7 @@ public class JsonParserRowDataDeSerSchemaTest {
                         false,
                         false,
                         TimestampFormat.ISO_8601,
+                        ZeroTimestampBehavior.FAIL,
                         new String[][] {
                             new String[] {"f1"},
                             new String[] {"f3", "f2"},

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -405,6 +405,53 @@ public class JsonRowDataSerDeSchemaTest {
         assertThat(deserializationSchema.deserialize(null)).isNull();
     }
 
+    @Test
+    void testDeserializationZeroTimestamp() throws Exception {
+        // Root
+        ObjectNode root = OBJECT_MAPPER.createObjectNode();
+        root.put("zeroDate", "0000-00-00");
+        root.put("zeroTimestamp", "0000-00-00 00:00:00");
+        byte[] serializedJson = OBJECT_MAPPER.writeValueAsBytes(root);
+
+        DataType dataType =
+                ROW(FIELD("zeroDate", TIMESTAMP()), FIELD("zeroTimestamp", TIMESTAMP()));
+        RowType schema = (RowType) dataType.getLogicalType();
+
+        // convert to null on parsing zero timestamp
+        JsonRowDataDeserializationSchema deserializationSchema =
+                new JsonRowDataDeserializationSchema(
+                        schema,
+                        InternalTypeInfo.of(schema),
+                        true,
+                        false,
+                        TimestampFormat.SQL,
+                        JsonFormatOptions.ZeroTimestampBehavior.CONVERT_TO_NULL);
+        open(deserializationSchema);
+
+        Row expected = new Row(2);
+        expected.setField(0, null);
+        expected.setField(1, null);
+        Row actual = convertToExternal(deserializationSchema.deserialize(serializedJson), dataType);
+        assertThat(actual).isEqualTo(expected);
+
+        // fail on parsing zero timestamp
+        deserializationSchema =
+                new JsonRowDataDeserializationSchema(
+                        schema,
+                        InternalTypeInfo.of(schema),
+                        true,
+                        false,
+                        TimestampFormat.SQL,
+                        JsonFormatOptions.ZeroTimestampBehavior.FAIL);
+        open(deserializationSchema);
+        String errorMessage =
+                "Unable to parse zero timestamp '0000-00-00' in 'FAIL' zero-timestamp.behavior.";
+        JsonRowDataDeserializationSchema finalDeserializationSchema = deserializationSchema;
+        assertThatThrownBy(() -> finalDeserializationSchema.deserialize(serializedJson))
+                .rootCause()
+                .hasMessage(errorMessage);
+    }
+
     @TestTemplate
     void testDeserializationMissingNode() throws Exception {
         DataType dataType = ROW(FIELD("name", STRING()));


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull requests support a new json-format option:*zero-timestamp.behavior* when we deserialize a json string to RowData.  

In MySQL, there is a special type of datetime data, which is zero datatime, such as "0000-00-00 00:00:00". This kind of datetime is illegal in Java, so MySQL JDBC provides a parameter to convert zero datetime to null. However, currently this kind of data cannot be parsed normally by flink json in the timestamp format, so I hope to add an option to handle zero datetime to ensure that MySQL will not report errors in data migration scenarios.


## Brief change log

  - *Support a new json-format option:*zero-timestamp.behavior* when we deserialize a json string to RowData. *


## Verifying this change


This change is already covered by existing tests, such as *JsonRowDataSerDeSchemaTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
