### PR TITLE
[FLINK-33685][client] Refactor StandaloneClusterId to distinguish different remote clusters

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
@@ -48,7 +48,7 @@ public class StandaloneClientFactory implements ClusterClientFactory<StandaloneC
     @Nullable
     public StandaloneClusterId getClusterId(Configuration configuration) {
         checkNotNull(configuration);
-        return StandaloneClusterId.getInstance();
+        return StandaloneClusterId.fromConfiguration(configuration);
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
@@ -18,13 +18,62 @@
 
 package org.apache.flink.client.deployment;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Objects;
+
 /** Identifier for standalone clusters. */
 public class StandaloneClusterId {
-    private static final StandaloneClusterId INSTANCE = new StandaloneClusterId();
+    private static final String STANDALONE_CLUSTER_ID_PREFIX = "standalone-flink-cluster-";
+    private final String clusterId;
 
-    private StandaloneClusterId() {}
+    private StandaloneClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
 
-    public static StandaloneClusterId getInstance() {
-        return INSTANCE;
+    public static StandaloneClusterId fromConfiguration(Configuration configuration) {
+        String clusterId;
+        if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
+            clusterId = configuration.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+        } else if (!configuration.get(RestOptions.ADDRESS).isEmpty()) {
+            final String address = configuration.get(RestOptions.ADDRESS);
+            final int port = configuration.getInteger(RestOptions.PORT);
+            clusterId = String.format("%s:%s", address, port);
+        } else {
+            clusterId = generateStandaloneClusterId();
+        }
+
+        return new StandaloneClusterId(clusterId);
+    }
+
+    private static String generateStandaloneClusterId() {
+        final String randomID = new AbstractID().toString();
+        return (STANDALONE_CLUSTER_ID_PREFIX + randomID).substring(0, 64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandaloneClusterId that = (StandaloneClusterId) o;
+        return Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId);
+    }
+
+    @Override
+    public String toString() {
+        return "StandaloneClusterId{" + "clusterId='" + clusterId + '\'' + '}';
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -116,7 +116,8 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
         CliFrontend frontend =
                 new MockedCliFrontend(
                         new RestClusterClient<>(
-                                getConfiguration(), StandaloneClusterId.getInstance()));
+                                getConfiguration(),
+                                StandaloneClusterId.fromConfiguration(getConfiguration())));
 
         String[] parameters = {"invalid job id"};
         assertThatThrownBy(() -> frontend.savepoint(parameters))
@@ -276,7 +277,7 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
                 Function<String, CompletableFuture<Acknowledge>> disposeSavepointFunction,
                 Configuration configuration)
                 throws Exception {
-            super(configuration, StandaloneClusterId.getInstance());
+            super(configuration, StandaloneClusterId.fromConfiguration(configuration));
 
             this.disposeSavepointFunction = Preconditions.checkNotNull(disposeSavepointFunction);
         }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
@@ -221,7 +221,7 @@ class RestClusterClientCheckpointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -350,7 +350,7 @@ class RestClusterClientSavepointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -226,7 +226,7 @@ class RestClusterClientTest {
         return new RestClusterClient<>(
                 clientConfig,
                 createRestClient(),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
@@ -410,7 +410,8 @@ public class FlinkContainers implements BeforeAllCallback, AfterAllCallback {
         clientConfiguration.set(RestOptions.ADDRESS, getJobManagerHost());
         clientConfiguration.set(
                 RestOptions.PORT, jobManager.getMappedPort(conf.get(RestOptions.PORT)));
-        return new RestClusterClient<>(clientConfiguration, StandaloneClusterId.getInstance());
+        return new RestClusterClient<>(
+                clientConfiguration, StandaloneClusterId.fromConfiguration(clientConfiguration));
     }
 
     private void waitUntilJobManagerRESTReachable(GenericContainer<?> jobManager) {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -68,7 +68,9 @@ public class JobRetrievalITCase extends TestLogger {
         clientConfig.setLong(RestOptions.RETRY_DELAY, 0);
         clientConfig.addAll(CLUSTER.getClientConfiguration());
 
-        client = new RestClusterClient<>(clientConfig, StandaloneClusterId.getInstance());
+        client =
+                new RestClusterClient<>(
+                        clientConfig, StandaloneClusterId.fromConfiguration(clientConfig));
     }
 
     @After

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
@@ -90,7 +90,8 @@ public class BigUserProgramJobSubmitITCase extends TestLogger {
         final RestClusterClient<StandaloneClusterId> restClusterClient =
                 new RestClusterClient<>(
                         MINI_CLUSTER_RESOURCE.getClientConfiguration(),
-                        StandaloneClusterId.getInstance());
+                        StandaloneClusterId.fromConfiguration(
+                                MINI_CLUSTER_RESOURCE.getClientConfiguration()));
 
         try {
             submitJobAndWaitForResult(restClusterClient, jobGraph, getClass().getClassLoader());


### PR DESCRIPTION
## What is the purpose of the change

`StandaloneClusterId` is a singleton, which means `StandaloneClusterDescriptor` cannot distinguish different remote running clusters.


## Brief change log

  - Infer the unique cluster id from `Configuration`


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests in


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
