### PR TITLE
[FLINK-33737][Scheduler] Merge multiple Exceptions into one attempt for exponential-delay restart-strategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
@@ -111,6 +111,12 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
     @Override
     public void notifyFailure(Throwable cause) {
         long now = clock.absoluteTimeMillis();
+
+        // Merge multiple failures into one attempt if there are tasks will be restarted later.
+        if (now <= nextRestartTimestamp) {
+            return;
+        }
+
         if ((now - nextRestartTimestamp) >= resetBackoffThresholdMS) {
             setInitialBackoff();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategyTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.clock.ManualClock;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,13 +41,16 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
     @Test
     void testMaxAttempts() {
         int maxAttempts = 13;
+        ManualClock clock = new ManualClock();
+        long maxBackoffMS = 3L;
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(), 1L, 3L, 1.2, 4L, 0.25, maxAttempts);
+                        clock, 1L, maxBackoffMS, 1.2, 10L, 0.25, maxAttempts);
 
         for (int i = 0; i <= maxAttempts; i++) {
             assertThat(restartStrategy.canRestart()).isTrue();
             restartStrategy.notifyFailure(failure);
+            clock.advanceTime(Duration.ofMillis(maxBackoffMS + 1));
         }
         assertThat(restartStrategy.canRestart()).isFalse();
     }
@@ -131,24 +135,28 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         double backoffMultiplier = 2.3;
         long maxBackoffMS = 300L;
 
+        ManualClock clock = new ManualClock();
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
                 new ExponentialDelayRestartBackoffTimeStrategy(
-                        new ManualClock(),
+                        clock,
                         initialBackoffMS,
                         maxBackoffMS,
                         backoffMultiplier,
-                        8L,
+                        Integer.MAX_VALUE,
                         jitterFactor,
                         10);
 
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(4L); // 4
+        clock.advanceTime(Duration.ofMillis(maxBackoffMS + 1));
 
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(9L); // 4 * 2.3
+        clock.advanceTime(Duration.ofMillis(maxBackoffMS + 1));
 
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(21L); // 4 * 2.3 * 2.3
+        clock.advanceTime(Duration.ofMillis(maxBackoffMS + 1));
     }
 
     @Test
@@ -156,21 +164,25 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         final long initialBackoffMS = 2L;
         final long maxBackoffMS = 7L;
 
+        ManualClock clock = new ManualClock();
         final ExponentialDelayRestartBackoffTimeStrategyFactory restartStrategyFactory =
                 new ExponentialDelayRestartBackoffTimeStrategyFactory(
-                        new ManualClock(),
+                        clock,
                         initialBackoffMS,
                         maxBackoffMS,
                         2.0,
-                        1L,
+                        Integer.MAX_VALUE,
                         0.25,
                         Integer.MAX_VALUE);
 
-        assertCorrectRandomRangeWithFailureCount(restartStrategyFactory, 2, 3L, 4L, 5L);
+        assertCorrectRandomRangeWithFailureCount(
+                restartStrategyFactory, clock, maxBackoffMS + 1, 2, 3L, 4L, 5L);
 
-        assertCorrectRandomRangeWithFailureCount(restartStrategyFactory, 3, 6L, 7L);
+        assertCorrectRandomRangeWithFailureCount(
+                restartStrategyFactory, clock, maxBackoffMS + 1, 3, 6L, 7L);
 
-        assertCorrectRandomRangeWithFailureCount(restartStrategyFactory, 4, 7L);
+        assertCorrectRandomRangeWithFailureCount(
+                restartStrategyFactory, clock, maxBackoffMS + 1, 4, 7L);
     }
 
     @Test
@@ -178,26 +190,31 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         double jitterFactor = 1;
         long maxBackoffMS = 7L;
 
