### PR TITLE
[FLINK-33727][table] Use different sink names for restore tests

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationTestPrograms.java
@@ -45,7 +45,7 @@ public class DeduplicationTestPrograms {
     static final TableTestProgram DEDUPLICATE =
             TableTestProgram.of("deduplicate-asc", "validates deduplication in ascending")
                     .setupTableSource(
-                            SourceTestStep.newBuilder("MyTable")
+                            SourceTestStep.newBuilder("DEDUPLICATE_Table")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -57,7 +57,7 @@ public class DeduplicationTestPrograms {
                                     .producedAfterRestore(DATA2)
                                     .build())
                     .setupTableSink(
-                            SinkTestStep.newBuilder("MySink")
+                            SinkTestStep.newBuilder("DEDUPLICATE_Sink")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -84,7 +84,7 @@ public class DeduplicationTestPrograms {
                             "deduplicate-asc-proctime",
                             "validates deduplication in ascending with proctime")
                     .setupTableSource(
-                            SourceTestStep.newBuilder("MyTable")
+                            SourceTestStep.newBuilder("DEDUPLICATE_PROCTIME_Table")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -96,7 +96,7 @@ public class DeduplicationTestPrograms {
                                     .producedAfterRestore(DATA2)
                                     .build())
                     .setupTableSink(
-                            SinkTestStep.newBuilder("MySink")
+                            SinkTestStep.newBuilder("DEDUPLICATE_PROCTIME_Sink")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -109,19 +109,19 @@ public class DeduplicationTestPrograms {
                                     .consumedAfterRestore(Row.of(8L, "bill", "banana", 8000L))
                                     .build())
                     .runSql(
-                            "insert into MySink "
+                            "insert into DEDUPLICATE_PROCTIME_Sink "
                                     + "select order_id, user, product, order_time \n"
                                     + "FROM ("
                                     + "  SELECT *,"
                                     + "    ROW_NUMBER() OVER (PARTITION BY product ORDER BY proctime ASC) AS row_num\n"
-                                    + "  FROM MyTable)"
+                                    + "  FROM DEDUPLICATE_PROCTIME_Table)"
                                     + "WHERE row_num = 1")
                     .build();
 
     static final TableTestProgram DEDUPLICATE_DESC =
             TableTestProgram.of("deduplicate-desc", "validates deduplication in descending")
                     .setupTableSource(
-                            SourceTestStep.newBuilder("MyTable")
+                            SourceTestStep.newBuilder("DEDUPLICATE_DESC_Table")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -133,7 +133,7 @@ public class DeduplicationTestPrograms {
                                     .producedAfterRestore(DATA2)
                                     .build())
                     .setupTableSink(
-                            SinkTestStep.newBuilder("MySink")
+                            SinkTestStep.newBuilder("DEDUPLICATE_DESC_Sink")
                                     .addSchema(
                                             "order_id bigint",
                                             "`user` varchar",
@@ -179,12 +179,12 @@ public class DeduplicationTestPrograms {
                                                     9000L))
                                     .build())
                     .runSql(
-                            "insert into MySink "
+                            "insert into DEDUPLICATE_DESC_Sink "
                                     + "select order_id, user, product, order_time \n"
                                     + "FROM ("
                                     + "  SELECT *,"
                                     + "    ROW_NUMBER() OVER (PARTITION BY product ORDER BY event_time DESC) AS row_num\n"
-                                    + "  FROM MyTable)"
+                                    + "  FROM DEDUPLICATE_DESC_Table)"
                                     + "WHERE row_num = 1")
                     .build();
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/ExpandTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/ExpandTestPrograms.java
@@ -42,7 +42,7 @@ public class ExpandTestPrograms {
                             IncrementalAggregateRule.TABLE_OPTIMIZER_INCREMENTAL_AGG_ENABLED(),
                             false)
                     .setupTableSource(
-                            SourceTestStep.newBuilder("MyTable")
+                            SourceTestStep.newBuilder("EXPAND_Table")
                                     .addSchema("a int", "b bigint", "c varchar")
                                     .producedBeforeRestore(
                                             Row.of(1, 1L, "Hi"),
@@ -51,7 +51,7 @@ public class ExpandTestPrograms {
                                     .producedAfterRestore(Row.of(5, 6L, "Hello there"))
                                     .build())
                     .setupTableSink(
-                            SinkTestStep.newBuilder("MySink")
+                            SinkTestStep.newBuilder("EXPAND_Sink")
                                     .addSchema(
                                             "b bigint",
                                             "a bigint",
@@ -68,7 +68,7 @@ public class ExpandTestPrograms {
                                             Row.ofKind(RowKind.UPDATE_AFTER, 5, 1L, "Hello there"))
                                     .build())
                     .runSql(
-                            "insert into MySink select a, "
+                            "insert into EXPAND_Sink select a, "
                                     + "count(distinct b) as b, "
                                     + "first_value(c) c "
                                     + "from MyTable group by a")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/JoinTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/JoinTestPrograms.java
@@ -111,7 +111,7 @@ public class JoinTestPrograms {
                         .setupTableSource(SOURCE_T1)
                         .setupTableSource(SOURCE_T2)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("NON_WINDOW_INNER_JOIN_Sink")
                                         .addSchema("a int", "c1 varchar", "c2 varchar")
                                         .consumedBeforeRestore(
                                                 Row.of(1, "BakerBaker", "Baker2"),
@@ -124,7 +124,7 @@ public class JoinTestPrograms {
                                                 Row.of(2, "PostRestoreRight", "Baker5"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into NON_WINDOW_INNER_JOIN_Sink "
                                         + "SELECT t2.a, t2.c, t1.c\n"
                                         + "FROM (\n"
                                         + " SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T1\n"
@@ -142,7 +142,7 @@ public class JoinTestPrograms {
                         .setupTableSource(SOURCE_T1)
                         .setupTableSource(SOURCE_T2)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("NON_WINDOW_INNER_JOIN_WITH_NULL_Sink")
                                         .addSchema("a int", "c1 varchar", "c2 varchar")
                                         .consumedBeforeRestore(
                                                 Row.of(1, "BakerBaker", "Baker2"),
@@ -156,7 +156,7 @@ public class JoinTestPrograms {
                                                 Row.of(2, "PostRestoreRight", "Baker5"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into NON_WINDOW_INNER_JOIN_WITH_NULL_Sink "
                                         + "SELECT t2.a, t2.c, t1.c\n"
                                         + "FROM (\n"
                                         + " SELECT if(a = 3, cast(null as int), a) as a, b, c FROM T1\n"
@@ -175,7 +175,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("CROSS_JOIN_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of("Adam", "Accounting"),
@@ -237,7 +237,7 @@ public class JoinTestPrograms {
                                                 Row.of("Ivana", "Research"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into CROSS_JOIN_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE, DEPARTMENT")
                         .build();
 
@@ -246,7 +246,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("JOIN_WITH_FILTER_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of("Baker", "Research"),
@@ -256,7 +256,7 @@ public class JoinTestPrograms {
                                                 Row.of("Ivana", "Research"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into JOIN_WITH_FILTER_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE, DEPARTMENT where salary = b2 and salary < CAST(2 AS BIGINT)")
                         .build();
 
@@ -266,13 +266,13 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("INNER_JOIN_WITH_DUPLICATE_KEY_Sink")
                                         .addSchema("deptno int", "department_num int")
                                         .consumedBeforeRestore(Row.of(2, 2))
                                         .consumedAfterRestore(Row.of(4, 4), Row.of(4, 4))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into INNER_JOIN_WITH_DUPLICATE_KEY_Sink "
                                         + "SELECT deptno, department_num FROM EMPLOYEE JOIN DEPARTMENT ON deptno = department_num AND deptno = b3")
                         .build();
 
@@ -282,7 +282,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("INNER_JOIN_WITH_NON_EQUI_JOIN_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(Row.of("Don", "Sales"))
                                         .consumedAfterRestore(
@@ -290,7 +290,7 @@ public class JoinTestPrograms {
                                                 Row.of("Juliet", "Engineering"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into INNER_JOIN_WITH_NON_EQUI_JOIN_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE JOIN DEPARTMENT ON deptno = department_num AND salary > b2")
                         .build();
 
@@ -303,7 +303,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("INNER_JOIN_WITH_EQUAL_PK_Sink")
                                         .addSchema("deptno int", "department_num int")
                                         .consumedBeforeRestore(
                                                 Row.of(1, 1), Row.of(2, 2), Row.of(3, 3))
@@ -311,7 +311,7 @@ public class JoinTestPrograms {
                                         .build())
                         .runSql(
                                 String.format(
-                                        "INSERT INTO MySink SELECT deptno, department_num FROM (%s) JOIN (%s) ON deptno = department_num",
+                                        "INSERT INTO INNER_JOIN_WITH_EQUAL_PK_Sink SELECT deptno, department_num FROM (%s) JOIN (%s) ON deptno = department_num",
                                         query1, query2))
                         .build();
 
@@ -320,7 +320,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("INNER_JOIN_WITH_PK_Sink")
                                         .addSchema("deptno int", "department_num int")
                                         .consumedBeforeRestore(
                                                 Row.of(1, 1),
@@ -332,7 +332,7 @@ public class JoinTestPrograms {
                                         .build())
                         .runSql(
                                 String.format(
-                                        "INSERT INTO MySink SELECT deptno, department_num FROM (%s) JOIN (%s) ON salary = b2",
+                                        "INSERT INTO INNER_JOIN_WITH_PK_Sink SELECT deptno, department_num FROM (%s) JOIN (%s) ON salary = b2",
                                         query1, query2))
                         .build();
 
@@ -341,7 +341,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("FULL_OUTER_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of("Adam", null),
@@ -359,7 +359,7 @@ public class JoinTestPrograms {
                                         .testMaterializedData()
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into FULL_OUTER_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE FULL OUTER JOIN DEPARTMENT ON deptno = department_num")
                         .build();
 
@@ -368,7 +368,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("LEFT_JOIN_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of("Adam", null),
@@ -385,7 +385,7 @@ public class JoinTestPrograms {
                                         .testMaterializedData()
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into LEFT_JOIN_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE LEFT JOIN DEPARTMENT ON deptno = department_num")
                         .build();
 
@@ -394,7 +394,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("RIGHT_JOIN_Sink")
                                         .addSchema("name varchar", "department_name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of(null, "Accounting"),
@@ -410,7 +410,7 @@ public class JoinTestPrograms {
                                         .testMaterializedData()
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into RIGHT_JOIN_Sink "
                                         + "SELECT name, department_name FROM EMPLOYEE RIGHT OUTER JOIN DEPARTMENT ON deptno = department_num")
                         .build();
 
@@ -419,7 +419,7 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("SEMI_JOIN_Sink")
                                         .addSchema("name varchar")
                                         .consumedBeforeRestore(
                                                 Row.of("Baker"), Row.of("Charlie"), Row.of("Don"))
@@ -427,7 +427,7 @@ public class JoinTestPrograms {
                                                 Row.of("Helena"), Row.of("Juliet"), Row.of("Ivana"))
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into SEMI_JOIN_Sink "
                                         + "SELECT name FROM EMPLOYEE WHERE deptno IN (SELECT department_num FROM DEPARTMENT)")
                         .build();
 
@@ -436,14 +436,14 @@ public class JoinTestPrograms {
                         .setupTableSource(EMPLOYEE)
                         .setupTableSource(DEPARTMENT_NONULLS)
                         .setupTableSink(
-                                SinkTestStep.newBuilder("MySink")
+                                SinkTestStep.newBuilder("ANTI_JOIN_Sink")
                                         .addSchema("name varchar")
                                         .consumedBeforeRestore(Row.of("Victor"))
                                         .consumedAfterRestore(Row.of("Juliet"), Row.of("Helena"))
                                         .testMaterializedData()
                                         .build())
                         .runSql(
-                                "insert into MySink "
+                                "insert into ANTI_JOIN_Sink "
                                         + "SELECT name FROM EMPLOYEE WHERE deptno NOT IN (SELECT department_num FROM DEPARTMENT)")
                         .build();
     }

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-asc-proctime/plan/deduplicate-asc-proctime.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-asc-proctime/plan/deduplicate-asc-proctime.json
@@ -5,7 +5,7 @@
     "type" : "stream-exec-table-source-scan_1",
     "scanTableSource" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_PROCTIME_Table`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -66,7 +66,7 @@
       }
     },
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[order_id, user, product, order_time])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, DEDUPLICATE_PROCTIME_Table]], fields=[order_id, user, product, order_time])",
     "inputProperties" : [ ]
   }, {
     "id" : 9,
@@ -259,7 +259,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_PROCTIME_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -296,7 +296,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[order_id, user, product, order_time])"
+    "description" : "Sink(table=[default_catalog.default_database.DEDUPLICATE_PROCTIME_Sink], fields=[order_id, user, product, order_time])"
   } ],
   "edges" : [ {
     "source" : 8,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-asc/plan/deduplicate-asc.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-asc/plan/deduplicate-asc.json
@@ -5,7 +5,7 @@
     "type" : "stream-exec-table-source-scan_1",
     "scanTableSource" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_Table`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -69,7 +69,7 @@
       }
     },
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[order_id, user, product, order_time])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, DEDUPLICATE_Table]], fields=[order_id, user, product, order_time])",
     "inputProperties" : [ ]
   }, {
     "id" : 2,
@@ -291,7 +291,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -328,7 +328,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[order_id, user, product, order_time])"
+    "description" : "Sink(table=[default_catalog.default_database.DEDUPLICATE_Sink], fields=[order_id, user, product, order_time])"
   } ],
   "edges" : [ {
     "source" : 1,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-desc/plan/deduplicate-desc.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-deduplicate_1/deduplicate-desc/plan/deduplicate-desc.json
@@ -5,7 +5,7 @@
     "type" : "stream-exec-table-source-scan_1",
     "scanTableSource" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_DESC_Table`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -69,7 +69,7 @@
       }
     },
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[order_id, user, product, order_time])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, DEDUPLICATE_DESC_Table]], fields=[order_id, user, product, order_time])",
     "inputProperties" : [ ]
   }, {
     "id" : 9,
@@ -291,7 +291,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`DEDUPLICATE_DESC_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -328,7 +328,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` BIGINT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[order_id, user, product, order_time])"
+    "description" : "Sink(table=[default_catalog.default_database.DEDUPLICATE_DESC_Sink], fields=[order_id, user, product, order_time])"
   } ],
   "edges" : [ {
     "source" : 8,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-expand_1/expand/plan/expand.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-expand_1/expand/plan/expand.json
@@ -5,7 +5,7 @@
     "type" : "stream-exec-table-source-scan_1",
     "scanTableSource" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "identifier" : "`default_catalog`.`default_database`.`EXPAND_Table`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -25,7 +25,7 @@
       }
     },
     "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
-    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, EXPAND_Table]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "id" : 2,
@@ -377,7 +377,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`EXPAND_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -411,7 +411,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `a` BIGINT, `c` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, a, c])"
+    "description" : "Sink(table=[default_catalog.default_database.EXPAND_Sink], fields=[b, a, c])"
   } ],
   "edges" : [ {
     "source" : 1,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/anti-join/plan/anti-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/anti-join/plan/anti-join.json
@@ -203,7 +203,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`ANTI_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -225,7 +225,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name])"
+    "description" : "Sink(table=[default_catalog.default_database.ANTI_JOIN_Sink], fields=[name])"
   } ],
   "edges" : [ {
     "source" : 98,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/cross-join/plan/cross-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/cross-join/plan/cross-join.json
@@ -145,7 +145,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`CROSS_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -170,7 +170,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.CROSS_JOIN_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 19,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-duplicate-key/plan/inner-join-with-duplicate-key.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-duplicate-key/plan/inner-join-with-duplicate-key.json
@@ -169,7 +169,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`INNER_JOIN_WITH_DUPLICATE_KEY_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -194,7 +194,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`deptno` INT, `department_num` INT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[deptno, department_num])"
+    "description" : "Sink(table=[default_catalog.default_database.INNER_JOIN_WITH_DUPLICATE_KEY_Sink], fields=[deptno, department_num])"
   } ],
   "edges" : [ {
     "source" : 33,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-equal-pk/plan/inner-join-with-equal-pk.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-equal-pk/plan/inner-join-with-equal-pk.json
@@ -227,7 +227,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`INNER_JOIN_WITH_EQUAL_PK_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -253,7 +253,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`deptno` INT, `department_num` INT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[deptno, department_num])"
+    "description" : "Sink(table=[default_catalog.default_database.INNER_JOIN_WITH_EQUAL_PK_Sink], fields=[deptno, department_num])"
   } ],
   "edges" : [ {
     "source" : 47,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-non-equi-join/plan/inner-join-with-non-equi-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-non-equi-join/plan/inner-join-with-non-equi-join.json
@@ -174,7 +174,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`INNER_JOIN_WITH_NON_EQUI_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -199,7 +199,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.INNER_JOIN_WITH_NON_EQUI_JOIN_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 40,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-pk/plan/inner-join-with-pk.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/inner-join-with-pk/plan/inner-join-with-pk.json
@@ -311,7 +311,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`INNER_JOIN_WITH_PK_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -336,7 +336,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`deptno` INT, `department_num` INT>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[deptno, department_num])"
+    "description" : "Sink(table=[default_catalog.default_database.INNER_JOIN_WITH_PK_Sink], fields=[deptno, department_num])"
   } ],
   "edges" : [ {
     "source" : 57,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/join-with-filter/plan/join-with-filter.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/join-with-filter/plan/join-with-filter.json
@@ -225,7 +225,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`JOIN_WITH_FILTER_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -250,7 +250,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.JOIN_WITH_FILTER_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 25,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/left-join/plan/left-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/left-join/plan/left-join.json
@@ -169,7 +169,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`LEFT_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -194,7 +194,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.LEFT_JOIN_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 77,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/non-window-inner-join-with-null-cond/plan/non-window-inner-join-with-null-cond.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/non-window-inner-join-with-null-cond/plan/non-window-inner-join-with-null-cond.json
@@ -264,7 +264,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`NON_WINDOW_INNER_JOIN_WITH_NULL_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -292,7 +292,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` INT, `c` VARCHAR(2147483647), `c0` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, c, c0])"
+    "description" : "Sink(table=[default_catalog.default_database.NON_WINDOW_INNER_JOIN_WITH_NULL_Sink], fields=[a, c, c0])"
   } ],
   "edges" : [ {
     "source" : 10,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/non-window-inner-join/plan/non-window-inner-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/non-window-inner-join/plan/non-window-inner-join.json
@@ -264,7 +264,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`NON_WINDOW_INNER_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -292,7 +292,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` INT, `c` VARCHAR(2147483647), `c0` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, c, c0])"
+    "description" : "Sink(table=[default_catalog.default_database.NON_WINDOW_INNER_JOIN_Sink], fields=[a, c, c0])"
   } ],
   "edges" : [ {
     "source" : 1,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/outer-join/plan/outer-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/outer-join/plan/outer-join.json
@@ -169,7 +169,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`FULL_OUTER_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -194,7 +194,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.FULL_OUTER_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 70,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/right-join/plan/right-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/right-join/plan/right-join.json
@@ -169,7 +169,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`RIGHT_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -194,7 +194,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647), `department_name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name, department_name])"
+    "description" : "Sink(table=[default_catalog.default_database.RIGHT_JOIN_Sink], fields=[name, department_name])"
   } ],
   "edges" : [ {
     "source" : 84,

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/semi-join/plan/semi-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/stream-exec-join_1/semi-join/plan/semi-join.json
@@ -165,7 +165,7 @@
     },
     "dynamicTableSink" : {
       "table" : {
-        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "identifier" : "`default_catalog`.`default_database`.`SEMI_JOIN_Sink`",
         "resolvedTable" : {
           "schema" : {
             "columns" : [ {
@@ -187,7 +187,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`name` VARCHAR(2147483647)>",
-    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[name])"
+    "description" : "Sink(table=[default_catalog.default_database.SEMI_JOIN_Sink], fields=[name])"
   } ],
   "edges" : [ {
     "source" : 91,


### PR DESCRIPTION

## What is the purpose of the change

In restore  tests there is `MySink` name for sinks and it seems to be the problem for restore tests. For more details see jira.
The PR just renames these sinks for every table program


## Verifying this change

The issue was 100% reproduced by executing all tests for `RestoreTestBase`
In same way it could be tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
