### PR TITLE
[FLINK-33472][Client] Solve the problem that the temporary file of flink-conf.yaml in S3AFileSystem cannot be uploaded

### DIFF
--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -34,6 +34,8 @@ under the License.
 		<!-- for testing (will override Hadoop's default dependency on too low SDK versions that
 			do not work with our httpcomponents version) -->
 		<aws.sdk.version>1.12.319</aws.sdk.version>
+		<leveldb.version>0.9</leveldb.version>
+		<s3mock.version>0.2.6</s3mock.version>
 		<surefire.module.config><!--
 			CommonTestUtils#setEnv
 			-->--add-opens=java.base/java.util=ALL-UNNAMED
@@ -248,6 +250,34 @@ under the License.
 			<artifactId>aws-java-sdk-sts</artifactId>
 			<version>${aws.sdk.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.iq80.leveldb</groupId>
+			<artifactId>leveldb</artifactId>
+			<version>${leveldb.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>guava</artifactId>
+					<groupId>com.google.guava</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.findify</groupId>
+			<artifactId>s3mock_${scala.binary.version}</artifactId>
+			<version>${s3mock.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.iq80.leveldb</groupId>
+					<artifactId>leveldb</artifactId>
+				</exclusion>
+				<exclusion>
+					<artifactId>aws-java-sdk-s3</artifactId>
+					<groupId>com.amazonaws</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1102,7 +1102,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
             fileUploader.registerSingleLocalResource(
                     flinkConfigFileName,
-                    new Path(tmpConfigurationFile.getAbsolutePath()),
+                    new Path(tmpConfigurationFile.toURI()),
                     "",
                     LocalResourceType.FILE,
                     true,
@@ -1132,7 +1132,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             LOG.info(
                     "Adding Yarn configuration {} to the AM container local resource bucket",
                     f.getAbsolutePath());
-            Path yarnSitePath = new Path(f.getAbsolutePath());
+            Path yarnSitePath = new Path(f.toURI());
             remoteYarnSiteXmlPath =
                     fileUploader
                             .registerSingleLocalResource(
@@ -1158,7 +1158,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             LOG.info(
                     "Adding KRB5 configuration {} to the AM container local resource bucket",
                     krb5.getAbsolutePath());
-            final Path krb5ConfPath = new Path(krb5.getAbsolutePath());
+            final Path krb5ConfPath = new Path(krb5.toURI());
             remoteKrb5Path =
                     fileUploader
                             .registerSingleLocalResource(


### PR DESCRIPTION
## What is the purpose of the change

*This pull request solve the problem that the temporary file of flink-conf.yaml in S3AFileSystem cannot be uploaded.*

## Brief change log
- *Modify YarnLocalResourceDescriptor# registerSingleLocalResource method's parameters, the parameters for the complete file path, the path contains scheme*

## Verifying this change
- Added s3mock as a tool for unit testing s3 file systems
- Added configuring fs.default-scheme as a prerequisite for triggering problems
- Create temporary files and write content
- Through YarnLocalResourceDescriptor# registerSingleLocalResource way to upload temporary files
- Verify that the content of the uploaded temporary file is the same as that of the written temporary file
## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature?    (no)
- If yes, how is the feature documented?    (not applicable)