### PR TITLE
[FLINK-33708][FLINK-33709] Introduce TraceReporter and use it to create checkpointing traces

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -100,6 +100,8 @@ pygmentsUseClasses = true
 [markup]
 [markup.goldmark.renderer]
   unsafe = true
+[markup.tableOfContents]
+  startLevel = 1
 
 [languages]
 [languages.en]

--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -287,6 +287,15 @@ Enabling RocksDB's native metrics may cause degraded performance and should be s
 ----
 ----
 
+# Traces
+
+Please refer to the [tracing system documentation]({{< ref "docs/ops/traces" >}}) for background on Flink's tracing infrastructure.
+
+{{< generated/trace_configuration >}}
+
+----
+----
+
 # History Server
 
 The history server keeps the information of completed jobs (graphs, runtimes, statistics). To enable it, you have to enable "job archiving" in the JobManager (`jobmanager.archive.fs.dir`).

--- a/docs/content.zh/docs/deployment/security/_index.md
+++ b/docs/content.zh/docs/deployment/security/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Security
 bookCollapseSection: true
-weight: 8
+weight: 9
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/docs/deployment/trace_reporters.md
+++ b/docs/content.zh/docs/deployment/trace_reporters.md
@@ -1,0 +1,75 @@
+---
+title: "Trace Reporters"
+weight: 7
+type: docs
+aliases:
+  - /deployment/trace_reporters.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Trace Reporters
+
+Flink allows reporting traces to external systems.
+For more information about Flink's tracing system go to the [tracing system documentation]({{< ref "docs/ops/traces" >}}).
+
+Traces can be exposed to an external system by configuring one or several reporters in `conf/flink-conf.yaml`. These
+reporters will be instantiated on each job and task manager when they are started.
+
+Below is a list of parameters that are generally applicable to all reporters.
+All properties are configured by setting `traces.reporter.<reporter_name>.<property>` in the configuration.
+Reporters may additionally offer implementation-specific parameters, which are documented in the respective reporter's section. 
+
+{{< include_reporter_config "layouts/shortcodes/generated/trace_reporters_section.html" >}}
+
+All reporter configurations must contain the `factory.class` property.
+
+Example reporter configuration that specifies multiple reporters:
+
+```yaml
+traces.reporters: otel,my_other_otel
+
+traces.reporter.otel.factory.class: org.apache.flink.common.metrics.OpenTelemetryTraceReporterFactory
+traces.reporter.otel.exporter.endpoint: http://127.0.0.1:1337
+traces.reporter.otel.scope.variables.additional: region:eu-west-1,environment:local-pnowojski-test,flink_runtime:1.17.1
+
+traces.reporter.my_other_otel.factory.class: org.apache.flink.common.metrics.OpenTelemetryTraceReporterFactory
+traces.reporter.my_other_otel.exporter.endpoint: http://196.168.0.1:31337
+```
+
+**Important:** The jar containing the reporter must be accessible when Flink is started.
+ Reporters are loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}).
+ All reporters documented on this page are available by default.
+
+You can write your own `Reporter` by implementing the `org.apache.flink.traces.reporter.TraceReporter` and `org.apache.flink.traces.reporter.TraceReporterFactory` interfaces.
+Be careful that all the method must not block for a significant amount of time, and any reporter needing more time should instead run the operation asynchronously.
+
+## Reporters
+
+The following sections list the supported reporters.
+
+### Slf4j
+#### (org.apache.flink.traces.slf4j.Slf4jTraceReporter)
+
+Example configuration:
+
+```yaml
+traces.reporter.slf4j.factory.class: org.apache.flink.traces.slf4j.Slf4jTraceReporterFactory
+```
+{{< top >}}

--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1,6 +1,6 @@
 ---
 title: "指标"
-weight: 6
+weight: 5
 type: docs
 aliases:
   - /zh/ops/metrics.html

