### PR TITLE
[FLINK-33628][runtime] Upgrades default ZooKeeper version from 3.7.1 to 3.8.3

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkTestcontainersConfigurator.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkTestcontainersConfigurator.java
@@ -107,7 +107,7 @@ class FlinkTestcontainersConfigurator {
 
     private GenericContainer<?> configureZookeeperContainer() {
         return configureContainer(
-                new GenericContainer<>(DockerImageName.parse("zookeeper").withTag("3.7.1")),
+                new GenericContainer<>(DockerImageName.parse("zookeeper").withTag("3.8.1")),
                 flinkContainersSettings.getZookeeperHostname(),
                 "Zookeeper");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ under the License.
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
-		<zookeeper.version>3.7.1</zookeeper.version>
+		<zookeeper.version>3.8.1</zookeeper.version>
 		<!-- Project `flink-benchmarks` uses zk testing server in `curator-test` for performance
 		benchmark, please confirm it will not affect the benchmarks when the version is bumped. -->
 		<curator.version>5.4.0</curator.version>


### PR DESCRIPTION
## What is the purpose of the change

Upgrades Flink's ZK default version from 3.7.1 to 3.8.3 to cover the most-recent stable version again for 1.19.

## Brief change log

* Upgrades `pom.xml` and TestContainer

## Verifying this change

* Trivial change: CI should still pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable