### PR TITLE
[FLINK-33759] flink parquet writer support write nested array or map type

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriter.java
@@ -355,9 +355,16 @@ public class ParquetRowDataWriter {
 
         @Override
         public void write(RowData row, int ordinal) {
-            recordConsumer.startGroup();
+            writeMapData(row.getMap(ordinal));
+        }
 
-            MapData mapData = row.getMap(ordinal);
+        @Override
+        public void write(ArrayData arrayData, int ordinal) {
+            writeMapData(arrayData.getMap(ordinal));
+        }
+
+        private void writeMapData(MapData mapData) {
+            recordConsumer.startGroup();
 
             if (mapData != null && mapData.size() > 0) {
                 recordConsumer.startField(repeatedGroupName, 0);
@@ -386,9 +393,6 @@ public class ParquetRowDataWriter {
             }
             recordConsumer.endGroup();
         }
-
-        @Override
-        public void write(ArrayData arrayData, int ordinal) {}
     }
 
     /** It writes an array type field to parquet. */
@@ -412,8 +416,16 @@ public class ParquetRowDataWriter {
 
         @Override
         public void write(RowData row, int ordinal) {
+            writeArrayData(row.getArray(ordinal));
+        }
+
+        @Override
+        public void write(ArrayData arrayData, int ordinal) {
+            writeArrayData(arrayData.getArray(ordinal));
+        }
+
+        private void writeArrayData(ArrayData arrayData) {
             recordConsumer.startGroup();
-            ArrayData arrayData = row.getArray(ordinal);
             int listLength = arrayData.size();
 
             if (listLength > 0) {
@@ -432,9 +444,6 @@ public class ParquetRowDataWriter {
             }
             recordConsumer.endGroup();
         }
-
-        @Override
-        public void write(ArrayData arrayData, int ordinal) {}
     }
 
     /** It writes a row type field to parquet. */

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
@@ -98,6 +98,17 @@ class ParquetRowDataWriterTest {
                             new VarCharType(VarCharType.MAX_LENGTH)),
                     RowType.of(new VarCharType(VarCharType.MAX_LENGTH), new IntType()));
 
+    private static final RowType NESTED_ARRAY_MAP_TYPE =
+            RowType.of(
+                    new IntType(),
+                    new ArrayType(true, new ArrayType(true, new IntType())),
+                    new ArrayType(
+                            true,
+                            new MapType(
+                                    true,
+                                    new VarCharType(VarCharType.MAX_LENGTH),
+                                    new VarCharType(VarCharType.MAX_LENGTH))));
+
     @SuppressWarnings("unchecked")
     private static final DataFormatConverters.DataFormatConverter<RowData, Row> CONVERTER_COMPLEX =
             DataFormatConverters.getConverterForDataType(
@@ -108,6 +119,12 @@ class ParquetRowDataWriterTest {
             DataFormatConverters.getConverterForDataType(
                     TypeConversions.fromLogicalToDataType(ROW_TYPE));
 
+    @SuppressWarnings("unchecked")
+    private static final DataFormatConverters.DataFormatConverter<RowData, Row>
+            NESTED_ARRAY_MAP_CONVERTER =
+                    DataFormatConverters.getConverterForDataType(
+                            TypeConversions.fromLogicalToDataType(NESTED_ARRAY_MAP_TYPE));
+
     @Test
     void testTypes(@TempDir java.nio.file.Path folder) throws Exception {
         Configuration conf = new Configuration();
@@ -115,6 +132,8 @@ class ParquetRowDataWriterTest {
         innerTest(folder, conf, false);
         complexTypeTest(folder, conf, true);
         complexTypeTest(folder, conf, false);
+        nestedArrayAndMapTest(folder, conf, true);
+        nestedArrayAndMapTest(folder, conf, false);
     }
 
     @Test
@@ -125,6 +144,8 @@ class ParquetRowDataWriterTest {
         innerTest(folder, conf, false);
         complexTypeTest(folder, conf, true);
         complexTypeTest(folder, conf, false);
+        nestedArrayAndMapTest(folder, conf, true);
+        nestedArrayAndMapTest(folder, conf, false);
     }
 
     private void innerTest(java.nio.file.Path folder, Configuration conf, boolean utcTimestamp)
@@ -216,6 +237,43 @@ class ParquetRowDataWriterTest {
         assertThat(fileContent).isEqualTo(rows);
     }
 
+    public void nestedArrayAndMapTest(
+            java.nio.file.Path folder, Configuration conf, boolean utcTimestamp) throws Exception {
+        Path path = new Path(folder.toString(), UUID.randomUUID().toString());
+        int number = 1000;
+        List<Row> rows = new ArrayList<>(number);
+
+        for (int i = 0; i < number; i++) {
+            Integer v = i;
+            Map<String, String> mp1 = new HashMap<>();
+            mp1.put(null, "val_" + i);
+            Map<String, String> mp2 = new HashMap<>();
+            mp2.put("key_" + i, null);
+            mp2.put("key@" + i, "val@" + i);
+
+            rows.add(
+                    Row.of(
+                            v,
+                            new Integer[][] {{i, i + 1, null}, {i, i + 2, null}, null},
+                            new Map[] {null, mp1, mp2}));
+        }
+
+        ParquetWriterFactory<RowData> factory =
+                ParquetRowDataBuilder.createWriterFactory(
+                        NESTED_ARRAY_MAP_TYPE, conf, utcTimestamp);
+        BulkWriter<RowData> writer =
+                factory.create(path.getFileSystem().create(path, FileSystem.WriteMode.OVERWRITE));
+        for (int i = 0; i < number; i++) {
+            writer.addElement(NESTED_ARRAY_MAP_CONVERTER.toInternal(rows.get(i)));
+        }
+        writer.flush();
+        writer.finish();
+
+        File file = new File(path.getPath());
+        final List<Row> fileContent = readNestedArrayAndMap(file);
+        assertThat(fileContent).isEqualTo(rows);
+    }
+
     private static List<Row> readParquetFile(File file) throws IOException {
         InputFile inFile =
                 HadoopInputFile.fromPath(
@@ -239,6 +297,70 @@ class ParquetRowDataWriterTest {
                 }
 
                 Row row = Row.of(new Integer[] {c0}, c1, Row.of(c21, c22));
+                results.add(row);
+            }
+        }
+
+        return results;
+    }
+
+    // TODO: If parquet vectorized reader support nested array or map, remove this function
+    private static List<Row> readNestedArrayAndMap(File file) throws IOException {
+        InputFile inFile =
+                HadoopInputFile.fromPath(
+                        new org.apache.hadoop.fs.Path(file.toURI()), new Configuration());
+
+        ArrayList<Row> results = new ArrayList<>();
+        try (ParquetReader<GenericRecord> reader =
+                AvroParquetReader.<GenericRecord>builder(inFile).build()) {
+            GenericRecord next;
+            while ((next = reader.read()) != null) {
+                Integer c0 = (Integer) next.get(0);
+
+                // read array<array<int>>
+                List<Integer[]> nestedArray = new ArrayList<>();
+                ArrayList<GenericData.Record> recordList =
+                        (ArrayList<GenericData.Record>) next.get(1);
+                recordList.forEach(
+                        record -> {
+                            ArrayList<GenericData.Record> origVals =
+                                    (ArrayList<GenericData.Record>) record.get(0);
+                            List<Integer> intArrays = (origVals == null) ? null : new ArrayList<>();
+                            if (origVals != null) {
+                                origVals.forEach(
+                                        r -> {
+                                            intArrays.add((Integer) r.get(0));
+                                        });
+                            }
+                            nestedArray.add(
+                                    origVals == null ? null : intArrays.toArray(new Integer[0]));
+                        });
+
+                // read array<map<String, String>>
+                List<Map<String, String>> nestedMap = new ArrayList<>();
+                recordList = (ArrayList<GenericData.Record>) next.get(2);
+                recordList.forEach(
+                        record -> {
+                            Map<Utf8, Utf8> origMp = (Map<Utf8, Utf8>) record.get(0);
+                            Map<String, String> mp = (origMp == null) ? null : new HashMap<>();
+                            if (origMp != null) {
+                                for (Utf8 key : origMp.keySet()) {
+                                    String k = key == null ? null : key.toString();
+                                    String v =
+                                            origMp.get(key) == null
+                                                    ? null
+                                                    : origMp.get(key).toString();
+                                    mp.put(k, v);
+                                }
+                            }
+                            nestedMap.add(mp);
+                        });
+
+                Row row =
+                        Row.of(
+                                c0,
+                                nestedArray.toArray(new Integer[0][0]),
+                                nestedMap.toArray(new Map[0]));
                 results.add(row);
             }
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

see: [FLINK-33759](https://issues.apache.org/jira/browse/FLINK-33759)


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
