### PR TITLE
[FLINK-33728][k8s] do not rewatch when KubernetesResourceManagerDrive…

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -505,6 +505,13 @@ public class KubernetesConfigOptions {
                                     + "Flink. A typical use-case is when one uses Flink Kubernetes "
                                     + "Operator.");
 
+    public static final ConfigOption<Boolean> KUBERNETES_IGNORE_WATCH_DISCONNECT =
+            ConfigOptions.key("kubernetes.ignore-watch-disconnect")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "keep the jm running even watch disconnected ");
+
     /**
      * This will only be used to support blocklist mechanism, which is experimental currently, so we
      * do not want to expose this option in the documentation.


### PR DESCRIPTION


## What is the purpose of the change

solve the k8s watch failure cause the whole job fail


## Brief change log

not rewatch until next request resource


## Verifying this change




This change added tests and can be verified as follows:



  - Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
