### PR TITLE
[FLINK-33655][tests] Upgrade ArchUnit to 1.2.0 to support java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.9.1</junit5.version>
-		<archunit.version>1.0.0</archunit.version>
+		<archunit.version>1.2.0</archunit.version>
 		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
## What is the purpose of the change

The minimum ArchUnit supporting java 21 is 1.1.0 so need to bump ArchUnit to support java 21

## Verifying this change

This change is a trivial rework

to reproduce the problem (run with java 21)
```
mvn clean install -DskipTests -Dfast -Pjava21-target
mvn verify -pl flink-architecture-tests/flink-architecture-tests-production/ -Darchunit.freeze.store.default.allowStoreUpdate=false
```
same commands could be used to check that fix is working

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
