### PR TITLE
[FLINK-33684][datastream] Use IncrementalDelayRetryStrategy in CollectResultFetcher

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CollectOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CollectOptions.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * Config options for {@link org.apache.flink.util.concurrent.RetryStrategy} in
+ * CollectResultFetcher.
+ */
+@PublicEvolving
+@ConfigGroups(
+        groups = {
+            @ConfigGroup(
+                    name = "ExponentialDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.exponential-delay"),
+            @ConfigGroup(
+                    name = "FixedDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.fixed-delay"),
+            @ConfigGroup(
+                    name = "IncrementalDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.incremental-delay"),
+        })
+public class CollectOptions {
+
+    private static final String COLLECT_STRATEGY_PARAM = "collect-strategy";
+    public static final String FIXED_DELAY_LABEL = "fixed-delay";
+    public static final String EXPONENTIAL_DELAY_LABEL = "exponential-delay";
+
+    public static final String INCREMENTAL_DELAY_LABEL = "incremental-delay";
+
+    private static String createParameterPrefix(String paramGroupKey) {
+        return COLLECT_STRATEGY_PARAM + "." + paramGroupKey + ".";
+    }
+
+    private static String createFixedDelayParameterPrefix(String parameter) {
+        return createParameterPrefix(FIXED_DELAY_LABEL) + parameter;
+    }
+
+    private static String createExponentialBackoffParameterPrefix(String parameter) {
+        return createParameterPrefix(EXPONENTIAL_DELAY_LABEL) + parameter;
+    }
+
+    private static String createIncrementalDelayParameterPrefix(String parameter) {
+        return createParameterPrefix(INCREMENTAL_DELAY_LABEL) + parameter;
+    }
+
+    public static String extractAlphaNumericCharacters(String paramName) {
+        return paramName.replaceAll("[^a-zA-Z0-9]", "");
+    }
+
+    public static final ConfigOption<String> COLLECT_STRATEGY =
+            ConfigOptions.key(COLLECT_STRATEGY_PARAM + ".type")
+                    .stringType()
+                    .defaultValue(FIXED_DELAY_LABEL)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the retry strategy to use in CollectResultFetcher.")
+                                    .linebreak()
+                                    .text("Accepted values are:")
+                                    .list(
+                                            text(
+                                                    "%s, %s: CollectResultFetcher will send collect "
+                                                            + "request to cluster in a fixed interval up "
+                                                            + "to the point where the job is considered "
+                                                            + "successful or a set amount of retries is "
+                                                            + "reached.",
+                                                    code(FIXED_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    FIXED_DELAY_LABEL))),
+                                            text(
+                                                    "%s, %s: Exponential delay retry strategy "
+                                                            + "triggers the collect request with an "
+                                                            + "exponentially increasing delay up to "
+                                                            + " a configured max delay or the point "
+                                                            + "where the job is succeeded or a set "
+                                                            + "amount of retries is reached.",
+                                                    code(EXPONENTIAL_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    EXPONENTIAL_DELAY_LABEL))),
+                                            text(
+                                                    "%s, %s: Incremental delay retry strategy "
+                                                            + "triggers the collect request with an "
+                                                            + "incremental delay up to a configured "
+                                                            + "max delay or the point where the job "
+                                                            + "is succeeded or a set amount of retries "
+                                                            + "is reached.",
+                                                    code(INCREMENTAL_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    INCREMENTAL_DELAY_LABEL))))
+                                    .text(
+                                            "The default configuration relies on an fixed delayed "
+                                                    + "retry strategy with the given default values.")
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_FIXED_DELAY_ATTEMPTS =
+            ConfigOptions.key(createFixedDelayParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()), code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_FIXED_DELAY_DELAY =
+            ConfigOptions.key(createFixedDelayParameterPrefix("delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(100))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Amount of time that CollectResultFetcher waits before next retry. "
+                                                    + "It can be specified using the following notation: \"1 min\", "
+                                                    + "\"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("initial-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Starting duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("max-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The highest possible duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_INITIAL_DELAY =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("initial-delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Starting duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_INCREMENT =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("increment"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The delay increment between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_DELAY =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("max-delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The highest possible duration between fetch "
+                                                    + "retries if %s has been set to %s. It can be "
+                                                    + "specified using the following notation: "
+                                                    + "\"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_ATTEMPTS =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/CollectRetryStrategyFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/CollectRetryStrategyFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.configuration.CollectOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.IncrementalDelayRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * {@code CollectRetryStrategyFactory} is used to create {@link RetryStrategy} for {@link
+ * org.apache.flink.streaming.api.operators.collect.CollectResultFetcher}. It extracts all the
+ * necessary information from the passed {@link Configuration}.
+ *
+ * @see CollectOptions
+ */
+public enum CollectRetryStrategyFactory {
+    INSTANCE;
+
+    /** Creates the {@link RetryStrategy} instance based on the passed {@link Configuration}. */
+    public Supplier<RetryStrategy> createRetryStrategySupplier(ReadableConfig configuration) {
+        final String configuredRetryStrategy = configuration.get(CollectOptions.COLLECT_STRATEGY);
+        if (isRetryStrategy(
+                CollectOptions.FIXED_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createFixedRetryStrategy(configuration);
+        } else if (isRetryStrategy(
+                CollectOptions.EXPONENTIAL_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createExponentialBackoffRetryStrategy(configuration);
+        } else if (isRetryStrategy(
+                CollectOptions.INCREMENTAL_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createIncrementalDelayRetryStrategy(configuration);
+        }
+
+        throw new IllegalArgumentException(
+                createInvalidCollectStrategyErrorMessage(configuredRetryStrategy));
+    }
+
+    private static FixedRetryStrategy createFixedRetryStrategy(ReadableConfig configuration) {
+        final Duration delay = configuration.get(CollectOptions.COLLECT_STRATEGY_FIXED_DELAY_DELAY);
+        final int maxAttempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_FIXED_DELAY_ATTEMPTS);
+
+        return new FixedRetryStrategy(maxAttempts, delay);
+    }
+
+    private static ExponentialBackoffRetryStrategy createExponentialBackoffRetryStrategy(
+            ReadableConfig configuration) {
+        final Duration minDelay =
+                configuration.get(
+                        CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF);
+        final Duration maxDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF);
+        final int maxAttempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS);
+
+        return new ExponentialBackoffRetryStrategy(maxAttempts, minDelay, maxDelay);
+    }
+
+    private static IncrementalDelayRetryStrategy createIncrementalDelayRetryStrategy(
+            ReadableConfig configuration) {
+        final Duration initialDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_INITIAL_DELAY);
+        final Duration increment =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_INCREMENT);
+        final int attempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_ATTEMPTS);
+        final Duration maxDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_DELAY);
+
+        return new IncrementalDelayRetryStrategy(attempts, initialDelay, increment, maxDelay);
+    }
+
+    private static String createInvalidCollectStrategyErrorMessage(String configuredRetryStrategy) {
+        final StringBuilder msgBuilder = new StringBuilder();
+        msgBuilder
+                .append("Unknown collect retry strategy '")
+                .append(configuredRetryStrategy)
+                .append("'. Valid strategies are ");
+
+        final String validOptionsStr =
+                String.join(
+                        ", ",
+                        CollectOptions.INCREMENTAL_DELAY_LABEL,
+                        CollectOptions.EXPONENTIAL_DELAY_LABEL,
+                        CollectOptions.FIXED_DELAY_LABEL);
+
+        return msgBuilder.append(validOptionsStr).toString();
+    }
+
+    private static boolean isRetryStrategy(
+            String retryStrategyLabel, String configuredRetryStrategy) {
+        final String retryStrategy = configuredRetryStrategy.toLowerCase();
+        return retryStrategy.equals(retryStrategyLabel)
+                || retryStrategy.equals(
+                        CollectOptions.extractAlphaNumericCharacters(retryStrategyLabel));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcherRetryITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcherRetryITCase.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.collect.utils.TestJobClient;
+import org.apache.flink.streaming.api.operators.collect.utils.TestSimpleCountCoordinationRequestHandler;
+import org.apache.flink.util.OptionalFailure;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.IncrementalDelayRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/** Tests for {@link CollectResultIterator}. */
+public class CollectResultFetcherRetryITCase extends TestLogger {
+    private final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
+    private static final OperatorID TEST_OPERATOR_ID = new OperatorID();
+
+    private static final JobID TEST_JOB_ID = new JobID();
+    private static final String ACCUMULATOR_NAME = "accumulatorName";
+
+    private final AtomicLong totalRetryInterval = new AtomicLong(0L);
+
+    private final Consumer<RetryStrategy> retryAction =
+            retryStrategy -> {
+                long delay = retryStrategy.getRetryDelay().toMillis();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(delay);
+                    totalRetryInterval.getAndAdd(delay);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+    @Test
+    public void testFetcherWithIncrementalDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        long increment = 100L;
+        long maxDelay = 1000L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new IncrementalDelayRetryStrategy(
+                                        Integer.MAX_VALUE,
+                                        Duration.ofMillis(initDelay),
+                                        Duration.ofMillis(increment),
+                                        Duration.ofMillis(maxDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        long currentDelay = initDelay;
+
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            if (i > 1) {
+                currentDelay = Math.min(currentDelay + increment, maxDelay);
+            }
+
+            expect += currentDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    @Test
+    public void testFetcherWithExponentialBackoffDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        long maxDelay = 1000L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new ExponentialBackoffRetryStrategy(
+                                        Integer.MAX_VALUE,
+                                        Duration.ofMillis(initDelay),
+                                        Duration.ofMillis(maxDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        long currentDelay = initDelay;
+
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            if (i > 1) {
+                currentDelay = Math.min(currentDelay * 2, maxDelay);
+            }
+
+            expect += currentDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    @Test
+    public void testFetcherWithFixedDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new FixedRetryStrategy(
+                                        Integer.MAX_VALUE, Duration.ofMillis(initDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            expect += initDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    private Tuple2<CollectResultFetcher<Integer>, JobClient> createFetcherAndJobClient(
+            AbstractCollectResultBuffer<Integer> buffer,
+            TestSimpleCountCoordinationRequestHandler handler,
+            Supplier<RetryStrategy> retryStrategySupplier,
+            Consumer<RetryStrategy> retryAction) {
+        CollectResultFetcher<Integer> resultFetcher =
+                new CollectResultFetcher<>(
+                        buffer,
+                        CompletableFuture.completedFuture(TEST_OPERATOR_ID),
+                        ACCUMULATOR_NAME,
+                        retryStrategySupplier,
+                        retryAction,
+                        AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue().toMillis());
+
+        TestJobClient.JobInfoProvider infoProvider =
+                new TestJobClient.JobInfoProvider() {
+
+                    @Override
+                    public boolean isJobFinished() {
+                        return handler.isClosed();
+                    }
+
+                    @Override
+                    public Map<String, OptionalFailure<Object>> getAccumulatorResults() {
+                        return new HashMap<>();
+                    }
+                };
+
+        TestJobClient jobClient =
+                new TestJobClient(TEST_JOB_ID, TEST_OPERATOR_ID, handler, infoProvider);
+        resultFetcher.setJobClient(jobClient);
+
+        return Tuple2.of(resultFetcher, jobClient);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestSimpleCountCoordinationRequestHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestSimpleCountCoordinationRequestHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect.utils;
+
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.streaming.api.operators.collect.CollectCoordinationResponse;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestSimpleCountCoordinationRequestHandler implements CoordinationRequestHandler {
+
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    @Override
+    public CompletableFuture<CoordinationResponse> handleCoordinationRequest(
+            CoordinationRequest request) {
+        requestCount.getAndIncrement();
+        return CompletableFuture.completedFuture(
+                new CollectCoordinationResponse("", 0L, new ArrayList<>()));
+    }
+
+    public int getRequestCount() {
+        return requestCount.get();
+    }
+
+    public void close() {
+        isClosed.set(true);
+    }
+
+    public boolean isClosed() {
+        return isClosed.get();
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

Currently  `CollectResultFetcher` uses a fixed retry interval. This can be improved with `IncrementalDelayRetryStrategy`.  `IncrementalDelayRetryStrategy` is a balance between job E2E latency and request count.


## Brief change log

*(for example:)*
  - Use `IncrementalDelayRetryStrategy` in `CollectResultFetcher` to decide the retry interval  between requests.


## Verifying this change

  - *Added integration tests `CollectResultFetcherRetryITCase` to test the `CollectResultFetcher` retry behavior

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
