### PR TITLE
[FLINK-33807] Update JUnit to 5.10.1

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -27,20 +27,22 @@ import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.writer.BinaryRowWriter
-import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters
+
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 
 import java.nio.file.Files
 import java.util
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -60,7 +62,7 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
     // set state backend
 
     val baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
-    Files.deleteIfExists(baseCheckpointPath);
+    baseCheckpointPath.toFile.deleteOnExit();
     state match {
       case HEAP_BACKEND =>
         val conf = new Configuration()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -36,14 +36,11 @@ import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters
-import org.apache.flink.testutils.junit.utils.TempDirUtils
-import org.apache.flink.util.FileUtils
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.slf4j.LoggerFactory
 
-import java.io.{File, IOException}
 import java.nio.file.Files
 import java.util
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -62,14 +62,12 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
 
   private val classLoader = Thread.currentThread.getContextClassLoader
 
-  var baseCheckpointPath: File = _
-
   @BeforeEach
   override def before(): Unit = {
     super.before()
     // set state backend
 
-    baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
+    val baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
     Files.deleteIfExists(baseCheckpointPath);
     state match {
       case HEAP_BACKEND =>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -27,23 +27,20 @@ import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
-import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.writer.BinaryRowWriter
+import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters
-
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
-import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
 import java.util
-
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -54,8 +51,6 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
     case HEAP_BACKEND => false // TODO heap statebackend not support obj reuse now.
     case ROCKSDB_BACKEND => true
   }
-
-  private val log = LoggerFactory.getLogger(classOf[StreamingWithStateTestBase])
 
   private val classLoader = Thread.currentThread.getContextClassLoader
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.slf4j.LoggerFactory
 
 import java.io.{File, IOException}
+import java.nio.file.Files
 import java.util
 
 import scala.collection.JavaConversions._
@@ -68,8 +69,8 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
     super.before()
     // set state backend
 
-    // subfolder are managed here because the tests could fail during cleanup when concurrently executed (see FLINK-33820)
-    baseCheckpointPath = TempDirUtils.newFolder(tempFolder)
+    val baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
+    Files.deleteIfExists(baseCheckpointPath);
     state match {
       case HEAP_BACKEND =>
         val conf = new Configuration()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -69,7 +69,7 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
     super.before()
     // set state backend
 
-    val baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
+    baseCheckpointPath = Files.createTempDirectory(getClass.getCanonicalName)
     Files.deleteIfExists(baseCheckpointPath);
     state match {
       case HEAP_BACKEND =>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -87,19 +87,6 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
   @AfterEach
   override def after(): Unit = {
     super.after()
-    try {
-      FileUtils.deleteDirectory(baseCheckpointPath)
-    } catch {
-      case e: IOException =>
-        if (baseCheckpointPath.exists) {
-          log.error(
-            s"The temporary files are not being deleted gracefully, remaining files " +
-              s"${FileUtils.listFilesInDirectory(baseCheckpointPath.toPath, _ => true)}.",
-            e)
-        } else {
-          log.error("The temporary files are not being deleted gracefully.", e)
-        }
-    }
     assertThat(FailingCollectionSource.failedBefore).isTrue
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ under the License.
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.9.1</junit5.version>
+		<junit5.version>5.10.1</junit5.version>
 		<archunit.version>1.2.0</archunit.version>
 		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
## What is the purpose of the change

Bump junit to 5.10.1
This could improve error output for https://github.com/apache/flink/pull/23914#pullrequestreview-1777970575

since it was improved on JUnit level at https://github.com/junit-team/junit5/pull/3249/files#diff-722173375ef777095d4d3ba36f4e5063f25c21f23701ad4cbd470018c2888fa8
https://github.com/junit-team/junit5/issues/3236

## Verifying this change





## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
