### PR TITLE
[FLINK-33723] Disallow triggering incremental checkpoint explicitly from REST API

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1829,7 +1829,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">Triggers a checkpoint. This async operation would return a 'triggerid' for further query identifier.</td>
+      <td colspan="2">Triggers a checkpoint. The 'checkpointType' parameter does not support 'INCREMENTAL' option for now. See FLINK-33723. This async operation would return a 'triggerid' for further query identifier.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -491,8 +491,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/CheckpointingStatistics'
     post:
-      description: Triggers a checkpoint. This async operation would return a 'triggerid'
-        for further query identifier.
+      description: Triggers a checkpoint. The 'checkpointType' parameter does not
+        support 'INCREMENTAL' option for now. See FLINK-33723. This async operation
+        would return a 'triggerid' for further query identifier.
       operationId: triggerCheckpoint
       parameters:
       - name: jobid

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointHandlers.java
@@ -140,10 +140,13 @@ public class CheckpointHandlers {
                 throws RestHandlerException {
             final AsynchronousJobOperationKey operationKey = createOperationKey(request);
 
-            return gateway.triggerCheckpoint(
-                            operationKey,
-                            request.getRequestBody().getCheckpointType(),
-                            RpcUtils.INF_TIMEOUT)
+            CheckpointType checkpointType = request.getRequestBody().getCheckpointType();
+            if (checkpointType == CheckpointType.INCREMENTAL) {
+                throw new IllegalStateException(
+                        "Flink does not support triggering incremental checkpoint explicitly."
+                                + " See FLINK-33723.");
+            }
+            return gateway.triggerCheckpoint(operationKey, checkpointType, RpcUtils.INF_TIMEOUT)
                     .handle(
                             (acknowledge, throwable) -> {
                                 if (throwable == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointTriggerHeaders.java
@@ -63,7 +63,9 @@ public class CheckpointTriggerHeaders
 
     @Override
     protected String getAsyncOperationDescription() {
-        return "Triggers a checkpoint.";
+        return "Triggers a checkpoint."
+                + " The 'checkpointType' parameter does not support 'INCREMENTAL' option for now."
+                + " See FLINK-33723.";
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Currently, when a job is configured to run with incremental checkpoint disabled, user manually triggers an incremental checkpoint actually triggering a full checkpoint. That is because the files from full checkpoint cannot be shared with an incremental checkpoint. This PR removes the "INCREMENTAL" option in triggering checkpoint from REST API and throw exception if user tried to avoid misunderstanding.


## Brief change log

 - Throw exception in ```org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointHandlers```
 - Remove the 'INCREMENTAL' options in docs

## Verifying this change

 - Added unit test ```CheckpointHandlersTest#testDisallowTriggeringIncrementalCheckpoint``` for this case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
