### PR TITLE
[hotfix][sql-client] remove duplicated code in CliUtils

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliUtils.java
@@ -73,25 +73,25 @@ public final class CliUtils {
         while (iter.hasNext()) {
             // first line
             Tuple2<String, String> option = iter.next();
-            line1.style(AttributedStyle.DEFAULT.inverse());
-            line1.append(option.f0);
-            line1.style(AttributedStyle.DEFAULT);
-            line1.append(' ');
-            line1.append(option.f1);
-            repeatChar(line1, ' ', (11 - option.f1.length()) + space);
+            buildLine(line1, space, option);
             // second line
             if (iter.hasNext()) {
                 option = iter.next();
-                line2.style(AttributedStyle.DEFAULT.inverse());
-                line2.append(option.f0);
-                line2.style(AttributedStyle.DEFAULT);
-                line2.append(' ');
-                line2.append(option.f1);
-                repeatChar(line2, ' ', (11 - option.f1.length()) + space);
+                buildLine(line2, space, option);
             }
         }
 
         return Arrays.asList(line1.toAttributedString(), line2.toAttributedString());
+    }
+
+    private static void buildLine(
+            AttributedStringBuilder line1, int space, Tuple2<String, String> option) {
+        line1.style(AttributedStyle.DEFAULT.inverse());
+        line1.append(option.f0);
+        line1.style(AttributedStyle.DEFAULT);
+        line1.append(' ');
+        line1.append(option.f1);
+        repeatChar(line1, ' ', (11 - option.f1.length()) + space);
     }
 
     public static String[] typesToString(DataType[] types) {


### PR DESCRIPTION
## What is the purpose of the change

remove duplicated code in the CliUtils

## Verifying this change

This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)