### PR TITLE
[FLINK-32949][core]collect tm port binding with TaskManagerOptions

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -33,6 +33,12 @@
             <td>The local address of the network interface that the task manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.collect-sink.port</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The port used for the client to retrieve query results from the TaskManager. The default value is 0, which corresponds to a random port assignment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.bind-port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/common_host_port_section.html
+++ b/docs/layouts/shortcodes/generated/common_host_port_section.html
@@ -75,6 +75,12 @@
             <td>The local address of the network interface that the task manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.collect-sink.port</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The port used for the client to retrieve query results from the TaskManager. The default value is 0, which corresponds to a random port assignment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.bind-port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_configuration.html
@@ -33,6 +33,12 @@
             <td>The local address of the network interface that the task manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.collect-sink.port</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The port used for the client to retrieve query results from the TaskManager. The default value is 0, which corresponds to a random port assignment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.debug.memory.log</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -173,6 +173,19 @@ public class TaskManagerOptions {
                                     + RPC_PORT.key()
                                     + "') will be used.");
 
+    /** The default port that <code>CollectSinkFunction$ServerThread</code> is using. */
+    @Documentation.Section({
+        Documentation.Sections.COMMON_HOST_PORT,
+        Documentation.Sections.ALL_TASK_MANAGER
+    })
+    public static final ConfigOption<Integer> COLLECT_PORT =
+            key("taskmanager.collect-sink.port")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "The port used for the client to retrieve query results from the TaskManager. "
+                                    + "The default value is 0, which corresponds to a random port assignment.");
+
     /**
      * The initial registration backoff between two consecutive registration attempts. The backoff
      * is doubled for each new registration attempt until it reaches the maximum registration

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
@@ -371,7 +372,7 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
 
         private ServerThread(TypeSerializer<IN> serializer) throws Exception {
             this.serializer = serializer.duplicate();
-            this.serverSocket = new ServerSocket(0, 0, getBindAddress());
+            this.serverSocket = new ServerSocket(getPort(), 0, getBindAddress());
             this.running = true;
         }
 
@@ -468,22 +469,14 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
         }
 
         private InetSocketAddress getServerSocketAddress() {
-            RuntimeContext context = getRuntimeContext();
-            Preconditions.checkState(
-                    context instanceof StreamingRuntimeContext,
-                    "CollectSinkFunction can only be used in StreamTask");
-            StreamingRuntimeContext streamingContext = (StreamingRuntimeContext) context;
+            StreamingRuntimeContext streamingContext = getStreamingRuntimeContext();
             String taskManagerAddress =
                     streamingContext.getTaskManagerRuntimeInfo().getTaskManagerExternalAddress();
             return new InetSocketAddress(taskManagerAddress, serverSocket.getLocalPort());
         }
 
         private InetAddress getBindAddress() {
-            RuntimeContext context = getRuntimeContext();
-            Preconditions.checkState(
-                    context instanceof StreamingRuntimeContext,
-                    "CollectSinkFunction can only be used in StreamTask");
-            StreamingRuntimeContext streamingContext = (StreamingRuntimeContext) context;
+            StreamingRuntimeContext streamingContext = getStreamingRuntimeContext();
             String bindAddress =
                     streamingContext.getTaskManagerRuntimeInfo().getTaskManagerBindAddress();
 
@@ -495,6 +488,22 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
                 }
             }
             return null;
+        }
+
+        private int getPort() {
+            return getStreamingRuntimeContext()
+                    .getTaskManagerRuntimeInfo()
+                    .getConfiguration()
+                    .getInteger(TaskManagerOptions.COLLECT_PORT);
+        }
+
+        private StreamingRuntimeContext getStreamingRuntimeContext() {
+            RuntimeContext context = getRuntimeContext();
+            Preconditions.checkState(
+                    context instanceof StreamingRuntimeContext,
+                    "CollectSinkFunction can only be used in StreamTask");
+            StreamingRuntimeContext streamingContext = (StreamingRuntimeContext) context;
+            return streamingContext;
         }
 
         private void sendBackResults(List<byte[]> serializedResults) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
@@ -58,6 +58,7 @@ public class CollectSinkFunctionTestWrapper<IN> {
     private final int maxBytesPerBatch;
 
     private final IOManager ioManager;
+
     private final StreamingRuntimeContext runtimeContext;
     private final MockOperatorEventGateway gateway;
     private final CollectSinkOperatorCoordinator coordinator;
@@ -174,5 +175,9 @@ public class CollectSinkFunctionTestWrapper<IN> {
     public ArrayList<byte[]> getAccumulatorLocalValue() {
         Accumulator accumulator = runtimeContext.getAccumulator(ACCUMULATOR_NAME);
         return ((SerializedListAccumulator) accumulator).getLocalValue();
+    }
+
+    public StreamingRuntimeContext getRuntimeContext() {
+        return runtimeContext;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

CollectSinkFunction$ServerThread uses configured port 


## Brief change log


  - Add new TaskManagerOptions#COLLECT_PORT
  - CollectSinkFunction$ServerThread uses the port configured in TaskManagerOptions#COLLECT_PORT
  - upgrade test to JUnit 5 and AssertJ
  - Add new test


## Verifying this change

New test has been created in existing test `CollectSinkFunctionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)
  - 
## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