--- a/docs/content.zh/docs/ops/traces.md
+++ b/docs/content.zh/docs/ops/traces.md
@@ -1,0 +1,71 @@
+---
+title: "Traces"
+weight: 6
+type: docs
+aliases:
+  - /ops/traces.html
+  - /apis/traces.html
+  - /monitoring/traces.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Traces
+
+Flink exposes a tracing system that allows gathering and exposing traces to external systems.
+
+## Reporting traces
+
+You can access the tracing system from any user function that extends [RichFunction]({{< ref "docs/dev/datastream/user_defined_functions" >}}#rich-functions) by calling `getRuntimeContext().getMetricGroup()`.
+This method returns a `MetricGroup` object via which you can report a new single span trace.
+
+### Reporting single Span
+
+
+A `Span` represents something that happened in Flink at certain point of time, that will be reported to a `TraceReporter`.
+To report a `Span` you can use the `MetricGroup#addSpan(SpanBuilder)` method.
+
+Currently we don't support traces with multiple spans. Each `Span` is self-contained and represents things like a checkpoint or recovery.
+{{< tabs "9612d275-bdda-4322-a01f-ae6da805e917" >}}
+{{< tab "Java" >}}
+```java
+public class MyClass {
+    void doSomething() {
+        // (...)
+        metricGroup.addSpan(
+                Span.builder(MyClass.class, "SomeAction")
+                        .setStartTsMillis(startTs) // Optional
+                        .setEndTsMillis(endTs) // Optional
+                        .setAttribute("foo", "bar");
+    }
+}
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently reporting Spans from Python is not supported.
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## Reporter
+
+For information on how to set up Flink's trace reporters please take a look at the [trace reporters documentation]({{< ref "docs/deployment/trace_reporters" >}}).
+
+{{< top >}}

--- a/docs/content.zh/docs/ops/traces.md
+++ b/docs/content.zh/docs/ops/traces.md
@@ -68,4 +68,61 @@ Currently reporting Spans from Python is not supported.
 
 For information on how to set up Flink's trace reporters please take a look at the [trace reporters documentation]({{< ref "docs/deployment/trace_reporters" >}}).
 
+## System traces
+
+Flink reports traces listed below.
+
+The tables below generally feature 5 columns:
+
+* The "Scope" column describes what is that trace reported scope.
+
+* The "Name" column describes the name of the reported trace.
+
+* The "Attributes" column lists the names of all attributes that are reported with the given trace.
+
+* The "Description" column provides information as to what a given attribute is reporting.
+
+### Checkpointing
+
+Flink reports a single span trace for the whole checkpoint once checkpoint reaches a terminal state: COMPLETED or FAILED.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Name</th>
+      <th class="text-left" style="width: 20%">Attributes</th>
+      <th class="text-left" style="width: 32%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="6">org.apache.flink.runtime.checkpoint.CheckpointStatsTracker</th>
+      <th rowspan="6"><strong>Checkpoint</strong></th>
+      <td>startTs</td>
+      <td>Timestamp when the checkpoint has started.</td>
+    </tr>
+    <tr>
+      <td>endTs</td>
+      <td>Timestamp when the checkpoint has finished.</td>
+    </tr>
+    <tr>
+      <td>checkpointId</td>
+      <td>Id of the checkpoint.</td>
+    </tr>
+    <tr>
+      <td>checkpointedSize</td>
+      <td>Size in bytes of checkpointed state during this checkpoint. Might be smaller than fullSize if incremental checkpoints are used.</td>
+    </tr>
+    <tr>
+      <td>fullSize</td>
+      <td>Full size in bytes of the referenced state by this checkpoint. Might be larger than checkpointSize if incremental checkpoints are used.</td>
+    </tr>
+    <tr>
+      <td>checkpointStatus</td>
+      <td>What was the state of this checkpoint: FAILED or COMPLETED.</td>
+    </tr>
+  </tbody>
+</table>
+
 {{< top >}}

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -289,6 +289,15 @@ Enabling RocksDB's native metrics may cause degraded performance and should be s
 ----
 ----
 
+# Traces
+
+Please refer to the [tracing system documentation]({{< ref "docs/ops/traces" >}}) for background on Flink's tracing infrastructure.
+
+{{< generated/trace_configuration >}}
+
+----
+----
+
 # History Server
 
 The history server keeps the information of completed jobs (graphs, runtimes, statistics). To enable it, you have to enable "job archiving" in the JobManager (`jobmanager.archive.fs.dir`).

--- a/docs/content/docs/deployment/security/_index.md
+++ b/docs/content/docs/deployment/security/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Security
 bookCollapseSection: true
-weight: 8
+weight: 9
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/docs/deployment/trace_reporters.md
+++ b/docs/content/docs/deployment/trace_reporters.md
@@ -1,0 +1,75 @@
+---
+title: "Trace Reporters"
+weight: 7
+type: docs
+aliases:
+  - /deployment/trace_reporters.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Trace Reporters
+
+Flink allows reporting traces to external systems.
+For more information about Flink's tracing system go to the [tracing system documentation]({{< ref "docs/ops/traces" >}}).
+
+Traces can be exposed to an external system by configuring one or several reporters in `conf/flink-conf.yaml`. These
+reporters will be instantiated on each job and task manager when they are started.
+
+Below is a list of parameters that are generally applicable to all reporters.
+All properties are configured by setting `traces.reporter.<reporter_name>.<property>` in the configuration.
+Reporters may additionally offer implementation-specific parameters, which are documented in the respective reporter's section. 
+
+{{< include_reporter_config "layouts/shortcodes/generated/trace_reporters_section.html" >}}
+
+All reporter configurations must contain the `factory.class` property.
+
+Example reporter configuration that specifies multiple reporters:
+
+```yaml
+traces.reporters: otel,my_other_otel
+
+traces.reporter.otel.factory.class: org.apache.flink.common.metrics.OpenTelemetryTraceReporterFactory
+traces.reporter.otel.exporter.endpoint: http://127.0.0.1:1337
+traces.reporter.otel.scope.variables.additional: region:eu-west-1,environment:local-pnowojski-test,flink_runtime:1.17.1
+
+traces.reporter.my_other_otel.factory.class: org.apache.flink.common.metrics.OpenTelemetryTraceReporterFactory
+traces.reporter.my_other_otel.exporter.endpoint: http://196.168.0.1:31337
+```
+
+**Important:** The jar containing the reporter must be accessible when Flink is started.
+ Reporters are loaded as [plugins]({{< ref "docs/deployment/filesystems/plugins" >}}).
+ All reporters documented on this page are available by default.
+
+You can write your own `Reporter` by implementing the `org.apache.flink.traces.reporter.TraceReporter` and `org.apache.flink.traces.reporter.TraceReporterFactory` interfaces.
+Be careful that all the method must not block for a significant amount of time, and any reporter needing more time should instead run the operation asynchronously.
+
+## Reporters
+
+The following sections list the supported reporters.
+
+### Slf4j
+#### (org.apache.flink.traces.slf4j.Slf4jTraceReporter)
+
+Example configuration:
+
+```yaml
+traces.reporter.slf4j.factory.class: org.apache.flink.traces.slf4j.Slf4jTraceReporterFactory
+```
+{{< top >}}

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1,6 +1,6 @@
 ---
 title: "Metrics"
-weight: 6
+weight: 5
 type: docs
 aliases:
   - /ops/metrics.html

--- a/docs/content/docs/ops/traces.md
+++ b/docs/content/docs/ops/traces.md
@@ -1,0 +1,71 @@
+---
+title: "Traces"
+weight: 6
+type: docs
+aliases:
+  - /ops/traces.html
+  - /apis/traces.html
+  - /monitoring/traces.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Traces
+
+Flink exposes a tracing system that allows gathering and exposing traces to external systems.
+
+## Reporting traces
+
+You can access the tracing system from any user function that extends [RichFunction]({{< ref "docs/dev/datastream/user_defined_functions" >}}#rich-functions) by calling `getRuntimeContext().getMetricGroup()`.
+This method returns a `MetricGroup` object via which you can report a new single span trace.
+
+### Reporting single Span
+
+
+A `Span` represents something that happened in Flink at certain point of time, that will be reported to a `TraceReporter`.
+To report a `Span` you can use the `MetricGroup#addSpan(SpanBuilder)` method.
+
+Currently we don't support traces with multiple spans. Each `Span` is self-contained and represents things like a checkpoint or recovery.
+{{< tabs "9612d275-bdda-4322-a01f-ae6da805e917" >}}
+{{< tab "Java" >}}
+```java
+public class MyClass {
+    void doSomething() {
+        // (...)
+        metricGroup.addSpan(
+                Span.builder(MyClass.class, "SomeAction")
+                        .setStartTsMillis(startTs) // Optional
+                        .setEndTsMillis(endTs) // Optional
+                        .setAttribute("foo", "bar");
+    }
+}
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently reporting Spans from Python is not supported.
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## Reporter
+
+For information on how to set up Flink's trace reporters please take a look at the [trace reporters documentation]({{< ref "docs/deployment/trace_reporters" >}}).
+
+{{< top >}}

--- a/docs/content/docs/ops/traces.md
+++ b/docs/content/docs/ops/traces.md
@@ -68,4 +68,61 @@ Currently reporting Spans from Python is not supported.
 
 For information on how to set up Flink's trace reporters please take a look at the [trace reporters documentation]({{< ref "docs/deployment/trace_reporters" >}}).
 
+## System traces
+
+Flink reports traces listed below.
+
+The tables below generally feature 5 columns:
+
+* The "Scope" column describes what is that trace reported scope.
+
+* The "Name" column describes the name of the reported trace.
+
+* The "Attributes" column lists the names of all attributes that are reported with the given trace.
+
+* The "Description" column provides information as to what a given attribute is reporting.
+
+### Checkpointing
+
+Flink reports a single span trace for the whole checkpoint once checkpoint reaches a terminal state: COMPLETED or FAILED.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 22%">Name</th>
+      <th class="text-left" style="width: 20%">Attributes</th>
+      <th class="text-left" style="width: 32%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="6">org.apache.flink.runtime.checkpoint.CheckpointStatsTracker</th>
+      <th rowspan="6"><strong>Checkpoint</strong></th>
+      <td>startTs</td>
+      <td>Timestamp when the checkpoint has started.</td>
+    </tr>
+    <tr>
+      <td>endTs</td>
+      <td>Timestamp when the checkpoint has finished.</td>
+    </tr>
+    <tr>
+      <td>checkpointId</td>
+      <td>Id of the checkpoint.</td>
+    </tr>
+    <tr>
+      <td>checkpointedSize</td>
+      <td>Size in bytes of checkpointed state during this checkpoint. Might be smaller than fullSize if incremental checkpoints are used.</td>
+    </tr>
+    <tr>
+      <td>fullSize</td>
+      <td>Full size in bytes of the referenced state by this checkpoint. Might be larger than checkpointSize if incremental checkpoints are used.</td>
+    </tr>
+    <tr>
+      <td>checkpointStatus</td>
+      <td>What was the state of this checkpoint: FAILED or COMPLETED.</td>
+    </tr>
+  </tbody>
+</table>
+
 {{< top >}}

--- a/docs/layouts/shortcodes/generated/trace_configuration.html
+++ b/docs/layouts/shortcodes/generated/trace_configuration.html
@@ -1,0 +1,36 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.&lt;parameter&gt;</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Configures the parameter &lt;parameter&gt; for the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.factory.class</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The reporter factory class to use for the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.scope.variables.additional</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>The map of additional variables that should be included for the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
+            <td><h5>traces.reporters</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>An optional list of trace reporter names. If configured, only reporters whose name matches any of the names in the list will be started. Otherwise, all reporters that could be found in the configuration will be started.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/trace_reporters_section.html
+++ b/docs/layouts/shortcodes/generated/trace_reporters_section.html
@@ -1,0 +1,30 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.factory.class</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The reporter factory class to use for the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.scope.variables.additional</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>The map of additional variables that should be included for the reporter named &lt;name&gt;.</td>
+        </tr>
+        <tr>
+            <td><h5>traces.reporter.&lt;name&gt;.&lt;parameter&gt;</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Configures the parameter &lt;parameter&gt; for the reporter named &lt;name&gt;.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
@@ -106,6 +106,8 @@ public final class Documentation {
 
         public static final String METRIC_REPORTERS = "metric_reporters";
 
+        public static final String TRACE_REPORTERS = "trace_reporters";
+
         private Sections() {}
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1108,10 +1108,15 @@ public final class ConfigConstants {
     @Deprecated public static final String METRICS_REPORTERS_LIST = "metrics.reporters";
 
     /**
-     * The prefix for per-reporter configs. Has to be combined with a reporter name and the configs
-     * mentioned below.
+     * The prefix for per-metric reporter configs. Has to be combined with a reporter name and the
+     * configs mentioned below.
      */
     public static final String METRICS_REPORTER_PREFIX = "metrics.reporter.";
+    /**
+     * The prefix for per-trace reporter configs. Has to be combined with a reporter name and the
+     * configs mentioned below.
+     */
+    public static final String TRACES_REPORTER_PREFIX = "traces.reporter.";
 
     /** @deprecated use {@link MetricOptions#REPORTER_CLASS} */
     @Deprecated public static final String METRICS_REPORTER_CLASS_SUFFIX = "class";

--- a/flink-core/src/main/java/org/apache/flink/configuration/TraceOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TraceOptions.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.docs.Documentation;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Configuration options for traces and trace reporters. */
+@Experimental
+public class TraceOptions {
+
+    private static final String NAMED_REPORTER_CONFIG_PREFIX =
+            ConfigConstants.TRACES_REPORTER_PREFIX + "<name>";
+
+    /**
+     * An optional list of reporter names. If configured, only reporters whose name matches any of
+     * the names in the list will be started. Otherwise, all reporters that could be found in the
+     * configuration will be started.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * traces.reporters = foo,bar
+     *
+     * traces.reporter.foo.class = org.apache.flink.traces.reporter.OpenTelemetryTraceReporter
+     * traces.reporter.foo.endpoint = 127.0.0.1:4137
+     * }</pre>
+     */
+    public static final ConfigOption<String> TRACE_REPORTERS_LIST =
+            key("traces.reporters")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "An optional list of trace reporter names. If configured, only reporters whose name matches"
+                                    + " any of the names in the list will be started. Otherwise, all reporters that could be found in"
+                                    + " the configuration will be started.");
+
+    /**
+     * Returns a view over the given configuration via which options can be set/retrieved for the
+     * given reporter.
+     *
+     * <pre>
+     *     Configuration config = ...
+     *     MetricOptions.forReporter(config, "my_reporter")
+     *         .set(MetricOptions.REPORTER_INTERVAL, Duration.ofSeconds(10))
+     *         ...
+     * </pre>
+     *
+     * @param configuration backing configuration
+     * @param reporterName reporter name
+     * @return view over configuration
+     */
+    @Experimental
+    public static Configuration forTraceReporter(Configuration configuration, String reporterName) {
+        return new DelegatingConfiguration(
+                configuration, ConfigConstants.TRACES_REPORTER_PREFIX + reporterName + ".");
+    }
+
+    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.TRACE_REPORTERS, position = 1)
+    public static final ConfigOption<String> REPORTER_FACTORY_CLASS =
+            key("factory.class")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The reporter factory class to use for the reporter named <name>.");
+
+    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.TRACE_REPORTERS, position = 6)
+    public static final ConfigOption<String> REPORTER_CONFIG_PARAMETER =
+            key("<parameter>")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Configures the parameter <parameter> for the reporter named <name>.");
+
+    @Documentation.SuffixOption(NAMED_REPORTER_CONFIG_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.TRACE_REPORTERS, position = 3)
+    public static final ConfigOption<Map<String, String>> REPORTER_ADDITIONAL_VARIABLES =
+            key("scope.variables.additional")
+                    .mapType()
+                    .defaultValue(Collections.emptyMap())
+                    .withDescription(
+                            "The map of additional variables that should be included for the reporter named <name>.");
+
+    private TraceOptions() {}
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.metrics;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.traces.SpanBuilder;
 
 import java.util.Map;
 
@@ -32,6 +34,13 @@ import java.util.Map;
  */
 @Public
 public interface MetricGroup {
+
+    // ------------------------------------------------------------------------
+    //  Spans
+    // ------------------------------------------------------------------------
+
+    @Experimental
+    default void addSpan(SpanBuilder spanBuilder) {}
 
     // ------------------------------------------------------------------------
     //  Metrics

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/SimpleSpan.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/SimpleSpan.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.traces;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Basic implementation of {@link Span}. */
+@Internal
+public class SimpleSpan implements Span {
+
+    private final String scope;
+    private final String name;
+
+    private final HashMap<String, Object> attributes = new HashMap<>();
+    private long startTsMillis;
+    private long endTsMillis;
+
+    public SimpleSpan(
+            String scope,
+            String name,
+            long startTsMillis,
+            long endTsMillis,
+            HashMap<String, Object> attributes) {
+
+        this.scope = scope;
+        this.name = name;
+        this.startTsMillis = startTsMillis;
+        this.endTsMillis = endTsMillis;
+        this.attributes.putAll(attributes);
+    }
+
+    @Override
+    public String getScope() {
+        return scope;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public long getStartTsMillis() {
+        return startTsMillis;
+    }
+
+    @Override
+    public long getEndTsMillis() {
+        return endTsMillis;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String toString() {
+        return SimpleSpan.class.getSimpleName()
+                + "{"
+                + "scope="
+                + scope
+                + ", name="
+                + name
+                + ", startTsMillis="
+                + startTsMillis
+                + ", endTsMillis="
+                + endTsMillis
+                + ", attributes="
+                + attributes
+                + "}";
+    }
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/Span.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/Span.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.traces;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.Map;
+
+/**
+ * Span represents something that happened in Flink at certain point of time, that will be reported
+ * to a {@link org.apache.flink.traces.reporter.TraceReporter}.
+ *
+ * <p>Currently we don't support traces with multiple spans. Each span is self-contained and
+ * represents things like a checkpoint or recovery.
+ */
+@Experimental
+public interface Span {
+
+    static SpanBuilder builder(Class<?> classScope, String name) {
+        return new SpanBuilder(classScope, name);
+    }
+
+    String getScope();
+
+    String getName();
+
+    long getStartTsMillis();
+
+    long getEndTsMillis();
+
+    /**
+     * Currently returned values can be of type String, Long or Double, however more types can be
+     * added in the future.
+     */
+    Map<String, Object> getAttributes();
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/SpanBuilder.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/SpanBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.traces;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.HashMap;
+
+/** Builder used to construct {@link Span}. See {@link Span#builder(Class, String)}. */
+@Experimental
+public class SpanBuilder {
+    private final HashMap<String, Object> attributes = new HashMap<>();
+    private final Class<?> classScope;
+    private final String name;
+    private long startTsMillis;
+    private long endTsMillis;
+
+    /**
+     * @param classScope Flink's convention is that the scope of each {@link Span} is defined by the
+     *     class that is creating it. If you are building the {@link Span} in your class {@code
+     *     MyClass}, as the {@code classScope} you should pass {@code MyClass.class}.
+     * @param name Human read-able name of this span, that describes what does the built {@link
+     *     Span} will represent.
+     */
+    SpanBuilder(Class<?> classScope, String name) {
+        this.classScope = classScope;
+        this.name = name;
+    }
+
+    public Span build() {
+        long startTsMillisToBuild = startTsMillis;
+        if (startTsMillisToBuild == 0) {
+            startTsMillisToBuild = System.currentTimeMillis();
+        }
+        long endTsMillisToBuild = endTsMillis;
+        if (endTsMillisToBuild == 0) {
+            endTsMillisToBuild = startTsMillis;
+        }
+        return new SimpleSpan(
+                classScope.getCanonicalName(),
+                name,
+                startTsMillisToBuild,
+                endTsMillisToBuild,
+                attributes);
+    }
+
+    /**
+     * Optionally you can manually set the {@link Span}'s startTs. If not specified, {@code
+     * System.currentTimeMillis()} will be used.
+     */
+    public SpanBuilder setStartTsMillis(long startTsMillis) {
+        this.startTsMillis = startTsMillis;
+        return this;
+    }
+
+    /**
+     * Optionally you can manually set the {@link Span}'s endTs. If not specified, {@code
+     * startTsMillis} will be used (see {@link #setStartTsMillis(long)})..
+     */
+    public SpanBuilder setEndTsMillis(long endTsMillis) {
+        this.endTsMillis = endTsMillis;
+        return this;
+    }
+
+    /** Additional attribute to be attached to this {@link Span}. */
+    public SpanBuilder setAttribute(String key, String value) {
+        attributes.put(key, value);
+        return this;
+    }
+
+    /** Additional attribute to be attached to this {@link Span}. */
+    public SpanBuilder setAttribute(String key, long value) {
+        attributes.put(key, value);
+        return this;
+    }
+
+    /** Additional attribute to be attached to this {@link Span}. */
+    public SpanBuilder setAttribute(String key, double value) {
+        attributes.put(key, value);
+        return this;
+    }
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/reporter/TraceReporter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/reporter/TraceReporter.java
@@ -16,20 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.metrics.reporter;
+package org.apache.flink.traces.reporter;
 
-import org.apache.flink.annotation.Public;
-import org.apache.flink.metrics.Metric;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.traces.Span;
 
 /**
- * Metric reporters are used to export {@link Metric Metrics} to an external backend.
+ * Trace reporters are used to export {@link Span Spans} to an external backend.
  *
- * <p>Metric reporters are instantiated via a {@link MetricReporterFactory}.
+ * <p>Reporters are instantiated via a {@link TraceReporterFactory}.
  */
-@Public
-public interface MetricReporter {
+@Experimental
+public interface TraceReporter {
 
     // ------------------------------------------------------------------------
     //  life cycle
@@ -51,25 +50,5 @@ public interface MetricReporter {
     /** Closes this reporter. Should be used to close channels, streams and release resources. */
     void close();
 
-    // ------------------------------------------------------------------------
-    //  adding / removing metrics
-    // ------------------------------------------------------------------------
-
-    /**
-     * Called when a new {@link Metric} was added.
-     *
-     * @param metric the metric that was added
-     * @param metricName the name of the metric
-     * @param group the group that contains the metric
-     */
-    void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group);
-
-    /**
-     * Called when a {@link Metric} was removed.
-     *
-     * @param metric the metric that should be removed
-     * @param metricName the name of the metric
-     * @param group the group that contains the metric
-     */
-    void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group);
+    void notifyOfAddedSpan(Span span);
 }

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/reporter/TraceReporterFactory.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/traces/reporter/TraceReporterFactory.java
@@ -16,28 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.metrics.reporter;
+package org.apache.flink.traces.reporter;
 
-import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.Experimental;
 
 import java.util.Properties;
 
 /**
- * {@link MetricReporter} factory.
+ * {@link TraceReporter} factory.
  *
- * <p>Metric reporters that can be instantiated with a factory automatically qualify for being
- * loaded as a plugin, so long as the reporter jar is self-contained (excluding Flink dependencies)
- * and contains a {@code META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory}
- * file containing the qualified class name of the factory.
+ * <p>Trace reporters that can be instantiated with a factory automatically qualify for being loaded
+ * as a plugin, so long as the reporter jar is self-contained (excluding Flink dependencies) and
+ * contains a {@code META-INF/services/org.apache.flink.traces.reporter.SpanReporterFactory} file
+ * containing the qualified class name of the factory.
  */
-@Public
-public interface MetricReporterFactory {
+@Experimental
+public interface TraceReporterFactory {
 
     /**
-     * Creates a new metric reporter.
+     * Creates a new trace reporter.
      *
      * @param properties configured properties for the reporter
      * @return created metric reporter
      */
-    MetricReporter createMetricReporter(final Properties properties);
+    TraceReporter createTraceReporter(final Properties properties);
 }

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/traces/slf4j/Slf4jTraceReporter.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/traces/slf4j/Slf4jTraceReporter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.traces.slf4j;
+
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.traces.Span;
+import org.apache.flink.traces.reporter.TraceReporter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link TraceReporter} that exports {@link org.apache.flink.traces.Span Spans} via SLF4J {@link
+ * Logger}.
+ */
+public class Slf4jTraceReporter implements TraceReporter {
+    private static final Logger LOG = LoggerFactory.getLogger(Slf4jTraceReporter.class);
+
+    @Override
+    public void notifyOfAddedSpan(Span span) {
+        LOG.info("Reported span: {}", span);
+    }
+
+    @Override
+    public void open(MetricConfig metricConfig) {}
+
+    @Override
+    public void close() {}
+}

--- a/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/traces/slf4j/Slf4jTraceReporterFactory.java
+++ b/flink-metrics/flink-metrics-slf4j/src/main/java/org/apache/flink/traces/slf4j/Slf4jTraceReporterFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.traces.slf4j;
+
+import org.apache.flink.traces.reporter.TraceReporter;
+import org.apache.flink.traces.reporter.TraceReporterFactory;
+
+import java.util.Properties;
+
+/** {@link TraceReporterFactory} for {@link Slf4jTraceReporter}. */
+public class Slf4jTraceReporterFactory implements TraceReporterFactory {
+
+    @Override
+    public TraceReporter createTraceReporter(Properties properties) {
+        return new Slf4jTraceReporter();
+    }
+}

--- a/flink-metrics/flink-metrics-slf4j/src/main/resources/META-INF/services/org.apache.flink.traces.reporter.TraceReporterFactory
+++ b/flink-metrics/flink-metrics-slf4j/src/main/resources/META-INF/services/org.apache.flink.traces.reporter.TraceReporterFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.traces.slf4j.Slf4jTraceReporterFactory

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -55,6 +55,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
+import org.apache.flink.runtime.metrics.TraceReporterSetup;
 import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -465,7 +466,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         return new MetricRegistryImpl(
                 MetricRegistryConfiguration.fromConfiguration(
                         configuration, rpcSystemUtils.getMaximumMessageSizeInBytes(configuration)),
-                ReporterSetup.fromConfiguration(configuration, pluginManager));
+                ReporterSetup.fromConfiguration(configuration, pluginManager),
+                TraceReporterSetup.fromConfiguration(configuration, pluginManager));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -22,6 +22,8 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.traces.Span;
+import org.apache.flink.traces.SpanBuilder;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +39,9 @@ public interface MetricRegistry {
 
     /** Returns the number of registered reporters. */
     int getNumberReporters();
+
+    /** Add and log a {@link Span}. */
+    void addSpan(SpanBuilder spanBuilder);
 
     /**
      * Registers a new {@link Metric} with this registry.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/NoOpMetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/NoOpMetricRegistry.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.traces.SpanBuilder;
 
 /** Metric registry which does nothing. */
 public class NoOpMetricRegistry implements MetricRegistry {
@@ -47,6 +48,9 @@ public class NoOpMetricRegistry implements MetricRegistry {
 
     @Override
     public void unregister(Metric metric, String metricName, AbstractMetricGroup group) {}
+
+    @Override
+    public void addSpan(SpanBuilder spanBuilder) {}
 
     @Override
     public ScopeFormats getScopeFormats() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.metrics.filter.DefaultMetricFilter;
 import org.apache.flink.runtime.metrics.filter.MetricFilter;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.traces.reporter.TraceReporterFactory;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterators;
@@ -65,12 +66,12 @@ public final class ReporterSetup {
     private static final Logger LOG = LoggerFactory.getLogger(ReporterSetup.class);
 
     // regex pattern to split the defined reporters
-    private static final Pattern reporterListPattern = Pattern.compile("\\s*,\\s*");
+    private static final Pattern metricReporterListPattern = Pattern.compile("\\s*,\\s*");
 
     // regex pattern to extract the name from reporter configuration keys, e.g. "rep" from
     // "metrics.reporter.rep.class"
     @SuppressWarnings("deprecation")
-    private static final Pattern reporterClassPattern =
+    private static final Pattern metricReporterClassPattern =
             Pattern.compile(
                     Pattern.quote(ConfigConstants.METRICS_REPORTER_PREFIX)
                             +
@@ -192,14 +193,20 @@ public final class ReporterSetup {
         String includedReportersString = configuration.getString(MetricOptions.REPORTERS_LIST, "");
 
         Set<String> namedReporters =
-                findEnabledReportersInConfiguration(configuration, includedReportersString);
+                findEnabledTraceReportersInConfiguration(
+                        configuration,
+                        includedReportersString,
+                        metricReporterListPattern,
+                        metricReporterClassPattern,
+                        ConfigConstants.METRICS_REPORTER_PREFIX);
 
         if (namedReporters.isEmpty()) {
             return Collections.emptyList();
         }
 
         final List<Tuple2<String, Configuration>> reporterConfigurations =
-                loadReporterConfigurations(configuration, namedReporters);
+                loadReporterConfigurations(
+                        configuration, namedReporters, ConfigConstants.METRICS_REPORTER_PREFIX);
 
         final Map<String, MetricReporterFactory> reporterFactories =
                 loadAvailableReporterFactories(pluginManager);
@@ -207,8 +214,12 @@ public final class ReporterSetup {
         return setupReporters(reporterFactories, reporterConfigurations);
     }
 
-    private static Set<String> findEnabledReportersInConfiguration(
-            Configuration configuration, String includedReportersString) {
+    public static Set<String> findEnabledTraceReportersInConfiguration(
+            Configuration configuration,
+            String includedReportersString,
+            Pattern reporterListPattern,
+            Pattern reporterClassPattern,
+            String reporterPrefix) {
         Set<String> includedReporters =
                 reporterListPattern
                         .splitAsStream(includedReportersString)
@@ -219,24 +230,26 @@ public final class ReporterSetup {
         // use a TreeSet to make the reporter order deterministic, which is useful for testing
         Set<String> namedOrderedReporters = new TreeSet<>(String::compareTo);
 
-        // scan entire configuration for keys starting with METRICS_REPORTER_PREFIX and determine
+        // scan entire configuration for keys starting with reporterPrefix and determine
         // the set of enabled reporters
         for (String key : configuration.keySet()) {
-            if (key.startsWith(ConfigConstants.METRICS_REPORTER_PREFIX)) {
+            if (key.startsWith(reporterPrefix)) {
                 Matcher matcher = reporterClassPattern.matcher(key);
                 if (matcher.matches()) {
                     String reporterName = matcher.group(1);
                     if (includedReporters.isEmpty() || includedReporters.contains(reporterName)) {
                         if (namedOrderedReporters.contains(reporterName)) {
                             LOG.warn(
-                                    "Duplicate class configuration detected for reporter {}.",
+                                    "Duplicate class configuration detected for {}{}.",
+                                    reporterPrefix.replace('.', ' '),
                                     reporterName);
                         } else {
                             namedOrderedReporters.add(reporterName);
                         }
                     } else {
                         LOG.info(
-                                "Excluding reporter {}, not configured in reporter list ({}).",
+                                "Excluding {}{}, not configured in reporter list ({}).",
+                                reporterPrefix.replace('.', ' '),
                                 reporterName,
                                 includedReportersString);
                     }
@@ -246,16 +259,15 @@ public final class ReporterSetup {
         return namedOrderedReporters;
     }
 
-    private static List<Tuple2<String, Configuration>> loadReporterConfigurations(
-            Configuration configuration, Set<String> namedReporters) {
+    public static List<Tuple2<String, Configuration>> loadReporterConfigurations(
+            Configuration configuration, Set<String> namedReporters, String reporterPrefix) {
         final List<Tuple2<String, Configuration>> reporterConfigurations =
                 new ArrayList<>(namedReporters.size());
 
         for (String namedReporter : namedReporters) {
             DelegatingConfiguration delegatingConfiguration =
                     new DelegatingConfiguration(
-                            configuration,
-                            ConfigConstants.METRICS_REPORTER_PREFIX + namedReporter + '.');
+                            configuration, reporterPrefix + namedReporter + '.');
 
             reporterConfigurations.add(Tuple2.of(namedReporter, delegatingConfiguration));
         }
@@ -280,7 +292,8 @@ public final class ReporterSetup {
                 if (existingFactory == null) {
                     reporterFactories.put(factoryClassName, factory);
                     LOG.debug(
-                            "Found reporter factory {} at {} ",
+                            "Found {} {} at {} ",
+                            MetricReporterFactory.class.getSimpleName(),
                             factoryClassName,
                             new File(
                                             factory.getClass()
@@ -291,11 +304,12 @@ public final class ReporterSetup {
                                     .getCanonicalPath());
                 } else {
                     LOG.warn(
-                            "Multiple implementations of the same reporter were found in 'lib' and/or 'plugins' directories for {}. It is recommended to remove redundant reporter JARs to resolve used versions' ambiguity.",
+                            "Multiple implementations of the same {} were found in 'lib' and/or 'plugins' directories for {}. It is recommended to remove redundant reporter JARs to resolve used versions' ambiguity.",
+                            MetricReporter.class.getSimpleName(),
                             factoryClassName);
                 }
             } catch (Exception | ServiceConfigurationError e) {
-                LOG.warn("Error while loading reporter factory.", e);
+                LOG.warn("Error while loading {}.", TraceReporterFactory.class.getSimpleName(), e);
             }
         }
 
@@ -352,7 +366,8 @@ public final class ReporterSetup {
                         });
             } catch (Throwable t) {
                 LOG.error(
-                        "Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.",
+                        "Could not instantiate {} {}. Metrics might not be exposed/reported.",
+                        MetricReporter.class.getSimpleName(),
                         reporterName,
                         t);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TraceReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TraceReporterSetup.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TraceOptions;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.runtime.metrics.filter.DefaultMetricFilter;
+import org.apache.flink.runtime.metrics.filter.MetricFilter;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.traces.reporter.TraceReporter;
+import org.apache.flink.traces.reporter.TraceReporterFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.apache.flink.runtime.metrics.ReporterSetup.loadReporterConfigurations;
+
+/**
+ * Encapsulates everything needed for the instantiation and configuration of a {@link
+ * org.apache.flink.traces.reporter.TraceReporter}.
+ */
+public final class TraceReporterSetup {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TraceReporterSetup.class);
+
+    // regex pattern to split the defined reporters
+    private static final Pattern traceReporterListPattern = Pattern.compile("\\s*,\\s*");
+
+    // regex pattern to extract the name from trace reporter configuration keys, e.g. "rep" from
+    // "traces.reporter.rep.class"
+    @SuppressWarnings("deprecation")
+    private static final Pattern traceReporterClassPattern =
+            Pattern.compile(
+                    Pattern.quote(ConfigConstants.TRACES_REPORTER_PREFIX)
+                            +
+                            // [\S&&[^.]] = intersection of non-whitespace and non-period character
+                            // classes
+                            "([\\S&&[^.]]*)\\."
+                            + Pattern.quote(TraceOptions.REPORTER_FACTORY_CLASS.key()));
+
+    private final String name;
+    private final MetricConfig configuration;
+    private final TraceReporter reporter;
+    private final Map<String, String> additionalVariables;
+
+    public TraceReporterSetup(
+            final String name,
+            final MetricConfig configuration,
+            TraceReporter reporter,
+            final Map<String, String> additionalVariables) {
+        this.name = name;
+        this.configuration = configuration;
+        this.reporter = reporter;
+        this.additionalVariables = additionalVariables;
+    }
+
+    public Map<String, String> getAdditionalVariables() {
+        return additionalVariables;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @VisibleForTesting
+    MetricConfig getConfiguration() {
+        return configuration;
+    }
+
+    public TraceReporter getReporter() {
+        return reporter;
+    }
+
+    @VisibleForTesting
+    public static TraceReporterSetup forReporter(String reporterName, TraceReporter reporter) {
+        return createReporterSetup(
+                reporterName, new MetricConfig(), reporter, Collections.emptyMap());
+    }
+
+    @VisibleForTesting
+    public static TraceReporterSetup forReporter(
+            String reporterName, MetricConfig metricConfig, TraceReporter reporter) {
+        return createReporterSetup(reporterName, metricConfig, reporter, Collections.emptyMap());
+    }
+
+    private static TraceReporterSetup createReporterSetup(
+            String reporterName,
+            MetricConfig metricConfig,
+            TraceReporter reporter,
+            Map<String, String> additionalVariables) {
+        reporter.open(metricConfig);
+
+        return new TraceReporterSetup(reporterName, metricConfig, reporter, additionalVariables);
+    }
+
+    public static List<TraceReporterSetup> fromConfiguration(
+            final Configuration configuration, @Nullable final PluginManager pluginManager) {
+        String includedReportersString =
+                configuration.getString(TraceOptions.TRACE_REPORTERS_LIST, "");
+
+        Set<String> namedReporters =
+                ReporterSetup.findEnabledTraceReportersInConfiguration(
+                        configuration,
+                        includedReportersString,
+                        traceReporterListPattern,
+                        traceReporterClassPattern,
+                        ConfigConstants.TRACES_REPORTER_PREFIX);
+
+        if (namedReporters.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<Tuple2<String, Configuration>> reporterConfigurations =
+                loadReporterConfigurations(
+                        configuration, namedReporters, ConfigConstants.TRACES_REPORTER_PREFIX);
+
+        final Map<String, TraceReporterFactory> reporterFactories =
+                loadAvailableReporterFactories(pluginManager);
+
+        return setupReporters(reporterFactories, reporterConfigurations);
+    }
+
+    private static Map<String, TraceReporterFactory> loadAvailableReporterFactories(
+            @Nullable PluginManager pluginManager) {
+        final Map<String, TraceReporterFactory> reporterFactories = new HashMap<>(2);
+        final Iterator<TraceReporterFactory> factoryIterator =
+                getAllReporterFactories(pluginManager);
+        // do not use streams or for-each loops here because they do not allow catching individual
+        // ServiceConfigurationErrors
+        // such an error might be caused if the META-INF/services contains an entry to a
+        // non-existing factory class
+        while (factoryIterator.hasNext()) {
+            try {
+                TraceReporterFactory factory = factoryIterator.next();
+                String factoryClassName = factory.getClass().getName();
+                TraceReporterFactory existingFactory = reporterFactories.get(factoryClassName);
+                if (existingFactory == null) {
+                    reporterFactories.put(factoryClassName, factory);
+                    LOG.debug(
+                            "Found {} {} at {} ",
+                            TraceReporterFactory.class.getSimpleName(),
+                            factoryClassName,
+                            new File(
+                                            factory.getClass()
+                                                    .getProtectionDomain()
+                                                    .getCodeSource()
+                                                    .getLocation()
+                                                    .toURI())
+                                    .getCanonicalPath());
+                } else {
+                    LOG.warn(
+                            "Multiple implementations of the same {} were found in 'lib' and/or 'plugins' directories for {}. It is recommended to remove redundant reporter JARs to resolve used versions' ambiguity.",
+                            TraceReporter.class.getSimpleName(),
+                            factoryClassName);
+                }
+            } catch (Exception | ServiceConfigurationError e) {
+                LOG.warn("Error while loading {}.", TraceReporterFactory.class.getSimpleName(), e);
+            }
+        }
+
+        return Collections.unmodifiableMap(reporterFactories);
+    }
+
+    private static Iterator<TraceReporterFactory> getAllReporterFactories(
+            @Nullable PluginManager pluginManager) {
+        final Spliterator<TraceReporterFactory> factoryIteratorSPI =
+                ServiceLoader.load(TraceReporterFactory.class).spliterator();
+        final Spliterator<TraceReporterFactory> factoryIteratorPlugins =
+                pluginManager != null
+                        ? Spliterators.spliteratorUnknownSize(
+                                pluginManager.load(TraceReporterFactory.class), 0)
+                        : Collections.<TraceReporterFactory>emptyList().spliterator();
+
+        return Stream.concat(
+                        StreamSupport.stream(factoryIteratorPlugins, false),
+                        StreamSupport.stream(factoryIteratorSPI, false))
+                .iterator();
+    }
+
+    private static List<TraceReporterSetup> setupReporters(
+            Map<String, TraceReporterFactory> reporterFactories,
+            List<Tuple2<String, Configuration>> reporterConfigurations) {
+        List<TraceReporterSetup> reporterSetups = new ArrayList<>(reporterConfigurations.size());
+        for (Tuple2<String, Configuration> reporterConfiguration : reporterConfigurations) {
+            String reporterName = reporterConfiguration.f0;
+            Configuration reporterConfig = reporterConfiguration.f1;
+
+            try {
+                Optional<TraceReporter> metricReporterOptional =
+                        loadReporter(reporterName, reporterConfig, reporterFactories);
+
+                final MetricFilter metricFilter =
+                        DefaultMetricFilter.fromConfiguration(reporterConfig);
+
+                // massage user variables keys into scope format for parity to variable exclusion
+                Map<String, String> additionalVariables =
+                        reporterConfig.get(TraceOptions.REPORTER_ADDITIONAL_VARIABLES).entrySet()
+                                .stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                e -> ScopeFormat.asVariable(e.getKey()),
+                                                Entry::getValue));
+
+                metricReporterOptional.ifPresent(
+                        reporter -> {
+                            MetricConfig metricConfig = new MetricConfig();
+                            reporterConfig.addAllToProperties(metricConfig);
+                            reporterSetups.add(
+                                    createReporterSetup(
+                                            reporterName,
+                                            metricConfig,
+                                            reporter,
+                                            additionalVariables));
+                        });
+            } catch (Throwable t) {
+                LOG.error(
+                        "Could not instantiate {} {}. Metrics might not be exposed/reported.",
+                        TraceReporter.class.getSimpleName(),
+                        reporterName,
+                        t);
+            }
+        }
+        return reporterSetups;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Optional<TraceReporter> loadReporter(
+            final String reporterName,
+            final Configuration reporterConfig,
+            final Map<String, TraceReporterFactory> reporterFactories) {
+
+        final String factoryClassName = reporterConfig.get(TraceOptions.REPORTER_FACTORY_CLASS);
+
+        if (factoryClassName != null) {
+            return loadViaFactory(
+                    factoryClassName, reporterName, reporterConfig, reporterFactories);
+        }
+
+        LOG.warn(
+                "No reporter factory set for reporter {}. Traces might not be exposed/reported.",
+                reporterName);
+        return Optional.empty();
+    }
+
+    private static Optional<TraceReporter> loadViaFactory(
+            final String factoryClassName,
+            final String reporterName,
+            final Configuration reporterConfig,
+            final Map<String, TraceReporterFactory> reporterFactories) {
+
+        TraceReporterFactory factory = reporterFactories.get(factoryClassName);
+
+        if (factory == null) {
+            LOG.warn(
+                    "The reporter factory ({}) could not be found for reporter {}. Available factories: {}.",
+                    factoryClassName,
+                    reporterName,
+                    reporterFactories.keySet());
+            return Optional.empty();
+        } else {
+            return loadViaFactory(reporterConfig, factory);
+        }
+    }
+
+    private static Optional<TraceReporter> loadViaFactory(
+            final Configuration reporterConfig, final TraceReporterFactory factory) {
+
+        final MetricConfig metricConfig = new MetricConfig();
+        reporterConfig.addAllToProperties(metricConfig);
+
+        return Optional.of(factory.createTraceReporter(metricConfig));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -390,41 +390,43 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
         }
         // add the metric only if the group is still open
         synchronized (this) {
-            if (!closed) {
-                // immediately put without a 'contains' check to optimize the common case (no
-                // collision)
-                // collisions are resolved later
-                Metric prior = metrics.put(name, metric);
+            if (closed) {
+                return;
+            }
 
-                // check for collisions with other metric names
-                if (prior == null) {
-                    // no other metric with this name yet
+            // immediately put without a 'contains' check to optimize the common case (no
+            // collision)
+            // collisions are resolved later
+            Metric prior = metrics.put(name, metric);
 
-                    if (groups.containsKey(name)) {
-                        // we warn here, rather than failing, because metrics are tools that should
-                        // not fail the
-                        // program when used incorrectly
-                        LOG.warn(
-                                "Name collision: Adding a metric with the same name as a metric subgroup: '"
-                                        + name
-                                        + "'. Metric might not get properly reported. "
-                                        + Arrays.toString(scopeComponents));
-                    }
+            // check for collisions with other metric names
+            if (prior == null) {
+                // no other metric with this name yet
 
-                    registry.register(metric, name, this);
-                } else {
-                    // we had a collision. put back the original value
-                    metrics.put(name, prior);
-
-                    // we warn here, rather than failing, because metrics are tools that should not
-                    // fail the
+                if (groups.containsKey(name)) {
+                    // we warn here, rather than failing, because metrics are tools that should
+                    // not fail the
                     // program when used incorrectly
                     LOG.warn(
-                            "Name collision: Group already contains a Metric with the name '"
+                            "Name collision: Adding a metric with the same name as a metric subgroup: '"
                                     + name
-                                    + "'. Metric will not be reported."
+                                    + "'. Metric might not get properly reported. "
                                     + Arrays.toString(scopeComponents));
                 }
+
+                registry.register(metric, name, this);
+            } else {
+                // we had a collision. put back the original value
+                metrics.put(name, prior);
+
+                // we warn here, rather than failing, because metrics are tools that should not
+                // fail the
+                // program when used incorrectly
+                LOG.warn(
+                        "Name collision: Group already contains a Metric with the name '"
+                                + name
+                                + "'. Metric will not be reported."
+                                + Arrays.toString(scopeComponents));
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.traces.SpanBuilder;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -339,6 +340,25 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 
     public final boolean isClosed() {
         return closed;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+    //  Spans
+    // -----------------------------------------------------------------------------------------------------------------
+
+    @Override
+    public void addSpan(SpanBuilder spanBuilder) {
+        if (spanBuilder == null) {
+            LOG.warn("Ignoring attempted addition of a span due to being null");
+            return;
+        }
+        // add the span only if the group is still open
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            registry.addSpan(spanBuilder);
+        }
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobMetricGroup.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.traces.SpanBuilder;
 
 import javax.annotation.Nullable;
 
@@ -72,6 +73,11 @@ public abstract class JobMetricGroup<C extends ComponentMetricGroup<C>>
     protected QueryScopeInfo.JobQueryScopeInfo createQueryServiceMetricInfo(
             CharacterFilter filter) {
         return new QueryScopeInfo.JobQueryScopeInfo(this.jobId.toString());
+    }
+
+    @Override
+    public void addSpan(SpanBuilder spanBuilder) {
+        super.addSpan(spanBuilder.setAttribute("jobId", this.jobId.toString()));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.traces.SpanBuilder;
 
 import java.util.Map;
 
@@ -40,6 +41,11 @@ public class ProxyMetricGroup<P extends MetricGroup> implements MetricGroup {
 
     public ProxyMetricGroup(P parentMetricGroup) {
         this.parentMetricGroup = checkNotNull(parentMetricGroup);
+    }
+
+    @Override
+    public void addSpan(SpanBuilder spanBuilder) {
+        parentMetricGroup.addSpan(spanBuilder);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -77,6 +77,7 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
+import org.apache.flink.runtime.metrics.TraceReporterSetup;
 import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
@@ -1134,6 +1135,8 @@ public class MiniCluster implements AutoCloseableAsync {
         return new MetricRegistryImpl(
                 MetricRegistryConfiguration.fromConfiguration(config, maximumMessageSizeInBytes),
                 ReporterSetup.fromConfiguration(
+                        config, miniClusterConfiguration.getPluginManager()),
+                TraceReporterSetup.fromConfiguration(
                         config, miniClusterConfiguration.getPluginManager()));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
+import org.apache.flink.runtime.metrics.TraceReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.rpc.AddressResolution;
@@ -221,7 +222,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                             MetricRegistryConfiguration.fromConfiguration(
                                     configuration,
                                     rpcSystem.getMaximumMessageSizeInBytes(configuration)),
-                            ReporterSetup.fromConfiguration(configuration, pluginManager));
+                            ReporterSetup.fromConfiguration(configuration, pluginManager),
+                            TraceReporterSetup.fromConfiguration(configuration, pluginManager));
 
             final RpcService metricQueryServiceRpcService =
                     MetricUtils.startRemoteMetricsRpcService(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.GenericMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.traces.SpanBuilder;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -220,6 +221,9 @@ class RocksDBNativeMetricMonitorTest {
         public int getNumberReporters() {
             return 0;
         }
+
+        @Override
+        public void addSpan(SpanBuilder spanBuilder) {}
 
         @Override
         public void register(Metric metric, String metricName, AbstractMetricGroup group) {


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a concept of `Span` and `TraceReporter` and uses that to report checkpointing traces.

## Brief change log

Please check individual commit messages.

## Verifying this change

This change added tests and can be verified as follows:
- `CheckpointStatsTrackerTest#testSpanCreation` checks that a span with proper Checkpoint ID is created.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
