### PR TITLE
[FLINK-33584][Filesystems] Update Hadoop Filesystem dependencies to 3.3.6

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -87,6 +87,14 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.pjfanning</groupId>
+					<artifactId>jersey-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
-- org.apache.hadoop:hadoop-azure:3.3.4
+- org.apache.hadoop:hadoop-azure:3.3.6
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jackson:jackson-core-asl:1.9.13

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.eclipse.jetty:jetty-util-ajax:9.3.24.v20180605
 - org.eclipse.jetty:jetty-util:9.3.24.v20180605
-- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.wildfly.openssl:wildfly-openssl:1.1.3.Final
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -178,6 +178,14 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.pjfanning</groupId>
+					<artifactId>jersey-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -24,9 +24,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.4
-- org.apache.hadoop:hadoop-auth:3.3.4
-- org.apache.hadoop:hadoop-common:3.3.4
+- org.apache.hadoop:hadoop-annotations:3.3.6
+- org.apache.hadoop:hadoop-auth:3.3.6
+- org.apache.hadoop:hadoop-common:3.3.6
 - org.apache.kerby:kerb-core:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.3.0
+- com.fasterxml.woodstox:woodstox-core:5.4.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -19,7 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.1.1
+- org.apache.commons:commons-configuration2:2.8.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -166,6 +166,18 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>com.sun.xml.bind</groupId>
+						<artifactId>jaxb-impl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.github.pjfanning</groupId>
+						<artifactId>jersey-json</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.jersey</groupId>
+						<artifactId>jersey-json</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -73,6 +73,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -167,6 +171,10 @@ under the License.
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-json</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -85,6 +85,14 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.pjfanning</groupId>
+					<artifactId>jersey-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -19,7 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-aliyun:3.3.6
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.codehaus.jettison:jettison:1.1
+- org.codehaus.jettison:jettison:1.5.4
 - org.ini4j:ini4j:0.5.4
 - stax:stax-api:1.0.1
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opentracing:opentracing-api:0.33.0
 - io.opentracing:opentracing-noop:0.33.0
 - io.opentracing:opentracing-util:0.33.0
-- org.apache.hadoop:hadoop-aliyun:3.3.4
+- org.apache.hadoop:hadoop-aliyun:3.3.6
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jettison:jettison:1.1

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -183,6 +183,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -237,6 +241,10 @@ under the License.
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-impl</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -48,6 +48,18 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>com.github.pjfanning</groupId>
+						<artifactId>jersey-json</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>io.dropwizard.metrics</groupId>
+						<artifactId>metrics-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.xml.bind</groupId>
+						<artifactId>jaxb-impl</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -68,7 +68,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 
     @Override
     public String startMultiPartUpload(String key) throws IOException {
-        return s3accessHelper.initiateMultiPartUpload(key, null);
+        return s3accessHelper.initiateMultiPartUpload(key);
     }
 
     @Override
@@ -84,14 +84,13 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
                         null,
                         inputFile,
                         0L);
-        return s3accessHelper.uploadPart(uploadRequest, null);
+        return s3accessHelper.uploadPart(uploadRequest);
     }
 
     @Override
     public PutObjectResult putObject(String key, File inputFile) throws IOException {
-        final PutObjectRequest putRequest =
-                s3accessHelper.createPutObjectRequest(key, inputFile, null);
-        return s3accessHelper.putObject(putRequest, null, null);
+        final PutObjectRequest putRequest = s3accessHelper.createPutObjectRequest(key, inputFile);
+        return s3accessHelper.putObject(putRequest);
     }
 
     @Override
@@ -103,7 +102,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
             AtomicInteger errorCount)
             throws IOException {
         return s3accessHelper.completeMPUwithRetries(
-                destKey, uploadId, partETags, length, errorCount, null);
+                destKey, uploadId, partETags, length, errorCount);
     }
 
     @Override
@@ -161,6 +160,33 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
                 AuditSpanSource auditSpanSource,
                 AuditSpan auditSpan) {
             super(owner, conf, statisticsContext, auditSpanSource, auditSpan, null);
+        }
+
+        public PutObjectRequest createPutObjectRequest(String dest, File sourceFile) {
+            return super.createPutObjectRequest(dest, sourceFile, null);
+        }
+
+        public PutObjectResult putObject(PutObjectRequest putObjectRequest) throws IOException {
+            return super.putObject(putObjectRequest, null, null);
+        }
+
+        public CompleteMultipartUploadResult completeMPUwithRetries(
+                String destKey,
+                String uploadId,
+                List<PartETag> partETags,
+                long length,
+                AtomicInteger errorCount)
+                throws IOException {
+            return super.completeMPUwithRetries(
+                    destKey, uploadId, partETags, length, errorCount, null);
+        }
+
+        public UploadPartResult uploadPart(UploadPartRequest request) throws IOException {
+            return super.uploadPart(request, null);
+        }
+
+        public String initiateMultiPartUpload(String destKey) throws IOException {
+            return super.initiateMultiPartUpload(destKey, null);
         }
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -68,7 +68,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
 
     @Override
     public String startMultiPartUpload(String key) throws IOException {
-        return s3accessHelper.initiateMultiPartUpload(key);
+        return s3accessHelper.initiateMultiPartUpload(key, null);
     }
 
     @Override
@@ -84,13 +84,14 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
                         null,
                         inputFile,
                         0L);
