### PR TITLE
[FLINK-33698][datastream] Fix the backoff time calculation in ExponentialBackoffDelayRetryStrategy

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategiesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/retryable/AsyncRetryStrategiesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.retryable;
+
+import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for the {@link AsyncRetryStrategies}. */
+public class AsyncRetryStrategiesTest extends TestLogger {
+
+    @Test
+    public void testExponentialBackoffDelayRetryStrategy() {
+        int maxAttempts = 10;
+        long initialDelay = 100L;
+        long maxRetryDelay = 2000L;
+        double multiplier = 2;
+
+        AsyncRetryStrategy<Void> exponentialBackoffDelayRetryStrategy =
+                new AsyncRetryStrategies.ExponentialBackoffDelayRetryStrategyBuilder<Void>(
+                                maxAttempts, initialDelay, maxRetryDelay, multiplier)
+                        .build();
+
+        Assert.assertTrue(exponentialBackoffDelayRetryStrategy.canRetry(maxAttempts));
+        Assert.assertFalse(exponentialBackoffDelayRetryStrategy.canRetry(maxAttempts + 1));
+
+        // test if this strategy can be reused.
+        for (int j = 1; j <= 5; j++) {
+            long currentDelay = initialDelay;
+
+            for (int i = 1; i <= maxAttempts; i++) {
+                Assert.assertEquals(
+                        currentDelay, exponentialBackoffDelayRetryStrategy.getBackoffTimeMillis(i));
+                currentDelay = Math.min((long) (currentDelay * multiplier), maxRetryDelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix the backoff time calculation in ExponentialBackoffDelayRetryStrategy.

## Brief change log

The backoff time calculation in `ExponentialBackoffDelayRetryStrategy` should consider currentAttempts. It should generate consistent backoff time for specific attempt count.


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit test in  `AsyncRetryStrategiesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
