### PR TITLE
[hotfix] [tests] Per-class the lifecycle of mini-cluster in `ClientHeartbeatTest`.

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testutils.WaitingCancelableInvokable;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -45,10 +45,10 @@ class ClientHeartbeatTest {
     private final long clientHeartbeatInterval = 50;
     private final long clientHeartbeatTimeout = 1000;
 
-    private MiniCluster miniCluster;
+    private static MiniCluster miniCluster;
 
-    @AfterEach
-    void teardown() throws Exception {
+    @AfterAll
+    static void teardown() throws Exception {
         if (miniCluster != null) {
             miniCluster.close();
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This change is to make `miniCluster.close()` run only once after all tests finish and make the tests in test class `ClientHeartbeatTest` run faster. There are three tests in this test class. They are trying to submit different jobs through the cluster and assert the running status of `miniCluster` or the job status of submitted job. These tests are submitting jobs that are not related to each other. We also try to run these tests in different orders and they always pass.

Besides, test class `ClientHeartbeatTest` is similar to the test class `org.apache.flink.runtime.leaderelection.LeaderChangeClusterComponentsTest`. However, test class 
`LeaderChangeClusterComponentsTest` only close the `miniCluster` after all tests finish. It is a good choice to apply similar approach to the test class `ClientHeartbeatTest`.

The test runtime can change from `9.9113 s` to `8.9771 s` after applying this change.

## Brief change log

- This pull request changes the code such that `miniCluster.close()` run once after all tests finish rather than run after every test.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.
This pull request is just modifying tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no