-        return s3accessHelper.uploadPart(uploadRequest);
+        return s3accessHelper.uploadPart(uploadRequest, null);
     }
 
     @Override
     public PutObjectResult putObject(String key, File inputFile) throws IOException {
-        final PutObjectRequest putRequest = s3accessHelper.createPutObjectRequest(key, inputFile);
-        return s3accessHelper.putObject(putRequest);
+        final PutObjectRequest putRequest =
+                s3accessHelper.createPutObjectRequest(key, inputFile, null);
+        return s3accessHelper.putObject(putRequest, null, null);
     }
 
     @Override
@@ -102,7 +103,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
             AtomicInteger errorCount)
             throws IOException {
         return s3accessHelper.completeMPUwithRetries(
-                destKey, uploadId, partETags, length, errorCount);
+                destKey, uploadId, partETags, length, errorCount, null);
     }
 
     @Override
@@ -159,7 +160,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
                 S3AStatisticsContext statisticsContext,
                 AuditSpanSource auditSpanSource,
                 AuditSpan auditSpan) {
-            super(owner, conf, statisticsContext, auditSpanSource, auditSpan);
+            super(owner, conf, statisticsContext, auditSpanSource, auditSpan, null);
         }
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
+import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
@@ -163,7 +164,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
         }
 
         public PutObjectRequest createPutObjectRequest(String dest, File sourceFile) {
-            return super.createPutObjectRequest(dest, sourceFile, null);
+            return super.createPutObjectRequest(dest, sourceFile, PutObjectOptions.deletingDirs());
         }
 
         public PutObjectResult putObject(PutObjectRequest putObjectRequest) throws IOException {
@@ -178,7 +179,12 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
                 AtomicInteger errorCount)
                 throws IOException {
             return super.completeMPUwithRetries(
-                    destKey, uploadId, partETags, length, errorCount, null);
+                    destKey,
+                    uploadId,
+                    partETags,
+                    length,
+                    errorCount,
+                    PutObjectOptions.deletingDirs());
         }
 
         public UploadPartResult uploadPart(UploadPartRequest request) throws IOException {
@@ -186,7 +192,7 @@ public class HadoopS3AccessHelper implements S3AccessHelper {
         }
 
         public String initiateMultiPartUpload(String destKey) throws IOException {
-            return super.initiateMultiPartUpload(destKey, null);
+            return super.initiateMultiPartUpload(destKey, PutObjectOptions.deletingDirs());
         }
     }
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.3.0
+- com.fasterxml.woodstox:woodstox-core:5.4.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
@@ -25,7 +25,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.1.1
+- org.apache.commons:commons-configuration2:2.8.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -40,7 +40,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.wildfly.openssl:wildfly-openssl:1.1.3.Final
 - org.xerial.snappy:snappy-java:1.1.10.4
 - software.amazon.ion:ion-java:1.0.2
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -30,10 +30,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.4
-- org.apache.hadoop:hadoop-auth:3.3.4
-- org.apache.hadoop:hadoop-aws:3.3.4
-- org.apache.hadoop:hadoop-common:3.3.4
+- org.apache.hadoop:hadoop-annotations:3.3.6
+- org.apache.hadoop:hadoop-auth:3.3.6
+- org.apache.hadoop:hadoop-aws:3.3.6
+- org.apache.hadoop:hadoop-common:3.3.6
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.kerby:kerb-core:1.0.1

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -385,6 +385,18 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>com.github.pjfanning</groupId>
+						<artifactId>jersey-json</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>io.dropwizard.metrics</groupId>
+						<artifactId>metrics-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.xml.bind</groupId>
+						<artifactId>jaxb-impl</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -412,6 +424,14 @@ under the License.
 					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.xml.bind</groupId>
+						<artifactId>jaxb-impl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.github.pjfanning</groupId>
+						<artifactId>jersey-json</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -54,7 +54,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
 - org.weakref:jmxutils:1.19
-- org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.wildfly.openssl:wildfly-openssl:1.1.3.Final
 - org.xerial.snappy:snappy-java:1.1.10.4
 - software.amazon.ion:ion-java:1.0.2
 

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -42,10 +42,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.4
-- org.apache.hadoop:hadoop-auth:3.3.4
-- org.apache.hadoop:hadoop-aws:3.3.4
-- org.apache.hadoop:hadoop-common:3.3.4
+- org.apache.hadoop:hadoop-annotations:3.3.6
+- org.apache.hadoop:hadoop-auth:3.3.6
+- org.apache.hadoop:hadoop-aws:3.3.6
+- org.apache.hadoop:hadoop-common:3.3.6
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.hudi:hudi-presto-bundle:0.10.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.3
-- com.fasterxml.woodstox:woodstox-core:5.3.0
+- com.fasterxml.woodstox:woodstox-core:5.4.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2
 - commons-beanutils:commons-beanutils:1.9.4
@@ -37,7 +37,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.5
 - org.alluxio:alluxio-shaded-client:2.7.3
 - org.apache.commons:commons-compress:1.24.0
-- org.apache.commons:commons-configuration2:2.1.1
+- org.apache.commons:commons-configuration2:2.8.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<fs.hadoopshaded.version>3.3.4</fs.hadoopshaded.version>
+		<fs.hadoopshaded.version>3.3.6</fs.hadoopshaded.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## What is the purpose of the change

This is the PR superceding https://github.com/apache/flink/pull/23740 + adopting hadoop api change usage

## Brief change log

* cherry-pick from  https://github.com/apache/flink/pull/23740
* _flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/HadoopS3AccessHelper.java_

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
