### PR TITLE
[FLINK-33328] Allow TwoPhaseCommittingSink WithPreCommitTopology to alter the type of the Committable - mixin approach

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/CommitterInitContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/CommitterInitContext.java
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.connector.sink2;
+package org.apache.flink.api.connector.sink2;
 
-import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 
-/** Allows expert users to implement a custom topology before {@link SinkWriter}. */
-@Experimental
-@Deprecated
-public interface WithPreWriteTopology<InputT>
-        extends Sink<InputT>, SupportsPreWriteTopology<InputT> {}
+/** The interface exposes some runtime info for creating a {@link Committer}. */
+@PublicEvolving
+public interface CommitterInitContext extends InitContext {
+    /** @return The metric group this committer belongs to. */
+    SinkCommitterMetricGroup metricGroup();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/CommittingSinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/CommittingSinkWriter.java
@@ -16,14 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.connector.sink2;
+package org.apache.flink.api.connector.sink2;
 
-import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.annotation.PublicEvolving;
 
-/** Allows expert users to implement a custom topology before {@link SinkWriter}. */
-@Experimental
-@Deprecated
-public interface WithPreWriteTopology<InputT>
-        extends Sink<InputT>, SupportsPreWriteTopology<InputT> {}
+import java.io.IOException;
+import java.util.Collection;
+
+/** A {@link SinkWriter} that performs the first part of a two-phase commit protocol. */
+@PublicEvolving
+public interface CommittingSinkWriter<InputT, CommittableT> extends SinkWriter<InputT> {
+    /**
+     * Prepares for a commit.
+     *
+     * <p>This method will be called after {@link #flush(boolean)} and before {@link
+     * StatefulSinkWriter#snapshotState(long)}.
+     *
+     * @return The data to commit as the second step of the two-phase commit protocol.
+     * @throws IOException if fail to prepare for a commit.
+     */
+    Collection<CommittableT> prepareCommit() throws IOException, InterruptedException;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
@@ -30,12 +31,13 @@ import org.apache.flink.util.UserCodeClassLoader;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 
 /**
  * Base interface for developing a sink. A basic {@link Sink} is a stateless sink that can flush
  * data on checkpoint to achieve at-least-once consistency. Sinks with additional requirements
- * should implement {@link StatefulSink} or {@link TwoPhaseCommittingSink}.
+ * should implement {@link SupportsWriterState} or {@link SupportsCommitter}.
  *
  * <p>The {@link Sink} needs to be serializable. All configuration should be validated eagerly. The
  * respective sink writers are transient and will only be created in the subtasks on the
@@ -52,11 +54,30 @@ public interface Sink<InputT> extends Serializable {
      * @param context the runtime context.
      * @return A sink writer.
      * @throws IOException for any failure during creation.
+     * @deprecated Please implement {@link #createWriter(WriterInitContext)}. For backward
+     *     compatibility reasons - to keep {@link Sink} a functional interface - Flink did not
+     *     provide a default implementation. New {@link Sink} implementations should implement this
+     *     method, but it will not be used, and it will be removed in 1.20.0 release. Do not use
+     *     {@link Override} annotation when implementing this method, to prevent compilation errors
+     *     when migrating to 1.20.x release.
      */
+    @Deprecated
     SinkWriter<InputT> createWriter(InitContext context) throws IOException;
+
+    /**
+     * Creates a {@link SinkWriter}.
+     *
+     * @param context the runtime context.
+     * @return A sink writer.
+     * @throws IOException for any failure during creation.
+     */
+    default SinkWriter<InputT> createWriter(WriterInitContext context) throws IOException {
+        return createWriter(new InitContextWrapper(context));
+    }
 
     /** The interface exposes some runtime info for creating a {@link SinkWriter}. */
     @PublicEvolving
+    @Deprecated
     interface InitContext extends org.apache.flink.api.connector.sink2.InitContext {
         /**
          * Gets the {@link UserCodeClassLoader} to load classes that are not in system's classpath,
@@ -108,6 +129,82 @@ public interface Sink<InputT> extends Serializable {
         @Experimental
         default <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
             return Optional.empty();
+        }
+    }
+
+    /**
+     * Class for wrapping a new {@link WriterInitContext} to an old {@link InitContext} until
+     * deprecation.
+     *
+     * @deprecated Internal, do not use it.
+     */
+    @Deprecated
+    class InitContextWrapper implements InitContext {
+        private final WriterInitContext wrapped;
+
+        InitContextWrapper(WriterInitContext wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public int getSubtaskId() {
+            return wrapped.getSubtaskId();
+        }
+
+        @Override
+        public int getNumberOfParallelSubtasks() {
+            return wrapped.getNumberOfParallelSubtasks();
+        }
+
+        @Override
+        public int getAttemptNumber() {
+            return wrapped.getAttemptNumber();
+        }
+
+        @Override
+        public OptionalLong getRestoredCheckpointId() {
+            return wrapped.getRestoredCheckpointId();
+        }
+
+        @Override
+        public JobID getJobId() {
+            return wrapped.getJobId();
+        }
+
+        @Override
+        public UserCodeClassLoader getUserCodeClassLoader() {
+            return wrapped.getUserCodeClassLoader();
+        }
+
+        @Override
+        public MailboxExecutor getMailboxExecutor() {
+            return wrapped.getMailboxExecutor();
+        }
+
+        @Override
+        public ProcessingTimeService getProcessingTimeService() {
+            return wrapped.getProcessingTimeService();
+        }
+
+        @Override
+        public SinkWriterMetricGroup metricGroup() {
+            return wrapped.metricGroup();
+        }
+
+        @Override
+        public SerializationSchema.InitializationContext
+                asSerializationSchemaInitializationContext() {
+            return wrapped.asSerializationSchemaInitializationContext();
+        }
+
+        @Override
+        public boolean isObjectReuseEnabled() {
+            return wrapped.isObjectReuseEnabled();
+        }
+
+        @Override
+        public <IN> TypeSerializer<IN> createInputSerializer() {
+            return wrapped.createInputSerializer();
         }
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/StatefulSink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/StatefulSink.java
@@ -19,11 +19,9 @@
 package org.apache.flink.api.connector.sink2;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * A {@link Sink} with a stateful {@link SinkWriter}.
@@ -36,49 +34,43 @@ import java.util.List;
  * @param <WriterStateT> The type of the sink writer's state
  */
 @PublicEvolving
-public interface StatefulSink<InputT, WriterStateT> extends Sink<InputT> {
+@Deprecated
+public interface StatefulSink<InputT, WriterStateT>
+        extends Sink<InputT>, SupportsWriterState<InputT, WriterStateT> {
 
     /**
-     * Create a {@link StatefulSinkWriter}.
+     * Create a {@link org.apache.flink.api.connector.sink2.StatefulSinkWriter} from a recovered
+     * state.
      *
      * @param context the runtime context.
      * @return A sink writer.
      * @throws IOException for any failure during creation.
      */
-    StatefulSinkWriter<InputT, WriterStateT> createWriter(InitContext context) throws IOException;
+    default StatefulSinkWriter<InputT, WriterStateT> restoreWriter(
+            Sink.InitContext context, Collection<WriterStateT> recoveredState) throws IOException {
+        throw new UnsupportedOperationException(
+                "Deprecated, please use restoreWriter(WriterInitContext, Collection<WriterStateT>)");
+    }
 
     /**
-     * Create a {@link StatefulSinkWriter} from a recovered state.
+     * Create a {@link org.apache.flink.api.connector.sink2.StatefulSinkWriter} from a recovered
+     * state.
      *
      * @param context the runtime context.
      * @return A sink writer.
      * @throws IOException for any failure during creation.
      */
-    StatefulSinkWriter<InputT, WriterStateT> restoreWriter(
-            InitContext context, Collection<WriterStateT> recoveredState) throws IOException;
-
-    /**
-     * Any stateful sink needs to provide this state serializer and implement {@link
-     * StatefulSinkWriter#snapshotState(long)} properly. The respective state is used in {@link
-     * #restoreWriter(InitContext, Collection)} on recovery.
-     *
-     * @return the serializer of the writer's state type.
-     */
-    SimpleVersionedSerializer<WriterStateT> getWriterStateSerializer();
+    default StatefulSinkWriter<InputT, WriterStateT> restoreWriter(
+            WriterInitContext context, Collection<WriterStateT> recoveredState) throws IOException {
+        return restoreWriter(new InitContextWrapper(context), recoveredState);
+    }
 
     /**
      * A mix-in for {@link StatefulSink} that allows users to migrate from a sink with a compatible
      * state to this sink.
      */
     @PublicEvolving
-    interface WithCompatibleState {
-        /**
-         * A list of state names of sinks from which the state can be restored. For example, the new
-         * {@code FileSink} can resume from the state of an old {@code StreamingFileSink} as a
-         * drop-in replacement when resuming from a checkpoint/savepoint.
-         */
-        Collection<String> getCompatibleWriterStateNames();
-    }
+    interface WithCompatibleState extends SupportsWriterState.WithCompatibleState {}
 
     /**
      * A {@link SinkWriter} whose state needs to be checkpointed.
@@ -87,11 +79,6 @@ public interface StatefulSink<InputT, WriterStateT> extends Sink<InputT> {
      * @param <WriterStateT> The type of the writer's state
      */
     @PublicEvolving
-    interface StatefulSinkWriter<InputT, WriterStateT> extends SinkWriter<InputT> {
-        /**
-         * @return The writer's state.
-         * @throws IOException if fail to snapshot writer's state.
-         */
-        List<WriterStateT> snapshotState(long checkpointId) throws IOException;
-    }
+    interface StatefulSinkWriter<InputT, WriterStateT>
+            extends org.apache.flink.api.connector.sink2.StatefulSinkWriter<InputT, WriterStateT> {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/StatefulSinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/StatefulSinkWriter.java
@@ -16,14 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api.connector.sink2;
+package org.apache.flink.api.connector.sink2;
 
-import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.annotation.PublicEvolving;
 
-/** Allows expert users to implement a custom topology before {@link SinkWriter}. */
-@Experimental
-@Deprecated
-public interface WithPreWriteTopology<InputT>
-        extends Sink<InputT>, SupportsPreWriteTopology<InputT> {}
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A {@link SinkWriter} whose state needs to be checkpointed.
+ *
+ * @param <InputT> The type of the sink writer's input
+ * @param <WriterStateT> The type of the writer's state
+ */
+@PublicEvolving
+public interface StatefulSinkWriter<InputT, WriterStateT> extends SinkWriter<InputT> {
+    /**
+     * @return The writer's state.
+     * @throws IOException if fail to snapshot writer's state.
+     */
+    List<WriterStateT> snapshotState(long checkpointId) throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/SupportsCommitter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/SupportsCommitter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink2;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * A mixin interface for a {@link Sink} which supports exactly-once semantics using a two-phase
+ * commit protocol. The {@link Sink} consists of a {@link CommittingSinkWriter} that performs the
+ * precommits and a {@link Committer} that actually commits the data. To facilitate the separation
+ * the {@link CommittingSinkWriter} creates <i>committables</i> on checkpoint or end of input and
+ * the sends it to the {@link Committer}.
+ *
+ * <p>The {@link Sink} needs to be serializable. All configuration should be validated eagerly. The
+ * respective sink writers and committers are transient and will only be created in the subtasks on
+ * the taskmanagers.
+ *
+ * @param <CommittableT> The type of the committables.
+ */
+@PublicEvolving
+public interface SupportsCommitter<CommittableT> {
+
+    /**
+     * Creates a {@link Committer} that permanently makes the previously written data visible
+     * through {@link Committer#commit(Collection)}.
+     *
+     * @param context The context information for the committer initialization.
+     * @return A committer for the two-phase commit protocol.
+     * @throws IOException for any failure during creation.
+     */
+    Committer<CommittableT> createCommitter(CommitterInitContext context) throws IOException;
+
+    /** Returns the serializer of the committable type. */
+    SimpleVersionedSerializer<CommittableT> getCommittableSerializer();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/SupportsWriterState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/SupportsWriterState.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink2;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * A mixin interface for a {@link Sink} which supports a stateful {@link StatefulSinkWriter}.
+ *
+ * <p>The {@link Sink} needs to be serializable. All configuration should be validated eagerly. The
+ * respective sink writers are transient and will only be created in the subtasks on the
+ * taskmanagers.
+ *
+ * @param <InputT> The type of the sink's input
+ * @param <WriterStateT> The type of the sink writer's state
+ */
+@PublicEvolving
+public interface SupportsWriterState<InputT, WriterStateT> {
+
+    /**
+     * Create a {@link StatefulSinkWriter} from a recovered state.
+     *
+     * @param context the runtime context.
+     * @return A sink writer.
+     * @throws IOException for any failure during creation.
+     */
+    StatefulSinkWriter<InputT, WriterStateT> restoreWriter(
+            WriterInitContext context, Collection<WriterStateT> recoveredState) throws IOException;
+
+    /**
+     * Any stateful sink needs to provide this state serializer and implement {@link
+     * StatefulSinkWriter#snapshotState(long)} properly. The respective state is used in {@link
+     * #restoreWriter(WriterInitContext, Collection)} on recovery.
+     *
+     * @return the serializer of the writer's state type.
+     */
+    SimpleVersionedSerializer<WriterStateT> getWriterStateSerializer();
+
+    /**
+     * A mix-in for {@link SupportsWriterState} that allows users to migrate from a sink with a
+     * compatible state to this sink.
+     */
+    @PublicEvolving
+    interface WithCompatibleState {
+        /**
+         * A list of state names of sinks from which the state can be restored. For example, the new
+         * {@code FileSink} can resume from the state of an old {@code StreamingFileSink} as a
+         * drop-in replacement when resuming from a checkpoint/savepoint.
+         */
+        Collection<String> getCompatibleWriterStateNames();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/TwoPhaseCommittingSink.java
@@ -69,5 +69,6 @@ public interface TwoPhaseCommittingSink<InputT, CommT>
 
     /** A {@link SinkWriter} that performs the first part of a two-phase commit protocol. */
     @PublicEvolving
+    @Deprecated
     interface PrecommittingSinkWriter<InputT, CommT> extends CommittingSinkWriter<InputT, CommT> {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/WriterInitContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/WriterInitContext.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink2;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/** The interface exposes some runtime info for creating a {@link SinkWriter}. */
+@PublicEvolving
+public interface WriterInitContext extends org.apache.flink.api.connector.sink2.InitContext {
+    /**
+     * Gets the {@link UserCodeClassLoader} to load classes that are not in system's classpath, but
+     * are part of the jar file of a user job.
+     *
+     * @see UserCodeClassLoader
+     */
+    UserCodeClassLoader getUserCodeClassLoader();
+
+    /**
+     * Returns the mailbox executor that allows to execute {@link Runnable}s inside the task thread
+     * in between record processing.
+     *
+     * <p>Note that this method should not be used per-record for performance reasons in the same
+     * way as records should not be sent to the external system individually. Rather, implementers
+     * are expected to batch records and only enqueue a single {@link Runnable} per batch to handle
+     * the result.
+     */
+    MailboxExecutor getMailboxExecutor();
+
+    /**
+     * Returns a {@link ProcessingTimeService} that can be used to get the current time and register
+     * timers.
+     */
+    ProcessingTimeService getProcessingTimeService();
+
+    /** @return The metric group this writer belongs to. */
+    SinkWriterMetricGroup metricGroup();
+
+    /** Provides a view on this context as a {@link SerializationSchema.InitializationContext}. */
+    SerializationSchema.InitializationContext asSerializationSchemaInitializationContext();
+
+    /** Returns whether object reuse has been enabled or disabled. */
+    boolean isObjectReuseEnabled();
+
+    /** Creates a serializer for the type of sink's input. */
+    <IN> TypeSerializer<IN> createInputSerializer();
+
+    /**
+     * Returns a metadata consumer, the {@link SinkWriter} can publish metadata events of type
+     * {@link MetaT} to the consumer.
+     *
+     * <p>It is recommended to use a separate thread pool to publish the metadata because enqueuing
+     * a lot of these messages in the mailbox may lead to a performance decrease. thread, and the
+     * {@link Consumer#accept} method is executed very fast.
+     */
+    @Experimental
+    default <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
+        return Optional.empty();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
@@ -61,6 +61,15 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
         this.numberOfFailedCommittables = numberOfFailedCommittables;
     }
 
+    public CommittableSummary(CommittableSummary<?> origin) {
+        this.subtaskId = origin.subtaskId;
+        this.numberOfSubtasks = origin.numberOfSubtasks;
+        this.checkpointId = origin.checkpointId;
+        this.numberOfCommittables = origin.numberOfCommittables;
+        this.numberOfPendingCommittables = origin.numberOfPendingCommittables;
+        this.numberOfFailedCommittables = origin.numberOfFailedCommittables;
+    }
+
     public int getSubtaskId() {
         return subtaskId;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableWithLineage.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableWithLineage.java
@@ -44,6 +44,12 @@ public class CommittableWithLineage<CommT> implements CommittableMessage<CommT> 
         this.subtaskId = subtaskId;
     }
 
+    public CommittableWithLineage(CommT committable, CommittableWithLineage origin) {
+        this.committable = checkNotNull(committable);
+        this.checkpointId = origin.checkpointId;
+        this.subtaskId = origin.subtaskId;
+    }
+
     public CommT getCommittable() {
         return committable;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPostCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPostCommitTopology.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
@@ -30,7 +29,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  * unexpected side-effects.
  */
 @Experimental
-public interface SupportsPostCommitTopology<CommittableT> extends SupportsCommitter<CommittableT> {
+public interface SupportsPostCommitTopology<CommittableT> {
 
     /**
      * Adds a custom post-commit topology where all committables can be processed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPostCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPostCommitTopology.java
@@ -20,7 +20,8 @@ package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
  * Allows expert users to implement a custom topology after {@link Committer}.
@@ -29,6 +30,19 @@ import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
  * unexpected side-effects.
  */
 @Experimental
-@Deprecated
-public interface WithPostCommitTopology<InputT, CommT>
-        extends TwoPhaseCommittingSink<InputT, CommT>, SupportsPostCommitTopology<CommT> {}
+public interface SupportsPostCommitTopology<CommittableT> extends SupportsCommitter<CommittableT> {
+
+    /**
+     * Adds a custom post-commit topology where all committables can be processed.
+     *
+     * <p>It is strongly recommended to keep this pipeline stateless such that batch and streaming
+     * modes do not require special cases.
+     *
+     * <p>All operations need to be idempotent: on recovery, any number of committables may be
+     * replayed that have already been committed. It's mandatory that these committables have no
+     * effect on the external system.
+     *
+     * @param committables the stream of committables.
+     */
+    void addPostCommitTopology(DataStream<CommittableMessage<CommittableT>> committables);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreCommitTopology.java
@@ -20,15 +20,32 @@ package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.datastream.DataStream;
 
 /**
- * Allows expert users to implement a custom topology after {@link Committer}.
+ * Allows expert users to implement a custom topology after {@link SinkWriter} and before {@link
+ * Committer}.
  *
  * <p>It is recommended to use immutable committables because mutating committables can have
  * unexpected side-effects.
  */
 @Experimental
-@Deprecated
-public interface WithPostCommitTopology<InputT, CommT>
-        extends TwoPhaseCommittingSink<InputT, CommT>, SupportsPostCommitTopology<CommT> {}
+public interface SupportsPreCommitTopology<WriterResultT, CommittableT>
+        extends SupportsCommitter<CommittableT> {
+
+    /**
+     * Intercepts and modifies the committables sent on checkpoint or at end of input. Implementers
+     * need to ensure to modify all {@link CommittableMessage}s appropriately.
+     *
+     * @param committables the stream of committables.
+     * @return the custom topology before {@link Committer}.
+     */
+    DataStream<CommittableMessage<CommittableT>> addPreCommitTopology(
+            DataStream<CommittableMessage<WriterResultT>> committables);
+
+    /** Returns the serializer of the WriteResult type. */
+    SimpleVersionedSerializer<WriterResultT> getWriteResultSerializer();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreCommitTopology.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.api.connector.sink2;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 
@@ -33,8 +32,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  * unexpected side-effects.
  */
 @Experimental
-public interface SupportsPreCommitTopology<WriterResultT, CommittableT>
-        extends SupportsCommitter<CommittableT> {
+public interface SupportsPreCommitTopology<WriterResultT, CommittableT> {
 
     /**
      * Intercepts and modifies the committables sent on checkpoint or at end of input. Implementers

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
@@ -19,11 +19,19 @@
 package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.streaming.api.datastream.DataStream;
 
 /** Allows expert users to implement a custom topology before {@link SinkWriter}. */
 @Experimental
-@Deprecated
-public interface WithPreWriteTopology<InputT>
-        extends Sink<InputT>, SupportsPreWriteTopology<InputT> {}
+public interface SupportsPreWriteTopology<InputT> {
+
+    /**
+     * Adds an arbitrary topology before the writer. The topology may be used to repartition the
+     * data.
+     *
+     * @param inputDataStream the stream of input records.
+     * @return the custom topology before {@link SinkWriter}.
+     */
+    DataStream<InputT> addPreWriteTopology(DataStream<InputT> inputDataStream);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPreCommitTopology.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/sink2/WithPreCommitTopology.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 /**
  * Allows expert users to implement a custom topology after {@link SinkWriter} and before {@link
@@ -32,16 +32,11 @@ import org.apache.flink.streaming.api.datastream.DataStream;
  * unexpected side-effects.
  */
 @Experimental
+@Deprecated
 public interface WithPreCommitTopology<InputT, CommT>
-        extends TwoPhaseCommittingSink<InputT, CommT> {
-
-    /**
-     * Intercepts and modifies the committables sent on checkpoint or at end of input. Implementers
-     * need to ensure to modify all {@link CommittableMessage}s appropriately.
-     *
-     * @param committables the stream of committables.
-     * @return the custom topology before {@link Committer}.
-     */
-    DataStream<CommittableMessage<CommT>> addPreCommitTopology(
-            DataStream<CommittableMessage<CommT>> committables);
+        extends TwoPhaseCommittingSink<InputT, CommT>, SupportsPreCommitTopology<CommT, CommT> {
+    /** Defaults to {@link #getCommittableSerializer} for backward compatibility. */
+    default SimpleVersionedSerializer<CommT> getWriteResultSerializer() {
+        return getCommittableSerializer();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkV1Adapter.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink.ProcessingTimeService;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
@@ -49,7 +50,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.OptionalLong;
 
-import static org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.CommitterInitContext;
 import static org.apache.flink.util.IOUtils.closeAll;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -41,14 +41,12 @@ public final class CommitterOperatorFactory<CommT>
         implements OneInputStreamOperatorFactory<
                 CommittableMessage<CommT>, CommittableMessage<CommT>> {
 
-    private final TwoPhaseCommittingSink<?, CommT> sink;
+    private final SupportsCommitter<CommT> sink;
     private final boolean isBatchMode;
     private final boolean isCheckpointingEnabled;
 
     public CommitterOperatorFactory(
-            TwoPhaseCommittingSink<?, CommT> sink,
-            boolean isBatchMode,
-            boolean isCheckpointingEnabled) {
+            SupportsCommitter<CommT> sink, boolean isBatchMode, boolean isCheckpointingEnabled) {
         this.sink = checkNotNull(sink);
         this.isBatchMode = isBatchMode;
         this.isCheckpointingEnabled = isCheckpointingEnabled;
@@ -65,7 +63,7 @@ public final class CommitterOperatorFactory<CommT>
                             processingTimeService,
                             sink.getCommittableSerializer(),
                             context -> sink.createCommitter(context),
-                            sink instanceof WithPostCommitTopology,
+                            sink instanceof SupportsPostCommitTopology,
                             isBatchMode,
                             isCheckpointingEnabled);
             committerOperator.setup(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
@@ -132,7 +133,7 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
     @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
-        InitContext initContext = createInitContext(context.getRestoredCheckpointId());
+        WriterInitContext initContext = createInitContext(context.getRestoredCheckpointId());
         if (context.isRestored()) {
             if (committableSerializer != null) {
                 final ListState<List<CommT>> legacyCommitterState =
@@ -238,7 +239,7 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         }
     }
 
-    private InitContext createInitContext(OptionalLong restoredCheckpointId) {
+    private WriterInitContext createInitContext(OptionalLong restoredCheckpointId) {
         return new InitContextImpl(
                 getRuntimeContext(),
                 processingTimeService,
@@ -267,7 +268,7 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         }
     }
 
-    private static class InitContextImpl extends InitContextBase implements InitContext {
+    private static class InitContextImpl extends InitContextBase implements WriterInitContext {
 
         private final ProcessingTimeService processingTimeService;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -24,12 +24,12 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.StatefulSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.SupportsWriterState;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -113,18 +113,17 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         this.processingTimeService = checkNotNull(processingTimeService);
         this.mailboxExecutor = checkNotNull(mailboxExecutor);
         this.context = new Context<>();
-        this.emitDownstream = sink instanceof TwoPhaseCommittingSink;
+        this.emitDownstream = sink instanceof SupportsCommitter;
 
-        if (sink instanceof StatefulSink) {
+        if (sink instanceof SupportsWriterState) {
             writerStateHandler =
-                    new StatefulSinkWriterStateHandler<>((StatefulSink<InputT, ?>) sink);
+                    new StatefulSinkWriterStateHandler<>((SupportsWriterState<InputT, ?>) sink);
         } else {
             writerStateHandler = new StatelessSinkWriterStateHandler<>(sink);
         }
 
-        if (sink instanceof TwoPhaseCommittingSink) {
-            committableSerializer =
-                    ((TwoPhaseCommittingSink<InputT, CommT>) sink).getCommittableSerializer();
+        if (sink instanceof SupportsCommitter) {
+            committableSerializer = ((SupportsCommitter<CommT>) sink).getCommittableSerializer();
         } else {
             committableSerializer = null;
         }
@@ -188,13 +187,13 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         if (!emitDownstream) {
             // To support SinkV1 topologies with only a writer we have to call prepareCommit
             // although no committables are forwarded
-            if (sinkWriter instanceof PrecommittingSinkWriter) {
-                ((PrecommittingSinkWriter<?, ?>) sinkWriter).prepareCommit();
+            if (sinkWriter instanceof CommittingSinkWriter) {
+                ((CommittingSinkWriter<?, ?>) sinkWriter).prepareCommit();
             }
             return;
         }
         Collection<CommT> committables =
-                ((PrecommittingSinkWriter<?, CommT>) sinkWriter).prepareCommit();
+                ((CommittingSinkWriter<?, CommT>) sinkWriter).prepareCommit();
         StreamingRuntimeContext runtimeContext = getRuntimeContext();
         final int indexOfThisSubtask = runtimeContext.getIndexOfThisSubtask();
         final int numberOfParallelSubtasks = runtimeContext.getNumberOfParallelSubtasks();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterStateHandler.java
@@ -17,8 +17,8 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.runtime.state.StateInitializationContext;
 
 /**
@@ -38,6 +38,6 @@ interface SinkWriterStateHandler<InputT> {
     void snapshotState(long checkpointId) throws Exception;
 
     /** Creates a writer, potentially using state from {@link StateInitializationContext}. */
-    SinkWriter<InputT> createWriter(InitContext initContext, StateInitializationContext context)
-            throws Exception;
+    SinkWriter<InputT> createWriter(
+            WriterInitContext initContext, StateInitializationContext context) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterStateHandler.java
@@ -22,15 +22,18 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
-import org.apache.flink.api.connector.sink2.Sink.InitContext;
+import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSink;
-import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
-import org.apache.flink.api.connector.sink2.StatefulSink.WithCompatibleState;
+import org.apache.flink.api.connector.sink2.StatefulSinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsWriterState;
+import org.apache.flink.api.connector.sink2.SupportsWriterState.WithCompatibleState;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
 
@@ -59,7 +62,7 @@ final class StatefulSinkWriterStateHandler<InputT, WriterStateT>
      */
     private final Collection<String> previousSinkStateNames;
 
-    private final StatefulSink<InputT, WriterStateT> sink;
+    private final Sink<InputT> sink;
 
     // ------------------------------- runtime fields ---------------------------------------
 
@@ -88,7 +91,7 @@ final class StatefulSinkWriterStateHandler<InputT, WriterStateT>
 
     @Override
     public SinkWriter<InputT> createWriter(
-            InitContext initContext, StateInitializationContext context) throws Exception {
+            WriterInitContext initContext, StateInitializationContext context) throws Exception {
         final ListState<byte[]> rawState =
                 context.getOperatorStateStore().getListState(WRITER_RAW_STATES_DESC);
         writerState =
@@ -112,9 +115,14 @@ final class StatefulSinkWriterStateHandler<InputT, WriterStateT>
                 previousSinkStates.add(previousSinkState);
                 Iterables.addAll(states, previousSinkState.get());
             }
-            sinkWriter = sink.restoreWriter(initContext, states);
+
+            if (!(sink instanceof SupportsWriterState)) {
+                throw new IllegalArgumentException("Sink should implement SupportsWriterState");
+            }
+
+            sinkWriter = ((SupportsWriterState) sink).restoreWriter(initContext, states);
         } else {
-            sinkWriter = sink.createWriter(initContext);
+            sinkWriter = cast(sink.createWriter(initContext));
         }
         return sinkWriter;
     }
@@ -123,5 +131,12 @@ final class StatefulSinkWriterStateHandler<InputT, WriterStateT>
     public void snapshotState(long checkpointId) throws Exception {
         writerState.update(sinkWriter.snapshotState(checkpointId));
         previousSinkStates.forEach(ListState::clear);
+    }
+
+    private static StatefulSinkWriter cast(SinkWriter writer) {
+        Preconditions.checkArgument(
+                writer instanceof StatefulSinkWriter,
+                "The writer should implement StatefulSinkWriter");
+        return (StatefulSinkWriter) writer;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterStateHandler.java
@@ -18,8 +18,8 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.runtime.state.StateInitializationContext;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -35,7 +35,7 @@ final class StatelessSinkWriterStateHandler<InputT> implements SinkWriterStateHa
 
     @Override
     public SinkWriter<InputT> createWriter(
-            InitContext initContext, StateInitializationContext context) throws Exception {
+            WriterInitContext initContext, StateInitializationContext context) throws Exception {
         return sink.createWriter(initContext);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -24,15 +24,15 @@ import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessageTypeInfo;
 import org.apache.flink.streaming.api.connector.sink2.StandardSinkTopologies;
-import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -44,6 +44,7 @@ import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
 import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -135,16 +136,27 @@ public class SinkTransformationTranslator<Input, Output>
 
             DataStream<T> prewritten = inputStream;
 
-            if (sink instanceof WithPreWriteTopology) {
+            if (sink instanceof SupportsPreWriteTopology) {
                 prewritten =
                         adjustTransformations(
                                 prewritten,
-                                ((WithPreWriteTopology<T>) sink)::addPreWriteTopology,
+                                ((SupportsPreWriteTopology<T>) sink)::addPreWriteTopology,
                                 true,
                                 sink instanceof SupportsConcurrentExecutionAttempts);
             }
 
-            if (sink instanceof TwoPhaseCommittingSink) {
+            if (sink instanceof SupportsPreCommitTopology) {
+                Preconditions.checkArgument(
+                        sink instanceof SupportsCommitter,
+                        "Sink with SupportsPreCommitTopology should implement SupportsCommitter");
+            }
+            if (sink instanceof SupportsPostCommitTopology) {
+                Preconditions.checkArgument(
+                        sink instanceof SupportsCommitter,
+                        "Sink with SupportsPostCommitTopology should implement SupportsCommitter");
+            }
+
+            if (sink instanceof SupportsCommitter) {
                 addCommittingTopology(sink, prewritten);
             } else {
                 adjustTransformations(
@@ -173,13 +185,63 @@ public class SinkTransformationTranslator<Input, Output>
             }
         }
 
-        private <CommT> void addCommittingTopology(Sink<T> sink, DataStream<T> inputStream) {
-            TwoPhaseCommittingSink<T, CommT> committingSink =
-                    (TwoPhaseCommittingSink<T, CommT>) sink;
-            TypeInformation<CommittableMessage<CommT>> typeInformation =
+        private <CommittableT, WriteResultT> void addCommittingTopology(
+                Sink<T> sink, DataStream<T> inputStream) {
+            SupportsCommitter<CommittableT> committingSink = (SupportsCommitter<CommittableT>) sink;
+            TypeInformation<CommittableMessage<CommittableT>> committableTypeInformation =
                     CommittableMessageTypeInfo.of(committingSink::getCommittableSerializer);
 
-            DataStream<CommittableMessage<CommT>> written =
+            DataStream<CommittableMessage<CommittableT>> precommitted;
+            if (sink instanceof SupportsPreCommitTopology) {
+                SupportsPreCommitTopology<WriteResultT, CommittableT> preCommittingSink =
+                        (SupportsPreCommitTopology<WriteResultT, CommittableT>) sink;
+                TypeInformation<CommittableMessage<WriteResultT>> writeResultTypeInformation =
+                        CommittableMessageTypeInfo.of(preCommittingSink::getWriteResultSerializer);
+
+                DataStream<CommittableMessage<WriteResultT>> writerResult =
+                        addWriter(sink, inputStream, writeResultTypeInformation);
+
+                precommitted =
+                        adjustTransformations(
+                                writerResult, preCommittingSink::addPreCommitTopology, true, false);
+            } else {
+                precommitted = addWriter(sink, inputStream, committableTypeInformation);
+            }
+
+            DataStream<CommittableMessage<CommittableT>> committed =
+                    adjustTransformations(
+                            precommitted,
+                            pc ->
+                                    pc.transform(
+                                            COMMITTER_NAME,
+                                            committableTypeInformation,
+                                            new CommitterOperatorFactory<>(
+                                                    committingSink,
+                                                    isBatchMode,
+                                                    isCheckpointingEnabled)),
+                            false,
+                            false);
+
+            if (sink instanceof SupportsPostCommitTopology) {
+                DataStream<CommittableMessage<CommittableT>> postcommitted =
+                        addFailOverRegion(committed);
+                adjustTransformations(
+                        postcommitted,
+                        pc -> {
+                            ((SupportsPostCommitTopology<CommittableT>) sink)
+                                    .addPostCommitTopology(pc);
+                            return null;
+                        },
+                        true,
+                        false);
+            }
+        }
+
+        private <WriteResultT> DataStream<CommittableMessage<WriteResultT>> addWriter(
+                Sink<T> sink,
+                DataStream<T> inputStream,
+                TypeInformation<CommittableMessage<WriteResultT>> typeInformation) {
+            DataStream<CommittableMessage<WriteResultT>> written =
                     adjustTransformations(
                             inputStream,
                             input ->
@@ -190,42 +252,7 @@ public class SinkTransformationTranslator<Input, Output>
                             false,
                             sink instanceof SupportsConcurrentExecutionAttempts);
 
-            DataStream<CommittableMessage<CommT>> precommitted = addFailOverRegion(written);
-
-            if (sink instanceof WithPreCommitTopology) {
-                precommitted =
-                        adjustTransformations(
-                                precommitted,
-                                ((WithPreCommitTopology<T, CommT>) sink)::addPreCommitTopology,
-                                true,
-                                false);
-            }
-
-            DataStream<CommittableMessage<CommT>> committed =
-                    adjustTransformations(
-                            precommitted,
-                            pc ->
-                                    pc.transform(
-                                            COMMITTER_NAME,
-                                            typeInformation,
-                                            new CommitterOperatorFactory<>(
-                                                    committingSink,
-                                                    isBatchMode,
-                                                    isCheckpointingEnabled)),
-                            false,
-                            false);
-
-            if (sink instanceof WithPostCommitTopology) {
-                DataStream<CommittableMessage<CommT>> postcommitted = addFailOverRegion(committed);
-                adjustTransformations(
-                        postcommitted,
-                        pc -> {
-                            ((WithPostCommitTopology<T, CommT>) sink).addPostCommitTopology(pc);
-                            return null;
-                        },
-                        true,
-                        false);
-            }
+            return addFailOverRegion(written);
         }
 
         /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -67,10 +67,7 @@ public class SinkV2TransformationTranslatorITCase
                         .setWriterUidHash(writerHash)
                         .setCommitterUidHash(committerHash)
                         .build();
-        src.sinkTo(
-                        TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build(),
-                        operatorsUidHashes)
-                .name(NAME);
+        src.sinkTo(sinkWithCommitter(), operatorsUidHashes).name(NAME);
 
         final StreamGraph streamGraph = env.getStreamGraph();
 
@@ -87,9 +84,7 @@ public class SinkV2TransformationTranslatorITCase
         final String sinkUid = "f6b178ce445dc3ffaa06bad27a51fead";
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final DataStreamSource<Integer> src = env.fromElements(1, 2);
-        src.sinkTo(TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build())
-                .name(NAME)
-                .uid(sinkUid);
+        src.sinkTo(sinkWithCommitter()).name(NAME).uid(sinkUid);
 
         final StreamGraph streamGraph = env.getStreamGraph();
         assertEquals(findWriter(streamGraph).getTransformationUID(), sinkUid);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -36,7 +36,12 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.connector.source.mocks.MockSource;
@@ -70,6 +75,11 @@ import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessageTypeInfo;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
 import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
 import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
@@ -105,6 +115,7 @@ import org.apache.flink.streaming.api.transformations.MultipleInputTransformatio
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
@@ -128,6 +139,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2121,6 +2133,30 @@ class StreamingJobGraphGeneratorTest {
     }
 
     @Test
+    void testSinkWithAllInterfaces() {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        final DataStream<Integer> source = env.fromData(1, 2, 3).name("source");
+        source.rebalance().sinkTo(new TestSinkWithAllInterfaces()).name("sink");
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+        assertThat(jobGraph.getNumberOfVertices()).isEqualTo(6);
+        for (JobVertex jobVertex : jobGraph.getVertices()) {
+            assertThat(jobVertex.getName())
+                    .containsAnyOf(
+                            "source",
+                            "pre-writer",
+                            "Writer",
+                            "pre-committer",
+                            "post-committer",
+                            "Committer");
+        }
+    }
+
+    @Test
     void testSupportConcurrentExecutionAttempts() {
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
@@ -2402,6 +2438,114 @@ class StreamingJobGraphGeneratorTest {
         @Override
         public DataStream<Integer> addPreWriteTopology(DataStream<Integer> inputDataStream) {
             return inputDataStream.map(v -> v).name("pre-writer").rebalance();
+        }
+    }
+
+    private static class TestSinkWithAllInterfaces
+            implements Sink<Integer>,
+                    SupportsPreWriteTopology<Integer>,
+                    SupportsCommitter<Long>,
+                    SupportsPreCommitTopology<String, Long>,
+                    SupportsPostCommitTopology<Long> {
+
+        @Override
+        @Deprecated
+        public SinkWriter<Integer> createWriter(InitContext context) throws IOException {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public CommittingSinkWriter<Integer, String> createWriter(WriterInitContext context)
+                throws IOException {
+            return new CommittingSinkWriter<Integer, String>() {
+                @Override
+                public Collection<String> prepareCommit() throws IOException, InterruptedException {
+                    return null;
+                }
+
+                @Override
+                public void write(Integer element, Context context)
+                        throws IOException, InterruptedException {}
+
+                @Override
+                public void flush(boolean endOfInput) throws IOException, InterruptedException {}
+
+                @Override
+                public void close() throws Exception {}
+            };
+        }
+
+        @Override
+        public Committer<Long> createCommitter(CommitterInitContext context) throws IOException {
+            return new Committer<Long>() {
+                @Override
+                public void commit(Collection<CommitRequest<Long>> committables)
+                        throws IOException, InterruptedException {}
+
+                @Override
+                public void close() throws Exception {}
+            };
+        }
+
+        @Override
+        public SimpleVersionedSerializer<Long> getCommittableSerializer() {
+            return new LongSerializer();
+        }
+
+        @Override
+        public void addPostCommitTopology(DataStream<CommittableMessage<Long>> committables) {
+            committables
+                    .map(v -> (CommittableMessage<Void>) null)
+                    .name("post-committer")
+                    .returns(CommittableMessageTypeInfo.noOutput())
+                    .rebalance();
+        }
+
+        @Override
+        public DataStream<CommittableMessage<Long>> addPreCommitTopology(
+                DataStream<CommittableMessage<String>> committables) {
+            return committables
+                    .map(
+                            v -> {
+                                if (v instanceof CommittableSummary) {
+                                    return new CommittableSummary<Long>((CommittableSummary) v);
+                                } else {
+                                    CommittableWithLineage withLineage = (CommittableWithLineage) v;
+                                    return new CommittableWithLineage<>(
+                                            Long.valueOf(withLineage.getCommittable().toString()),
+                                            withLineage);
+                                }
+                            })
+                    .name("pre-committer")
+                    .returns(CommittableMessageTypeInfo.of(LongSerializer::new))
+                    .rebalance();
+        }
+
+        @Override
+        public SimpleVersionedSerializer<String> getWriteResultSerializer() {
+            return new TestSinkV2.StringSerializer();
+        }
+
+        @Override
+        public DataStream<Integer> addPreWriteTopology(DataStream<Integer> inputDataStream) {
+            return inputDataStream.map(v -> v).name("pre-writer").rebalance();
+        }
+    }
+
+    public static class LongSerializer implements SimpleVersionedSerializer<Long>, Serializable {
+        @Override
+        public int getVersion() {
+            return 0;
+        }
+
+        @Override
+        public byte[] serialize(Long obj) throws IOException {
+            return new byte[0];
+        }
+
+        @Override
+        public Long deserialize(int version, byte[] serialized) throws IOException {
+            return null;
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
@@ -56,7 +57,10 @@ abstract class CommitterOperatorTestBase {
                         CommittableMessage<String>, CommittableMessage<String>>
                 testHarness =
                         new OneInputStreamOperatorTestHarness<>(
-                                new CommitterOperatorFactory<>(sinkAndCounters.sink, false, true));
+                                new CommitterOperatorFactory<>(
+                                        (SupportsCommitter<String>) sinkAndCounters.sink,
+                                        false,
+                                        true));
         testHarness.open();
 
         final CommittableSummary<String> committableSummary =
@@ -89,7 +93,9 @@ abstract class CommitterOperatorTestBase {
         SinkAndCounters sinkAndCounters = sinkWithPostCommit();
         final OneInputStreamOperatorTestHarness<
                         CommittableMessage<String>, CommittableMessage<String>>
-                testHarness = createTestHarness(sinkAndCounters.sink, false, true);
+                testHarness =
+                        createTestHarness(
+                                (SupportsCommitter<String>) sinkAndCounters.sink, false, true);
         testHarness.open();
         testHarness.setProcessingTime(0);
 
@@ -131,7 +137,9 @@ abstract class CommitterOperatorTestBase {
 
         final OneInputStreamOperatorTestHarness<
                         CommittableMessage<String>, CommittableMessage<String>>
-                testHarness = createTestHarness(sinkAndCounters.sink, false, true);
+                testHarness =
+                        createTestHarness(
+                                (SupportsCommitter<String>) sinkAndCounters.sink, false, true);
         testHarness.open();
 
         final CommittableSummary<String> committableSummary =
@@ -167,7 +175,11 @@ abstract class CommitterOperatorTestBase {
         SinkAndCounters sinkAndCounters = sinkWithPostCommit();
         final OneInputStreamOperatorTestHarness<
                         CommittableMessage<String>, CommittableMessage<String>>
-                testHarness = createTestHarness(sinkAndCounters.sink, isBatchMode, !isBatchMode);
+                testHarness =
+                        createTestHarness(
+                                (SupportsCommitter<String>) sinkAndCounters.sink,
+                                isBatchMode,
+                                !isBatchMode);
         testHarness.open();
 
         final CommittableSummary<String> committableSummary =
@@ -212,7 +224,7 @@ abstract class CommitterOperatorTestBase {
                         CommittableMessage<String>, CommittableMessage<String>>
                 testHarness =
                         createTestHarness(
-                                sinkWithPostCommitWithRetry().sink,
+                                (SupportsCommitter<String>) sinkWithPostCommitWithRetry().sink,
                                 false,
                                 true,
                                 1,
@@ -255,7 +267,12 @@ abstract class CommitterOperatorTestBase {
                         CommittableMessage<String>, CommittableMessage<String>>
                 restored =
                         createTestHarness(
-                                sinkAndCounters.sink, false, true, 10, 10, subtaskIdAfterRecovery);
+                                (SupportsCommitter<String>) sinkAndCounters.sink,
+                                false,
+                                true,
+                                10,
+                                10,
+                                subtaskIdAfterRecovery);
 
         restored.initializeState(snapshot);
         restored.open();
@@ -292,7 +309,9 @@ abstract class CommitterOperatorTestBase {
                 testHarness =
                         new OneInputStreamOperatorTestHarness<>(
                                 new CommitterOperatorFactory<>(
-                                        sinkAndCounters.sink, false, isCheckpointingEnabled));
+                                        (SupportsCommitter<String>) sinkAndCounters.sink,
+                                        false,
+                                        isCheckpointingEnabled));
         testHarness.open();
 
         final CommittableSummary<String> committableSummary =
@@ -340,7 +359,7 @@ abstract class CommitterOperatorTestBase {
     private OneInputStreamOperatorTestHarness<
                     CommittableMessage<String>, CommittableMessage<String>>
             createTestHarness(
-                    TwoPhaseCommittingSink<?, String> sink,
+                    SupportsCommitter<String> sink,
                     boolean isBatchMode,
                     boolean isCheckpointingEnabled)
                     throws Exception {
@@ -351,7 +370,7 @@ abstract class CommitterOperatorTestBase {
     private OneInputStreamOperatorTestHarness<
                     CommittableMessage<String>, CommittableMessage<String>>
             createTestHarness(
-                    TwoPhaseCommittingSink<?, String> sink,
+                    SupportsCommitter<String> sink,
                     boolean isBatchMode,
                     boolean isCheckpointingEnabled,
                     int maxParallelism,
@@ -372,10 +391,10 @@ abstract class CommitterOperatorTestBase {
     abstract SinkAndCounters sinkWithoutPostCommit();
 
     static class SinkAndCounters {
-        TwoPhaseCommittingSink<?, String> sink;
+        Sink<?> sink;
         IntSupplier commitCounter;
 
-        public SinkAndCounters(TwoPhaseCommittingSink<?, String> sink, IntSupplier commitCounter) {
+        public SinkAndCounters(Sink<?> sink, IntSupplier commitCounter) {
             this.sink = sink;
             this.commitCounter = commitCounter;
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2CommitterOperatorTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-
 import java.util.Collection;
 
 class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
@@ -27,24 +25,22 @@ class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
     SinkAndCounters sinkWithPostCommit() {
         ForwardingCommitter committer = new ForwardingCommitter();
         return new SinkAndCounters(
-                (TwoPhaseCommittingSink<?, String>)
-                        TestSinkV2.newBuilder()
-                                .setCommitter(committer)
-                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
-                                .setWithPostCommitTopology(true)
-                                .build(),
+                TestSinkV2.newBuilder()
+                        .setCommitter(committer)
+                        .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                        .setWithPostCommitTopology(true)
+                        .build(),
                 () -> committer.successfulCommits);
     }
 
     @Override
     SinkAndCounters sinkWithPostCommitWithRetry() {
         return new SinkAndCounters(
-                (TwoPhaseCommittingSink<?, String>)
-                        TestSinkV2.newBuilder()
-                                .setCommitter(new TestSinkV2.RetryOnceCommitter())
-                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
-                                .setWithPostCommitTopology(true)
-                                .build(),
+                TestSinkV2.newBuilder()
+                        .setCommitter(new TestSinkV2.RetryOnceCommitter())
+                        .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                        .setWithPostCommitTopology(true)
+                        .build(),
                 () -> 0);
     }
 
@@ -52,12 +48,11 @@ class SinkV2CommitterOperatorTest extends CommitterOperatorTestBase {
     SinkAndCounters sinkWithoutPostCommit() {
         ForwardingCommitter committer = new ForwardingCommitter();
         return new SinkAndCounters(
-                (TwoPhaseCommittingSink<?, String>)
-                        TestSinkV2.newBuilder()
-                                .setCommitter(committer)
-                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
-                                .setWithPostCommitTopology(false)
-                                .build(),
+                TestSinkV2.newBuilder()
+                        .setCommitter(committer)
+                        .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                        .setWithPostCommitTopology(false)
+                        .build(),
                 () -> committer.successfulCommits);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkV2SinkWriterOperatorTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.operators.ProcessingTimeService;
-import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.api.java.tuple.Tuple3;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
@@ -114,7 +114,7 @@ class SinkV2SinkWriterOperatorTest extends SinkWriterOperatorTestBase {
         }
 
         @Override
-        public void init(Sink.InitContext context) {
+        public void init(WriterInitContext context) {
             this.processingTimeService = context.getProcessingTimeService();
             this.processingTimeService.registerTimer(1000, this);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkWithMixin.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkWithMixin.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+
+import java.io.IOException;
+
+/** A test sink that expands into a simple subgraph. Do not use in runtime. */
+public class TestExpandingSinkWithMixin
+        implements Sink<Integer>,
+                SupportsCommitter<Integer>,
+                SupportsPreWriteTopology<Integer>,
+                SupportsPreCommitTopology<Integer, Integer>,
+                SupportsPostCommitTopology<Integer> {
+
+    @Override
+    public void addPostCommitTopology(DataStream<CommittableMessage<Integer>> committables) {
+        committables.sinkTo(new DiscardingSink<>());
+    }
+
+    @Override
+    public DataStream<CommittableMessage<Integer>> addPreCommitTopology(
+            DataStream<CommittableMessage<Integer>> committables) {
+        return committables.map(value -> value).returns(committables.getType());
+    }
+
+    @Override
+    public DataStream<Integer> addPreWriteTopology(DataStream<Integer> inputDataStream) {
+        return inputDataStream.map(new NoOpIntMap());
+    }
+
+    @Override
+    public SinkWriter<Integer> createWriter(WriterInitContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    public SinkWriter<Integer> createWriter(InitContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Committer<Integer> createCommitter(CommitterInitContext context) {
+        return null;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getCommittableSerializer() {
+        return null;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getWriteResultSerializer() {
+        return null;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
 import org.apache.flink.api.connector.source.Boundedness;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.test.streaming.runtime;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.metrics.Counter;
@@ -258,7 +259,7 @@ public class SinkV2MetricsITCase extends TestLogger {
         private long sendTime;
 
         @Override
-        public void init(Sink.InitContext context) {
+        public void init(WriterInitContext context) {
             this.metricGroup = context.metricGroup();
             metricGroup.setCurrentSendTimeGauge(() -> sendTime);
         }


### PR DESCRIPTION
## What is the purpose of the change

Mixin based implementation for [FLIP-372](https://cwiki.apache.org/confluence/display/FLINK/FLIP-372%3A+Allow+TwoPhaseCommittingSink+WithPreCommitTopology+to+alter+the+type+of+the+Committable)

For now, just checking backward compatibility of the API changes

## Brief change log

- Moving inner classes to main classes:
    - `CommitterInitContext` from `Sink.CommitterInitContext` 
    - `CommittingSinkWriter` from `TwoPhaseCommittingSink.PrecommittingSinkWriter`
    -  `StatefulSinkWriter` from `StatefulSink.StatefulSinkWriter`
    - `WriterInitContext` from `Sink.InitContext`
- Moving to mixin interfaces:
   - `SupportsCommitter` from `TwoPhaseCommittingSink`
   - `SupportsWriterState` from `StatefulSink`
   - `SupportsPostCommitTopology` from `WithPostCommitToplogy`
   - `SupportsPreCommitTopology` from `WithPreCommitTopology`
   - `SupportsPreWriteTopology` from `WithPreWriteTopology`
- Deprecation methods with default implementations
- Few internal changes to make everything work

## Verifying this change

The CI will run all the tests to see if the change breaks anything

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
