### PR TITLE
[FLINK-33777] Fix ParquetTimestampITCase>FsStreamingSinkITCaseBase failing

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTimestampITCase.java
@@ -181,7 +181,7 @@ public class ParquetTimestampITCase extends FsStreamingSinkITCaseBase {
                                             Types.STRING,
                                             Types.STRING
                                         },
-                                        new String[] {"a", "b", "c", "d", "e"})));
+                                        new String[] {"f0", "f1", "f2", "f3", "f4"})));
     }
 
     @Override
@@ -198,7 +198,7 @@ public class ParquetTimestampITCase extends FsStreamingSinkITCaseBase {
                                             Types.STRING,
                                             Types.STRING
                                         },
-                                        new String[] {"a", "b", "c", "d", "e"})));
+                                        new String[] {"f0", "f1", "f2", "f3", "f4"})));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -25,8 +25,6 @@ import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.{DataTypes, Schema}
-import org.apache.flink.table.api.Expressions.{$, withAllColumns}
 import org.apache.flink.table.data.TimestampData
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
 import org.apache.flink.testutils.junit.utils.TempDirUtils

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.{DataTypes, Schema}
-import org.apache.flink.table.api.Expressions.$
+import org.apache.flink.table.api.Expressions.{$, withAllColumns}
 import org.apache.flink.table.data.TimestampData
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
 import org.apache.flink.testutils.junit.utils.TempDirUtils
@@ -176,15 +176,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
 
     tEnv.createTemporaryView(
       "my_table",
-      dataStream,
-      Schema
-        .newBuilder()
-        .column("f0", DataTypes.INT())
-        .column("f1", DataTypes.STRING())
-        .column("f2", DataTypes.STRING())
-        .column("f3", DataTypes.STRING())
-        .column("f4", DataTypes.STRING())
-        .build()
+      dataStream
     )
 
     val ddl: String = getDDL(


### PR DESCRIPTION
## What is the purpose of the change

There is a build failure[1] which is a result merging this https://github.com/apache/flink/pull/23885
however it was based on a commit before https://github.com/apache/flink/pull/18304 and didn't take into account that changes...


[1]  https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=55334&view=logs&j=2e8cb2f7-b2d3-5c62-9c05-cd756d33a819&t=2dd510a3-5041-5201-6dc3-54d310f68906&l=12272


## Verifying this change

This change is already covered by existing tests _ParquetTimestampITCase_


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
