### PR TITLE
[FLINK-33719][table] Cleanup the usage of deprecated StreamTableEnvir…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.functions.hive.util.TestHiveUDTF;
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
 import org.apache.flink.table.planner.runtime.utils.TestingRetractSink;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.RowToTuple2;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
@@ -225,8 +226,8 @@ public class HiveCatalogUdfITCase extends AbstractTestBase {
             StreamTableEnvironment streamTEnv = (StreamTableEnvironment) tEnv;
             TestingRetractSink sink = new TestingRetractSink();
             streamTEnv
-                    .toRetractStream(tEnv.sqlQuery(selectSql), Row.class)
-                    .map(new JavaToScala())
+                    .toChangelogStream(tEnv.sqlQuery(selectSql))
+                    .map(new RowToTuple2())
                     .addSink((SinkFunction) sink);
             env.execute("");
             results = JavaScalaConversionUtil.toJava(sink.getRetractResults());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Schema;
@@ -228,7 +227,7 @@ public class HiveCatalogUdfITCase extends AbstractTestBase {
             streamTEnv
                     .toChangelogStream(tEnv.sqlQuery(selectSql))
                     .map(new RowToTuple2())
-                    .addSink((SinkFunction) sink);
+                    .addSink(sink);
             env.execute("");
             results = JavaScalaConversionUtil.toJava(sink.getRetractResults());
         }

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImplTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 import org.apache.flink.table.utils.ExecutorMock;
 import org.apache.flink.table.utils.PlannerMock;
-import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +68,7 @@ class StreamTableEnvironmentImplTest {
         Duration minRetention = Duration.ofMinutes(1);
         tEnv.getConfig().setIdleStateRetention(minRetention);
         Table table = tEnv.fromDataStream(elements);
-        tEnv.toRetractStream(table, Row.class);
+        tEnv.toChangelogStream(table);
 
         assertThat(tEnv.getConfig().getIdleStateRetention()).isEqualTo(minRetention);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.runtime.stream.sql.join;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -29,14 +28,12 @@ import org.apache.flink.table.planner.runtime.utils.JoinReorderITCaseBase;
 import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
 import org.apache.flink.table.planner.runtime.utils.TestingRetractSink;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.planner.utils.RowToTuple2;
 
 import org.junit.jupiter.api.AfterEach;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import scala.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,8 +61,8 @@ public class JoinReorderITCase extends JoinReorderITCaseBase {
         Table table = streamTableEnvironment.sqlQuery(query);
         TestingRetractSink sink = new TestingRetractSink();
         streamTableEnvironment
-                .toRetractStream(table, Row.class)
-                .map(JavaScalaConversionUtil::toScala, TypeInformation.of(Tuple2.class))
+                .toChangelogStream(table)
+                .map(new RowToTuple2())
                 .addSink((SinkFunction) sink);
         try {
             env.execute();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.runtime.stream.sql.join;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -60,10 +59,7 @@ public class JoinReorderITCase extends JoinReorderITCaseBase {
         StreamTableEnvironment streamTableEnvironment = (StreamTableEnvironment) tEnv;
         Table table = streamTableEnvironment.sqlQuery(query);
         TestingRetractSink sink = new TestingRetractSink();
-        streamTableEnvironment
-                .toChangelogStream(table)
-                .map(new RowToTuple2())
-                .addSink((SinkFunction) sink);
+        streamTableEnvironment.toChangelogStream(table).map(new RowToTuple2()).addSink(sink);
         try {
             env.execute();
         } catch (Exception e) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/RowToTuple2.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/RowToTuple2.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+import scala.Tuple2;
+
+/** Row to scala Tuple2. */
+public class RowToTuple2 implements MapFunction<Row, Tuple2<Boolean, Row>> {
+
+    @Override
+    public scala.Tuple2<Boolean, Row> map(Row value) throws Exception {
+        if (value.getKind().equals(RowKind.DELETE)
+                || value.getKind().equals(RowKind.UPDATE_BEFORE)) {
+            return new scala.Tuple2<>(false, value);
+        } else {
+            return new scala.Tuple2<>(true, value);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOff, MiniBatchOn}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.CountNullNonNull
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
 import org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
@@ -88,7 +89,8 @@ class GroupAggregateHarnessTest(mode: StateBackendMode, miniBatch: MiniBatchMode
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toRetractStream[Row], "GroupAggregate")
+    val testHarness =
+      createHarnessTester(t1.toChangelogStream.map(new RowToTuple2), "GroupAggregate")
     val assertor = new RowDataHarnessAssertor(
       Array(DataTypes.STRING().getLogicalType, DataTypes.BIGINT().getLogicalType))
 
@@ -236,7 +238,8 @@ class GroupAggregateHarnessTest(mode: StateBackendMode, miniBatch: MiniBatchMode
     val t1 = tEnv.sqlQuery(sql)
 
     tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(t1.toRetractStream[Row], "GroupAggregate")
+    val testHarness =
+      createHarnessTester(t1.toChangelogStream.map(new RowToTuple2), "GroupAggregate")
     val outputTypes = Array(
       DataTypes.STRING().getLogicalType,
       DataTypes.BIGINT().getLogicalType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.JInt
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
 import org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
@@ -83,7 +84,9 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
 
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toRetractStream[Row], "Rank(strategy=[RetractStrategy")
+    val testHarness = createHarnessTester(
+      t1.toChangelogStream.map(new RowToTuple2()).setDescription("Row to scala Tuple2"),
+      "Rank(strategy=[RetractStrategy")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.STRING().getLogicalType,
@@ -179,7 +182,9 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
 
     val t1 = tEnv.sqlQuery(sql)
 
-    val testHarness = createHarnessTester(t1.toRetractStream[Row], "Rank(strategy=[RetractStrategy")
+    val testHarness = createHarnessTester(
+      t1.toChangelogStream.map(new RowToTuple2()).setDescription("Row to scala Tuple2"),
+      "Rank(strategy=[RetractStrategy")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.STRING().getLogicalType,
@@ -247,7 +252,9 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     val t1 = tEnv.sqlQuery(sql)
 
     val testHarness =
-      createHarnessTester(t1.toRetractStream[Row], "Rank(strategy=[UpdateFastStrategy")
+      createHarnessTester(
+        t1.toChangelogStream.map(new RowToTuple2),
+        "Rank(strategy=[UpdateFastStrategy")
     val assertor = new RowDataHarnessAssertor(
       Array(
         DataTypes.STRING().getLogicalType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateRemoveITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateRemoveITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithAggTestBase.AggMode
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchMode
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
-import org.apache.flink.table.planner.utils.TableTestUtil
+import org.apache.flink.table.planner.utils.{RowToTuple2, TableTestUtil}
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
@@ -288,7 +288,7 @@ class AggregateRemoveITCase(aggMode: AggMode, minibatch: MiniBatchMode, backend:
                              | ) t3
       """.stripMargin)
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = List("10")
     assertThat(sink.getRetractResults).isEqualTo(expected)
@@ -334,7 +334,7 @@ class AggregateRemoveITCase(aggMode: AggMode, minibatch: MiniBatchMode, backend:
     val sink = new TestingRetractSink
     env.setMaxParallelism(1)
     env.setParallelism(1)
-    t.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = rows.map(_.toString)
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.{InMemoryLookupableTableSource, StreamingWithStateTestBase, TestingAppendSink, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils._
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.functions.table.lookup.LookupCacheManager
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
@@ -304,7 +305,7 @@ class AsyncLookupJoinITCase(
       "for system_time as of t1.proctime AS D ON t1.id = D.id"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql2).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql2).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,Fabian,33", "8,null,null", "9,null,null")
@@ -330,7 +331,7 @@ class AsyncLookupJoinITCase(
     val sink = new TestingRetractSink
     assertThatThrownBy(
       () => {
-        tEnv.sqlQuery(sql2).toRetractStream[Row].addSink(sink).setParallelism(1)
+        tEnv.sqlQuery(sql2).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
 
         env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ChangelogSourceITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.runtime.stream.sql.ChangelogSourceITCase._
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithMiniBatchTestBase, TestData, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOff, MiniBatchOn}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.{Row, RowKind}
@@ -76,7 +77,7 @@ class ChangelogSourceITCase(
 
   @TestTemplate
   def testToRetractStream(): Unit = {
-    val result = tEnv.sqlQuery(s"SELECT * FROM users").toRetractStream[Row]
+    val result = tEnv.sqlQuery(s"SELECT * FROM users").toChangelogStream.map(new RowToTuple2)
     val sink = new TestingRetractSink()
     result.addSink(sink).setParallelism(result.parallelism)
     env.execute()
@@ -137,7 +138,7 @@ class ChangelogSourceITCase(
          |FROM users
          |""".stripMargin
 
-    val result = tEnv.sqlQuery(query).toRetractStream[Row]
+    val result = tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2)
     val sink = new TestingRetractSink()
     result.addSink(sink).setParallelism(result.parallelism)
     env.execute()
@@ -248,7 +249,7 @@ class ChangelogSourceITCase(
          |""".stripMargin
 
     val sink = new TestingRetractSink
-    val result = tEnv.sqlQuery(sql).toRetractStream[Row]
+    val result = tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2)
     result.addSink(sink).setParallelism(result.parallelism)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DeduplicateITCase.scala
@@ -27,9 +27,9 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOn}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assumptions.assumeThat
@@ -74,7 +74,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -104,7 +104,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -135,7 +135,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -165,7 +165,7 @@ class DeduplicateITCase(miniBatch: MiniBatchMode, mode: StateBackendMode)
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
@@ -30,9 +30,9 @@ import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy.{TABLE_EXEC_
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
@@ -188,7 +188,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
         |GROUP BY `string`
       """.stripMargin
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     val expected = if (useTimestampLtz) {
       Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/IntervalJoinITCase.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
 
@@ -390,7 +391,7 @@ class IntervalJoinITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     tEnv.createTemporaryView("T1", t1)
     tEnv.createTemporaryView("T2", t2)
     val sink = new TestingRetractSink
-    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val result = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     result.addSink(sink)
     env.execute()
     val expected = mutable.MutableList("A,1,5", "B,1,1")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
 
@@ -102,7 +103,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT * FROM A, B WHERE (a2 = 1 and b2 = 2) or (a1 = 2 and b1 = 4)"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.Seq(
@@ -120,7 +121,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT * FROM A, B WHERE (a2 = 1 AND true) OR (a1 = 2 AND b1 = 4) "
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable
@@ -172,7 +173,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT * FROM a, b WHERE (a1 = 1 AND b1 = 3) OR (a1 = 2 AND b3 is null) "
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList("1,2,hi a2,3,4,hi b1", "2,3,hi a3,4,5,null").toList
@@ -290,7 +291,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT a3, b4 FROM A, B WHERE a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
@@ -318,7 +319,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,3", "1,1", "3,3", "2,2", "3,3", "2,2")
@@ -330,7 +331,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT a3, b4 FROM A, B WHERE a2 = b2 AND a2 < 2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo")
@@ -342,7 +343,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1, b3 FROM A JOIN B ON a1 = b1 AND a1 = b3"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,2,2", "3,3,3")
@@ -364,7 +365,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT a1, a1, c2 FROM Table3 INNER JOIN Table5 ON d1 = d2 where d1 is true"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,Hello world", "1,1,Hi", "3,3,Hello world", "3,3,Hi")
@@ -381,7 +382,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     tEnv.createTemporaryView("Table5", ds2)
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hello world, how are you?,Hallo Welt wie", "I am fine.,Hallo Welt wie")
@@ -398,7 +399,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     tEnv.createTemporaryView("Table5", ds2)
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -418,7 +419,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         "WHERE a1 = b1 AND a1 < 4"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected =
@@ -431,7 +432,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT COUNT(b4), COUNT(a2) FROM A, B WHERE a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("6,6")
@@ -447,7 +448,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT b, c, e, g FROM ds1 LEFT OUTER JOIN ds2 ON b = e"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,Hi,null,null", "2,Hello world,null,null", "2,Hello,null,null")
@@ -463,7 +464,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT b, c, e, g FROM ds1 LEFT OUTER JOIN ds2 ON b = e"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,Hi,1,Hallo", "2,Hello world,2,Hallo Welt", "2,Hello,2,Hallo Welt")
@@ -515,7 +516,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT a3, b4 FROM A FULL OUTER JOIN B ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -549,7 +550,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     tEnv.createTemporaryView("Table5", ds2)
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -578,7 +579,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sqlQuery = "SELECT a3, b4 FROM A RIGHT OUTER JOIN B ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -609,7 +610,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) JOIN ($query2) ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1", "2,2", "3,3")
@@ -623,7 +624,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, a2, b1, b2 FROM ($query1) JOIN ($query2) ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,1,1")
@@ -635,7 +636,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A LEFT JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,null", "1,null", "2,null")
@@ -649,7 +650,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN ($query2) ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,null", "3,null", "2,null")
@@ -662,7 +663,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,null", "3,null", "2,null")
@@ -676,7 +677,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, a2, b1, b2 FROM ($query1) LEFT JOIN ($query2) ON a2 = b2 AND a1 > b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,null,null", "3,2,null,null", "2,2,null,null")
@@ -688,7 +689,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A LEFT JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1", "2,2", "3,3", "2,2", "3,3", "3,3")
@@ -702,7 +703,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN ($query2) ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,2", "1,1", "3,3")
@@ -715,7 +716,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) LEFT JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,3", "3,3", "3,3", "2,2", "2,2", "1,1")
@@ -729,7 +730,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, a2, b1, b2 FROM ($query1) LEFT JOIN ($query2) ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,1,1", "3,2,null,null", "2,2,null,null")
@@ -741,7 +742,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A RIGHT JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -770,7 +771,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN ($query2) ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("null,1", "null,3", "null,2", "null,5", "null,4")
@@ -783,7 +784,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -813,7 +814,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
 
     env.setParallelism(1)
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected =
@@ -826,7 +827,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A RIGHT JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -855,7 +856,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN ($query2) ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1", "2,2", "null,5", "3,3", "null,4")
@@ -868,7 +869,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) RIGHT JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -897,7 +898,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, a2, b1, b2 FROM ($query1) RIGHT JOIN ($query2) ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected =
@@ -910,7 +911,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A FULL JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -943,7 +944,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN ($query2) ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -965,7 +966,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN B ON a1 = b1 AND a2 > b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -999,7 +1000,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
 
     env.setParallelism(1)
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1020,7 +1021,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = "SELECT a1, b1 FROM A FULL JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1050,7 +1051,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN ($query2) ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("null,4", "1,1", "3,3", "2,2", "null,5")
@@ -1063,7 +1064,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, b1 FROM ($query1) FULL JOIN B ON a1 = b1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1092,7 +1093,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val query = s"SELECT a1, a2, b1, b2 FROM ($query1) FULL JOIN ($query2) ON a2 = b2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1138,7 +1139,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1181,7 +1182,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1223,7 +1224,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1266,7 +1267,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1309,7 +1310,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1355,7 +1356,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
         |""".stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList(
@@ -1390,7 +1391,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
 
     val t3 = tEnv.sqlQuery("select T1.a, b, c from T1, T2 WHERE T1.a = T2.a")
     val sink = new TestingRetractSink
-    t3.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t3.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = List("1,1,-1", "2,2,-2", "3,3,-3")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -1416,7 +1417,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("500")
@@ -1435,7 +1436,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
     val sql = "SELECT c, g FROM T3 join T5 on funcWithOpen(a + d) where b = e"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
@@ -1653,7 +1654,7 @@ class JoinITCase(state: StateBackendMode) extends StreamingWithStateTestBase(sta
 
   private def checkResult(sql: String, expected: Seq[Row]): Unit = {
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expectedResult = expected

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LimitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LimitITCase.scala
@@ -22,8 +22,8 @@ import org.apache.flink.table.api.{TableException, _}
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.TestTemplate
@@ -48,7 +48,7 @@ class LimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mod
     val sql = "SELECT * FROM T LIMIT 4"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("book,1,12", "book,2,19", "book,4,11", "fruit,4,33")
@@ -71,7 +71,7 @@ class LimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mod
     val sql = "SELECT * FROM T LIMIT 4 OFFSET 2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("book,4,11", "fruit,4,33", "fruit,3,44", "fruit,5,22")
@@ -94,7 +94,7 @@ class LimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mod
 
     val sql = "SELECT * FROM T OFFSET 2"
 
-    assertThatThrownBy(() => tEnv.sqlQuery(sql).toRetractStream[Row])
+    assertThatThrownBy(() => tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2))
       .hasMessage("FETCH is missed, which on streaming table is not supported currently.")
       .isInstanceOf[TableException]
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LimitableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LimitableSourceITCase.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.plan.rules.logical.PushLimitIntoTableSourceScanRule
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
-import org.apache.flink.types.Row
+import org.apache.flink.table.planner.utils.RowToTuple2
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, Test}
@@ -62,7 +62,7 @@ class LimitableSourceITCase extends StreamingTestBase() {
     val sql = "SELECT * FROM Source LIMIT 4"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("book,1,12", "book,2,19", "book,4,11", "fruit,4,33")
@@ -74,7 +74,7 @@ class LimitableSourceITCase extends StreamingTestBase() {
     val sql = "SELECT * FROM Source LIMIT 4 OFFSET 2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("book,4,11", "fruit,4,33", "fruit,3,44", "fruit,5,22")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.binary.BinaryStringData
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.{InMemoryLookupableTableSource, StreamingTestBase, TestingAppendSink, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.TestAddWithOpen
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.functions.table.fullcache.inputformat.FullCacheTestInputFormat
 import org.apache.flink.table.runtime.functions.table.lookup.LookupCacheManager
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
@@ -714,7 +715,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of t1.proctime AS D ON t1.id = D.id"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql2).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql2).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,Fabian,33", "8,null,null", "9,null,null")
@@ -736,7 +737,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of t1.proctime AS D ON D.id = 3"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql2).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql2).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3,Fabian,33", "8,Fabian,33", "9,Fabian,33")
@@ -759,7 +760,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, cacheType: LookupCacheType)
       "for system_time as of t1.proctime AS D ON D.id = 3"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql2).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql2).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("3", "8", "9")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PruneAggregateCallITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PruneAggregateCallITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithAggTestBase.AggMode
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchMode
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
-import org.apache.flink.table.planner.utils.TableTestUtil
+import org.apache.flink.table.planner.utils.{RowToTuple2, TableTestUtil}
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
@@ -127,7 +127,7 @@ class PruneAggregateCallITCase(
     val sink = new TestingRetractSink
     env.setMaxParallelism(1)
     env.setParallelism(1)
-    t.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = rows.map(_.toString)
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/RankITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/RankITCase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
@@ -61,7 +62,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = List("book,2,19,1", "book,1,12,2", "fruit,3,44,1", "fruit,4,33,2")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -102,7 +103,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -426,7 +427,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("book,1,22,2,1", "book,2,19,1,2", "fruit,3,44,1,1", "fruit,5,34,2,2")
@@ -463,7 +464,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("book,2,19,1,2", "fruit,5,34,2,2")
@@ -1116,7 +1117,8 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
                    |  FROM MyView)
                    |WHERE rank_num <= 2
                    |""".stripMargin)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink1)
       .setParallelism(1)
 
@@ -1131,7 +1133,8 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
            |  FROM MyView)
            |WHERE rank_num <= 2
            |""".stripMargin)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink2)
       .setParallelism(1)
     env.execute()
@@ -1301,7 +1304,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1344,7 +1347,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = List("book,aws,1", "book,aws,2", "fruit,aws,3", "fruit,aws,4")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SemiAntiJoinStreamITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SemiAntiJoinStreamITCase.scala
@@ -22,8 +22,8 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestData, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
@@ -74,7 +74,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val query = "SELECT a, b, c FROM ds1 WHERE a in (SELECT d from ds2 WHERE d < 3)"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,Hi", "2,2,Hello")
@@ -114,7 +114,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val query = "SELECT a FROM ds1 WHERE a in (SELECT sum(c) from ds2 GROUP BY d)"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = Seq("1", "2", "10", "6", "8")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -148,7 +148,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1", "2", "10", "6", "8")
@@ -164,7 +164,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val query = "SELECT c FROM ds1 WHERE NOT EXISTS (SELECT * from ds2 WHERE b = g)"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(query).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(query).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = Seq("2", "3", "4", "5")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -207,7 +207,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = Seq("11,f")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -263,7 +263,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = Seq("8,f")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -275,7 +275,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,Hi", "2,2,Hello", "3,2,Hello world")
@@ -288,7 +288,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,2,Hello", "3,2,Hello world")
@@ -303,7 +303,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,3", "2,2")
@@ -317,7 +317,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,2", "2,3")
@@ -332,7 +332,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     assertThat(sink.getRetractResults.size).isZero
@@ -344,7 +344,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     assertThat(sink.getRetractResults.size).isZero
@@ -356,7 +356,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,Hi")
@@ -372,7 +372,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1")
@@ -387,7 +387,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,2", "1,1", "2,3")
@@ -403,7 +403,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
     val result = tEnv.sqlQuery(query)
 
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1", "2,3", "2,2")
@@ -429,7 +429,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1", "1", "2", "2", "3", "3")
@@ -461,7 +461,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("20,RESEARCH,DALLAS")
@@ -486,7 +486,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
       """.stripMargin
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1", "1", "2", "2", "3", "3", "4", "4", "5", "5")
@@ -511,7 +511,7 @@ class SemiAntiJoinStreamITCase(state: StateBackendMode) extends StreamingWithSta
       "SELECT a + 10, c FROM l WHERE b > 10 AND NOT (c like 'abc' OR NOT EXISTS (SELECT d FROM r))"
     val result = tEnv.sqlQuery(query)
     val sink = new TestingRetractSink
-    result.toRetractStream[Row].addSink(sink).setParallelism(1)
+    result.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("14,Hello World!")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SortITCase.scala
@@ -22,9 +22,8 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
-import org.apache.flink.table.planner.utils.InternalConfigOptions
+import org.apache.flink.table.planner.utils.{InternalConfigOptions, RowToTuple2}
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.TestTemplate
@@ -47,7 +46,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val da = env.fromCollection(data).toTable(tEnv, 'a1, 'a2)
     tEnv.createTemporaryView("a", da)
 
-    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toRetractStream[Row])
+    assertThatThrownBy(() => tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2))
       .hasMessage("Sort on a non-time-attribute field is not supported.")
       .isInstanceOf[TableException]
   }
