### PR TITLE
[FLINK-33672] Use MapState.entries() instead of keys() and get() in over window

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/ProcTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/ProcTimeRangeBoundedPrecedingFunction.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Process Function used for the aggregate in bounded proc-time OVER window.
@@ -197,13 +198,14 @@ public class ProcTimeRangeBoundedPrecedingFunction<K>
         // when we find timestamps that are out of interest, we retrieve corresponding elements
         // and eliminate them. Multiple elements could have been received at the same timestamp
         // the removal of old elements happens only once per proctime as onTimer is called only once
-        Iterator<Long> iter = inputState.keys().iterator();
+        Iterator<Map.Entry<Long, List<RowData>>> iter = inputState.entries().iterator();
         List<Long> markToRemove = new ArrayList<Long>();
         while (iter.hasNext()) {
-            Long elementKey = iter.next();
+            Map.Entry<Long, List<RowData>> element = iter.next();
+            Long elementKey = element.getKey();
             if (elementKey < limit) {
                 // element key outside of window. Retract values
-                List<RowData> elementsRemove = inputState.get(elementKey);
+                List<RowData> elementsRemove = element.getValue();
                 if (elementsRemove != null) {
                     int iRemove = 0;
                     while (iRemove < elementsRemove.size()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Process Function for RANGE clause event-time bounded OVER window.
@@ -227,12 +228,13 @@ public class RowTimeRangeBoundedPrecedingFunction<K>
             List<Long> retractTsList = new ArrayList<Long>();
 
             // do retraction
-            Iterator<Long> dataTimestampIt = inputState.keys().iterator();
-            while (dataTimestampIt.hasNext()) {
-                Long dataTs = dataTimestampIt.next();
+            Iterator<Map.Entry<Long, List<RowData>>> iter = inputState.entries().iterator();
+            while (iter.hasNext()) {
+                Map.Entry<Long, List<RowData>> data = iter.next();
+                Long dataTs = data.getKey();
                 Long offset = timestamp - dataTs;
                 if (offset > precedingOffset) {
-                    List<RowData> retractDataList = inputState.get(dataTs);
+                    List<RowData> retractDataList = data.getValue();
                     if (retractDataList != null) {
                         dataListIndex = 0;
                         while (dataListIndex < retractDataList.size()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Process Function for ROWS clause event-time bounded OVER window.
@@ -251,11 +252,12 @@ public class RowTimeRowsBoundedPrecedingFunction<K>
                     if (null == retractList) {
                         // find the smallest timestamp
                         retractTs = Long.MAX_VALUE;
-                        for (Long dataTs : inputState.keys()) {
+                        for (Map.Entry<Long, List<RowData>> entry : inputState.entries()) {
+                            Long dataTs = entry.getKey();
                             if (dataTs < retractTs) {
                                 retractTs = dataTs;
                                 // get the oldest rows to retract them
-                                retractList = inputState.get(dataTs);
+                                retractList = entry.getValue();
                             }
                         }
                     }


### PR DESCRIPTION
## What is the purpose of the change

This PR replaces any combination of key iteration and getting the value for iterated key from MapState with a entry iteration followed by getKey() and getValue() of iterated entry. This could save the overhead of get() in MapState.

## Brief change log

Equivalent transformation of code in package ```org.apache.flink.table.runtime.operators.over```.

## Verifying this change

This change is a trivial rework without any new test coverage. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
