### PR TITLE
[FLINK-33541][table-planner] function RAND and RAND_INTEGER should return type nullable if the arguments are nullable

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1581,7 +1581,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(SCALAR)
                     .notDeterministic()
                     .inputTypeStrategy(or(NO_ARGS, sequence(logical(LogicalTypeRoot.INTEGER))))
-                    .outputTypeStrategy(explicit(DataTypes.DOUBLE().notNull()))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.DOUBLE())))
                     .build();
 
     public static final BuiltInFunctionDefinition RAND_INTEGER =
@@ -1595,7 +1595,7 @@ public final class BuiltInFunctionDefinitions {
                                     sequence(
                                             logical(LogicalTypeRoot.INTEGER),
                                             logical(LogicalTypeRoot.INTEGER))))
-                    .outputTypeStrategy(explicit(INT().notNull()))
+                    .outputTypeStrategy(nullableIfArgs(explicit(INT())))
                     .build();
 
     public static final BuiltInFunctionDefinition BIN =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -940,7 +940,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
             new SqlFunction(
                     "RAND",
                     SqlKind.OTHER_FUNCTION,
-                    ReturnTypes.DOUBLE,
+                    ReturnTypes.cascade(
+                            ReturnTypes.explicit(SqlTypeName.DOUBLE),
+                            SqlTypeTransforms.TO_NULLABLE),
                     null,
                     OperandTypes.or(
                             new SqlSingleOperandTypeChecker[] {
@@ -958,7 +960,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
             new SqlFunction(
                     "RAND_INTEGER",
                     SqlKind.OTHER_FUNCTION,
-                    ReturnTypes.INTEGER,
+                    ReturnTypes.cascade(
+                            ReturnTypes.explicit(SqlTypeName.INTEGER),
+                            SqlTypeTransforms.TO_NULLABLE),
                     null,
                     OperandTypes.or(
                             new SqlSingleOperandTypeChecker[] {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/RandCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/RandCallGen.scala
@@ -39,11 +39,12 @@ class RandCallGen(isRandInteger: Boolean, hasSeed: Boolean) extends CallGenerato
     }
 
     if (isRandInteger) {
-      generateCallIfArgsNotNull(ctx, new IntType(), operands) {
+      generateCallIfArgsNotNull(ctx, new IntType(returnType.isNullable), operands) {
         terms => s"$randField.nextInt(${terms.last})"
       }
     } else {
-      generateCallIfArgsNotNull(ctx, new DoubleType(), operands)(_ => s"$randField.nextDouble()")
+      generateCallIfArgsNotNull(ctx, new DoubleType(returnType.isNullable), operands)(
+        _ => s"$randField.nextDouble()")
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -55,8 +55,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -133,7 +135,7 @@ abstract class BuiltInFunctionTestBase {
 
         private final List<TestItem> testItems;
 
-        private Object[] fieldData;
+        private @Nullable Object[] fieldData;
 
         private @Nullable AbstractDataType<?>[] fieldDataTypes;
 
@@ -178,6 +180,11 @@ abstract class BuiltInFunctionTestBase {
                     singletonList(expression), singletonList(result), singletonList(dataType));
         }
 
+        TestSetSpec testTableApiResult(Expression expression, AbstractDataType<?> dataType) {
+            return testTableApiResult(
+                    singletonList(expression), emptyList(), singletonList(dataType));
+        }
+
         TestSetSpec testTableApiResult(
                 List<Expression> expression,
                 List<Object> result,
@@ -207,6 +214,10 @@ abstract class BuiltInFunctionTestBase {
 
         TestSetSpec testSqlResult(String expression, Object result, AbstractDataType<?> dataType) {
             return testSqlResult(expression, singletonList(result), singletonList(dataType));
+        }
+
+        TestSetSpec testSqlResult(String expression, AbstractDataType<?> dataType) {
+            return testSqlResult(expression, emptyList(), singletonList(dataType));
         }
 
         TestSetSpec testSqlResult(
@@ -303,8 +314,13 @@ abstract class BuiltInFunctionTestBase {
                         functions.forEach(
                                 f -> env.createTemporarySystemFunction(f.getSimpleName(), f));
 
+                        Preconditions.checkArgument(
+                                !(fieldData == null && fieldDataTypes != null),
+                                "The field data type is set but the field data is not.");
                         final Table inputTable;
-                        if (fieldDataTypes == null) {
+                        if (fieldData == null) {
+                            inputTable = null;
+                        } else if (fieldDataTypes == null) {
                             inputTable = env.fromValues(Row.of(fieldData));
                         } else {
                             final DataTypes.UnresolvedField[] fields =
@@ -329,7 +345,12 @@ abstract class BuiltInFunctionTestBase {
     }
 
     private interface TestItem {
-        void test(TableEnvironmentInternal env, Table inputTable) throws Exception;
+        /**
+         * @param env The table environment for test to execute.
+         * @param inputTable The input table of this test that contains input data and data type. If
+         *     it is null, the test is not dependent on the input data.
+         */
+        void test(TableEnvironmentInternal env, @Nullable Table inputTable) throws Exception;
     }
 
     private abstract static class ResultTestItem<T> implements TestItem {
@@ -343,10 +364,11 @@ abstract class BuiltInFunctionTestBase {
             this.dataTypes = dataTypes;
         }
 
-        abstract Table query(TableEnvironment env, Table inputTable);
+        abstract Table query(TableEnvironment env, @Nullable Table inputTable);
 
         @Override
-        public void test(TableEnvironmentInternal env, Table inputTable) throws Exception {
+        public void test(TableEnvironmentInternal env, @Nullable Table inputTable)
+                throws Exception {
             final Table resultTable = this.query(env, inputTable);
 
             final List<DataType> expectedDataTypes =
@@ -360,20 +382,27 @@ abstract class BuiltInFunctionTestBase {
                 assertThat(iterator).as("No more rows expected.").isExhausted();
 
                 for (int i = 0; i < row.getArity(); i++) {
-                    assertThat(
-                                    result.getResolvedSchema()
-                                            .getColumnDataTypes()
-                                            .get(i)
-                                            .getLogicalType())
-                            .as("Logical type for spec [%d] of test [%s] doesn't match.", i, this)
-                            .isEqualTo(expectedDataTypes.get(i).getLogicalType());
+                    if (!expectedDataTypes.isEmpty()) {
+                        assertThat(
+                                        result.getResolvedSchema()
+                                                .getColumnDataTypes()
+                                                .get(i)
+                                                .getLogicalType())
+                                .as(
+                                        "Logical type for spec [%d] of test [%s] doesn't match.",
+                                        i, this)
+                                .isEqualTo(expectedDataTypes.get(i).getLogicalType());
+                    }
 
-                    assertThat(Row.of(row.getField(i)))
-                            .as("Result for spec [%d] of test [%s] doesn't match.", i, this)
-                            .isEqualTo(
-                                    // Use Row.equals() to enable equality for complex structure,
-                                    // i.e. byte[]
-                                    Row.of(this.results.get(i)));
+                    if (!this.results.isEmpty()) {
+                        assertThat(Row.of(row.getField(i)))
+                                .as("Result for spec [%d] of test [%s] doesn't match.", i, this)
+                                .isEqualTo(
+                                        // Use Row.equals() to enable equality for complex
+                                        // structure,
+                                        // i.e. byte[]
+                                        Row.of(this.results.get(i)));
+                    }
                 }
             }
         }
@@ -397,7 +426,7 @@ abstract class BuiltInFunctionTestBase {
             this.expectedDuringValidation = expectedDuringValidation;
         }
 
-        abstract Table query(TableEnvironment env, Table inputTable);
+        abstract Table query(TableEnvironment env, @Nullable Table inputTable);
 
         Consumer<? super Throwable> errorMatcher() {
             if (errorClass != null && errorMessage != null) {
@@ -410,7 +439,7 @@ abstract class BuiltInFunctionTestBase {
         }
 
         @Override
-        public void test(TableEnvironmentInternal env, Table inputTable) {
+        public void test(TableEnvironmentInternal env, @Nullable Table inputTable) {
             AtomicReference<TableResult> tableResult = new AtomicReference<>();
 
             Throwable t =
@@ -442,8 +471,14 @@ abstract class BuiltInFunctionTestBase {
         }
 
         @Override
-        Table query(TableEnvironment env, Table inputTable) {
-            return inputTable.select(expression.toArray(new Expression[] {}));
+        Table query(TableEnvironment env, @Nullable Table inputTable) {
+            if (inputTable != null) {
+                return inputTable.select(expression.toArray(new Expression[] {}));
+            } else {
+                // use a mock collection table with row "0" to avoid pruning the project
+                // node with expression by PruneEmptyRules.PROJECT_INSTANCE
+                return env.fromValues(row(0)).select(expression.toArray(new Expression[] {}));
+            }
         }
 
         @Override
@@ -484,8 +519,12 @@ abstract class BuiltInFunctionTestBase {
         }
 
         @Override
-        Table query(TableEnvironment env, Table inputTable) {
-            return env.sqlQuery("SELECT " + expression + " FROM " + inputTable);
+        Table query(TableEnvironment env, @Nullable Table inputTable) {
+            if (inputTable != null) {
+                return env.sqlQuery("SELECT " + expression + " FROM " + inputTable);
+            } else {
+                return env.sqlQuery("SELECT " + expression);
+            }
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
@@ -23,6 +23,10 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.rand;
+import static org.apache.flink.table.api.Expressions.randInteger;
+
 /**
  * Test for {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND} and {@link
  * org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND_INTEGER} and their return type.
@@ -36,32 +40,39 @@ public class RandFunctionTest extends BuiltInFunctionTestBase {
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(10)
                         .andDataTypes(DataTypes.INT())
-                        .testSqlResult("RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE()),
+                        .testSqlResult("RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE())
+                        .testTableApiResult(rand($("f0")), 0.7304302967434272, DataTypes.DOUBLE()),
                 // RAND(INT NOT NULL)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(10)
                         .andDataTypes(DataTypes.INT().notNull())
-                        .testSqlResult(
-                                "RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE().notNull()),
+                        .testSqlResult("RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE().notNull())
+                        .testTableApiResult(
+                                rand($("f0")), 0.7304302967434272, DataTypes.DOUBLE().notNull()),
                 // RAND_INTEGER(INT, INT)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(5, 10)
                         .andDataTypes(DataTypes.INT(), DataTypes.INT())
-                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT())
+                        .testTableApiResult(randInteger($("f0"), $("f1")), 7, DataTypes.INT()),
                 // RAND_INTEGER(INT, INT NOT NULL)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(5, 10)
                         .andDataTypes(DataTypes.INT(), DataTypes.INT().notNull())
-                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT())
+                        .testTableApiResult(randInteger($("f0"), $("f1")), 7, DataTypes.INT()),
                 // RAND_INTEGER(INT NOT NULL, INT)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(5, 10)
                         .andDataTypes(DataTypes.INT().notNull(), DataTypes.INT())
-                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT())
+                        .testTableApiResult(randInteger($("f0"), $("f1")), 7, DataTypes.INT()),
                 // RAND_INTEGER(INT NOT NULL, INT NOT NULL)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(5, 10)
                         .andDataTypes(DataTypes.INT().notNull(), DataTypes.INT().notNull())
-                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT().notNull()));
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT().notNull())
+                        .testTableApiResult(
+                                randInteger($("f0"), $("f1")), 7, DataTypes.INT().notNull()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
@@ -36,6 +36,10 @@ public class RandFunctionITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
+                // RAND()
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .testSqlResult("RAND()", DataTypes.DOUBLE().notNull())
+                        .testTableApiResult(rand(), DataTypes.DOUBLE().notNull()),
                 // RAND(INT)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(10)
@@ -49,6 +53,18 @@ public class RandFunctionITCase extends BuiltInFunctionTestBase {
                         .testSqlResult("RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE().notNull())
                         .testTableApiResult(
                                 rand($("f0")), 0.7304302967434272, DataTypes.DOUBLE().notNull()),
+                // RAND_INTEGER(INT)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5)
+                        .andDataTypes(DataTypes.INT())
+                        .testSqlResult("RAND_INTEGER(f0)", DataTypes.INT())
+                        .testTableApiResult(randInteger($("f0")), DataTypes.INT()),
+                // RAND_INTEGER(INT NOT NULL)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5)
+                        .andDataTypes(DataTypes.INT().notNull())
+                        .testSqlResult("RAND_INTEGER(f0)", DataTypes.INT().notNull())
+                        .testTableApiResult(randInteger($("f0")), DataTypes.INT().notNull()),
                 // RAND_INTEGER(INT, INT)
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
                         .onFieldsWithData(5, 10)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionITCase.java
@@ -31,7 +31,7 @@ import static org.apache.flink.table.api.Expressions.randInteger;
  * Test for {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND} and {@link
  * org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND_INTEGER} and their return type.
  */
-public class RandFunctionTest extends BuiltInFunctionTestBase {
+public class RandFunctionITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RandFunctionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import java.util.stream.Stream;
+
+/**
+ * Test for {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND} and {@link
+ * org.apache.flink.table.functions.BuiltInFunctionDefinitions#RAND_INTEGER} and their return type.
+ */
+public class RandFunctionTest extends BuiltInFunctionTestBase {
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(
+                // RAND(INT)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(10)
+                        .andDataTypes(DataTypes.INT())
+                        .testSqlResult("RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE()),
+                // RAND(INT NOT NULL)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(10)
+                        .andDataTypes(DataTypes.INT().notNull())
+                        .testSqlResult(
+                                "RAND(f0)", 0.7304302967434272, DataTypes.DOUBLE().notNull()),
+                // RAND_INTEGER(INT, INT)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5, 10)
+                        .andDataTypes(DataTypes.INT(), DataTypes.INT())
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                // RAND_INTEGER(INT, INT NOT NULL)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5, 10)
+                        .andDataTypes(DataTypes.INT(), DataTypes.INT().notNull())
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                // RAND_INTEGER(INT NOT NULL, INT)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5, 10)
+                        .andDataTypes(DataTypes.INT().notNull(), DataTypes.INT())
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT()),
+                // RAND_INTEGER(INT NOT NULL, INT NOT NULL)
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.RAND)
+                        .onFieldsWithData(5, 10)
+                        .andDataTypes(DataTypes.INT().notNull(), DataTypes.INT().notNull())
+                        .testSqlResult("RAND_INTEGER(f0, f1)", 7, DataTypes.INT().notNull()));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -2668,6 +2668,7 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testRandAndIf(): Unit = {
     // test RAND
+    testSqlApi("IF(1 = 1, RAND(), cast(1.0 as double))")
 
     // test RAND(INT) and IF(BOOLEAN, DOUBLE, DOUBLE NOT NULL)
     testSqlApi("IF(1 = 1, RAND(f7), cast(1.0 as double))", "0.731057369148862")
@@ -2679,6 +2680,15 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi("IF(1 = 1, RAND(1), cast(1.0 as double))", "0.7308781907032909")
 
     // test RAND_INTEGER
+
+    // test RAND_INTEGER(INT) and IF(BOOLEAN, INT, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(f7), 1)")
+
+    // test RAND_INTEGER(INT NOT NULL) and IF(BOOLEAN, INT NOT NULL, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(10), 1)")
+
+    // test RAND_INTEGER(NULL) and IF(BOOLEAN, NULL, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(cast(null as int)), 1)")
 
     // test RAND_INTEGER(INT, INT NOT NULL) and IF(BOOLEAN, INT, INT NOT NULL)
     testSqlApi("IF(1 = 1, RAND_INTEGER(f7, 10), 1)", "4")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -2614,8 +2614,12 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   def testIf(): Unit = {
     // test IF(BOOL, INT, BIGINT), will do implicit type coercion.
     testSqlApi("IF(f7 > 5, f14, f4)", "44")
+
     // test input with null
     testSqlApi("IF(f7 < 5, cast(null as int), f4)", "NULL")
+
+    // test IF(BOOLEAN, INT, INT NOT NULL)
+    testSqlApi("IF(f7 < 5, cast(null as int), 0)", "NULL")
 
     // f0 is a STRING, cast(f0 as double) should never be ran
     testSqlApi("IF(1 = 1, f6, cast(f0 as double))", "4.6")
@@ -2659,6 +2663,37 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     //    testSqlApi(
     //      "IF(f7 < 5, f18, f52)",
     //      "1996-11-10 06:55:44.333")
+  }
+
+  @Test
+  def testRandAndIf(): Unit = {
+    // test RAND
+
+    // test RAND(INT) and IF(BOOLEAN, DOUBLE, DOUBLE NOT NULL)
+    testSqlApi("IF(1 = 1, RAND(f7), cast(1.0 as double))", "0.731057369148862")
+
+    // test RAND(NULL) and IF(BOOLEAN, NULL, DOUBLE NOT NULL)
+    testSqlApi("IF(1 = 1, RAND(cast(null as int)), cast(1.0 as double))", "NULL")
+
+    // test RAND(INT NOT NULL) and IF(BOOLEAN, DOUBLE NOT NULL, DOUBLE NOT NULL)
+    testSqlApi("IF(1 = 1, RAND(1), cast(1.0 as double))", "0.7308781907032909")
+
+    // test RAND_INTEGER
+
+    // test RAND_INTEGER(INT, INT NOT NULL) and IF(BOOLEAN, INT, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(f7, 10), 1)", "4")
+
+    // test RAND_INTEGER(INT NOT NULL, INT) and IF(BOOLEAN, INT, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(3, f7), 1)", "2")
+
+    // test RAND_INTEGER(NULL, INT NOT NULL) and IF(BOOLEAN, NULL, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(cast(null as int), 10), 1)", "NULL")
+
+    // test RAND_INTEGER(INT NOT NULL, INT) and IF(BOOLEAN, NULL, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(3, cast(null as int)), 1)", "NULL")
+
+    // test RAND_INTEGER(INT NOT NULL, INT NOT NULL) and IF(BOOLEAN, INT NOT NULL, INT NOT NULL)
+    testSqlApi("IF(1 = 1, RAND_INTEGER(3, 99), 1)", "50")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -313,7 +313,7 @@ abstract class ExpressionTestBase(isStreaming: Boolean = true) {
 
   private def addTestExpr(
       relNode: RelNode,
-      expected: String,
+      @Nullable expected: String,
       summaryString: String,
       exceptionClass: Class[_ <: Throwable],
       exprs: mutable.ArrayBuffer[_]): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -57,6 +57,8 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
+import javax.annotation.Nullable
+
 import java.util.Collections
 
 import scala.collection.JavaConverters._
@@ -187,6 +189,10 @@ abstract class ExpressionTestBase(isStreaming: Boolean = true) {
     addSqlTestExpr(sqlExpr, expected, validExprs)
   }
 
+  def testSqlApi(sqlExpr: String): Unit = {
+    addSqlTestExpr(sqlExpr, null, validExprs)
+  }
+
   def testExpectedAllApisException(
       expr: Expression,
       sqlExpr: String,
@@ -282,7 +288,7 @@ abstract class ExpressionTestBase(isStreaming: Boolean = true) {
 
   private def addSqlTestExpr(
       sqlExpr: String,
-      expected: String,
+      @Nullable expected: String,
       exprsContainer: mutable.ArrayBuffer[_],
       exceptionClass: Class[_ <: Throwable] = null): Unit = {
     // create RelNode from SQL expression
@@ -344,6 +350,10 @@ abstract class ExpressionTestBase(isStreaming: Boolean = true) {
       .zip(result)
       .foreach {
         case ((originalExpr, optimizedExpr, expected), actual) =>
+          if (expected == null) {
+            // no need to check the result
+            return
+          }
           val original = if (originalExpr == null) "" else s"for: [$originalExpr]"
           assertEquals(
             expected,


### PR DESCRIPTION
## What is the purpose of the change

Currently RAND and RAND_INTEGER are always return type "NOT NULL" as built in functions in `FlinkSqlOperatorTable`. But when codegen, the result type is always nullable in `RandCallGen`.

Actually, the result type of RAND and RAND_INTEGER should depend on the types of arguments. For example, If the argument is nullable, the return type should be nullable.

This bug causes the error with pattern "IF(1 = 1, RAND(0), 0)", because the following logic:
1. the result type of RAND is always "not null" when validation in `FlinkSqlOperatorTable`, and the third param is 0 that is always "not null", so the return type of operator IF is always "not null".
2. when codegen operator RAND, the return type of RAND(0) is always "nullable"
3. when codegen operator IF, the CAST rule cannot cast from "nullable" (the second arg RAND) to "not null"(the result type), so the exception throws.

## Brief change log

  - *correct the return type to be nullable when one of its args is nullable during validation*
  - *correct the final return type to be nullable when the original result type is nullable during codegen*
  - *add tests*


## Verifying this change

Some tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