@@ -67,7 +66,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingRetractSink
     tEnv.getConfig
       .set(InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED, Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -93,7 +92,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     tEnv.getConfig.set(
       InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED,
       Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -118,7 +117,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingRetractSink
     tEnv.getConfig
       .set(InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED, Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -143,7 +142,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingRetractSink
     tEnv.getConfig
       .set(InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED, Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -174,7 +173,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingRetractSink
     tEnv.getConfig
       .set(InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED, Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -203,7 +202,7 @@ class SortITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val sink = new TestingRetractSink
     tEnv.getConfig
       .set(InternalConfigOptions.TABLE_EXEC_NON_TEMPORAL_SORT_ENABLED, Boolean.box(true))
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SortLimitITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SortLimitITCase.scala
@@ -22,8 +22,8 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.TestTemplate
@@ -48,7 +48,7 @@ class SortLimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val sql = "SELECT * FROM T ORDER BY num DESC LIMIT 2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("fruit,3,44", "fruit,4,33")
@@ -66,7 +66,7 @@ class SortLimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val sql = "SELECT a, max(b) FROM T GROUP BY a ORDER BY a LIMIT 2"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,3", "2,4")
@@ -84,7 +84,7 @@ class SortLimitITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val sql = "SELECT a, max(b) FROM T GROUP BY a ORDER BY a LIMIT 2 OFFSET 1"
 
     val sink = new TestingRetractSink
-    tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
+    tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,4", "3,5")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SplitAggregateITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.runtime.utils.StreamingWithAggTestBase.{Ag
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.MiniBatchOn
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => mLocalTime}
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
 
@@ -195,7 +196,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -212,7 +213,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT COUNT(DISTINCT c) FROM T")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("5")
@@ -224,7 +225,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT COUNT(DISTINCT b), COUNT(DISTINCT c) FROM T")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List("6,5")
@@ -236,7 +237,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT a, SUM(b), COUNT(DISTINCT c), avg(b) FROM T GROUP BY a")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,3,2,1", "2,29,5,3", "3,10,2,5", "4,21,3,5")
@@ -248,7 +249,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT a, COUNT(DISTINCT c) FROM T GROUP BY a")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,2", "2,5", "3,2", "4,3")
@@ -260,7 +261,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT a, COUNT(DISTINCT b), MAX(b), MIN(b) FROM T GROUP BY a")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,2,2,1", "2,4,5,2", "3,1,5,5", "4,2,6,5")
@@ -272,7 +273,7 @@ class SplitAggregateITCase(
     val t1 = tEnv.sqlQuery("SELECT a, COUNT(DISTINCT a), COUNT(b) FROM T GROUP BY a")
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,1,2", "2,1,8", "3,1,2", "4,1,4")
@@ -292,7 +293,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,1,2,1", "2,3,4,3", "3,1,null,5", "4,2,6,5")
@@ -313,7 +314,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("2,2,2,1", "5,1,4,2", "6,2,2,1")
@@ -338,7 +339,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("2,2,2", "4,1,1", "8,1,1")
@@ -363,7 +364,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("2,7,2,2", "4,6,1,1", "8,5,1,1")
@@ -387,7 +388,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List(
@@ -426,7 +427,7 @@ class SplitAggregateITCase(
 
     val t1 = tEnv.sqlQuery(sql)
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected =
@@ -465,7 +466,7 @@ class SplitAggregateITCase(
 
     val t1 = tEnv.sqlQuery(sql)
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,1,50", "1,ALL,50")
@@ -486,7 +487,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,2,1,2,1", "2,4,3,4,3", "3,1,1,null,5", "4,2,2,6,5")
@@ -508,7 +509,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = List("1,1,3,2,3,1", "2,3,24,8,29,3", "3,1,null,2,10,5", "4,2,6,4,21,5")
@@ -526,7 +527,7 @@ class SplitAggregateITCase(
        """.stripMargin)
 
     val sink = new TestingRetractSink
-    t1.toRetractStream[Row].addSink(sink)
+    t1.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = Map[String, List[String]](

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -124,7 +124,8 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testProjectWithoutInputRef(): Unit = {
-    val result = tEnv.sqlQuery("SELECT COUNT(*) FROM MyTable").toRetractStream[Row]
+    val result =
+      tEnv.sqlQuery("SELECT COUNT(*) FROM MyTable").toChangelogStream.map(new RowToTuple2)
     val sink = new TestingRetractSink()
     result.addSink(sink).setParallelism(result.parallelism)
     env.execute()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalSortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalSortITCase.scala
@@ -25,8 +25,8 @@ import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.TestTemplate
@@ -62,7 +62,7 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val sqlQuery = "SELECT key, str, `int` FROM T ORDER BY rowtime"
 
     val sink = new TestingRetractSink
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -108,7 +108,7 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val sqlQuery = "SELECT key, str, `int` FROM T ORDER BY rowtime"
 
     val sink = new TestingRetractSink
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -162,7 +162,7 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val sqlQuery = "SELECT key, str, `int` FROM T ORDER BY rowtime, `int`"
 
     val sink = new TestingRetractSink
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -217,7 +217,7 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val sqlQuery = "SELECT key, str, `int` FROM T ORDER BY rowtime, `int`"
 
     val sink = new TestingRetractSink
-    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sqlQuery).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -247,7 +247,7 @@ class TemporalSortITCase(mode: StateBackendMode) extends StreamingWithStateTestB
     val sql = "SELECT a, b, c FROM T ORDER BY proctime"
 
     val sink = new TestingRetractSink
-    val results = tEnv.sqlQuery(sql).toRetractStream[Row]
+    val results = tEnv.sqlQuery(sql).toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimestampITCase.scala
@@ -22,8 +22,8 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.utils.{RowToTuple2, TestDataTypeTableSourceWithTime}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
-import org.apache.flink.table.planner.utils.TestDataTypeTableSourceWithTime
 import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
@@ -102,7 +102,8 @@ class TimestampITCase extends StreamingTestBase {
     val sink = new TestingRetractSink()
     tEnv
       .sqlQuery("SELECT COUNT(a), c FROM T GROUP BY c")
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(
@@ -119,7 +120,8 @@ class TimestampITCase extends StreamingTestBase {
     val sink = new TestingRetractSink()
     tEnv
       .sqlQuery("SELECT COUNT(a), e FROM T GROUP BY e")
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(
@@ -136,7 +138,8 @@ class TimestampITCase extends StreamingTestBase {
     val sink = new TestingRetractSink()
     tEnv
       .sqlQuery("SELECT COUNT(DISTINCT c), b FROM T GROUP BY b")
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(
@@ -153,7 +156,8 @@ class TimestampITCase extends StreamingTestBase {
     val sink = new TestingRetractSink()
     tEnv
       .sqlQuery("SELECT COUNT(DISTINCT e), b FROM T GROUP BY b")
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(
@@ -170,7 +174,8 @@ class TimestampITCase extends StreamingTestBase {
     val sink = new TestingRetractSink()
     tEnv
       .sqlQuery("SELECT MAX(c), MIN(c), b FROM T GROUP BY b")
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(
@@ -192,7 +197,8 @@ class TimestampITCase extends StreamingTestBase {
                    |  (SELECT b, MAX(c) AS x, MIN(c) AS y FROM T GROUP BY b, c)
                    |GROUP BY b
        """.stripMargin)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink)
     env.execute()
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
@@ -24,12 +24,11 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.ConcatDistinctAggFunction
-import org.apache.flink.table.planner.runtime.utils.{FailingCollectionSource, StreamingWithStateTestBase, TestData, TestingAppendSink, TestingRetractSink}
+import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
-import org.apache.flink.table.planner.utils.AggregatePhaseStrategy
+import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, RowToTuple2}
 import org.apache.flink.table.planner.utils.AggregatePhaseStrategy._
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
@@ -988,7 +987,7 @@ class WindowAggregateITCase(
         """.stripMargin
     val sink = new TestingRetractSink()
     val res = tEnv.sqlQuery(sql)
-    res.toRetractStream[Row].addSink(sink)
+    res.toChangelogStream.map(new RowToTuple2).addSink(sink)
     // do not verify the result due to proctime window aggregate result is non-deterministic
     env.execute()
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CalcITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.expressions.utils._
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingAppendSink, TestingRetractSink, UserDefinedFunctionTestUtils}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
@@ -90,7 +91,7 @@ class CalcITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select(lit("1").count())
 
     val sink = new TestingRetractSink
-    ds.toRetractStream[Row].addSink(sink).setParallelism(1)
+    ds.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = mutable.MutableList("3")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -28,9 +28,8 @@ import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, WeightedAvg}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TestData._
-import org.apache.flink.table.planner.utils.CountAggFunction
+import org.apache.flink.table.planner.utils.{CountAggFunction, RowToTuple2}
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, Disabled, TestTemplate}
@@ -369,7 +368,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -383,7 +382,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
 
     val expected = Seq("Hi,Hallo")
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -403,7 +402,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "I am fine.,Hallo Welt wie")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -418,7 +417,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val expected = Seq("Hello world, how are you?,Hallo Welt wie", "I am fine.,Hallo Welt wie")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -439,7 +438,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "I am fine.,IJK")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -454,7 +453,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val expected = Seq("6")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -473,7 +472,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val expected = Seq("6,3", "4,2", "1,1")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -494,7 +493,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val expected = Seq("2,1,Hello", "2,1,Hello world", "1,0,Hi")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -509,7 +508,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "I am fine.,IJK")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -529,7 +528,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "Comment#2,IJK")
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -574,7 +573,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -614,7 +613,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -654,7 +653,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -686,7 +685,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -717,7 +716,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -757,7 +756,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -797,7 +796,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -845,7 +844,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     )
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -895,7 +894,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "null,KLM"
     )
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -946,7 +945,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "null,KLM"
     )
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
   }
@@ -975,7 +974,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val results = ds1.join(ds2, 'a < 'd).select('a, 'd)
 
     val sink = new TestingRetractSink
-    results.toRetractStream[Row].addSink(sink).setParallelism(1)
+    results.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
     val expected = Seq("6,10")
     assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
@@ -991,7 +990,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joined = ds1.leftOuterJoin(table1, 'a === 'c)
 
     val sink = new TestingRetractSink
-    joined.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joined.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,left,null,null", "2,left,2,right")
@@ -1005,7 +1004,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e).select('b, 'c, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,Hi,null,null", "2,Hello world,null,null", "2,Hello,null,null")
@@ -1019,7 +1018,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e).select('b, 'c, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1075,7 +1074,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('leftPk, 'leftA.count)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,2")
@@ -1157,7 +1156,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .where('leftPk === 'rightPk)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,5,1,2")
@@ -1232,7 +1231,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .where('leftPk === 'rightPk)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,4,1,2", "1,5,1,2")
@@ -1266,7 +1265,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('leftPk, 'leftA.count)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,2")
@@ -1427,7 +1426,8 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val result = leftTableWithPk
       .join(rightTable, 'a === 'bb && ('a < 4 || 'a > 4))
       .select('a, 'b, 'c, 'd)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
 
     val sink = new TestingRetractSink
     result.addSink(sink).setParallelism(1)
@@ -1498,7 +1498,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('b === 'e).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt")
@@ -1513,7 +1513,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('b === 'e && 'b < 2).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo")
@@ -1528,7 +1528,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('b === 'e && 'a < 6).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1548,7 +1548,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).filter('a === 'd && 'b === 'h).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1569,7 +1569,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).where('a === 'd).select('g.count)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("6")
@@ -1588,7 +1588,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('b.sum, 'g.count)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("6,3", "4,2", "1,1")
@@ -1609,7 +1609,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .select('a, 'f, 'l)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("2,1,Hello", "2,1,Hello world", "1,0,Hi")
@@ -1624,7 +1624,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).filter('a === 'd && ('b === 'e || 'b === 'e - 10)).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("Hi,Hallo", "Hello,Hallo Welt", "I am fine.,IJK")
@@ -1639,7 +1639,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.join(ds2).filter('b === 'h + 1 && 'a - 1 === 'd + 2).select('c, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq(
@@ -1713,7 +1713,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       .where('leftA === 'rightA)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("4,1,1,1", "4,1,2,1")
@@ -1734,7 +1734,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e).select('b, 'e)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,null", "2,null")
@@ -1752,7 +1752,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e).select('b, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,null,null", "2,null,null")
@@ -1770,7 +1770,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e && 'a < 'b).select('b, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,null,null", "2,null,null")
@@ -1785,7 +1785,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e).select('b, 'c, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,Hi,null,null", "2,Hello world,null,null", "2,Hello,null,null")
@@ -1800,7 +1800,7 @@ class JoinITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
     val joinT = ds1.leftOuterJoin(ds2, 'b === 'e && 'a < 'd).select('a, 'b, 'c, 'e, 'g)
 
     val sink = new TestingRetractSink
-    joinT.toRetractStream[Row].addSink(sink).setParallelism(1)
+    joinT.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("1,1,Hi,null,null", "2,2,Hello,null,null", "3,2,Hello world,null,null")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/LegacyTableSinkITCase.scala
@@ -27,12 +27,11 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.planner.runtime.utils.{TestingAppendTableSink, TestingRetractTableSink, TestingUpsertTableSink}
 import org.apache.flink.table.planner.runtime.utils.TestData.{smallTupleData3, tupleData3, tupleData5}
-import org.apache.flink.table.planner.utils.{MemoryTableSourceSinkUtil, TableTestUtil}
+import org.apache.flink.table.planner.utils.{MemoryTableSourceSinkUtil, RowToTuple2, TableTestUtil}
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.utils.LegacyRowExtension
 import org.apache.flink.test.junit5.MiniClusterExtension
 import org.apache.flink.test.util.TestBaseUtils
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Assertions._
@@ -581,7 +580,7 @@ class LegacyTableSinkITCase {
       .select('num, 'w.rowtime, 'w.rowtime.as('rowtime2))
 
     assertThatExceptionOfType(classOf[TableException])
-      .isThrownBy(() => r.toRetractStream[Row])
+      .isThrownBy(() => r.toChangelogStream.map(new RowToTuple2))
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/RetractionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/RetractionITCase.scala
@@ -22,9 +22,8 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
-import org.apache.flink.table.planner.utils.TableFunc0
+import org.apache.flink.table.planner.utils.{RowToTuple2, TableFunc0}
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.TestTemplate
@@ -59,7 +58,7 @@ class RetractionITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       .select('count, 'count.count.as('frequency))
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = Seq("1,2", "2,1", "6,1")
@@ -77,7 +76,7 @@ class RetractionITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       .select('cnt.sum)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = Seq("10")
@@ -95,7 +94,7 @@ class RetractionITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       .select('count, 'count.count)
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = Seq("10,1")
@@ -132,7 +131,7 @@ class RetractionITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       .select('sum, 'pk.count.as('count))
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = Seq(
@@ -172,7 +171,7 @@ class RetractionITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
       .select('cnt, 'word.count.as('frequency))
 
     val sink = new TestingRetractSink
-    resultTable.toRetractStream[Row].addSink(sink)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink)
     env.execute()
 
     val expected = Seq("1,2", "2,1", "6,1")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/SubQueryITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/SubQueryITCase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
 import org.apache.flink.types.Row
 
@@ -54,7 +55,7 @@ class SubQueryITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(
     val result = tableA.where('a.in(tableB.select('x)))
 
     val sink = new TestingRetractSink
-    val results = result.toRetractStream[Row]
+    val results = result.toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -93,7 +94,7 @@ class SubQueryITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(
       .where('a.in(tableB.where('y.like("%Hanoi%")).groupBy('y).select('x.sum)))
 
     val sink = new TestingRetractSink
-    val results = result.toRetractStream[Row]
+    val results = result.toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 
@@ -136,7 +137,7 @@ class SubQueryITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(
       .where('a.in(tableB.select('x)) && 'b.in(tableC.select('w)))
 
     val sink = new TestingRetractSink
-    val results = result.toRetractStream[Row]
+    val results = result.toChangelogStream.map(new RowToTuple2)
     results.addSink(sink).setParallelism(1)
     env.execute()
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -25,9 +25,8 @@ import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase,
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.OverloadedDoubleMaxFunction
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TestData.tupleData3
-import org.apache.flink.table.planner.utils.{TableAggSum, Top3, Top3Accum, Top3WithMapView, Top3WithRetractInput}
+import org.apache.flink.table.planner.utils._
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
-import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
@@ -55,7 +54,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .as("category", "v1", "v2")
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -89,7 +88,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .as("v1", "v2")
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -114,7 +113,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .select('category, 'v1.max)
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -140,7 +139,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .as("category", "v1", "v2")
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -175,7 +174,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .select('v1, 'v2)
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -195,7 +194,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .select('b, 'sum)
 
     val sink = new TestingRetractSink()
-    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    resultTable.toChangelogStream.map(new RowToTuple2).addSink(sink).setParallelism(1)
     env.execute()
 
     val expected = List(
@@ -226,7 +225,8 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
           .select('b, 'a.sum.as('a))
           .flatAggregate(top3('a).as('v1, 'v2))
           .select('v1, 'v2)
-          .toRetractStream[Row]
+          .toChangelogStream
+          .map(new RowToTuple2)
 
         env.execute()
       })
@@ -246,7 +246,8 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .flatAggregate(call(classOf[OverloadedDoubleMaxFunction], 'a).as('max))
       .select('b, 'max)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink1)
       .setParallelism(1)
 
@@ -256,7 +257,8 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .flatAggregate(call(classOf[OverloadedDoubleMaxFunction], 'a).as('max))
       .select('b, 'max)
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
       .addSink(sink2)
       .setParallelism(1)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableToDataStreamITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.TestSinkContextTableSink
 import org.apache.flink.table.planner.runtime.utils.{AbstractExactlyOnceSink, StreamingTestBase, TestingRetractSink, TestSinkUtil}
+import org.apache.flink.table.planner.utils.RowToTuple2
 import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.assertThat
@@ -115,7 +116,8 @@ final class TableToDataStreamITCase extends StreamingTestBase {
           |WHERE rowNum = 1
       """.stripMargin
       )
-      .toRetractStream[Row]
+      .toChangelogStream
+      .map(new RowToTuple2)
 
     val sink = new StringWithTimestampRetractSink[Row]
     dataStream.addSink(sink)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/RowToTuple2.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/RowToTuple2.scala
@@ -15,25 +15,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.flink.table.planner.utils
 
-package org.apache.flink.table.planner.utils;
-
-import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.types.Row;
-import org.apache.flink.types.RowKind;
-
-import scala.Tuple2;
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.types.{Row, RowKind}
 
 /** Row to scala Tuple2. */
-public class RowToTuple2 implements MapFunction<Row, Tuple2<Boolean, Row>> {
+class RowToTuple2 extends MapFunction[Row, (Boolean, Row)] {
 
-    @Override
-    public scala.Tuple2<Boolean, Row> map(Row value) throws Exception {
-        if (value.getKind().equals(RowKind.DELETE)
-                || value.getKind().equals(RowKind.UPDATE_BEFORE)) {
-            return new scala.Tuple2<>(false, value);
-        } else {
-            return new scala.Tuple2<>(true, value);
-        }
+  /**
+   * The mapping method. Takes an element from the input data set and transforms it into exactly one
+   * element.
+   *
+   * @param value
+   *   The input value.
+   * @return
+   *   The transformed value
+   * @throws Exception
+   *   This method may throw exceptions. Throwing an exception will cause the operation to fail and
+   *   may trigger recovery.
+   */
+  override def map(row: Row): (Boolean, Row) = {
+    if (row.getKind == RowKind.DELETE || row.getKind == RowKind.UPDATE_BEFORE) {
+      (false, row)
+    } else {
+      (true, row)
     }
+  }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The PR is about to replace deprecated StreamTableEnvironment#toRetractDataStream with StreamTableEnvironment#toChangelogStream as mentioned in javadoc*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
