### PR TITLE
[FLINK-33736][Scheduler] Update default value of exponential-delay.max-backoff and exponential-delay.backoff-multiplier

### DIFF
--- a/docs/content.zh/docs/ops/state/task_failure_recovery.md
+++ b/docs/content.zh/docs/ops/state/task_failure_recovery.md
@@ -159,7 +159,7 @@ restart-strategy.type: exponential-delay
 ```yaml
 restart-strategy.exponential-delay.initial-backoff: 10 s
 restart-strategy.exponential-delay.max-backoff: 2 min
-restart-strategy.exponential-delay.backoff-multiplier: 2.0
+restart-strategy.exponential-delay.backoff-multiplier: 1.4
 restart-strategy.exponential-delay.reset-backoff-threshold: 10 min
 restart-strategy.exponential-delay.jitter-factor: 0.1
 restart-strategy.exponential-delay.attempts-before-reset-backoff: 10

--- a/docs/content/docs/ops/state/task_failure_recovery.md
+++ b/docs/content/docs/ops/state/task_failure_recovery.md
@@ -164,7 +164,7 @@ For example:
 ```yaml
 restart-strategy.exponential-delay.initial-backoff: 10 s
 restart-strategy.exponential-delay.max-backoff: 2 min
-restart-strategy.exponential-delay.backoff-multiplier: 2.0
+restart-strategy.exponential-delay.backoff-multiplier: 1.4
 restart-strategy.exponential-delay.reset-backoff-threshold: 10 min
 restart-strategy.exponential-delay.jitter-factor: 0.1
 restart-strategy.exponential-delay.attempts-before-reset-backoff: 10

--- a/docs/layouts/shortcodes/generated/exponential_delay_restart_strategy_configuration.html
+++ b/docs/layouts/shortcodes/generated/exponential_delay_restart_strategy_configuration.html
@@ -16,7 +16,7 @@
         </tr>
         <tr>
             <td><h5>restart-strategy.exponential-delay.backoff-multiplier</h5></td>
-            <td style="word-wrap: break-word;">2.0</td>
+            <td style="word-wrap: break-word;">1.5</td>
             <td>Double</td>
             <td>Backoff value is multiplied by this value after every failure,until max backoff is reached if <code class="highlighter-rouge">restart-strategy.type</code> has been set to <code class="highlighter-rouge">exponential-delay</code>.</td>
         </tr>
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <td><h5>restart-strategy.exponential-delay.max-backoff</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
+            <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>The highest possible duration between restarts if <code class="highlighter-rouge">restart-strategy.type</code> has been set to <code class="highlighter-rouge">exponential-delay</code>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestartStrategyOptions.java
@@ -173,7 +173,7 @@ public class RestartStrategyOptions {
     public static final ConfigOption<Duration> RESTART_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF =
             ConfigOptions.key("restart-strategy.exponential-delay.max-backoff")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(5))
+                    .defaultValue(Duration.ofMinutes(1))
                     .withDescription(
                             Description.builder()
                                     .text(
@@ -185,7 +185,7 @@ public class RestartStrategyOptions {
     public static final ConfigOption<Double> RESTART_STRATEGY_EXPONENTIAL_DELAY_BACKOFF_MULTIPLIER =
             ConfigOptions.key("restart-strategy.exponential-delay.backoff-multiplier")
                     .doubleType()
-                    .defaultValue(2.0)
+                    .defaultValue(1.5)
                     .withDescription(
                             Description.builder()
                                     .text(


### PR DESCRIPTION
## What is the purpose of the change

See [FLIP-364: Improve the exponential-delay restart-strategy](https://cwiki.apache.org/confluence/x/uJqzDw) . This PR  includes the subtask1 of FLIP-364.

## Brief change log

- [FLINK-33736][Scheduler] Update default value of exponential-delay.max-backoff and exponential-delay.backoff-multiplier

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Java doc and config doc are updated.
