### PR TITLE
[FLINK-33664][ci] Setup cron build for java 21

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -57,6 +57,9 @@ function build_image() {
     if [[ ${PROFILE} == *"jdk17"* ]]; then
         java_version=17
     fi
+    if [[ ${PROFILE} == *"jdk21"* ]]; then
+        java_version=21
+    fi
 
     cd flink-docker
     ./add-custom.sh -u ${file_server_address}:9999/flink.tgz -n ${image_name} -j ${java_version}

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -152,6 +152,17 @@ stages:
           jdk: 17
       - template: jobs-template.yml
         parameters:
+          stage_name: cron_jdk17
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-20.04'
+          environment: PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk11 -Djdk17 -Djdk21 -Pjava21-target"
+          run_end_to_end: true
+          container: flink-build-container
+          jdk: 21
+      - template: jobs-template.yml
+        parameters:
           stage_name: cron_adaptive_scheduler
           test_pool_definition:
             name: Default

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -126,8 +126,8 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 echo "============ Run license check ============"
 
 find $MVN_VALIDATION_DIR
-# We use a different Scala version with Java 17
-if [[ ${PROFILE} != *"jdk17"* ]]; then
+# We use a different Scala version with Java 17 and 21
+if [[ ${PROFILE} != *"jdk17"* ]] && [[ ${PROFILE} != *"jdk21"* ]]; then
   MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
 fi
 


### PR DESCRIPTION

## What is the purpose of the change

The PR enables cron build for java 21

## Verifying this change

I've also scheduled build with forced `java21-target` for latest available master's commit 
on my azure pipeline
https://dev.azure.com/snuyanzin/flink/_build/results?buildId=2620&view=results

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
