### PR TITLE
[FLINK-33693][checkpoint] Force aligned barrier works with timeoutable aligned checkpoint barrier

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -182,9 +182,7 @@ public class RecordWriterOutput<OUT>
     }
 
     public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
-        if (isPriorityEvent
-                && event instanceof CheckpointBarrier
-                && !supportsUnalignedCheckpoints) {
+        if (event instanceof CheckpointBarrier && !supportsUnalignedCheckpoints) {
             final CheckpointBarrier barrier = (CheckpointBarrier) event;
             event = barrier.withOptions(barrier.getCheckpointOptions().withUnalignedUnsupported());
             isPriorityEvent = false;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/RecordWriterOutputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/RecordWriterOutputTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions.AlignmentType;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
+import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RecordWriterOutput}. */
+class RecordWriterOutputTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testDisableUnalignedCheckpoint(boolean supportsUnalignedCheckpoints) throws IOException {
+        Queue<Tuple2<AbstractEvent, Boolean>> queue = new LinkedList<>();
+
+        RecordWriter<SerializationDelegate<StreamRecord<Long>>> task1 =
+                new RecordWriterBuilder<SerializationDelegate<StreamRecord<Long>>>()
+                        .build(
+                                new MockResultPartitionWriter() {
+                                    @Override
+                                    public void broadcastEvent(
+                                            AbstractEvent event, boolean isPriorityEvent) {
+                                        queue.add(Tuple2.of(event, isPriorityEvent));
+                                    }
+                                });
+
+        RecordWriterOutput<Long> writerOutput =
+                new RecordWriterOutput<>(
+                        task1, LongSerializer.INSTANCE, null, supportsUnalignedCheckpoints);
+
+        // Test unalignedBarrier
+        CheckpointBarrier unalignedBarrier =
+                new CheckpointBarrier(
+                        0,
+                        1L,
+                        CheckpointOptions.unaligned(
+                                CheckpointType.CHECKPOINT,
+                                CheckpointStorageLocationReference.getDefault()));
+
+        writerOutput.broadcastEvent(unalignedBarrier, true);
+        assertAlignmentTypeAndIsPriorityEvent(
+                queue.poll(),
+                supportsUnalignedCheckpoints
+                        ? AlignmentType.UNALIGNED
+                        : AlignmentType.FORCED_ALIGNED,
+                supportsUnalignedCheckpoints);
+
+        // Test alignedTimeoutBarrier
+        CheckpointBarrier alignedTimeoutBarrier =
+                new CheckpointBarrier(
+                        0,
+                        1L,
+                        CheckpointOptions.alignedWithTimeout(
+                                CheckpointType.CHECKPOINT,
+                                CheckpointStorageLocationReference.getDefault(),
+                                1000));
+
+        writerOutput.broadcastEvent(alignedTimeoutBarrier, false);
+        assertAlignmentTypeAndIsPriorityEvent(
+                queue.poll(),
+                supportsUnalignedCheckpoints ? AlignmentType.ALIGNED : AlignmentType.FORCED_ALIGNED,
+                false);
+    }
+
+    private void assertAlignmentTypeAndIsPriorityEvent(
+            Tuple2<AbstractEvent, Boolean> unalignedResult,
+            AlignmentType expectedAlignmentType,
+            boolean isPriorityEvent) {
+        assertThat(unalignedResult).isNotNull();
+
+        assertThat(unalignedResult.f0).isInstanceOf(CheckpointBarrier.class);
+        assertThat(((CheckpointBarrier) unalignedResult.f0).getCheckpointOptions().getAlignment())
+                .isSameAs(expectedAlignmentType);
+        assertThat(unalignedResult.f1).isEqualTo(isPriorityEvent);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

FLINK-21945 will convert the unaligned checkpoint barrier and timeoutable aligned checkpoint barrier to force aligned barrier. However, Force aligned barrier logic doesn't work for  timeoutable aligned checkpoint barrier.

Bug at org.apache.flink.streaming.runtime.io.RecordWriterOutput#broadcastEvent, we will call withUnalignedUnsupported to convert the unaligned checkpoint barrier to FORCED_ALIGNED barrier when the supportsUnalignedCheckpoints is false.

However, the if has one condition: isPriorityEvent. When  aligned checkpoint timeout is enabled, flink will emit one timeoutable barrier. It isn't PriorityEvent.


## Brief change log

[FLINK-33693][checkpoint] Force aligned barrier works with timeoutable aligned checkpoint barrier

- Remove the condition: isPriorityEvent


## Verifying this change

This change added tests and can be verified as follows:

  - Added test: `RecordWriterOutputTest#testDisableUnalignedCheckpoint`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