+        ManualClock clock = new ManualClock();
         final ExponentialDelayRestartBackoffTimeStrategyFactory restartStrategyFactory =
                 new ExponentialDelayRestartBackoffTimeStrategyFactory(
-                        new ManualClock(),
+                        clock,
                         1L,
                         maxBackoffMS,
                         2.0,
-                        8L,
+                        Integer.MAX_VALUE,
                         jitterFactor,
                         Integer.MAX_VALUE);
 
-        assertCorrectRandomRangeWithFailureCount(restartStrategyFactory, 1, 1L, 2L);
-
-        assertCorrectRandomRangeWithFailureCount(restartStrategyFactory, 2, 1L, 2L, 3L, 4L);
+        assertCorrectRandomRangeWithFailureCount(
+                restartStrategyFactory, clock, maxBackoffMS + 1, 1, 1L, 2L);
 
         assertCorrectRandomRangeWithFailureCount(
-                restartStrategyFactory, 3, 1L, 2L, 3L, 4L, 5L, 6L, 7L);
+                restartStrategyFactory, clock, maxBackoffMS + 1, 2, 1L, 2L, 3L, 4L);
+
+        assertCorrectRandomRangeWithFailureCount(
+                restartStrategyFactory, clock, maxBackoffMS + 1, 3, 1L, 2L, 3L, 4L, 5L, 6L, 7L);
     }
 
     private void assertCorrectRandomRangeWithFailureCount(
             ExponentialDelayRestartBackoffTimeStrategyFactory factory,
+            ManualClock clock,
+            long advanceMsEachFailure,
             int failureCount,
             Long... expectedNumbers)
             throws Exception {
@@ -205,6 +222,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
                 () -> {
                     RestartBackoffTimeStrategy restartStrategy = factory.create();
                     for (int i = 0; i < failureCount; i++) {
+                        clock.advanceTime(Duration.ofMillis(advanceMsEachFailure));
                         restartStrategy.notifyFailure(failure);
                     }
                     return restartStrategy.getBackoffTime();
@@ -218,7 +236,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         final long initialBackoffMS = 1L;
         final long maxBackoffMS = 9L;
         double backoffMultiplier = 2.0;
-        final long resetBackoffThresholdMS = 8L;
+        final long resetBackoffThresholdMS = 80L;
         double jitterFactor = 0.25;
 
         final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
@@ -237,7 +255,7 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(initialBackoffMS);
 
         // ensure backoff time is initial after the first failure
-        clock.advanceTime(50, TimeUnit.MILLISECONDS);
+        clock.advanceTime(resetBackoffThresholdMS + 1, TimeUnit.MILLISECONDS);
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.canRestart()).isTrue();
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(initialBackoffMS);
@@ -253,11 +271,104 @@ class ExponentialDelayRestartBackoffTimeStrategyTest {
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.canRestart()).isTrue();
         assertThat(restartStrategy.getBackoffTime()).isOne();
+        clock.advanceTime(Duration.ofMillis(maxBackoffMS + 1));
 
         // ensure backoff still increases
         restartStrategy.notifyFailure(failure);
         assertThat(restartStrategy.canRestart()).isTrue();
         assertThat(restartStrategy.getBackoffTime()).isEqualTo(2L);
+    }
+
+    @Test
+    void testMergeMultipleExceptionsIntoOneAttempt() {
+        ManualClock clock = new ManualClock();
+        long initialBackoffMS = 2L;
+        double backoffMultiplier = 2.0d;
+        final long maxBackoffMS = 6L;
+        final long resetBackoffThresholdMS = 80L;
+
+        final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
+                new ExponentialDelayRestartBackoffTimeStrategy(
+                        clock,
+                        initialBackoffMS,
+                        maxBackoffMS,
+                        backoffMultiplier,
+                        resetBackoffThresholdMS,
+                        0.d,
+                        3);
+
+        // All exceptions merged into one attempt if the time is same.
+        long currentBackOffMs = initialBackoffMS;
+        checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+        // After advance time it's a new round, so new exception will be a new attempt.
+        clock.advanceTime(1, TimeUnit.MILLISECONDS);
+        currentBackOffMs *= backoffMultiplier;
+        checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+        // After advance time it's a new round, so new exception will be a new attempt.
+        clock.advanceTime(1, TimeUnit.MILLISECONDS);
+        currentBackOffMs = maxBackoffMS;
+        checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+        // After advance time it's a new round, and it reaches the maxAttempts.
+        clock.advanceTime(1, TimeUnit.MILLISECONDS);
+        restartStrategy.notifyFailure(failure);
+        assertThat(restartStrategy.canRestart()).isFalse();
+    }
+
+    @Test
+    void testMergingExceptionsWorksWithResetting() {
+        ManualClock clock = new ManualClock();
+        long initialBackoffMS = 2L;
+        double backoffMultiplier = 2.0d;
+        final long maxBackoffMS = 6L;
+        final long resetBackoffThresholdMS = 80L;
+
+        final ExponentialDelayRestartBackoffTimeStrategy restartStrategy =
+                new ExponentialDelayRestartBackoffTimeStrategy(
+                        clock,
+                        initialBackoffMS,
+                        maxBackoffMS,
+                        backoffMultiplier,
+                        resetBackoffThresholdMS,
+                        0.d,
+                        3);
+
+        // Test the merging logic works well after a series of resetting.
+        for (int i = 0; i < 10; i++) {
+            // All exceptions merged into one attempt if the time is same.
+            long currentBackOffMs = initialBackoffMS;
+            checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+            // After advance time it's a new round, so new exception will be a new attempt.
+            clock.advanceTime(1, TimeUnit.MILLISECONDS);
+            currentBackOffMs *= backoffMultiplier;
+            checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+            // After advance time it's a new round, so new exception will be a new attempt.
+            clock.advanceTime(1, TimeUnit.MILLISECONDS);
+            currentBackOffMs = maxBackoffMS;
+            checkMultipleExceptionsAreMerged(clock, currentBackOffMs, restartStrategy);
+
+            // After resetBackoffThresholdMS, the restartStrategy should be reset.
+            clock.advanceTime(resetBackoffThresholdMS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void checkMultipleExceptionsAreMerged(
+            ManualClock clock,
+            long expectedBackoffMS,
+            ExponentialDelayRestartBackoffTimeStrategy restartStrategy) {
+        for (int advanceMs = 0; advanceMs < expectedBackoffMS; advanceMs++) {
+            for (int i = 0; i < 10; i++) {
+                restartStrategy.notifyFailure(failure);
+                assertThat(restartStrategy.canRestart()).isTrue();
+                assertThat(restartStrategy.getBackoffTime())
+                        .isEqualTo(expectedBackoffMS - advanceMs);
+            }
+            clock.advanceTime(1, TimeUnit.MILLISECONDS);
+        }
     }
 
     private void assertCorrectRandomRange(Callable<Long> numberGenerator, Long... expectedNumbers)


### PR DESCRIPTION
## What is the purpose of the change

Merge multiple Exceptions into one attempt for exponential-delay restart-strategy. See [FLIP-364: Improve the exponential-delay restart-strategy](https://cwiki.apache.org/confluence/x/uJqzDw) get more details.

## Brief change log

- [FLINK-33737][Scheduler][refactor] Replace currentBackoffMS and lastFailureTimestamp with nextRestartTimestamp
- [FLINK-33737][Scheduler] Merge multiple Exceptions into one attempt for exponential-delay restart-strategy

Note: this PR is useful for FLINK-33565 (Support concurrentExceptions), and I have submitted a POC [PR](https://github.com/apache/flink/pull/24003) for FLINK-33565, it works well. (That PR depend on the current PR.)

## Verifying this change

- Added some unit tests in ExponentialDelayRestartBackoffTimeStrategyTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? yes
  - Add the doc in FLINK-33739