### PR TITLE
[FLINK-33624][table] Bump Guava to 32.1.3-jre

### DIFF
--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.google.guava:guava:31.1-jre
+- com.google.guava:guava:32.1.3-jre
 - com.google.guava:failureaccess:1.0.1
 - org.apache.calcite:calcite-core:1.32.0
 - org.apache.calcite:calcite-linq4j:1.32.0

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -84,6 +84,6 @@ under the License.
 		more details are in FLINK-27995 -->
 		<janino.version>3.1.10</janino.version>
 		<jsonpath.version>2.7.0</jsonpath.version>
-		<guava.version>31.1-jre</guava.version>
+		<guava.version>32.1.3-jre</guava.version>
 	</properties>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

Bump Guava to 32.1.3-jre

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
