### PR TITLE
[hotfix][doc] add repo links of externalized connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ This is an active open-source project. We are always open to people who want to 
 Contact us if you are looking for implementation tasks that fit your skills.
 This article describes [how to contribute to Apache Flink](https://flink.apache.org/contributing/how-to-contribute.html).
 
+## Externalized Connectors
+
+Most Flink connectors have been externalized to individual repos under the [Apache Software Foundation](https://github.com/apache):
+
+* [flink-connector-aws](https://github.com/apache/flink-connector-aws)
+* [flink-connector-cassandra](https://github.com/apache/flink-connector-cassandra)
+* [flink-connector-elasticsearch](https://github.com/apache/flink-connector-elasticsearch)
+* [flink-connector-gcp-pubsub](https://github.com/apache/flink-connector-gcp-pubsub)
+* [flink-connector-hbase](https://github.com/apache/flink-connector-hbase)
+* [flink-connector-hive](https://github.com/apache/flink-connector-hive)
+* [flink-connector-jdbc](https://github.com/apache/flink-connector-jdbc)
+* [flink-connector-kafka](https://github.com/apache/flink-connector-kafka)
+* [flink-connector-mongodb](https://github.com/apache/flink-connector-mongodb)
+* [flink-connector-opensearch](https://github.com/apache/flink-connector-opensearch)
+* [flink-connector-prometheus](https://github.com/apache/flink-connector-prometheus)
+* [flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar)
+* [flink-connector-rabbitmq](https://github.com/apache/flink-connector-rabbitmq)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Most Flink connectors have been externalized to individual repos under the [Apac
 * [flink-connector-elasticsearch](https://github.com/apache/flink-connector-elasticsearch)
 * [flink-connector-gcp-pubsub](https://github.com/apache/flink-connector-gcp-pubsub)
 * [flink-connector-hbase](https://github.com/apache/flink-connector-hbase)
-* [flink-connector-hive](https://github.com/apache/flink-connector-hive)
 * [flink-connector-jdbc](https://github.com/apache/flink-connector-jdbc)
 * [flink-connector-kafka](https://github.com/apache/flink-connector-kafka)
 * [flink-connector-mongodb](https://github.com/apache/flink-connector-mongodb)


### PR DESCRIPTION
## What is the purpose of the change

Add the externalized connector repos into the doc to ease developer find the related connectors.

## Verifying this change

This change is a trivial doc update.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
