### PR TITLE
[FLINK-33625][runtime] Support System out and err to be redirected to LOG or discarded

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -711,6 +711,61 @@ public class TaskManagerOptions {
                             "Time we wait for the timers in milliseconds to finish all pending timer threads"
                                     + " when the stream task is cancelled.");
 
+    /** This configures how to redirect the {@link System#out} and {@link System#err}. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<SystemOutMode> TASK_MANAGER_SYSTEM_OUT_MODE =
+            ConfigOptions.key("taskmanager.system-out.mode")
+                    .enumType(SystemOutMode.class)
+                    .defaultValue(SystemOutMode.DEFAULT)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Mode for the redirection of %s or %s for %s.",
+                                            code("System.out"),
+                                            code("System.err"),
+                                            code("TaskManagers"))
+                                    .list(
+                                            text(
+                                                    "%s: %s don't redirect the %s and %s, it's the default value.",
+                                                    code(SystemOutMode.DEFAULT.name()),
+                                                    code("TaskManagers"),
+                                                    code("System.out"),
+                                                    code("System.err")),
+                                            text(
+                                                    "%s: %s redirect %s and %s to LOG.info and LOG.error.",
+                                                    code(SystemOutMode.LOG.name()),
+                                                    code("TaskManagers"),
+                                                    code("System.out"),
+                                                    code("System.err")),
+                                            text(
+                                                    "%s: %s ignore %s and %s directly.",
+                                                    code(SystemOutMode.IGNORE.name()),
+                                                    code("TaskManagers"),
+                                                    code("System.out"),
+                                                    code("System.err")))
+                                    .build());
+
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<Boolean> TASK_MANAGER_SYSTEM_OUT_LOG_THREAD_NAME =
+            ConfigOptions.key("taskmanager.system-out.log.thread-name.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            String.format(
+                                    "Whether log the thread name when %s is LOG.",
+                                    TASK_MANAGER_SYSTEM_OUT_MODE.key()));
+
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<MemorySize> TASK_MANAGER_SYSTEM_OUT_LOG_CACHE_SIZE =
+            ConfigOptions.key("taskmanager.system-out.log.cache-upper-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("100 kb"))
+                    .withDescription(
+                            String.format(
+                                    "The cache upper size when Flink caches current line context "
+                                            + "of  System.out or System.out when %s is LOG.",
+                                    TASK_MANAGER_SYSTEM_OUT_MODE.key()));
+
     @Documentation.Section({
         Documentation.Sections.EXPERT_SCHEDULING,
         Documentation.Sections.ALL_TASK_MANAGER
@@ -733,6 +788,19 @@ public class TaskManagerOptions {
                                                     "The %s mode is the default mode without any specified strategy.",
                                                     code(TaskManagerLoadBalanceMode.NONE.name())))
                                     .build());
+
+    /** Type of redirection of {@link System#out} and {@link System#err}. */
+    public enum SystemOutMode {
+
+        /** Don't change the System.out and System.err, it's the default value. */
+        DEFAULT,
+
+        /** Redirect System.out and err to LOG. */
+        LOG,
+
+        /** Ignore all System.out and err directly. */
+        IGNORE
+    }
 
     /** Type of {@link TaskManagerOptions#TASK_MANAGER_LOAD_BALANCE_MODE}. */
     public enum TaskManagerLoadBalanceMode {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SystemOutRedirectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SystemOutRedirectionUtils.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions.SystemOutMode;
+
+import org.apache.commons.io.output.NullPrintStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_MANAGER_SYSTEM_OUT_LOG_CACHE_SIZE;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_MANAGER_SYSTEM_OUT_LOG_THREAD_NAME;
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_MANAGER_SYSTEM_OUT_MODE;
+
+/** Utility class for redirect the {@link System#out} and {@link System#err}. */
+public class SystemOutRedirectionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SystemOutRedirectionUtils.class);
+
+    /**
+     * Redirect {@link System#out} and {@link System#err} based on {@link
+     * TaskManagerOptions#TASK_MANAGER_SYSTEM_OUT_MODE} related options.
+     */
+    public static void redirectSystemOutAndError(Configuration conf) {
+        SystemOutMode systemOutMode = conf.get(TASK_MANAGER_SYSTEM_OUT_MODE);
+        switch (systemOutMode) {
+            case LOG:
+                redirectToCurrentLog(
+                        conf.get(TASK_MANAGER_SYSTEM_OUT_LOG_CACHE_SIZE).getBytes(),
+                        conf.get(TASK_MANAGER_SYSTEM_OUT_LOG_THREAD_NAME));
+                break;
+            case IGNORE:
+                ignoreSystemOutAndError();
+                break;
+            case DEFAULT:
+            default:
+                break;
+        }
+    }
+
+    private static void ignoreSystemOutAndError() {
+        System.setOut(new NullPrintStream());
+        System.setErr(new NullPrintStream());
+    }
+
+    private static void redirectToCurrentLog(long byteLimitEachLine, boolean logThreadName) {
+        redirectToLoggingRedirector(LOG::info, LOG::error, byteLimitEachLine, logThreadName);
+    }
+
+    @VisibleForTesting
+    static void redirectToLoggingRedirector(
+            LoggingRedirector outRedirector,
+            LoggingRedirector errRedirector,
+            long byteLimitEachLine,
+            boolean logThreadName) {
+        System.setOut(new LoggingPrintStream(outRedirector, byteLimitEachLine, logThreadName));
+        System.setErr(new LoggingPrintStream(errRedirector, byteLimitEachLine, logThreadName));
+    }
+
+    /** The redirector of log. */
+    @VisibleForTesting
+    interface LoggingRedirector {
+
+        void redirect(String logContext);
+    }
+
+    /** Redirect the PrintStream to LoggingRedirector. */
+    private static class LoggingPrintStream extends PrintStream {
+
+        private final LoggingRedirector loggingRedirector;
+
+        private final LineContextCache helper;
+
+        private final boolean logThreadName;
+
+        private LoggingPrintStream(
+                LoggingRedirector loggingRedirector,
+                long byteLimitEachLine,
+                boolean logThreadName) {
+            super(new LineContextCache(byteLimitEachLine));
+            helper = (LineContextCache) super.out;
+            this.loggingRedirector = loggingRedirector;
+            this.logThreadName = logThreadName;
+        }
+
+        public void write(int b) {
+            super.write(b);
+            tryLogCurrentLine();
+        }
+
+        public void write(byte[] buf, int off, int len) {
+            super.write(buf, off, len);
+            tryLogCurrentLine();
+        }
+
+        private void tryLogCurrentLine() {
+            synchronized (this) {
+                helper.tryGenerateContext()
+                        .ifPresent(
+                                logContext -> {
+                                    if (!logThreadName) {
+                                        loggingRedirector.redirect(logContext);
+                                        return;
+                                    }
+                                    loggingRedirector.redirect(
+                                            String.format(
+                                                    "Thread Name: %s , log context: %s",
+                                                    Thread.currentThread().getName(), logContext));
+                                });
+            }
+        }
+    }
+
+    /**
+     * Cache the context of current line. When current line is ended or the context size reaches the
+     * upper size, it can generate the line context.
+     */
+    private static class LineContextCache extends ByteArrayOutputStream {
+
+        private static final byte[] LINE_SEPARATOR_BYTES = System.lineSeparator().getBytes();
+        private static final int LINE_SEPARATOR_LENGTH = LINE_SEPARATOR_BYTES.length;
+
+        /** The upper byte size of current line. */
+        private final long byteLimitEachLine;
+
+        private LineContextCache(long byteLimitEachLine) {
+            this.byteLimitEachLine = byteLimitEachLine;
+        }
+
+        public synchronized Optional<String> tryGenerateContext() {
+            if (isLineEnded()) {
+                try {
+                    return Optional.of(new String(buf, 0, count - LINE_SEPARATOR_LENGTH));
+                } finally {
+                    reset();
+                }
+            }
+            if (count >= byteLimitEachLine) {
+                try {
+                    return Optional.of(new String(buf, 0, count));
+                } finally {
+                    reset();
+                }
+            }
+            return Optional.empty();
+        }
+
+        private synchronized boolean isLineEnded() {
+            if (count < LINE_SEPARATOR_LENGTH) {
+                return false;
+            }
+
+            if (LINE_SEPARATOR_LENGTH == 1) {
+                return LINE_SEPARATOR_BYTES[0] == buf[count - 1];
+            }
+
+            for (int i = 0; i < LINE_SEPARATOR_LENGTH; i++) {
+                if (LINE_SEPARATOR_BYTES[i] == buf[count - LINE_SEPARATOR_LENGTH + i]) {
+                    continue;
+                }
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -606,6 +606,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
         LOG.info("Starting TaskManager with ResourceID: {}", resourceID.getStringWithMetadata());
 
+        SystemOutRedirectionUtils.redirectSystemOutAndError(configuration);
+
         String externalAddress = rpcService.getAddress();
 
         final TaskExecutorResourceSpec taskExecutorResourceSpec =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/SystemOutRedirectionUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/SystemOutRedirectionUtilsTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions.SystemOutMode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static org.apache.flink.configuration.TaskManagerOptions.TASK_MANAGER_SYSTEM_OUT_MODE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SystemOutRedirectionUtils} */
+class SystemOutRedirectionUtilsTest {
+
+    private PrintStream originalOut;
+    private PrintStream originalErr;
+
+    private Queue<String> outCollector;
+    private Queue<String> errCollector;
+
+    @BeforeEach
+    void beforeEach() {
+        originalOut = System.out;
+        originalErr = System.err;
+
+        outCollector = new LinkedList<>();
+        errCollector = new LinkedList<>();
+    }
+
+    @AfterEach
+    void afterEach() {
+        // Recover the original out and err.
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Test
+    void testDefaultSystemOutAndErr() {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outStream));
+        System.setErr(new PrintStream(errStream));
+        SystemOutRedirectionUtils.redirectSystemOutAndError(new Configuration());
+
+        String logContext = "This is log context!";
+        System.out.print(logContext);
+        assertThat(outStream.toString()).isEqualTo(logContext);
+
+        System.err.print(logContext);
+        assertThat(errStream.toString()).isEqualTo(logContext);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = SystemOutMode.class,
+            names = {"IGNORE", "LOG"})
+    void testSystemOutAndErrAreRedirected(SystemOutMode systemOutMode) {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outStream));
+        System.setErr(new PrintStream(errStream));
+
+        Configuration conf = new Configuration();
+        conf.set(TASK_MANAGER_SYSTEM_OUT_MODE, systemOutMode);
+        SystemOutRedirectionUtils.redirectSystemOutAndError(conf);
+
+        String logContext = "This is log context!";
+        System.out.print(logContext);
+        assertThat(outStream.toByteArray()).isEmpty();
+
+        System.err.print(logContext);
+        assertThat(errStream.toByteArray()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testLogThreadName(boolean logThreadName) {
+        SystemOutRedirectionUtils.redirectToLoggingRedirector(
+                outCollector::add, errCollector::add, 100000, logThreadName);
+
+        // Test for the whole context.
+        String logContext = "This is" + System.lineSeparator() + " log context!";
+        System.out.println(logContext);
+        System.err.println(logContext);
+        assertThat(outCollector.poll())
+                .isEqualTo(generateExpectedContext(logContext, logThreadName));
+        assertThat(errCollector.poll())
+                .isEqualTo(generateExpectedContext(logContext, logThreadName));
+
+        // Test for print with println
+        String part1 = "Log " + System.lineSeparator() + "context part 1.";
+        String part2 = "Log context part 2.";
+        System.out.print(part1);
+        System.err.print(part1);
+        assertThat(outCollector).isEmpty();
+        assertThat(errCollector).isEmpty();
+
+        System.out.println(part2);
+        System.err.println(part2);
+        assertThat(outCollector.poll())
+                .isEqualTo(generateExpectedContext(part1 + part2, logThreadName));
+        assertThat(errCollector.poll())
+                .isEqualTo(generateExpectedContext(part1 + part2, logThreadName));
+
+        // Test for print with print(System.lineSeparator())
+        System.out.print(part1);
+        System.err.print(part1);
+        assertThat(outCollector).isEmpty();
+        assertThat(errCollector).isEmpty();
+
+        System.out.print(System.lineSeparator());
+        System.err.print(System.lineSeparator());
+        assertThat(outCollector.poll()).isEqualTo(generateExpectedContext(part1, logThreadName));
+        assertThat(errCollector.poll()).isEqualTo(generateExpectedContext(part1, logThreadName));
+    }
+
+    private String generateExpectedContext(String originalLogContext, boolean logThreadName) {
+        if (!logThreadName) {
+            return originalLogContext;
+        }
+        return String.format(
+                "Thread Name: %s , log context: %s",
+                Thread.currentThread().getName(), originalLogContext);
+    }
+
+    @Test
+    void testByteLimitEachLine() {
+        int byteLimitEachLine = 100;
+        SystemOutRedirectionUtils.redirectToLoggingRedirector(
+                outCollector::add, errCollector::add, byteLimitEachLine, false);
+
+        StringBuilder expectedContext = new StringBuilder();
+        for (int i = 0; i < byteLimitEachLine; i++) {
+            assertThat(outCollector).isEmpty();
+            assertThat(errCollector).isEmpty();
+            System.out.print('a');
+            System.err.print('a');
+            expectedContext.append('a');
+        }
+        assertThat(outCollector.poll()).isEqualTo(expectedContext.toString());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Get more from https://cwiki.apache.org/confluence/x/4guZE

## Brief change log

[FLINK-33625][runtime] Support System out and err to be redirected to LOG or discarded


## Verifying this change

This change added tests and can be verified as follows:

  - *Added SystemOutRedirectionUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
