### PR TITLE
[hotfix][test] Migrate JsonRowDeserializationSchemaTest/JsonRowSerializationSchemaTest to Junit5 and Assertj

### DIFF
--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.types.Row;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -32,9 +32,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.flink.connector.testutils.formats.SchemaTestUtils.open;
 import static org.apache.flink.formats.utils.SerializationSchemaMatcher.whenSerializedWith;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link JsonRowSerializationSchema}. */
 public class JsonRowSerializationSchemaTest {
@@ -63,10 +62,11 @@ public class JsonRowSerializationSchemaTest {
                 new JsonRowDeserializationSchema.Builder(rowSchema).build();
 
         assertThat(
-                row,
-                whenSerializedWith(serializationSchema)
-                        .andDeserializedWith(deserializationSchema)
-                        .equalsTo(row));
+                        whenSerializedWith(serializationSchema)
+                                .andDeserializedWith(deserializationSchema)
+                                .equalsTo(row)
+                                .matches(row))
+                .isTrue();
     }
 
     @Test
@@ -88,7 +88,7 @@ public class JsonRowSerializationSchemaTest {
         open(deserializationSchema);
 
         byte[] bytes = serializationSchema.serialize(row1);
-        assertEquals(row1, deserializationSchema.deserialize(bytes));
+        assertThat(deserializationSchema.deserialize(bytes)).isEqualTo(row1);
 
         final Row row2 = new Row(3);
         row2.setField(0, 10);
@@ -96,7 +96,7 @@ public class JsonRowSerializationSchemaTest {
         row2.setField(2, "newStr");
 
         bytes = serializationSchema.serialize(row2);
-        assertEquals(row2, deserializationSchema.deserialize(bytes));
+        assertThat(deserializationSchema.deserialize(bytes)).isEqualTo(row2);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class JsonRowSerializationSchemaTest {
             String json = jsons[i];
             Row row = deserializationSchema.deserialize(json.getBytes());
             String result = new String(serializationSchema.serialize(row));
-            assertEquals(expected[i], result);
+            assertThat(result).isEqualTo(expected[i]);
         }
     }
 
@@ -161,10 +161,11 @@ public class JsonRowSerializationSchemaTest {
                 new JsonRowDeserializationSchema.Builder(rowSchema).build();
 
         assertThat(
-                row,
-                whenSerializedWith(serializationSchema)
-                        .andDeserializedWith(deserializationSchema)
-                        .equalsTo(row));
+                        whenSerializedWith(serializationSchema)
+                                .andDeserializedWith(deserializationSchema)
+                                .equalsTo(row)
+                                .matches(row))
+                .isTrue();
     }
 
     @Test
@@ -179,10 +180,8 @@ public class JsonRowSerializationSchemaTest {
         final JsonRowSerializationSchema serializationSchema =
                 new JsonRowSerializationSchema.Builder(rowSchema).build();
         open(serializationSchema);
-        assertThat(
-                row,
-                whenSerializedWith(serializationSchema)
-                        .failsWithException(instanceOf(RuntimeException.class)));
+        assertThatThrownBy(() -> serializationSchema.serialize(row))
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -242,9 +241,10 @@ public class JsonRowSerializationSchemaTest {
                 new JsonRowDeserializationSchema.Builder(rowSchema).build();
 
         assertThat(
-                row,
-                whenSerializedWith(serializationSchema)
-                        .andDeserializedWith(deserializationSchema)
-                        .equalsTo(row));
+                        whenSerializedWith(serializationSchema)
+                                .andDeserializedWith(deserializationSchema)
+                                .equalsTo(row)
+                                .matches(row))
+                .isTrue();
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When reading the code about json format, I found the test classes `JsonRowDeserializationSchemaTest` and `JsonRowSerializationSchemaTest` are missed to migrate to junit5.

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs
