### PR TITLE
[FLINK-33689][table-runtime] Fix JsonObjectAggFunction can't retract records when enabling LocalGlobal.

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1999,21 +1999,9 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
   @TestTemplate
   def testGroupJsonObjectAggWithRetract(): Unit = {
     val data = new mutable.MutableList[(Long, String, Long)]
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
-    data.+=((2L, "Hallo", 2L))
+    for (_ <- 1 to 15) {
+      data += ((2L, "Hallo", 2L))
+    }
     val sql =
       s"""
          |select
@@ -2034,5 +2022,105 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
         "{\"30\":2}"
       )
     assertThat(sink.getRetractResults).isEqualTo(expected)
+  }
+
+  @TestTemplate
+  def testNestedGroupJsonObjectAggSimple(): Unit = {
+    val data = new mutable.MutableList[(Long, String, Long)]
+    for (_ <- 1 to 15) {
+      data += ((2L, "Hallo", 2L))
+    }
+
+    val sql =
+      s"""
+         |select
+         |   JSON_OBJECTAGG(key k value v)
+         |from (
+         |  select k, v from (
+         |    select
+         |             cast(SUM(a1) as string) as k,t1 as v
+         |       from
+         |             (select sum(a) as a1, sum(t) as t1 from Table6 group by c)
+         |       group by t1)
+         |  )
+         |""".stripMargin
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'c, 't)
+    tEnv.createTemporaryView("Table6", t)
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected =
+      List(
+        "{\"30\":30}"
+      )
+    assertThat(sink.getRetractResults).isEqualTo(expected)
+  }
+
+  @TestTemplate
+  def testNestedGroupByJsonObjectAggWithSum(): Unit = {
+    val sink = new TestingRetractSink
+    val sql =
+      s"""
+         |SELECT
+         |    d, JSON_OBJECTAGG(key k value v)
+         |FROM (
+         |    SELECT
+         |        d, CAST(SUM(a1) AS STRING) AS k, t1 AS v
+         |    FROM (
+         |        SELECT d, SUM(e) AS a1, SUM(h) AS t1 FROM Table5 GROUP BY d
+         |    )
+         |    GROUP BY d, t1
+         |) GROUP BY d
+         |""".stripMargin
+
+    val t = failingDataSource(TestData.tupleData5).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.createTemporaryView("Table5", t)
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List(
+      "1,{\"1\":1}",
+      "2,{\"5\":3}",
+      "3,{\"15\":7}",
+      "4,{\"34\":6}",
+      "5,{\"65\":11}"
+    )
+    assertThat(sink.getRetractResults.sorted).isEqualTo(expected)
+  }
+
+  @TestTemplate
+  def testNestedGroupByJsonObjectAggWithSumMax(): Unit = {
+    val sink = new TestingRetractSink
+    val sql =
+      s"""
+         |select
+         |    JSON_OBJECTAGG(key cast(max_e as string) value max_f)
+         |from (
+         |    SELECT
+         |    d,
+         |    MAX(sum_e) AS max_e,
+         |    MAX(sum_f) AS max_f
+         |FROM (
+         |    SELECT
+         |        d,
+         |        h,
+         |        SUM(e) AS sum_e,
+         |        SUM(f) As sum_f
+         |    FROM
+         |        Table5
+         |    GROUP BY
+         |        d, h
+         |  ) AS sub
+         |  GROUP BY d
+         |)
+         |""".stripMargin
+
+    val t = failingDataSource(TestData.tupleData5).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    tEnv.createTemporaryView("Table5", t)
+    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List(
+      "{\"1\":0,\"17\":15,\"29\":27,\"3\":2,\"9\":7}"
+    )
+    assertThat(sink.getRetractResults.sorted).isEqualTo(expected)
   }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/JsonObjectAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/JsonObjectAggFunction.java
@@ -124,7 +124,7 @@ public class JsonObjectAggFunction
 
     public void retract(Accumulator acc, StringData keyData, @Nullable StringData valueData)
             throws Exception {
-        if (acc.map.contains(keyData)) {
+        if (acc.map.contains(keyData) && acc.map.get(keyData).equals(valueData)) {
             acc.map.remove(keyData);
         } else {
             acc.retractMap.put(keyData, valueData);
@@ -133,17 +133,20 @@ public class JsonObjectAggFunction
 
     public void merge(Accumulator acc, Iterable<Accumulator> others) throws Exception {
         for (final Accumulator other : others) {
-            for (final StringData key : other.map.keys()) {
-                assertKeyNotPresent(acc, key);
-                acc.map.put(key, other.map.get(key));
-            }
             for (final StringData key : other.retractMap.keys()) {
-                if (acc.map.contains(key)) {
-                    if (acc.map.get(key).equals(other.retractMap.get(key))) {
-                        acc.map.remove(key);
-                    }
+                if (acc.map.contains(key) && acc.map.get(key).equals(other.retractMap.get(key))) {
+                    acc.map.remove(key);
                 } else {
                     acc.retractMap.put(key, other.retractMap.get(key));
+                }
+            }
+            for (final StringData key : other.map.keys()) {
+                if (acc.retractMap.contains(key)
+                        && acc.retractMap.get(key).equals(other.map.get(key))) {
+                    acc.retractMap.remove(key);
+                } else {
+                    assertKeyNotPresent(acc, key);
+                    acc.map.put(key, other.map.get(key));
                 }
             }
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/JsonObjectAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/JsonObjectAggFunction.java
@@ -90,6 +90,11 @@ public class JsonObjectAggFunction
                         "map",
                         MapView.newMapViewDataType(
                                 DataTypes.STRING().notNull().toInternal(),
+                                DataTypes.STRING().toInternal())),
+                DataTypes.FIELD(
+                        "retractMap",
+                        MapView.newMapViewDataType(
+                                DataTypes.STRING().notNull().toInternal(),
                                 DataTypes.STRING().toInternal())));
     }
 
@@ -119,7 +124,11 @@ public class JsonObjectAggFunction
 
     public void retract(Accumulator acc, StringData keyData, @Nullable StringData valueData)
             throws Exception {
-        acc.map.remove(keyData);
+        if (acc.map.contains(keyData)) {
+            acc.map.remove(keyData);
+        } else {
+            acc.retractMap.put(keyData, valueData);
+        }
     }
 
     public void merge(Accumulator acc, Iterable<Accumulator> others) throws Exception {
@@ -127,6 +136,15 @@ public class JsonObjectAggFunction
             for (final StringData key : other.map.keys()) {
                 assertKeyNotPresent(acc, key);
                 acc.map.put(key, other.map.get(key));
+            }
+            for (final StringData key : other.retractMap.keys()) {
+                if (acc.map.contains(key)) {
+                    if (acc.map.get(key).equals(other.retractMap.get(key))) {
+                        acc.map.remove(key);
+                    }
+                } else {
+                    acc.retractMap.put(key, other.retractMap.get(key));
+                }
             }
         }
     }
@@ -166,6 +184,7 @@ public class JsonObjectAggFunction
     public static class Accumulator {
 
         public MapView<StringData, StringData> map = new MapView<>();
+        public MapView<StringData, StringData> retractMap = new MapView<>();
 
         @Override
         public boolean equals(Object other) {
@@ -178,12 +197,12 @@ public class JsonObjectAggFunction
             }
 
             final Accumulator that = (Accumulator) other;
-            return Objects.equals(map, that.map);
+            return Objects.equals(map, that.map) && Objects.equals(retractMap, that.retractMap);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(map);
+            return Objects.hash(map, retractMap);
         }
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* This pull request fix JsonObjectAggFunction which can't retract records when enabling LocalGlobal. The retract function in JsonObjectAggFunction now directly deletes the key from the recorded map. When localGlobal is enabled, the content recorded in the previous stage has already been committed to the global stage. Therefore, if there is a need to retract the content from the previous stage, the existing accumulator's map does not store the corresponding content which leads to a retraction failure.*


## Brief change log

  - Modify the Acculator and functions in JsonObjectAggFunction to retract the content that needs to be retracted . 
  - add test. 


## Verifying this change

Some tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
