### PR TITLE
[FLINK-33751] use modules correctly when deserializing json plan

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -339,12 +339,24 @@ public class PlannerContext {
 
     /** Returns builtin the operator table and external the operator for this environment. */
     private SqlOperatorTable getBuiltinSqlOperatorTable() {
-        return SqlOperatorTables.chain(
-                new FunctionCatalogOperatorTable(
-                        context.getFunctionCatalog(),
-                        context.getCatalogManager().getDataTypeFactory(),
-                        typeFactory,
-                        context.getRexFactory()),
-                FlinkSqlOperatorTable.instance(context.isBatchMode()));
+        List<String> modulesList = getFlinkContext().getModuleManager().listModules();
+        if (modulesList.size() > 0 && !modulesList.get(0).equals("core")) {
+            return SqlOperatorTables.chain(
+                    new FunctionCatalogOperatorTable(
+                            context.getFunctionCatalog(),
+                            context.getCatalogManager().getDataTypeFactory(),
+                            typeFactory,
+                            context.getRexFactory()),
+                    FlinkSqlOperatorTable.instance(context.isBatchMode()));
+        } else {
+            // by default, we should prefer FlinkSqlOperatorTable.
+            return SqlOperatorTables.chain(
+                    FlinkSqlOperatorTable.instance(context.isBatchMode()),
+                    new FunctionCatalogOperatorTable(
+                            context.getFunctionCatalog(),
+                            context.getCatalogManager().getDataTypeFactory(),
+                            typeFactory,
+                            context.getRexFactory()));
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -530,7 +530,7 @@ final class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
                             syntax,
                             foundOperators,
                             SqlNameMatchers.liberal());
-            if (foundOperators.size() != 1) {
+            if (foundOperators.size() < 1) {
                 return Optional.empty();
             }
             return Optional.of(foundOperators.get(0));


### PR DESCRIPTION
## What is the purpose of the change

use modules correctly when deserializing json plan


## Brief change log

fix 2 bug in deserializing json plan:
1. if 2 Operators were found, it will return empty;
2. foundOperators is not ordered by modules order.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *(please describe tests)*.

