### PR TITLE
[FLINK-33718][table] Cleanup the usage of deprecated StreamTableEnvironment#toAppendStream

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -895,9 +895,18 @@ class HiveTableSinkITCase {
                                             Types.STRING,
                                             Types.STRING,
                                             Types.STRING));
+                    /*tEnv.createTemporaryView(
+                    "my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));*/
                     tEnv.createTemporaryView(
-                            "my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"));
-
+                            "my_table",
+                            stream,
+                            Schema.newBuilder()
+                                    .column("f0", DataTypes.INT())
+                                    .column("f1", DataTypes.STRING())
+                                    .column("f2", DataTypes.STRING())
+                                    .column("f3", DataTypes.STRING())
+                                    .column("f4", DataTypes.STRING())
+                                    .build());
                     // DDL
                     tEnv.executeSql(
                             "create external table sink_table (a int,b string,c string"

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSin
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -146,7 +147,11 @@ public class StreamSQLTestProgram {
         Table result = tEnv.sqlQuery(finalAgg);
         // convert Table into append-only DataStream
         DataStream<Row> resultStream =
-                tEnv.toAppendStream(result, Types.ROW(Types.INT, Types.SQL_TIMESTAMP));
+                tEnv.toDataStream(
+                        result,
+                        DataTypes.ROW(
+                                DataTypes.INT(),
+                                DataTypes.TIMESTAMP().bridgedTo(java.sql.Timestamp.class)));
 
         final StreamingFileSink<Row> sink =
                 StreamingFileSink.forRowFormat(

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
@@ -61,9 +61,10 @@ public class ProtobufTestHelper {
         Table table = tableEnv.fromDataStream(rows);
         tableEnv.createTemporaryView("t", table);
         table = tableEnv.sqlQuery("select * from t");
-        List<RowData> resultRows =
-                tableEnv.toAppendStream(table, InternalTypeInfo.of(rowType)).executeAndCollect(1);
-        return resultRows.get(0);
+        List<Object> resultRows =
+                tableEnv.toDataStream(table, InternalTypeInfo.of(rowType).getDataType())
+                        .executeAndCollect(1);
+        return (RowData) resultRows.get(0);
     }
 
     public static byte[] rowToPbBytes(RowData row, Class messageClass) throws Exception {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.runtime.operators.python.scalar;
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -33,6 +32,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.python.PythonEnv;
@@ -224,7 +224,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
         DataStream<Tuple2<Integer, Integer>> ds = env.fromData(new Tuple2<>(1, 2));
         Table t = tEnv.fromDataStream(ds, $("a"), $("b")).select(call("pyFunc", $("a"), $("b")));
         // force generating the physical plan for the given table
-        tEnv.toAppendStream(t, BasicTypeInfo.INT_TYPE_INFO);
+        tEnv.toDataStream(t, DataTypes.INT());
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
         List<JobVertex> vertices = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertThat(vertices).hasSize(1);

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
@@ -54,7 +54,7 @@ class StreamTableEnvironmentImplTest {
         Duration minRetention = Duration.ofMinutes(1);
         tEnv.getConfig().setIdleStateRetention(minRetention);
         Table table = tEnv.fromDataStream(elements);
-        tEnv.toDataStream(table, Row.class);
+        tEnv.toDataStream(table);
 
         assertThat(tEnv.getConfig().getIdleStateRetention()).isEqualTo(minRetention);
     }

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
@@ -54,7 +54,7 @@ class StreamTableEnvironmentImplTest {
         Duration minRetention = Duration.ofMinutes(1);
         tEnv.getConfig().setIdleStateRetention(minRetention);
         Table table = tEnv.fromDataStream(elements);
-        tEnv.toAppendStream(table, Row.class);
+        tEnv.toDataStream(table, Row.class);
 
         assertThat(tEnv.getConfig().getIdleStateRetention()).isEqualTo(minRetention);
     }

--- a/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImplTest.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/test/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImplTest.scala
@@ -45,7 +45,7 @@ class StreamTableEnvironmentImplTest {
     val retention = Duration.ofMinutes(1)
     tEnv.getConfig.setIdleStateRetention(retention)
     val table = tEnv.fromDataStream(elements)
-    tEnv.toAppendStream[Row](table)
+    tEnv.toDataStream(table)
 
     assertThat(tEnv.getConfig.getMinIdleStateRetentionTime).isEqualTo(retention.toMillis)
     assertThat(tEnv.getConfig.getMaxIdleStateRetentionTime).isEqualTo(retention.toMillis * 3 / 2)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.catalog.CatalogStore;
 import org.apache.flink.table.catalog.GenericInMemoryCatalogStore;
 import org.apache.flink.table.catalog.listener.CatalogListener1;
 import org.apache.flink.table.catalog.listener.CatalogListener2;
-import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +65,7 @@ class EnvironmentTest {
 
         // trigger translation
         Table table = tEnv.sqlQuery("SELECT * FROM test");
-        tEnv.toDataStream(table, Row.class);
+        tEnv.toDataStream(table);
 
         assertThat(env.getParallelism()).isEqualTo(128);
         assertThat(env.getConfig().getAutoWatermarkInterval()).isEqualTo(800);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
@@ -66,7 +66,7 @@ class EnvironmentTest {
 
         // trigger translation
         Table table = tEnv.sqlQuery("SELECT * FROM test");
-        tEnv.toAppendStream(table, Row.class);
+        tEnv.toDataStream(table, Row.class);
 
         assertThat(env.getParallelism()).isEqualTo(128);
         assertThat(env.getConfig().getAutoWatermarkInterval()).isEqualTo(800);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -202,7 +202,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
     checkEmptyFile(sink1Path)
 
     val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
-    val resultSet = streamTableEnv.toDataStream(table, classOf[Row])
+    val resultSet = streamTableEnv.toDataStream(table)
     val sink = new TestingAppendSink
     resultSet.addSink(sink)
 
@@ -236,7 +236,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
     checkEmptyFile(sink1Path)
 
     val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
-    val resultSet = streamTableEnv.toDataStream(table, classOf[Row])
+    val resultSet = streamTableEnv.toDataStream(table)
     val sink = new TestingAppendSink
     resultSet.addSink(sink)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -202,7 +202,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
     checkEmptyFile(sink1Path)
 
     val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
-    val resultSet = streamTableEnv.toAppendStream(table, classOf[Row])
+    val resultSet = streamTableEnv.toDataStream(table, classOf[Row])
     val sink = new TestingAppendSink
     resultSet.addSink(sink)
 
@@ -236,7 +236,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
     checkEmptyFile(sink1Path)
 
     val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
-    val resultSet = streamTableEnv.toAppendStream(table, classOf[Row])
+    val resultSet = streamTableEnv.toDataStream(table, classOf[Row])
     val sink = new TestingAppendSink
     resultSet.addSink(sink)
 
@@ -281,7 +281,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
     checkEmptyFile(sink1Path)
 
     val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
-    val resultSet = streamTableEnv.toAppendStream[Row](table)
+    val resultSet = streamTableEnv.toDataStream(table)
     val sink = new TestingAppendSink
     resultSet.addSink(sink)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/OverWindowValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/OverWindowValidationTest.scala
@@ -43,7 +43,7 @@ class OverWindowValidationTest extends TableTestBase {
       "from T1"
 
     assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => streamUtil.tableEnv.sqlQuery(sqlQuery).toAppendStream[Row])
+      .isThrownBy(() => streamUtil.tableEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]))
   }
 
   /** OVER clause is necessary for [[OverAgg0]] window function. */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/OverWindowValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/OverWindowValidationTest.scala
@@ -43,7 +43,7 @@ class OverWindowValidationTest extends TableTestBase {
       "from T1"
 
     assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => streamUtil.tableEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]))
+      .isThrownBy(() => streamUtil.tableEnv.sqlQuery(sqlQuery).toDataStream)
   }
 
   /** OVER clause is necessary for [[OverAgg0]] window function. */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/AggregateValidationTest.scala
@@ -153,8 +153,7 @@ class AggregateValidationTest extends TableTestBase {
       sql: String,
       keywords: String,
       clazz: Class[_ <: Throwable] = classOf[ValidationException]): Unit = {
-    val callable: ThrowingCallable = () =>
-      util.tableEnv.toAppendStream[Row](util.tableEnv.sqlQuery(sql))
+    val callable: ThrowingCallable = () => util.tableEnv.toDataStream(util.tableEnv.sqlQuery(sql))
     if (keywords != null) {
       assertThatExceptionOfType(clazz)
         .isThrownBy(callable)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/LegacyTableSinkValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/LegacyTableSinkValidationTest.scala
@@ -44,7 +44,7 @@ class LegacyTableSinkValidationTest extends TableTestBase {
         () => {
           t.groupBy('text)
             .select('text, 'id.count, 'num.sum)
-            .toDataStream(classOf[Row])
+            .toDataStream
             .addSink(new TestingAppendSink)
           env.execute()
         })
@@ -93,7 +93,7 @@ class LegacyTableSinkValidationTest extends TableTestBase {
           ds1
             .leftOuterJoin(ds2, 'a === 'd && 'b === 'h)
             .select('c, 'g)
-            .toDataStream(classOf[Row])
+            .toDataStream
             .addSink(new TestingAppendSink)
           env.execute()
         })

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/LegacyTableSinkValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/LegacyTableSinkValidationTest.scala
@@ -44,7 +44,7 @@ class LegacyTableSinkValidationTest extends TableTestBase {
         () => {
           t.groupBy('text)
             .select('text, 'id.count, 'num.sum)
-            .toAppendStream[Row]
+            .toDataStream(classOf[Row])
             .addSink(new TestingAppendSink)
           env.execute()
         })
@@ -93,7 +93,7 @@ class LegacyTableSinkValidationTest extends TableTestBase {
           ds1
             .leftOuterJoin(ds2, 'a === 'd && 'b === 'h)
             .select('c, 'g)
-            .toAppendStream[Row]
+            .toDataStream(classOf[Row])
             .addSink(new TestingAppendSink)
           env.execute()
         })

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/SetOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/SetOperatorsValidationTest.scala
@@ -44,7 +44,7 @@ class SetOperatorsValidationTest extends TableTestBase {
       .isThrownBy(
         () => {
           val unionDs = ds1.unionAll(ds2)
-          unionDs.toAppendStream[Row].addSink(sink)
+          unionDs.toDataStream(classOf[Row]).addSink(sink)
           env.execute()
         })
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -67,7 +67,7 @@ class SetOperatorsValidationTest extends TableTestBase {
       .isThrownBy(
         () => {
           val unionDs = ds1.unionAll(ds2)
-          unionDs.toAppendStream[Row].addSink(sink)
+          unionDs.toDataStream(classOf[Row]).addSink(sink)
           env.execute()
         })
     assertThat(sink.getAppendResults.isEmpty).isTrue

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/SetOperatorsValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/SetOperatorsValidationTest.scala
@@ -44,7 +44,7 @@ class SetOperatorsValidationTest extends TableTestBase {
       .isThrownBy(
         () => {
           val unionDs = ds1.unionAll(ds2)
-          unionDs.toDataStream(classOf[Row]).addSink(sink)
+          unionDs.toDataStream.addSink(sink)
           env.execute()
         })
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -67,7 +67,7 @@ class SetOperatorsValidationTest extends TableTestBase {
       .isThrownBy(
         () => {
           val unionDs = ds1.unionAll(ds2)
-          unionDs.toDataStream(classOf[Row]).addSink(sink)
+          unionDs.toDataStream.addSink(sink)
           env.execute()
         })
     assertThat(sink.getAppendResults.isEmpty).isTrue

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/pojos.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/pojos.scala
@@ -41,7 +41,7 @@ class MyPojo() {
 }
 
 class NonPojo {
-  val x = new java.util.HashMap[String, String]()
+  var x = new java.util.HashMap[String, String]()
 
   override def toString: String = x.toString
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
@@ -140,7 +140,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val outputType = Array(
       DataTypes.BIGINT().getLogicalType,
       DataTypes.STRING().getLogicalType,
@@ -174,7 +174,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -277,7 +277,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -367,7 +367,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -465,7 +465,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -592,7 +592,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -714,7 +714,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/OverAggregateHarnessTest.scala
@@ -140,7 +140,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val outputType = Array(
       DataTypes.BIGINT().getLogicalType,
       DataTypes.STRING().getLogicalType,
@@ -174,7 +174,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -277,7 +277,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -367,7 +367,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -465,7 +465,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -592,7 +592,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,
@@ -714,7 +714,7 @@ class OverAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(m
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "OverAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "OverAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.BIGINT().getLogicalType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -161,7 +161,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val outputTypes =
       Array(
@@ -194,7 +194,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(
@@ -328,7 +328,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(
@@ -509,7 +509,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val stream: DataStream[Row] = t1.toDataStream(classOf[Row])
+    val stream: DataStream[Row] = t1.toDataStream
 
     val testHarness = createHarnessTesterForNoState(stream, "LocalWindowAggregate")
     // window aggregate put window properties at the end of aggs

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -161,7 +161,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val outputTypes =
       Array(
@@ -194,7 +194,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(
@@ -328,7 +328,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(
@@ -509,7 +509,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val stream: DataStream[Row] = t1.toAppendStream[Row]
+    val stream: DataStream[Row] = t1.toDataStream(classOf[Row])
 
     val testHarness = createHarnessTesterForNoState(stream, "LocalWindowAggregate")
     // window aggregate put window properties at the end of aggs

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateUseDaylightTimeHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateUseDaylightTimeHarnessTest.scala
@@ -92,7 +92,7 @@ class WindowAggregateUseDaylightTimeHarnessTest(backend: StateBackendMode, timeZ
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream, "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateUseDaylightTimeHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateUseDaylightTimeHarnessTest.scala
@@ -92,7 +92,7 @@ class WindowAggregateUseDaylightTimeHarnessTest(backend: StateBackendMode, timeZ
         |GROUP BY `name`, window_start, window_end
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTester(t1.toAppendStream[Row], "WindowAggregate")
+    val testHarness = createHarnessTester(t1.toDataStream(classOf[Row]), "WindowAggregate")
     // window aggregate put window properties at the end of aggs
     val assertor = new RowDataHarnessAssertor(
       Array(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowTableFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowTableFunctionHarnessTest.scala
@@ -91,7 +91,7 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
     val testHarness =
-      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
+      createHarnessTesterForNoState(t1.toDataStream, "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)
@@ -209,7 +209,7 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
     val testHarness =
-      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
+      createHarnessTesterForNoState(t1.toDataStream, "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)
@@ -427,7 +427,7 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
     val testHarness =
-      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
+      createHarnessTesterForNoState(t1.toDataStream, "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowTableFunctionHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowTableFunctionHarnessTest.scala
@@ -90,7 +90,8 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
         |FROM TABLE(TUMBLE(TABLE T1, DESCRIPTOR(proctime), INTERVAL '5' SECOND))
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTesterForNoState(t1.toAppendStream[Row], "WindowTableFunction")
+    val testHarness =
+      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)
@@ -207,7 +208,8 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
         |  HOP(TABLE T1, DESCRIPTOR(proctime), INTERVAL '5' SECOND, INTERVAL '10' SECOND))
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTesterForNoState(t1.toAppendStream[Row], "WindowTableFunction")
+    val testHarness =
+      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)
@@ -424,7 +426,8 @@ class WindowTableFunctionHarnessTest(backend: StateBackendMode, shiftTimeZone: Z
         |  CUMULATE(TABLE T1, DESCRIPTOR(proctime), INTERVAL '5' SECOND, INTERVAL '15' SECOND))
       """.stripMargin
     val t1 = tEnv.sqlQuery(sql)
-    val testHarness = createHarnessTesterForNoState(t1.toAppendStream[Row], "WindowTableFunction")
+    val testHarness =
+      createHarnessTesterForNoState(t1.toDataStream(classOf[Row]), "WindowTableFunction")
 
     testHarness.open()
     ingestData(testHarness)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.table.api.{DataTypes, Schema}
 import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.data.TimestampData
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
@@ -169,7 +170,18 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
 
     resultPath = TempDirUtils.newFolder(tempFolder).toURI.toString
 
-    tEnv.createTemporaryView("my_table", dataStream, $("a"), $("b"), $("c"), $("d"), $("e"))
+    tEnv.createTemporaryView(
+      "my_table",
+      dataStream,
+      Schema
+        .newBuilder()
+        .column("f0", DataTypes.INT())
+        .column("f1", DataTypes.STRING())
+        .column("f2", DataTypes.STRING())
+        .column("f3", DataTypes.STRING())
+        .column("f4", DataTypes.STRING())
+        .build()
+    )
 
     val ddl =
       s"""

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -181,7 +181,7 @@ class AsyncLookupJoinITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -194,7 +194,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -207,7 +207,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -220,7 +220,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22", "3,15,Fabian,Fabian,33")
@@ -235,7 +235,7 @@ class AsyncLookupJoinITCase(
       "WHERE T.id > 1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -252,7 +252,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -269,7 +269,7 @@ class AsyncLookupJoinITCase(
       "ON mod1(T.id, 4) = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -285,7 +285,7 @@ class AsyncLookupJoinITCase(
       "WHERE add(T.id, D.id) > 3 AND add(T.id, 2) > 3 AND add (D.id, 2) > 3"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -348,7 +348,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -365,7 +365,7 @@ class AsyncLookupJoinITCase(
       "where errorFunc(D.name) > cast(1000 as decimal(10,4))" // should exception here
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
 
     assertThatThrownBy(() => env.execute())
       .satisfies(anyCauseMatches(classOf[NumberFormatException], "Cannot parse"))
@@ -400,7 +400,7 @@ class AsyncLookupJoinITCase(
           |ON T.id = D.id
           |""".stripMargin
       val sink = new TestingAppendSink
-      tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+      tEnv.sqlQuery(sql).toDataStream.addSink(sink)
       env.execute()
 
       // Validate that only one cache is registered
@@ -447,7 +447,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 
@@ -466,7 +466,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table_with_lookup_threshold3 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 
@@ -496,7 +496,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -181,7 +181,7 @@ class AsyncLookupJoinITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -194,7 +194,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -207,7 +207,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -220,7 +220,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22", "3,15,Fabian,Fabian,33")
@@ -235,7 +235,7 @@ class AsyncLookupJoinITCase(
       "WHERE T.id > 1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -252,7 +252,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -269,7 +269,7 @@ class AsyncLookupJoinITCase(
       "ON mod1(T.id, 4) = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -285,7 +285,7 @@ class AsyncLookupJoinITCase(
       "WHERE add(T.id, D.id) > 3 AND add(T.id, 2) > 3 AND add (D.id, 2) > 3"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -348,7 +348,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -365,7 +365,7 @@ class AsyncLookupJoinITCase(
       "where errorFunc(D.name) > cast(1000 as decimal(10,4))" // should exception here
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
 
     assertThatThrownBy(() => env.execute())
       .satisfies(anyCauseMatches(classOf[NumberFormatException], "Cannot parse"))
@@ -400,7 +400,7 @@ class AsyncLookupJoinITCase(
           |ON T.id = D.id
           |""".stripMargin
       val sink = new TestingAppendSink
-      tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+      tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
       env.execute()
 
       // Validate that only one cache is registered
@@ -447,7 +447,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 
@@ -466,7 +466,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table_with_lookup_threshold3 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 
@@ -496,7 +496,7 @@ class AsyncLookupJoinITCase(
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -61,7 +61,7 @@ class CalcITCase extends StreamingTestBase {
 
     val result = tEnv
       .sqlQuery("SELECT CASE WHEN true THEN CAST(2 AS INT) ELSE CAST('2017-12-11' AS DATE) END")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -101,9 +101,9 @@ class CalcITCase extends StreamingTestBase {
 
     val outputType = InternalTypeInfo.ofFields(new IntType(), new BooleanType())
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[RowData]
+    val result = tEnv.sqlQuery(sqlQuery)
     val sink = new TestingAppendRowDataSink(outputType)
-    result.addSink(sink)
+    tEnv.toDataStream(result, outputType.getDataType).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -136,9 +136,9 @@ class CalcITCase extends StreamingTestBase {
 
     val outputType = InternalTypeInfo.ofFields(new IntType(), new IntType(), new BigIntType())
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[RowData]
+    val result = tEnv.sqlQuery(sqlQuery)
     val sink = new TestingAppendRowDataSink(outputType)
-    result.addSink(sink)
+    tEnv.toDataStream(result, outputType.getDataType).addSink(sink)
     env.execute()
 
     val expected = List("+I(1,1,1)")
@@ -164,9 +164,9 @@ class CalcITCase extends StreamingTestBase {
     val outputType =
       InternalTypeInfo.ofFields(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE, new IntType())
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[RowData]
+    val result = tEnv.sqlQuery(sqlQuery)
     val sink = new TestingAppendRowDataSink(outputType)
-    result.addSink(sink)
+    tEnv.toDataStream(result, outputType.getDataType).addSink(sink)
     env.execute()
 
     val expected = List("+I(Hello,Worlds,1)", "+I(Hello again,Worlds,2)")
@@ -194,7 +194,7 @@ class CalcITCase extends StreamingTestBase {
     val t = ds.toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -219,7 +219,7 @@ class CalcITCase extends StreamingTestBase {
     val t = ds.toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -237,7 +237,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -255,7 +255,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -297,7 +297,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTable", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -335,7 +335,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTable", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -358,7 +358,7 @@ class CalcITCase extends StreamingTestBase {
       .mkString(",")
     val sqlQuery = s"select $selectList from MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -451,7 +451,7 @@ class CalcITCase extends StreamingTestBase {
        """.stripMargin
     tEnv.executeSql(ddl)
 
-    val result = tEnv.sqlQuery("select a, c from SimpleTable").toAppendStream[Row]
+    val result = tEnv.sqlQuery("select a, c from SimpleTable").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -494,7 +494,7 @@ class CalcITCase extends StreamingTestBase {
         |    deepNested.nested2.num AS nestedNum
         |from NestedTable
         |""".stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -508,7 +508,7 @@ class CalcITCase extends StreamingTestBase {
   def testDecimalArrayWithDifferentPrecision(): Unit = {
     val sqlQuery = "SELECT ARRAY[0.12, 0.5, 0.99]"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -521,7 +521,7 @@ class CalcITCase extends StreamingTestBase {
   def testDecimalMapWithDifferentPrecision(): Unit = {
     val sqlQuery = "SELECT Map['a', 0.12, 'b', 0.5]"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -701,7 +701,7 @@ class CalcITCase extends StreamingTestBase {
         |'DH-9908N'
         |)
         |""".stripMargin
-    val result = tEnv.sqlQuery(sql).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sql).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -778,7 +778,7 @@ class CalcITCase extends StreamingTestBase {
       .sqlQuery("""
                   | SELECT * FROM MyTable WHERE b LIKE '%"%'
                   |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -802,9 +802,9 @@ class CalcITCase extends StreamingTestBase {
                    |  ) t1
                    |) t2
                    |""".stripMargin)
-      .toAppendStream[Row]
+
     val sink = new TestingAppendSink
-    result.addSink(sink)
+    tEnv.toDataStream(result, DataTypes.ROW(DataTypes.DOUBLE())).addSink(sink)
     env.execute()
 
     val expected = List("2.0", "2.0", "2.0")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -61,7 +61,7 @@ class CalcITCase extends StreamingTestBase {
 
     val result = tEnv
       .sqlQuery("SELECT CASE WHEN true THEN CAST(2 AS INT) ELSE CAST('2017-12-11' AS DATE) END")
-      .toDataStream(classOf[Row])
+      .toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -194,7 +194,7 @@ class CalcITCase extends StreamingTestBase {
     val t = ds.toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -219,7 +219,7 @@ class CalcITCase extends StreamingTestBase {
     val t = ds.toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -237,7 +237,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -255,7 +255,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTableRow", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -297,7 +297,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTable", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -335,7 +335,7 @@ class CalcITCase extends StreamingTestBase {
       .toTable(tEnv, 'a, 'b, 'c)
     tEnv.createTemporaryView("MyTable", t)
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -358,7 +358,7 @@ class CalcITCase extends StreamingTestBase {
       .mkString(",")
     val sqlQuery = s"select $selectList from MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -451,7 +451,7 @@ class CalcITCase extends StreamingTestBase {
        """.stripMargin
     tEnv.executeSql(ddl)
 
-    val result = tEnv.sqlQuery("select a, c from SimpleTable").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("select a, c from SimpleTable").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -494,7 +494,7 @@ class CalcITCase extends StreamingTestBase {
         |    deepNested.nested2.num AS nestedNum
         |from NestedTable
         |""".stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -508,7 +508,7 @@ class CalcITCase extends StreamingTestBase {
   def testDecimalArrayWithDifferentPrecision(): Unit = {
     val sqlQuery = "SELECT ARRAY[0.12, 0.5, 0.99]"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -521,7 +521,7 @@ class CalcITCase extends StreamingTestBase {
   def testDecimalMapWithDifferentPrecision(): Unit = {
     val sqlQuery = "SELECT Map['a', 0.12, 'b', 0.5]"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -701,7 +701,7 @@ class CalcITCase extends StreamingTestBase {
         |'DH-9908N'
         |)
         |""".stripMargin
-    val result = tEnv.sqlQuery(sql).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sql).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -778,7 +778,7 @@ class CalcITCase extends StreamingTestBase {
       .sqlQuery("""
                   | SELECT * FROM MyTable WHERE b LIKE '%"%'
                   |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
@@ -70,7 +70,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("1,abc", "1,abc", "1,bcd", "1,bcd", "1,hhh", "1,hhh", "1,xxx", "1,xxx")
@@ -82,7 +82,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM LATERAL TABLE(str_split()) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("a", "b", "c")
@@ -94,7 +94,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM LATERAL TABLE(str_split('Jack,John', ',')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("Jack", "John")
@@ -111,7 +111,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM T1, LATERAL TABLE(str_split('Jack,John', ',')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -129,7 +129,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new NonDeterministicTableFunc())
     val query = "SELECT * FROM LATERAL TABLE(str_split('Jack#John')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val res = sink.getAppendResults
@@ -147,7 +147,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new NonDeterministicTableFunc())
     val query = "SELECT * FROM T1, LATERAL TABLE(str_split('Jack#John')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val res = sink.getAppendResults
@@ -172,7 +172,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query1).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query1).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("1,abc", "1,bcd", "1,hhh", "1,xxx")
@@ -196,14 +196,14 @@ class CorrelateITCase extends StreamingTestBase {
                               |SELECT a, b, s
                               |FROM T1, LATERAL TABLE(str_split(c, ',')) as T2(s)
        """.stripMargin)
-    t1.toDataStream(classOf[Row]).addSink(sink1)
+    t1.toDataStream.addSink(sink1)
 
     // correlate 2
     val t2 = tEnv.sqlQuery(s"""
                               |SELECT a, c, s
                               |FROM T1, LATERAL TABLE(str_split(b, ',')) as T3(s)
       """.stripMargin)
-    t2.toDataStream(classOf[Row]).addSink(sink2)
+    t2.toDataStream.addSink(sink2)
 
     env.execute()
 
@@ -230,7 +230,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("tfFunc", new TableFunc7)
     tEnv
       .sqlQuery("SELECT rfFunc(a) as d, e FROM MyTable, LATERAL TABLE(tfFunc(rfFunc(a))) as T(e)")
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
 
     env.execute()
@@ -255,7 +255,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("1,3018-06-10")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
@@ -70,7 +70,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("1,abc", "1,abc", "1,bcd", "1,bcd", "1,hhh", "1,hhh", "1,xxx", "1,xxx")
@@ -82,7 +82,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM LATERAL TABLE(str_split()) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("a", "b", "c")
@@ -94,7 +94,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM LATERAL TABLE(str_split('Jack,John', ',')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("Jack", "John")
@@ -111,7 +111,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new StringSplit())
     val query = "SELECT * FROM T1, LATERAL TABLE(str_split('Jack,John', ',')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -129,7 +129,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new NonDeterministicTableFunc())
     val query = "SELECT * FROM LATERAL TABLE(str_split('Jack#John')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val res = sink.getAppendResults
@@ -147,7 +147,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("str_split", new NonDeterministicTableFunc())
     val query = "SELECT * FROM T1, LATERAL TABLE(str_split('Jack#John')) as T0(d)"
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val res = sink.getAppendResults
@@ -172,7 +172,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query1).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query1).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("1,abc", "1,bcd", "1,hhh", "1,xxx")
@@ -196,14 +196,14 @@ class CorrelateITCase extends StreamingTestBase {
                               |SELECT a, b, s
                               |FROM T1, LATERAL TABLE(str_split(c, ',')) as T2(s)
        """.stripMargin)
-    t1.toAppendStream[Row].addSink(sink1)
+    t1.toDataStream(classOf[Row]).addSink(sink1)
 
     // correlate 2
     val t2 = tEnv.sqlQuery(s"""
                               |SELECT a, c, s
                               |FROM T1, LATERAL TABLE(str_split(b, ',')) as T3(s)
       """.stripMargin)
-    t2.toAppendStream[Row].addSink(sink2)
+    t2.toDataStream(classOf[Row]).addSink(sink2)
 
     env.execute()
 
@@ -230,7 +230,7 @@ class CorrelateITCase extends StreamingTestBase {
     tEnv.createTemporarySystemFunction("tfFunc", new TableFunc7)
     tEnv
       .sqlQuery("SELECT rfFunc(a) as d, e FROM MyTable, LATERAL TABLE(tfFunc(rfFunc(a))) as T(e)")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
 
     env.execute()
@@ -255,7 +255,7 @@ class CorrelateITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("1,3018-06-10")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
@@ -68,7 +68,7 @@ class FilterableSourceITCase extends StreamingTestBase {
     val query = "SELECT * FROM MyTable WHERE a > 1"
     val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
 
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink()
     result.addSink(sink)
 
@@ -108,7 +108,7 @@ class FilterableSourceITCase extends StreamingTestBase {
     val query = "SELECT * FROM MyTable WHERE a > 1"
     val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
 
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink()
     result.addSink(sink)
 
@@ -148,7 +148,7 @@ class FilterableSourceITCase extends StreamingTestBase {
         .sqlQuery(
           "select a,b from TableWithWatermark WHERE LOWER(c) = 'world'"
         )
-        .toDataStream(classOf[Row])
+        .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
@@ -68,7 +68,7 @@ class FilterableSourceITCase extends StreamingTestBase {
     val query = "SELECT * FROM MyTable WHERE a > 1"
     val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
 
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink()
     result.addSink(sink)
 
@@ -108,7 +108,7 @@ class FilterableSourceITCase extends StreamingTestBase {
     val query = "SELECT * FROM MyTable WHERE a > 1"
     val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
 
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink()
     result.addSink(sink)
 
@@ -148,7 +148,7 @@ class FilterableSourceITCase extends StreamingTestBase {
         .sqlQuery(
           "select a,b from TableWithWatermark WHERE LOWER(c) = 'world'"
         )
-        .toAppendStream[Row]
+        .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
@@ -111,7 +111,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -159,7 +159,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("9")
@@ -220,7 +220,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         | GROUP BY 'a', TUMBLE(rowtime, INTERVAL '0.003' SECOND)
       """.stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "1970-01-01T00:00:00.003,2",
@@ -308,7 +308,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -421,7 +421,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY currency, TUMBLE(currency_time, INTERVAL '5' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "US Dollar,1,102,1970-01-01T00:00,1970-01-01T00:00:05",
@@ -508,7 +508,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY TUMBLE(currency_time, INTERVAL '5' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected =
       Seq("1970-01-01T00:00,1970-01-01T00:00:05,702", "1970-01-01T00:00:15,1970-01-01T00:00:20,118")
@@ -537,7 +537,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY `string`, TUMBLE(rowtime, INTERVAL '0.005' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hi,1970-01-01T00:00,1970-01-01T00:00:00.005,1",
@@ -579,7 +579,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY c, SESSION(rowtime, INTERVAL '0.005' SECOND)
       """.stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
@@ -111,7 +111,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -159,7 +159,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("9")
@@ -220,7 +220,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         | GROUP BY 'a', TUMBLE(rowtime, INTERVAL '0.003' SECOND)
       """.stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "1970-01-01T00:00:00.003,2",
@@ -308,7 +308,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -421,7 +421,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY currency, TUMBLE(currency_time, INTERVAL '5' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "US Dollar,1,102,1970-01-01T00:00,1970-01-01T00:00:05",
@@ -508,7 +508,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY TUMBLE(currency_time, INTERVAL '5' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
     val expected =
       Seq("1970-01-01T00:00,1970-01-01T00:00:05,702", "1970-01-01T00:00:15,1970-01-01T00:00:20,118")
@@ -537,7 +537,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY `string`, TUMBLE(rowtime, INTERVAL '0.005' SECOND)
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hi,1970-01-01T00:00,1970-01-01T00:00:00.005,1",
@@ -579,7 +579,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY c, SESSION(rowtime, INTERVAL '0.005' SECOND)
       """.stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
@@ -76,7 +76,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
   }
@@ -119,7 +119,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
   }
@@ -162,7 +162,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -212,7 +212,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -267,7 +267,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -322,7 +322,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -447,7 +447,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -515,7 +515,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -567,7 +567,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -620,7 +620,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
 
     val sink = new TestingAppendSink
     val t_r = tEnv.sqlQuery(sqlQuery)
-    val result = t_r.toDataStream(classOf[Row])
+    val result = t_r.toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -673,7 +673,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -718,7 +718,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -769,7 +769,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -825,7 +825,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -868,7 +868,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -916,7 +916,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -969,7 +969,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -1012,7 +1012,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
   }
@@ -1060,7 +1060,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -1115,7 +1115,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
@@ -76,7 +76,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
   }
@@ -119,7 +119,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
   }
@@ -162,7 +162,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -212,7 +212,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -267,7 +267,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -322,7 +322,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
@@ -447,7 +447,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -515,7 +515,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -567,7 +567,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -620,7 +620,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
 
     val sink = new TestingAppendSink
     val t_r = tEnv.sqlQuery(sqlQuery)
-    val result = t_r.toAppendStream[Row]
+    val result = t_r.toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -673,7 +673,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -718,7 +718,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -769,7 +769,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -825,7 +825,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -868,7 +868,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -916,7 +916,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList[String](
@@ -969,7 +969,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -1012,7 +1012,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
   }
@@ -1060,7 +1060,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -1115,7 +1115,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T2", t2)
 
     val sink = new TestingAppendSink
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -217,7 +217,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -270,7 +270,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -306,7 +306,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT b, c, e, g FROM ds1 JOIN ds2 ON b = e"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
@@ -493,7 +493,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -217,7 +217,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -270,7 +270,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -306,7 +306,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT b, c, e, g FROM ds1 JOIN ds2 ON b = e"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
@@ -493,7 +493,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
@@ -66,7 +66,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT name, val, id FROM T").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT name, val, id FROM T").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -104,7 +104,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT rtime, name, id FROM T").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT rtime, name, id FROM T").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -147,7 +147,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime"))
 
     val sqlQuery = "SELECT name, id FROM T"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -185,7 +185,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime"))
 
     val sqlQuery = "SELECT COUNT(1) FROM T WHERE ptime > 0"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -223,7 +223,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT rtime FROM T").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT rtime FROM T").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -267,7 +267,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime",
           mapping))
 
-    val result = tEnv.sqlQuery("SELECT name, rtime, val FROM T").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT name, rtime, val FROM T").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -344,7 +344,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
         |    deepNested.nested2.num AS nestedNum
         |FROM T
       """.stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -362,7 +362,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       "MyTable")
 
     val sqlQuery = "SELECT id, name FROM MyTable WHERE amount > 4 AND price < 9"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -376,7 +376,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     TestPartitionableSourceFactory.createTemporaryTable(tEnv, "PartitionableTable", true)
 
     val sqlQuery = "SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A'"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -391,7 +391,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     val sink = new TestingAppendSink()
     tEnv
       .sqlQuery("SELECT id, `first`, `last`, score FROM persons WHERE id < 4 ")
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
 
     env.execute()
@@ -415,7 +415,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
 
     env.execute()
 
@@ -441,7 +441,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       TestData.smallData3,
       "MyInputFormatTable")
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream.addSink(sink)
 
     env.execute()
 
@@ -473,7 +473,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     val sink = new TestingAppendSink()
     tEnv
       .sqlQuery("SELECT a, b, c, d FROM MyInputFormatTable")
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
 
     env.execute()
@@ -508,7 +508,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
 
     TestStreamTableSource.createTemporaryTable(tEnv, tableSchema, "MyInputFormatTable", data)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery("SELECT a, b, c FROM MyInputFormatTable").toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery("SELECT a, b, c FROM MyInputFormatTable").toDataStream.addSink(sink)
 
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LegacyTableSourceITCase.scala
@@ -66,7 +66,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT name, val, id FROM T").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT name, val, id FROM T").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -104,7 +104,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT rtime, name, id FROM T").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT rtime, name, id FROM T").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -147,7 +147,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime"))
 
     val sqlQuery = "SELECT name, id FROM T"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -185,7 +185,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime"))
 
     val sqlQuery = "SELECT COUNT(1) FROM T WHERE ptime > 0"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -194,6 +194,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     assertThat(sink.getAppendResults.sorted).isEqualTo(expected.sorted)
   }
 
+  @Test
   def testProjectOnlyRowtime(): Unit = {
     val data = Seq(
       Row.of(new JInt(1), new JLong(1), new JLong(10L), "Mary"),
@@ -222,16 +223,16 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "rtime",
           "ptime"))
 
-    val result = tEnv.sqlQuery("SELECT rtime FROM T").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT rtime FROM T").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
 
     val expected = Seq(
-      "1970-01-01 00:00:00.001",
-      "1970-01-01 00:00:00.002",
-      "1970-01-01 00:00:00.002",
-      "1970-01-01 00:00:02.001")
+      "1970-01-01T00:00:00.001",
+      "1970-01-01T00:00:00.002",
+      "1970-01-01T00:00:00.002",
+      "1970-01-01T00:00:02.001")
     assertThat(sink.getAppendResults.sorted).isEqualTo(expected.sorted)
   }
 
@@ -266,7 +267,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
           "ptime",
           mapping))
 
-    val result = tEnv.sqlQuery("SELECT name, rtime, val FROM T").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT name, rtime, val FROM T").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -343,7 +344,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
         |    deepNested.nested2.num AS nestedNum
         |FROM T
       """.stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -361,7 +362,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       "MyTable")
 
     val sqlQuery = "SELECT id, name FROM MyTable WHERE amount > 4 AND price < 9"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -375,7 +376,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     TestPartitionableSourceFactory.createTemporaryTable(tEnv, "PartitionableTable", true)
 
     val sqlQuery = "SELECT * FROM PartitionableTable WHERE part2 > 1 and id > 2 AND part1 = 'A'"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -390,7 +391,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     val sink = new TestingAppendSink()
     tEnv
       .sqlQuery("SELECT id, `first`, `last`, score FROM persons WHERE id < 4 ")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
 
     env.execute()
@@ -414,7 +415,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       """.stripMargin
 
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 
@@ -440,7 +441,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
       TestData.smallData3,
       "MyInputFormatTable")
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 
@@ -470,7 +471,10 @@ class LegacyTableSourceITCase extends StreamingTestBase {
     TestDataTypeTableSource.createTemporaryTable(tEnv, tableSchema, "MyInputFormatTable", data.seq)
 
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery("SELECT a, b, c, d FROM MyInputFormatTable").toAppendStream[Row].addSink(sink)
+    tEnv
+      .sqlQuery("SELECT a, b, c, d FROM MyInputFormatTable")
+      .toDataStream(classOf[Row])
+      .addSink(sink)
 
     env.execute()
 
@@ -504,7 +508,7 @@ class LegacyTableSourceITCase extends StreamingTestBase {
 
     TestStreamTableSource.createTemporaryTable(tEnv, tableSchema, "MyInputFormatTable", data)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery("SELECT a, b, c FROM MyInputFormatTable").toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery("SELECT a, b, c FROM MyInputFormatTable").toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -208,7 +208,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -224,7 +224,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "WHERE add(T.id, D.id) > 3 AND add(T.id, 2) > 3 AND add (D.id, 2) > 3"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -245,7 +245,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark")
@@ -258,7 +258,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.id = 1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -276,7 +276,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -289,7 +289,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -302,7 +302,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22", "3,15,Fabian,Fabian,33")
@@ -315,7 +315,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -328,7 +328,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -344,7 +344,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "ON t1.content = D.name AND t1.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -357,7 +357,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND 3 = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -370,7 +370,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.name = 'Fabian' AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -383,7 +383,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.name = 'Fabian' AND 3 = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -402,7 +402,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -416,7 +416,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.len < 15"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -435,7 +435,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND add(T.id, 2) > 4"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -454,7 +454,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("null,15,null", "3,15,Fabian", "null,11,null", "9,12,null")
@@ -467,7 +467,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id and T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -481,7 +481,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -494,7 +494,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("null,15,null", "3,15,Fabian", "null,11,null", "null,12,null")
@@ -507,7 +507,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.id = null"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -519,7 +519,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND null = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -532,7 +532,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "ON T.id = D.id + 4 AND T.content = concat(D.name, '!') AND D.age = 11"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("9,Hello world!,11,5")
@@ -550,7 +550,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -569,7 +569,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id and D.nominal_age > 12"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22,23", "3,15,Fabian,Fabian,33,34")
@@ -620,7 +620,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
         |  CONCAT(CAST(CURRENT_DATE AS VARCHAR), ' 00:00:00')
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
     assertThat(sink.getAppendResults).isEqualTo(Seq())
   }
@@ -654,7 +654,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
           |ON T.id = D.id
           |""".stripMargin
       val sink = new TestingAppendSink
-      tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+      tEnv.sqlQuery(sql).toDataStream.addSink(sink)
       env.execute()
 
       // Validate that only one cache is registered
@@ -785,7 +785,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 
@@ -804,7 +804,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold3 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 
@@ -829,7 +829,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 
@@ -849,7 +849,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -208,7 +208,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -224,7 +224,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "WHERE add(T.id, D.id) > 3 AND add(T.id, 2) > 3 AND add (D.id, 2) > 3"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -245,7 +245,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark")
@@ -258,7 +258,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.id = 1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -276,7 +276,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -289,7 +289,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark", "3,15,Fabian,Fabian")
@@ -302,7 +302,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id WHERE T.len <= D.age"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22", "3,15,Fabian,Fabian,33")
@@ -315,7 +315,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -328,7 +328,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -344,7 +344,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "ON t1.content = D.name AND t1.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,12,Julian", "3,15,Fabian")
@@ -357,7 +357,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND 3 = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -370,7 +370,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.name = 'Fabian' AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -383,7 +383,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.name = 'Fabian' AND 3 = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -402,7 +402,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -416,7 +416,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND T.len < 15"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -435,7 +435,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id AND add(T.id, 2) > 4"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -454,7 +454,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("null,15,null", "3,15,Fabian", "null,11,null", "9,12,null")
@@ -467,7 +467,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id and T.content = D.name"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -481,7 +481,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("3,15,Fabian")
@@ -494,7 +494,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("null,15,null", "3,15,Fabian", "null,11,null", "null,12,null")
@@ -507,7 +507,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON D.id = null"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -519,7 +519,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.content = D.name AND null = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -532,7 +532,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "ON T.id = D.id + 4 AND T.content = concat(D.name, '!') AND D.age = 11"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("9,Hello world!,11,5")
@@ -550,7 +550,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -569,7 +569,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of T.proctime AS D ON T.id = D.id and D.nominal_age > 12"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,15,Hello,Jark,22,23", "3,15,Fabian,Fabian,33,34")
@@ -620,7 +620,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
         |  CONCAT(CAST(CURRENT_DATE AS VARCHAR), ' 00:00:00')
         |""".stripMargin
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     assertThat(sink.getAppendResults).isEqualTo(Seq())
   }
@@ -654,7 +654,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
           |ON T.id = D.id
           |""".stripMargin
       val sink = new TestingAppendSink
-      tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+      tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
       env.execute()
 
       // Validate that only one cache is registered
@@ -785,7 +785,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 
@@ -804,7 +804,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold3 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 
@@ -829,7 +829,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 
@@ -849,7 +849,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
                    |JOIN user_table_with_lookup_threshold2 for system_time as of T.proctime AS D
                    |ON T.id = D.id
                    |""".stripMargin)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -86,7 +86,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -133,7 +133,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -187,7 +187,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -247,7 +247,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
     val table = tEnv.sqlQuery(sqlQuery)
 
     val sink = new TestingAppendSink()
-    val result = table.toDataStream(classOf[Row])
+    val result = table.toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -308,7 +308,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -360,7 +360,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -424,7 +424,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -476,7 +476,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -522,7 +522,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -583,7 +583,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -627,7 +627,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -696,7 +696,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -753,7 +753,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -789,7 +789,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 
@@ -847,7 +847,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -86,7 +86,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -133,7 +133,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -187,7 +187,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -247,7 +247,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
     val table = tEnv.sqlQuery(sqlQuery)
 
     val sink = new TestingAppendSink()
-    val result = table.toAppendStream[Row]
+    val result = table.toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -308,7 +308,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -360,7 +360,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -424,7 +424,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -476,7 +476,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -522,7 +522,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -583,7 +583,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -627,7 +627,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -696,7 +696,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -753,7 +753,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -789,7 +789,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 
@@ -847,7 +847,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |""".stripMargin
 
     val sink = new TestingAppendSink()
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(sink)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -90,7 +90,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -129,7 +129,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
     val sink = new TestingAppendSink
 
-    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink))
+    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink))
       .hasMessageContaining("LEAD Function is not supported in stream mode")
 
     env.execute()
@@ -143,7 +143,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     val sqlQuery = "SELECT a, ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime()) FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -179,7 +179,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -214,7 +214,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -249,7 +249,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -289,7 +289,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -327,7 +327,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -366,7 +366,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -397,7 +397,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -427,7 +427,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -498,7 +498,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       " FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -570,7 +570,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -646,7 +646,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       " FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -713,7 +713,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -781,7 +781,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporarySystemFunction("LTCNT", new LargerThanCount)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -849,7 +849,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporarySystemFunction("LTCNT", classOf[LargerThanCount])
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -908,7 +908,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -965,7 +965,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1034,7 +1034,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -1071,7 +1071,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "    PARTITION BY a ORDER BY proctime RANGE UNBOUNDED preceding) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1139,7 +1139,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM " +
       "  MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1203,7 +1203,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM " +
       "  MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1238,7 +1238,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1290,7 +1290,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "  PairCount(DISTINCT a, b) OVER (ORDER BY proctime RANGE UNBOUNDED preceding) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1326,7 +1326,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     val sqlQuery = "select sum(d) over (ORDER BY proctime rows between unbounded preceding " +
       "and current row) from T"
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -90,7 +90,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -129,7 +129,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
     val sink = new TestingAppendSink
 
-    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink))
+    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink))
       .hasMessageContaining("LEAD Function is not supported in stream mode")
 
     env.execute()
@@ -143,7 +143,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     val sqlQuery = "SELECT a, ROW_NUMBER() OVER (PARTITION BY a ORDER BY proctime()) FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -179,7 +179,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -214,7 +214,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -249,7 +249,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -289,7 +289,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM MyTable"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -327,7 +327,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -366,7 +366,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -397,7 +397,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -427,7 +427,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "from T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -498,7 +498,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       " FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -570,7 +570,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -646,7 +646,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       " FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -713,7 +713,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM T1"
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -781,7 +781,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporarySystemFunction("LTCNT", new LargerThanCount)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -849,7 +849,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporarySystemFunction("LTCNT", classOf[LargerThanCount])
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -908,7 +908,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -965,7 +965,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1034,7 +1034,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     tEnv.createTemporaryView("T1", t1)
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sqlQuery).toDataStream.addSink(sink)
     env.execute()
 
     val expected = List(
@@ -1071,7 +1071,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "    PARTITION BY a ORDER BY proctime RANGE UNBOUNDED preceding) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1139,7 +1139,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM " +
       "  MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1203,7 +1203,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "FROM " +
       "  MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1238,7 +1238,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "    PARTITION BY a ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1290,7 +1290,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "  PairCount(DISTINCT a, b) OVER (ORDER BY proctime RANGE UNBOUNDED preceding) " +
       "FROM MyTable"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -1326,7 +1326,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
     val sqlQuery = "select sum(d) over (ORDER BY proctime rows between unbounded preceding " +
       "and current row) from T"
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
@@ -130,7 +130,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testSimplePartitionFieldPredicate1(): Unit = {
     val query = "SELECT * FROM PartitionableTable WHERE part1 = 'A'"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -146,7 +146,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
     val query = "SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -161,7 +161,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testUnconvertedExpression(): Unit = {
     val query = "select * from PartitionableTable where trim(part1) = 'A' and part2 > 1"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -175,7 +175,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
     val query = "SELECT * FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -190,7 +190,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
     val query = "SELECT name FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PartitionableSourceITCase.scala
@@ -130,7 +130,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testSimplePartitionFieldPredicate1(): Unit = {
     val query = "SELECT * FROM PartitionableTable WHERE part1 = 'A'"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -146,7 +146,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPartialPartitionFieldPredicatePushDown(): Unit = {
     val query = "SELECT * FROM PartitionableTable WHERE (id > 2 OR part1 = 'A') AND part2 > 1"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -161,7 +161,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testUnconvertedExpression(): Unit = {
     val query = "select * from PartitionableTable where trim(part1) = 'A' and part2 > 1"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -175,7 +175,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPushDownPartitionAndFiltersContainPartitionKeys(): Unit = {
     val query = "SELECT * FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -190,7 +190,7 @@ class PartitionableSourceITCase(val sourceFetchPartitions: Boolean, val useCatal
   @TestTemplate
   def testPushDownPartitionAndFiltersContainPartitionKeysWithSingleProjection(): Unit = {
     val query = "SELECT name FROM PartitionableAndFilterableTable WHERE part1 = 'A' AND id > 1"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
@@ -77,7 +77,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c FROM VirtualTable"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -129,7 +129,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c FROM VirtualTable1"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -187,7 +187,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c.d FROM NestedTable"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -242,7 +242,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, d FROM UdfTable WHERE b > 2"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -293,7 +293,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     val expectedData = Seq("1")
 
     val query = "SELECT a FROM MetadataTable WHERE b > 2"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
@@ -77,7 +77,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c FROM VirtualTable"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -129,7 +129,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c FROM VirtualTable1"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -187,7 +187,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, c.d FROM NestedTable"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -242,7 +242,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     )
 
     val query = "SELECT a, b, d FROM UdfTable WHERE b > 2"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -293,7 +293,7 @@ class SourceWatermarkITCase extends StreamingTestBase {
     val expectedData = Seq("1")
 
     val query = "SELECT a FROM MetadataTable WHERE b > 2"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -47,7 +47,7 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
   }
 
   override def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink()
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -47,7 +47,7 @@ abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSys
   }
 
   override def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink()
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
@@ -41,7 +41,7 @@ class TableScanITCase extends StreamingTestBase {
     val tableName = "MyTable"
     WithoutTimeAttributesTableSource.createTemporaryTable(tEnv, tableName)
     val sqlQuery = s"SELECT * from $tableName"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -63,7 +63,7 @@ class TableScanITCase extends StreamingTestBase {
     tEnv.asInstanceOf[TableEnvironmentInternal].registerTableSourceInternal(tableName, tableSource)
 
     val sqlQuery = s"SELECT name FROM $tableName"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -106,7 +106,7 @@ class TableScanITCase extends StreamingTestBase {
          |FROM $tableName
          |GROUP BY TUMBLE(rowtime, INTERVAL '0.005' SECOND)
        """.stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -144,7 +144,7 @@ class TableScanITCase extends StreamingTestBase {
 
     tEnv
       .sqlQuery(sqlQuery)
-      .toDataStream(classOf[Row])
+      .toDataStream
       // append current watermark to each row to verify that original watermarks were preserved
       .process(new ProcessFunction[Row, Row] {
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
@@ -41,7 +41,7 @@ class TableScanITCase extends StreamingTestBase {
     val tableName = "MyTable"
     WithoutTimeAttributesTableSource.createTemporaryTable(tEnv, tableName)
     val sqlQuery = s"SELECT * from $tableName"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -63,7 +63,7 @@ class TableScanITCase extends StreamingTestBase {
     tEnv.asInstanceOf[TableEnvironmentInternal].registerTableSourceInternal(tableName, tableSource)
 
     val sqlQuery = s"SELECT name FROM $tableName"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -106,7 +106,7 @@ class TableScanITCase extends StreamingTestBase {
          |FROM $tableName
          |GROUP BY TUMBLE(rowtime, INTERVAL '0.005' SECOND)
        """.stripMargin
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -144,7 +144,7 @@ class TableScanITCase extends StreamingTestBase {
 
     tEnv
       .sqlQuery(sqlQuery)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       // append current watermark to each row to verify that original watermarks were preserved
       .process(new ProcessFunction[Row, Row] {
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -113,7 +113,7 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testSimpleProject(): Unit = {
-    val result = tEnv.sqlQuery("SELECT a, c FROM MyTable").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT a, c FROM MyTable").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -145,7 +145,7 @@ class TableSourceITCase extends StreamingTestBase {
         |FROM NestedTable
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -163,7 +163,7 @@ class TableSourceITCase extends StreamingTestBase {
       """
         |SELECT nestedItem.deepArray[nestedItem.deepMap['Monday']] FROM  NestedTable
         |""".stripMargin
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -175,7 +175,7 @@ class TableSourceITCase extends StreamingTestBase {
   @Test
   def testTableSourceWithFilterable(): Unit = {
     val query = "SELECT id, amount, name FROM FilterableTable WHERE amount > 4 AND price < 9"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -188,7 +188,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testTableSourceWithFunctionFilterable(): Unit = {
     val query = "SELECT id, amount, name FROM FilterableTable " +
       "WHERE amount > 4 AND price < 9 AND upper(name) = 'RECORD_5'"
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -214,7 +214,7 @@ class TableSourceITCase extends StreamingTestBase {
          |""".stripMargin
     )
 
-    val result = tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -253,7 +253,7 @@ class TableSourceITCase extends StreamingTestBase {
          |""".stripMargin
     )
 
-    val result = tEnv.sqlQuery("SELECT * FROM T").toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery("SELECT * FROM T").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -279,7 +279,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testSimpleMetadataAccess(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT `a`, `b`, `metadata_2` FROM MetadataTable")
-      .toDataStream(classOf[Row])
+      .toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -292,7 +292,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testComplexMetadataAccess(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT `a`, `other_metadata`, `b`, `metadata_2`, `computed` FROM MetadataTable")
-      .toDataStream(classOf[Row])
+      .toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -308,7 +308,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testDuplicateMetadataFromSameKey(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT other_metadata, other_metadata2, metadata_2 FROM MetadataTable")
-      .toDataStream(classOf[Row])
+      .toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -330,7 +330,7 @@ class TableSourceITCase extends StreamingTestBase {
         |FROM NestedTable
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -376,7 +376,7 @@ class TableSourceITCase extends StreamingTestBase {
         |SELECT id, deepNested.nested1.name AS nestedName FROM NestedTable
         |   WHERE nested.`value` > 20000
     """.stripMargin
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -394,7 +394,7 @@ class TableSourceITCase extends StreamingTestBase {
         |   nestedItem.deepArray[2].`value` FROM NestedTable
         |WHERE nestedItem.deepArray[2].`value` > 1
       """.stripMargin
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -413,7 +413,7 @@ class TableSourceITCase extends StreamingTestBase {
         |WHERE nestedItem.deepMap['Monday'] = 1
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(query).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.runtime.stream.sql
 import org.apache.flink.api.scala._
 import org.apache.flink.core.testutils.{EachCallbackWrapper, FlinkAssertions}
 import org.apache.flink.core.testutils.FlinkAssertions.{anyCauseMatches, assertThatChainOfCauses}
-import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.{DataTypes, TableException}
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestData, TestingAppendSink, TestingRetractSink}
@@ -113,7 +113,7 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testSimpleProject(): Unit = {
-    val result = tEnv.sqlQuery("SELECT a, c FROM MyTable").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT a, c FROM MyTable").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -145,7 +145,7 @@ class TableSourceITCase extends StreamingTestBase {
         |FROM NestedTable
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -163,7 +163,7 @@ class TableSourceITCase extends StreamingTestBase {
       """
         |SELECT nestedItem.deepArray[nestedItem.deepMap['Monday']] FROM  NestedTable
         |""".stripMargin
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -175,7 +175,7 @@ class TableSourceITCase extends StreamingTestBase {
   @Test
   def testTableSourceWithFilterable(): Unit = {
     val query = "SELECT id, amount, name FROM FilterableTable WHERE amount > 4 AND price < 9"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -188,7 +188,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testTableSourceWithFunctionFilterable(): Unit = {
     val query = "SELECT id, amount, name FROM FilterableTable " +
       "WHERE amount > 4 AND price < 9 AND upper(name) = 'RECORD_5'"
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -214,7 +214,7 @@ class TableSourceITCase extends StreamingTestBase {
          |""".stripMargin
     )
 
-    val result = tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT a, c FROM MyInputFormatTable").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -245,8 +245,7 @@ class TableSourceITCase extends StreamingTestBase {
          |  `m` TIMESTAMP(9),
          |  `n` TIMESTAMP(9) WITH LOCAL TIME ZONE,
          |  `o` ARRAY<BIGINT>,
-         |  `p` ROW<f1 BIGINT, f2 STRING, f3 DOUBLE>,
-         |  `q` MAP<STRING, INT>
+         |  `p` ROW<f1 BIGINT, f2 STRING, f3 DOUBLE>
          |) WITH (
          |  'connector' = 'values',
          |  'data-id' = '$dataId'
@@ -254,7 +253,7 @@ class TableSourceITCase extends StreamingTestBase {
          |""".stripMargin
     )
 
-    val result = tEnv.sqlQuery("SELECT * FROM T").toAppendStream[Row]
+    val result = tEnv.sqlQuery("SELECT * FROM T").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -262,15 +261,15 @@ class TableSourceITCase extends StreamingTestBase {
     val expected = Seq(
       "true,127,32767,2147483647,9223372036854775807,-1.123,-1.123,5.10,1234567891012345.1000000000," +
         "1,1,1969-01-01,00:00:00.123,1969-01-01T00:00:00.123456789,1969-01-01T00:00:00.123456789Z," +
-        "[1, 2, 3],1,a,2.3,{k1=1}",
+        "[1, 2, 3],1,a,2.3",
       "false,-128,-32768,-2147483648,-9223372036854775808,3.4,3.4,6.10," +
         "61234567891012345.1000000000,12,12,1970-09-30,01:01:01.123,1970-09-30T01:01:01.123456," +
-        "1970-09-30T01:01:01.123456Z,[4, 5],null,b,4.56,{k4=4, k2=2}",
+        "1970-09-30T01:01:01.123456Z,[4, 5],null,b,4.56",
       "true,0,0,0,0,0.12,0.12,7.10,71234567891012345.1000000000,123,123,1990-12-24,08:10:24.123," +
-        "1990-12-24T08:10:24.123,1990-12-24T08:10:24.123Z,[6, null, 7],3,null,7.86,{k3=null}",
+        "1990-12-24T08:10:24.123,1990-12-24T08:10:24.123Z,[6, null, 7],3,null,7.86",
       "false,5,4,123,1234,1.2345,1.2345,8.12,812345678910123451.0123456789,1234,1234,2020-05-01," +
-        "23:23:23,2020-05-01T23:23:23,2020-05-01T23:23:23Z,[8],4,c,null,{null=3}",
-      "null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null"
+        "23:23:23,2020-05-01T23:23:23,2020-05-01T23:23:23Z,[8],4,c,null",
+      "null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null"
     )
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
       .isEqualTo(expected.sorted.mkString("\n"))
@@ -280,7 +279,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testSimpleMetadataAccess(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT `a`, `b`, `metadata_2` FROM MetadataTable")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -293,7 +292,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testComplexMetadataAccess(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT `a`, `other_metadata`, `b`, `metadata_2`, `computed` FROM MetadataTable")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -309,7 +308,7 @@ class TableSourceITCase extends StreamingTestBase {
   def testDuplicateMetadataFromSameKey(): Unit = {
     val result = tEnv
       .sqlQuery("SELECT other_metadata, other_metadata2, metadata_2 FROM MetadataTable")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -331,7 +330,7 @@ class TableSourceITCase extends StreamingTestBase {
         |FROM NestedTable
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -377,7 +376,7 @@ class TableSourceITCase extends StreamingTestBase {
         |SELECT id, deepNested.nested1.name AS nestedName FROM NestedTable
         |   WHERE nested.`value` > 20000
     """.stripMargin
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -395,7 +394,7 @@ class TableSourceITCase extends StreamingTestBase {
         |   nestedItem.deepArray[2].`value` FROM NestedTable
         |WHERE nestedItem.deepArray[2].`value` > 1
       """.stripMargin
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -414,7 +413,7 @@ class TableSourceITCase extends StreamingTestBase {
         |WHERE nestedItem.deepMap['Monday'] = 1
       """.stripMargin
 
-    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val result = tEnv.sqlQuery(query).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalTableFunctionJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalTableFunctionJoinITCase.scala
@@ -91,7 +91,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
       "Rates",
       ratesHistory.createTemporalTableFunction($"proctime", $"currency"))
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -106,7 +106,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
       .sqlQuery(
         "SELECT amount, currency, proctime() as proctime " +
           "FROM (VALUES (1, 2.0)) AS T(amount, currency)")
-      .toDataStream(classOf[Row])
+      .toDataStream
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -162,7 +162,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
     tEnv.createTemporaryView(
       "Orders",
       tEnv.sqlQuery("SELECT * FROM Orders1 UNION ALL SELECT * FROM Orders2"))
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -224,7 +224,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
 
     // Scan from registered table to test for interplay between
     // LogicalCorrelateToTemporalTableJoinRule and TableScanRule
-    val result = tEnv.from("TemporalJoinResult").toDataStream(classOf[Row])
+    val result = tEnv.from("TemporalJoinResult").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -297,7 +297,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
 
     // Scan from registered table to test for interplay between
     // LogicalCorrelateToTemporalTableJoinRule and TableScanRule
-    val result = tEnv.from("TemporalJoinResult").toDataStream(classOf[Row])
+    val result = tEnv.from("TemporalJoinResult").toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalTableFunctionJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalTableFunctionJoinITCase.scala
@@ -91,7 +91,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
       "Rates",
       ratesHistory.createTemporalTableFunction($"proctime", $"currency"))
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -106,7 +106,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
       .sqlQuery(
         "SELECT amount, currency, proctime() as proctime " +
           "FROM (VALUES (1, 2.0)) AS T(amount, currency)")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -162,7 +162,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
     tEnv.createTemporaryView(
       "Orders",
       tEnv.sqlQuery("SELECT * FROM Orders1 UNION ALL SELECT * FROM Orders2"))
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     result.addSink(new TestingAppendSink)
     env.execute()
   }
@@ -224,7 +224,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
 
     // Scan from registered table to test for interplay between
     // LogicalCorrelateToTemporalTableJoinRule and TableScanRule
-    val result = tEnv.from("TemporalJoinResult").toAppendStream[Row]
+    val result = tEnv.from("TemporalJoinResult").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -297,7 +297,7 @@ class TemporalTableFunctionJoinITCase(state: StateBackendMode)
 
     // Scan from registered table to test for interplay between
     // LogicalCorrelateToTemporalTableJoinRule and TableScanRule
-    val result = tEnv.from("TemporalJoinResult").toAppendStream[Row]
+    val result = tEnv.from("TemporalJoinResult").toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
@@ -81,7 +81,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -118,7 +118,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink(TimeZone.getTimeZone(zoneId))
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -155,7 +155,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -192,7 +192,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(query).toDataStream.addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
@@ -81,7 +81,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -118,7 +118,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink(TimeZone.getTimeZone(zoneId))
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -155,7 +155,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(
@@ -192,7 +192,7 @@ class TimeAttributeITCase extends StreamingTestBase {
       """.stripMargin
     tEnv.executeSql(ddl)
     val sink = new TestingAppendSink()
-    tEnv.sqlQuery(query).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(query).toDataStream(classOf[Row]).addSink(sink)
     env.execute("SQL JOB")
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
@@ -51,7 +51,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, s FROM T, UNNEST(T.b) AS A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -77,7 +77,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) AS A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -97,7 +97,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, s, t FROM T, UNNEST(T.b) AS A (s, t) WHERE s > 13"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -210,7 +210,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) as A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -282,7 +282,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
       "  (SELECT a, b FROM T WHERE a < 3) as tf, " +
       "  UNNEST(tf.b) as A (x, y) " +
       "WHERE x > a"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -305,7 +305,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, A._1, A._2 FROM T, UNNEST(T.b) AS A where A._1 > 13"
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -336,7 +336,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
         |WHERE b2 <> '42.6'
     """.stripMargin
 
-    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/UnnestITCase.scala
@@ -51,7 +51,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, s FROM T, UNNEST(T.b) AS A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -77,7 +77,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) AS A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -97,7 +97,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, s, t FROM T, UNNEST(T.b) AS A (s, t) WHERE s > 13"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -210,7 +210,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) as A (s)"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -282,7 +282,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
       "  (SELECT a, b FROM T WHERE a < 3) as tf, " +
       "  UNNEST(tf.b) as A (x, y) " +
       "WHERE x > a"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -305,7 +305,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
     tEnv.createTemporaryView("T", t)
 
     val sqlQuery = "SELECT a, b, A._1, A._2 FROM T, UNNEST(T.b) AS A where A._1 > 13"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()
@@ -336,7 +336,7 @@ class UnnestITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mo
         |WHERE b2 <> '42.6'
     """.stripMargin
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     result.addSink(sink)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
@@ -17,9 +17,6 @@
  */
 package org.apache.flink.table.planner.runtime.stream.sql
 
-import org.apache.flink.streaming.api.scala._
-import org.apache.flink.table.api.bridge.scala._
-import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingAppendRowDataSink}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.{IntType, VarCharType}
@@ -36,9 +33,9 @@ class ValuesITCase extends StreamingTestBase {
 
     val outputType = InternalTypeInfo.ofFields(new IntType(), new VarCharType(5))
 
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[RowData]
+    val table = tEnv.sqlQuery(sqlQuery)
     val sink = new TestingAppendRowDataSink(outputType)
-    result.addSink(sink).setParallelism(1)
+    tEnv.toDataStream(table, outputType.getDataType).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("+I(1,Alice)", "+I(1,Bob)")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
@@ -190,7 +190,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -225,7 +225,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -260,7 +260,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -289,7 +289,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -322,7 +322,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -350,7 +350,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -378,7 +378,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -401,7 +401,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -446,7 +446,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -476,7 +476,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -508,7 +508,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -553,7 +553,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -593,7 +593,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -629,7 +629,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -657,7 +657,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -685,7 +685,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -716,7 +716,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -764,7 +764,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -801,7 +801,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -841,7 +841,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -873,7 +873,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -905,7 +905,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -926,7 +926,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
@@ -190,7 +190,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -225,7 +225,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -260,7 +260,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -289,7 +289,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -322,7 +322,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -350,7 +350,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -378,7 +378,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -401,7 +401,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -446,7 +446,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -476,7 +476,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -508,7 +508,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -553,7 +553,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -593,7 +593,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -629,7 +629,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -657,7 +657,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -685,7 +685,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -716,7 +716,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -764,7 +764,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -801,7 +801,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -841,7 +841,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -873,7 +873,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -905,7 +905,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -926,7 +926,7 @@ class WindowAggregateITCase(
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
@@ -92,7 +92,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -141,7 +141,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -185,7 +185,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -232,7 +232,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDeduplicateITCase.scala
@@ -92,7 +92,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -141,7 +141,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -185,7 +185,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -232,7 +232,7 @@ class WindowDeduplicateITCase(mode: StateBackendMode) extends StreamingWithState
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
@@ -190,7 +190,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -223,7 +223,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -250,7 +250,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -277,7 +277,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -315,7 +315,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -364,7 +364,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -406,7 +406,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -448,7 +448,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -474,7 +474,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -514,7 +514,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -541,7 +541,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -568,7 +568,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -598,7 +598,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -645,7 +645,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -676,7 +676,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -707,7 +707,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
@@ -190,7 +190,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -223,7 +223,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -250,7 +250,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -277,7 +277,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -315,7 +315,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -364,7 +364,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -406,7 +406,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -448,7 +448,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -474,7 +474,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -514,7 +514,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -541,7 +541,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -568,7 +568,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -598,7 +598,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -645,7 +645,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -676,7 +676,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
@@ -707,7 +707,7 @@ class WindowDistinctAggregateITCase(splitDistinct: Boolean, backend: StateBacken
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.sorted.mkString("\n"))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowJoinITCase.scala
@@ -127,7 +127,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -172,7 +172,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -244,7 +244,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -316,7 +316,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -384,7 +384,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -431,7 +431,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -502,7 +502,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -542,7 +542,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -600,7 +600,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -640,7 +640,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -699,7 +699,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -739,7 +739,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -805,7 +805,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -843,7 +843,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -906,7 +906,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -951,7 +951,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -995,7 +995,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1040,7 +1040,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1085,7 +1085,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1134,7 +1134,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowJoinITCase.scala
@@ -127,7 +127,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -172,7 +172,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -244,7 +244,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -316,7 +316,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -384,7 +384,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -431,7 +431,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -502,7 +502,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -542,7 +542,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -600,7 +600,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -640,7 +640,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -699,7 +699,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -739,7 +739,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -805,7 +805,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -843,7 +843,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
          |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = if (useTimestampLtz) {
@@ -906,7 +906,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -951,7 +951,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -995,7 +995,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1040,7 +1040,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1085,7 +1085,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1134,7 +1134,7 @@ class WindowJoinITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |""".stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
@@ -94,7 +94,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -139,7 +139,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -179,7 +179,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -216,7 +216,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -269,7 +269,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -322,7 +322,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -372,7 +372,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -420,7 +420,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -470,7 +470,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -513,7 +513,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -553,7 +553,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -615,7 +615,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -673,7 +673,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -729,7 +729,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -777,7 +777,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -816,7 +816,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -860,7 +860,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -934,7 +934,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
@@ -94,7 +94,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -139,7 +139,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -179,7 +179,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -216,7 +216,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -269,7 +269,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -322,7 +322,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -372,7 +372,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -420,7 +420,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -470,7 +470,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -513,7 +513,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -553,7 +553,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -615,7 +615,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -673,7 +673,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -729,7 +729,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -777,7 +777,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -816,7 +816,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -860,7 +860,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -934,7 +934,7 @@ class WindowRankITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
@@ -83,7 +83,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -135,7 +135,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -188,7 +188,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -241,7 +241,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -315,7 +315,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowTableFunctionITCase.scala
@@ -83,7 +83,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -135,7 +135,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -188,7 +188,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -241,7 +241,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -315,7 +315,7 @@ class WindowTableFunctionITCase(mode: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingAppendSink
-    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
@@ -62,7 +62,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c, udfLen('c).as('len))
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello,5", "Hello world,11")
@@ -74,7 +74,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -102,7 +102,9 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallNestedTupleData).toTable(tEnv, '_1, '_2).select('*)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(
+      DataTypes.ROW(DataTypes.ROW(DataTypes.INT(), DataTypes.INT()), DataTypes.STRING()))
+      .addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,one", "2,2,two", "3,3,three")
@@ -114,7 +116,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv).select('_1)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1", "2", "3")
@@ -132,7 +134,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a, 'b)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -168,7 +170,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a, 'b, 'c)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -183,7 +185,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv, 'a, 'b, 'c)
 
     val sink = new TestingAppendSink
-    ds.filter('a === 3).toAppendStream[Row].addSink(sink)
+    ds.filter('a === 3).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3,2,Hello world")
@@ -199,7 +201,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val filterDs = ds.filter(false)
     val sink = new TestingAppendSink
-    filterDs.toAppendStream[Row].addSink(sink)
+    filterDs.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -212,7 +214,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
      */
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv, 'a, 'b, 'c)
     val sink = new TestingAppendSink
-    ds.filter(true).toAppendStream[Row].addSink(sink)
+    ds.filter(true).toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -230,7 +232,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .filter('a % 2 === 0)
       .where($"b" === 3 || $"b" === 4 || $"b" === 5)
     val sink = new TestingAppendSink
-    filterDs.toAppendStream[Row].addSink(sink)
+    filterDs.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -254,7 +256,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .filter('a % 2 !== 0)
       .where(($"b" !== 1) && ($"b" !== 2) && ($"b" !== 3))
     val sink = new TestingAppendSink
-    filterDs.toAppendStream[Row].addSink(sink)
+    filterDs.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
       "7,4,Comment#1",
@@ -279,7 +281,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello")
@@ -302,7 +304,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c)
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello", "Hello world")
@@ -324,7 +326,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val sink = new TestingAppendSink
     val result = t.select(func0('c), func1('c), func2('c))
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -346,7 +348,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         suffix + i
       }
     })('a, ">>"))
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -365,7 +367,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingAppendSink
     val result = t.select(NonStaticObjectScalarFunction('a, ">>"))
 
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -394,7 +396,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         // will cause ValidationException here, see FLINK-15162
         val result = t.select(new NonStaticClassScalarFunction()('a, ">>"))
 
-        result.toAppendStream[Row].addSink(sink)
+        result.toDataStream(classOf[Row]).addSink(sink)
 
         env.execute()
 
@@ -432,7 +434,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select(SubstringFunc('*))
 
     val sink = new TestingAppendSink
-    table.toAppendStream[Row].addSink(sink)
+    table.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = List("Foo", "mpl")
@@ -447,7 +449,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     tEnv.createTemporaryFunction("func", NestingFunc)
     tEnv
       .sqlQuery("select func(func(f1)) from t1")
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
       .addSink(new TestingAppendSink)
     env.execute()
   }
@@ -487,7 +489,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(tupleData3).toTable(tEnv).select(map('_1, '_3))
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -545,7 +547,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .dropColumns($"c2")
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -567,7 +569,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func1('b))
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3", "4", "5")
@@ -586,7 +588,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func1('b))
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3", "4", "5")
@@ -602,7 +604,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func25('a))
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     sink.getAppendResults.foreach {
@@ -619,7 +621,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .toTable(tEnv)
       .select(map('_2, 30, 10L, '_1))
 
-    val results = ds.toAppendStream[Row]
+    val results = ds.toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     results.addSink(sink)
     env.execute()
@@ -635,7 +637,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .toTable(tEnv)
       .select(map('_1, '_3))
 
-    val results = ds.toAppendStream[Row]
+    val results = ds.toDataStream(classOf[Row])
     val sink = new TestingAppendSink
     results.addSink(sink)
     env.execute()
@@ -659,7 +661,10 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('*)
 
     val sink = new TestingAppendSink
-    table.toAppendStream[Row].addSink(sink)
+    table
+      .toDataStream(
+        DataTypes.ROW(DataTypes.ROW(DataTypes.INT(), DataTypes.INT()), DataTypes.STRING()))
+      .addSink(sink)
     env.execute()
 
     val expected = List("0,0,0", "1,1,1", "2,2,2")
@@ -675,7 +680,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         .limit(1)
         .select(currentDatabase())
     val sink1 = new TestingAppendSink
-    result1.toAppendStream[Row].addSink(sink1)
+    result1.toDataStream(classOf[Row]).addSink(sink1)
     env.execute()
     assertThat(sink1.getAppendResults.sorted).isEqualTo(List(tEnv.getCurrentDatabase))
 
@@ -694,7 +699,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .limit(1)
       .select(currentDatabase())
     val sink2 = new TestingAppendSink
-    result2.toAppendStream[Row].addSink(sink2)
+    result2.toDataStream(classOf[Row]).addSink(sink2)
     env.execute()
     assertThat(sink2.getAppendResults.sorted).isEqualTo(List(tEnv.getCurrentDatabase))
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
@@ -62,7 +62,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c, udfLen('c).as('len))
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello,5", "Hello world,11")
@@ -74,7 +74,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -116,7 +116,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv).select('_1)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1", "2", "3")
@@ -134,7 +134,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a, 'b)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -170,7 +170,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a, 'b, 'c)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -185,7 +185,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv, 'a, 'b, 'c)
 
     val sink = new TestingAppendSink
-    ds.filter('a === 3).toDataStream(classOf[Row]).addSink(sink)
+    ds.filter('a === 3).toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3,2,Hello world")
@@ -201,7 +201,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val filterDs = ds.filter(false)
     val sink = new TestingAppendSink
-    filterDs.toDataStream(classOf[Row]).addSink(sink)
+    filterDs.toDataStream.addSink(sink)
     env.execute()
 
     assertThat(sink.getAppendResults.isEmpty).isTrue
@@ -214,7 +214,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
      */
     val ds = env.fromCollection(smallTupleData3).toTable(tEnv, 'a, 'b, 'c)
     val sink = new TestingAppendSink
-    ds.filter(true).toDataStream(classOf[Row]).addSink(sink)
+    ds.filter(true).toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -232,7 +232,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .filter('a % 2 === 0)
       .where($"b" === 3 || $"b" === 4 || $"b" === 5)
     val sink = new TestingAppendSink
-    filterDs.toDataStream(classOf[Row]).addSink(sink)
+    filterDs.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -256,7 +256,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .filter('a % 2 !== 0)
       .where(($"b" !== 1) && ($"b" !== 2) && ($"b" !== 3))
     val sink = new TestingAppendSink
-    filterDs.toDataStream(classOf[Row]).addSink(sink)
+    filterDs.toDataStream.addSink(sink)
     env.execute()
     val expected = mutable.MutableList(
       "7,4,Comment#1",
@@ -281,7 +281,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello")
@@ -304,7 +304,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('c)
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hello", "Hello world")
@@ -326,7 +326,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val sink = new TestingAppendSink
     val result = t.select(func0('c), func1('c), func2('c))
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -348,7 +348,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         suffix + i
       }
     })('a, ">>"))
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -367,7 +367,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingAppendSink
     val result = t.select(NonStaticObjectScalarFunction('a, ">>"))
 
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -396,7 +396,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         // will cause ValidationException here, see FLINK-15162
         val result = t.select(new NonStaticClassScalarFunction()('a, ">>"))
 
-        result.toDataStream(classOf[Row]).addSink(sink)
+        result.toDataStream.addSink(sink)
 
         env.execute()
 
@@ -434,7 +434,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select(SubstringFunc('*))
 
     val sink = new TestingAppendSink
-    table.toDataStream(classOf[Row]).addSink(sink)
+    table.toDataStream.addSink(sink)
     env.execute()
 
     val expected = List("Foo", "mpl")
@@ -449,7 +449,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     tEnv.createTemporaryFunction("func", NestingFunc)
     tEnv
       .sqlQuery("select func(func(f1)) from t1")
-      .toDataStream(classOf[Row])
+      .toDataStream
       .addSink(new TestingAppendSink)
     env.execute()
   }
@@ -489,7 +489,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val ds = env.fromCollection(tupleData3).toTable(tEnv).select(map('_1, '_3))
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -547,7 +547,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .dropColumns($"c2")
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -569,7 +569,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func1('b))
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3", "4", "5")
@@ -588,7 +588,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func1('b))
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3", "4", "5")
@@ -604,7 +604,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .map(Func25('a))
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     sink.getAppendResults.foreach {
@@ -621,7 +621,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .toTable(tEnv)
       .select(map('_2, 30, 10L, '_1))
 
-    val results = ds.toDataStream(classOf[Row])
+    val results = ds.toDataStream
     val sink = new TestingAppendSink
     results.addSink(sink)
     env.execute()
@@ -637,7 +637,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .toTable(tEnv)
       .select(map('_1, '_3))
 
-    val results = ds.toDataStream(classOf[Row])
+    val results = ds.toDataStream
     val sink = new TestingAppendSink
     results.addSink(sink)
     env.execute()
@@ -680,7 +680,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         .limit(1)
         .select(currentDatabase())
     val sink1 = new TestingAppendSink
-    result1.toDataStream(classOf[Row]).addSink(sink1)
+    result1.toDataStream.addSink(sink1)
     env.execute()
     assertThat(sink1.getAppendResults.sorted).isEqualTo(List(tEnv.getCurrentDatabase))
 
@@ -699,7 +699,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .limit(1)
       .select(currentDatabase())
     val sink2 = new TestingAppendSink
-    result2.toDataStream(classOf[Row]).addSink(sink2)
+    result2.toDataStream.addSink(sink2)
     env.execute()
     assertThat(sink2.getAppendResults.sorted).isEqualTo(List(tEnv.getCurrentDatabase))
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
@@ -57,7 +57,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(pojoFunc0('c))
       .where('age > 20)
       .select('c, 'name, 'age)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -75,10 +75,11 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val result = t
       .leftOuterJoinLateral(func0('c).as('d, 'e))
       .select('c, 'd, 'e)
-      .toAppendStream[Row]
 
     val sink = new TestingAppendSink
-    result.addSink(sink)
+    tEnv
+      .toDataStream(result, DataTypes.ROW(DataTypes.STRING(), DataTypes.STRING(), DataTypes.INT()))
+      .addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -100,7 +101,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
         val result = t
           .leftOuterJoinLateral(func0('c).as('s, 'l), 'a === 'l)
           .select('c, 's, 'l)
-          .toAppendStream[Row]
+          .toDataStream(classOf[Row])
 
         val sink = new TestingAppendSink
         result.addSink(sink)
@@ -121,7 +122,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(Func18('d, "J"))
       .select('c, 'd, 'e)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -143,7 +144,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('a, 's)
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3,Hello", "3,world")
@@ -166,7 +167,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('a, 's)
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected =
@@ -189,7 +190,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('c, 'd, 'e, 'f, 'g)
       .joinLateral(func32('c).as('h, 'i))
       .select('c, 'd, 'f, 'h, 'e, 'g, 'i)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -217,7 +218,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0("1", "2", 'c))
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -242,7 +243,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0("1", "2"))
 
     val sink1 = new TestingAppendSink
-    result1.toAppendStream[Row].addSink(sink1)
+    result1.toDataStream(classOf[Row]).addSink(sink1)
     env.execute()
 
     val expected1 = mutable.MutableList(
@@ -263,7 +264,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0())
 
     val sink2 = new TestingAppendSink
-    result2.toAppendStream[Row].addSink(sink2)
+    result2.toDataStream(classOf[Row]).addSink(sink2)
     env.execute()
     assertThat(sink2.getAppendResults.isEmpty).isTrue()
   }
@@ -285,7 +286,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('c, 'f2)
 
     val sink = new TestingAppendSink
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,2,3,3", "1,2,3,3")
@@ -302,7 +303,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(func26('e))
       .select('c, 'd, 'e)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -327,7 +328,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(dateFormat(currentTimestamp(), "yyyyMMdd") === 'd)
       .select('c, 'd, 'e)
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -349,7 +350,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    ds.toAppendStream[Row].addSink(sink)
+    ds.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Jack,4", "22,2", "John,4", "19,2", "Anna,4", "44,2")
@@ -373,7 +374,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
     val sink = new TestingAppendSink
 
-    result.toAppendStream[Row].addSink(sink)
+    result.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
@@ -57,7 +57,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(pojoFunc0('c))
       .where('age > 20)
       .select('c, 'name, 'age)
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -101,7 +101,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
         val result = t
           .leftOuterJoinLateral(func0('c).as('s, 'l), 'a === 'l)
           .select('c, 's, 'l)
-          .toDataStream(classOf[Row])
+          .toDataStream
 
         val sink = new TestingAppendSink
         result.addSink(sink)
@@ -122,7 +122,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(Func18('d, "J"))
       .select('c, 'd, 'e)
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -144,7 +144,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('a, 's)
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("3,Hello", "3,world")
@@ -167,7 +167,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('a, 's)
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected =
@@ -190,7 +190,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('c, 'd, 'e, 'f, 'g)
       .joinLateral(func32('c).as('h, 'i))
       .select('c, 'd, 'f, 'h, 'e, 'g, 'i)
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -218,7 +218,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0("1", "2", 'c))
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -243,7 +243,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0("1", "2"))
 
     val sink1 = new TestingAppendSink
-    result1.toDataStream(classOf[Row]).addSink(sink1)
+    result1.toDataStream.addSink(sink1)
     env.execute()
 
     val expected1 = mutable.MutableList(
@@ -264,7 +264,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(varArgsFunc0())
 
     val sink2 = new TestingAppendSink
-    result2.toDataStream(classOf[Row]).addSink(sink2)
+    result2.toDataStream.addSink(sink2)
     env.execute()
     assertThat(sink2.getAppendResults.isEmpty).isTrue()
   }
@@ -286,7 +286,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('c, 'f2)
 
     val sink = new TestingAppendSink
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("1,2,3,3", "1,2,3,3")
@@ -303,7 +303,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(func26('e))
       .select('c, 'd, 'e)
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -328,7 +328,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .joinLateral(func0('c).as('d, 'e))
       .where(dateFormat(currentTimestamp(), "yyyyMMdd") === 'd)
       .select('c, 'd, 'e)
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val sink = new TestingAppendSink
     result.addSink(sink)
@@ -350,7 +350,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    ds.toDataStream(classOf[Row]).addSink(sink)
+    ds.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Jack,4", "22,2", "John,4", "19,2", "Anna,4", "44,2")
@@ -374,7 +374,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
     val sink = new TestingAppendSink
 
-    result.toDataStream(classOf[Row]).addSink(sink)
+    result.toDataStream.addSink(sink)
     env.execute()
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
@@ -82,7 +82,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(s"Hello world,2,3,12,3,2", s"Hello,2,2,3,2,2")
@@ -123,7 +123,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -153,7 +153,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(s"2,1,1,1,2", s"2,2,6,2,2")
@@ -181,7 +181,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select(weightAvgFun('long, 'int), countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("12,2", "3,2")
@@ -247,7 +247,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -279,7 +279,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -304,7 +304,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hallo,1,1970-01-01T00:00,1970-01-01T00:00:00.003",
@@ -340,7 +340,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -366,7 +366,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -392,7 +392,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowITCase.scala
@@ -82,7 +82,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(s"Hello world,2,3,12,3,2", s"Hello,2,2,3,2,2")
@@ -123,7 +123,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -153,7 +153,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(s"2,1,1,1,2", s"2,2,6,2,2")
@@ -181,7 +181,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select(weightAvgFun('long, 'int), countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("12,2", "3,2")
@@ -206,7 +206,14 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('int.count, 'w.start, 'w.end, 'w.rowtime)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable
+      .toDataStream(
+        DataTypes.ROW(
+          DataTypes.BIGINT(),
+          DataTypes.TIMESTAMP(3),
+          DataTypes.TIMESTAMP(3),
+          DataTypes.TIMESTAMP(3)))
+      .addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -240,7 +247,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -272,7 +279,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -297,7 +304,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hallo,1,1970-01-01T00:00,1970-01-01T00:00:00.003",
@@ -333,7 +340,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -359,7 +366,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -385,7 +392,7 @@ class GroupWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBa
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -72,7 +72,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('long, 'x, 'y)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -117,7 +117,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("Hello,2,2", "Hello,4,4", "Hello,8,8", "Hello World,9,9", "Hello,16,16")
@@ -138,7 +138,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("5,5", "6,6", "7,7", "12,12", "13,13", "14,14", "19,19", "20,20", "21,21")
@@ -159,7 +159,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('w.start, 'w.end, 'long, 'x, 'y + 1)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -205,7 +205,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("2,2", "2,2", "3,3", "3,3")
@@ -232,7 +232,15 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('f0, 'f1, 'w.start, 'w.end, 'w.rowtime)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable
+      .toDataStream(
+        DataTypes.ROW(
+          DataTypes.INT(),
+          DataTypes.INT(),
+          DataTypes.TIMESTAMP(3),
+          DataTypes.TIMESTAMP(3),
+          DataTypes.TIMESTAMP(3)))
+      .addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -276,7 +284,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -312,7 +320,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -339,7 +347,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hallo,2,2,1970-01-01T00:00,1970-01-01T00:00:00.003",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/GroupWindowTableAggregateITCase.scala
@@ -72,7 +72,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('long, 'x, 'y)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -117,7 +117,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("Hello,2,2", "Hello,4,4", "Hello,8,8", "Hello World,9,9", "Hello,16,16")
@@ -138,7 +138,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("5,5", "6,6", "7,7", "12,12", "13,13", "14,14", "19,19", "20,20", "21,21")
@@ -159,7 +159,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('w.start, 'w.end, 'long, 'x, 'y + 1)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -205,7 +205,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("2,2", "2,2", "3,3", "3,3")
@@ -284,7 +284,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -320,7 +320,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -347,7 +347,7 @@ class GroupWindowTableAggregateITCase(mode: StateBackendMode)
       .select('string, 'f0, 'f1, 'w.start, 'w.end)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hallo,2,2,1970-01-01T00:00,1970-01-01T00:00:00.003",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -107,7 +107,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'b1, 'b2)
 
     val sink = new TestingAppendSink
-    joinedTable.toDataStream(classOf[Row]).addSink(sink)
+    joinedTable.toDataStream.addSink(sink)
 
     env.execute()
 
@@ -142,7 +142,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'b1, 'b2)
 
     val sink = new TestingAppendSink
-    joinedTable.toDataStream(classOf[Row]).addSink(sink)
+    joinedTable.toDataStream.addSink(sink)
 
     env.execute()
 
@@ -179,7 +179,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'a3, 'b1, 'b2, 'b3)
 
     val sink = new TestingAppendSink
-    joinedTable.toDataStream(classOf[Row]).addSink(sink)
+    joinedTable.toDataStream.addSink(sink)
 
     env.execute()
 
@@ -347,7 +347,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    val results = windowedTable.toDataStream(classOf[Row])
+    val results = windowedTable.toDataStream
     results.addSink(sink)
     env.execute()
 
@@ -956,7 +956,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
   def testNonEqualInnerJoin(): Unit = {
     val ds1 = failingDataSource(data2).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = failingDataSource(data3).toTable(tEnv, 'd, 'e, 'f)
-    val results = ds1.join(ds2, 'a < 'd).select('a, 'd).toDataStream(classOf[Row])
+    val results = ds1.join(ds2, 'a < 'd).select('a, 'd).toDataStream
 
     val sink = new TestingAppendSink
     results.addSink(sink)
@@ -1037,7 +1037,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('b === 'e).select('b, 'c, 'e, 'g)
 
     val sink = new TestingAppendSink
-    joinT.toDataStream(classOf[Row]).addSink(sink)
+    joinT.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
@@ -1315,7 +1315,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .where('leftPk === 'rightPk)
 
     val sink = new TestingAppendSink
-    resultTable.toDataStream(classOf[Row]).addSink(sink)
+    resultTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1484,7 +1484,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     // proctime window output uncertain results, so assert has been ignored here.

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -107,7 +107,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'b1, 'b2)
 
     val sink = new TestingAppendSink
-    joinedTable.toAppendStream[Row].addSink(sink)
+    joinedTable.toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 
@@ -142,7 +142,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'b1, 'b2)
 
     val sink = new TestingAppendSink
-    joinedTable.toAppendStream[Row].addSink(sink)
+    joinedTable.toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 
@@ -179,7 +179,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a1, 'a2, 'a3, 'b1, 'b2, 'b3)
 
     val sink = new TestingAppendSink
-    joinedTable.toAppendStream[Row].addSink(sink)
+    joinedTable.toDataStream(classOf[Row]).addSink(sink)
 
     env.execute()
 
@@ -347,7 +347,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    val results = windowedTable.toAppendStream[Row]
+    val results = windowedTable.toDataStream(classOf[Row])
     results.addSink(sink)
     env.execute()
 
@@ -956,7 +956,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
   def testNonEqualInnerJoin(): Unit = {
     val ds1 = failingDataSource(data2).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = failingDataSource(data3).toTable(tEnv, 'd, 'e, 'f)
-    val results = ds1.join(ds2, 'a < 'd).select('a, 'd).toAppendStream[Row]
+    val results = ds1.join(ds2, 'a < 'd).select('a, 'd).toDataStream(classOf[Row])
 
     val sink = new TestingAppendSink
     results.addSink(sink)
@@ -1037,7 +1037,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('b === 'e).select('b, 'c, 'e, 'g)
 
     val sink = new TestingAppendSink
-    joinT.toAppendStream[Row].addSink(sink)
+    joinT.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
@@ -1315,7 +1315,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .where('leftPk === 'rightPk)
 
     val sink = new TestingAppendSink
-    resultTable.toAppendStream[Row].addSink(sink)
+    resultTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -1484,7 +1484,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
         countDistinct('long))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     // proctime window output uncertain results, so assert has been ignored here.

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
@@ -545,7 +545,7 @@ class LegacyTableSinkITCase {
   }
 
   @Test
-  def testToAppendStreamMultiRowtime(): Unit = {
+  def testToDataStreamMultiRowtime(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.getConfig.enableObjectReuse()
     val tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
@@ -561,7 +561,7 @@ class LegacyTableSinkITCase {
       .select('num, 'w.rowtime, 'w.rowtime.as('rowtime2))
 
     assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => r.toAppendStream[Row])
+      .isThrownBy(() => r.toDataStream(classOf[Row]))
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
@@ -561,7 +561,7 @@ class LegacyTableSinkITCase {
       .select('num, 'w.rowtime, 'w.rowtime.as('rowtime2))
 
     assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => r.toDataStream(classOf[Row]))
+      .isThrownBy(() => r.toDataStream)
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverAggregateITCase.scala
@@ -79,7 +79,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'mycount, 'wAvg, 'countDist)
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -123,7 +123,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, weightAvgFun('a, 42, 'b, "2").over('w).as('wAvg))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -197,7 +197,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       )
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -260,7 +260,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -316,7 +316,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       )
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -372,7 +372,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -433,7 +433,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -485,7 +485,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('a, 'c.sum.over('w), 'c.min.over('w), countDist('e).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -546,7 +546,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('a, 'c.sum.over('w), 'c.min.over('w), countDist('e).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -607,7 +607,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'a, 'a.count.over('w), 'a.sum.over('w), countDist('a).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -680,7 +680,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'b, 'a.count.over('w), 'a.sum.over('w), countDist('a).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -732,7 +732,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'a, 'a.count.over('w), ('a / 'a).sum.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toDataStream(classOf[Row]).addSink(sink)
+    windowedTable.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverAggregateITCase.scala
@@ -79,7 +79,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'mycount, 'wAvg, 'countDist)
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -123,7 +123,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, weightAvgFun('a, 42, 'b, "2").over('w).as('wAvg))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -197,7 +197,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       )
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -260,7 +260,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -316,7 +316,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       )
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -372,7 +372,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -433,7 +433,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
         ('b.cast(DataTypes.FLOAT).as('b)).avg.distinct.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
     val expected = Seq(
       "Hello,1,1,1.0",
@@ -485,7 +485,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('a, 'c.sum.over('w), 'c.min.over('w), countDist('e).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -546,7 +546,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('a, 'c.sum.over('w), 'c.min.over('w), countDist('e).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -607,7 +607,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'a, 'a.count.over('w), 'a.sum.over('w), countDist('a).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -680,7 +680,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'b, 'a.count.over('w), 'a.sum.over('w), countDist('a).over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -732,7 +732,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       .select('c, 'a, 'a.count.over('w), ('a / 'a).sum.over('w))
 
     val sink = new TestingAppendSink
-    windowedTable.toAppendStream[Row].addSink(sink)
+    windowedTable.toDataStream(classOf[Row]).addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/SetOperatorsITCase.scala
@@ -49,7 +49,7 @@ class SetOperatorsITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val unionDs = ds1.unionAll(ds2).select('c)
 
     val sink = new TestingAppendSink
-    unionDs.toDataStream(classOf[Row]).addSink(sink)
+    unionDs.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hi", "Hello", "Hello world", "Hi", "Hello", "Hello world")
@@ -64,7 +64,7 @@ class SetOperatorsITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val unionDs = ds1.unionAll(ds2.select('a, 'b, 'c)).filter('b < 2).select('c)
 
     val sink = new TestingAppendSink
-    unionDs.toDataStream(classOf[Row]).addSink(sink)
+    unionDs.toDataStream.addSink(sink)
     env.execute()
 
     val expected = mutable.MutableList("Hi", "Hallo")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
@@ -62,7 +62,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
       """.stripMargin
 
     tEnv.executeSql(sourceDDL)
-    val dataStream = tEnv.sqlQuery("SELECT a, ts FROM src").toDataStream(classOf[Row])
+    val dataStream = tEnv.sqlQuery("SELECT a, ts FROM src").toDataStream
 
     val expected = List(
       "+I[A, 1970-01-01T00:00:01], 1000",
@@ -157,7 +157,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
           | FROM t1
       """.stripMargin
       )
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val expected = List(
       "+I[A_, 1, 1970-01-01T00:00:01], 1000",
@@ -278,7 +278,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
       """.stripMargin
 
     tEnv.executeSql(sourceDDL)
-    val dataStream = tEnv.sqlQuery("SELECT a, ts, proctime FROM src").toDataStream(classOf[Row])
+    val dataStream = tEnv.sqlQuery("SELECT a, ts, proctime FROM src").toDataStream
 
     val expected =
       "ROW<`a` STRING, `ts` TIMESTAMP(3), `proctime` TIMESTAMP_LTZ(3) NOT NULL> NOT NULL(org.apache.flink.types.Row, org.apache.flink.table.runtime.typeutils.ExternalSerializer)"
@@ -303,7 +303,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
           | FROM t1
       """.stripMargin
       )
-      .toDataStream(classOf[Row])
+      .toDataStream
 
     val expected =
       "ROW<`EXPR$0` STRING, `ts` BIGINT, `proctime` TIMESTAMP_LTZ(3)> NOT NULL(org.apache.flink.types.Row, org.apache.flink.table.runtime.typeutils.ExternalSerializer)"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
@@ -62,7 +62,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
       """.stripMargin
 
     tEnv.executeSql(sourceDDL)
-    val dataStream = tEnv.sqlQuery("SELECT a, ts FROM src").toAppendStream[Row]
+    val dataStream = tEnv.sqlQuery("SELECT a, ts FROM src").toDataStream(classOf[Row])
 
     val expected = List(
       "+I[A, 1970-01-01T00:00:01], 1000",
@@ -157,7 +157,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
           | FROM t1
       """.stripMargin
       )
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
     val expected = List(
       "+I[A_, 1, 1970-01-01T00:00:01], 1000",
@@ -260,7 +260,7 @@ final class TableToDataStreamITCase extends StreamingTestBase {
   }
 
   @Test
-  def testFromTableToAppendStreamWithProctime(): Unit = {
+  def testFromTableToDataStreamWithProctime(): Unit = {
     val data = List(rowOf(localDateTime(1L), "A"))
 
     val dataId: String = TestValuesTableFactory.registerData(data)
@@ -278,9 +278,10 @@ final class TableToDataStreamITCase extends StreamingTestBase {
       """.stripMargin
 
     tEnv.executeSql(sourceDDL)
-    val dataStream = tEnv.sqlQuery("SELECT a, ts, proctime FROM src").toAppendStream[Row]
+    val dataStream = tEnv.sqlQuery("SELECT a, ts, proctime FROM src").toDataStream(classOf[Row])
 
-    val expected = "Row(a: String, ts: LocalDateTime, proctime: Instant)"
+    val expected =
+      "ROW<`a` STRING, `ts` TIMESTAMP(3), `proctime` TIMESTAMP_LTZ(3) NOT NULL> NOT NULL(org.apache.flink.types.Row, org.apache.flink.table.runtime.typeutils.ExternalSerializer)"
     assertThat(dataStream.dataType.toString).isEqualTo(expected)
   }
 
@@ -302,9 +303,10 @@ final class TableToDataStreamITCase extends StreamingTestBase {
           | FROM t1
       """.stripMargin
       )
-      .toAppendStream[Row]
+      .toDataStream(classOf[Row])
 
-    val expected = "Row(EXPR$0: String, ts: Long, proctime: Instant)"
+    val expected =
+      "ROW<`EXPR$0` STRING, `ts` BIGINT, `proctime` TIMESTAMP_LTZ(3)> NOT NULL(org.apache.flink.types.Row, org.apache.flink.table.runtime.typeutils.ExternalSerializer)"
     assertThat(ds2.dataType.toString).isEqualTo(expected)
   }
 


### PR DESCRIPTION

## What is the purpose of the change

The PR is about to replace deprecated `StreamTableEnvironment#toAppendStream` with `StreamTableEnvironment#toDataStream` as mentioned in javadoc

## Brief change log

tests in table-planner


## Verifying this change


This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable))
