### PR TITLE
[FLINK-33603][1.18][Filesystem] Bundle Guava for GCS connector

### DIFF
--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -178,6 +178,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.14.3
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
-- com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -75,20 +75,12 @@ under the License.
 					<artifactId>commons-lang3</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.checkerframework</groupId>
 					<artifactId>checker-qual</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.google.j2objc</groupId>
 					<artifactId>j2objc-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>failureaccess</artifactId>
 				</exclusion>
 				<!-- exclude dependency because of its GPLv2 license, see https://github.com/apache/flink/pull/15599#issuecomment-850241316 -->
 				<exclusion>
@@ -112,10 +104,6 @@ under the License.
 				<exclusion>
 					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-lang3</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>com.google.errorprone</groupId>

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -33,6 +33,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.flogger:flogger-system-backend:0.7.1
 - com.google.flogger:flogger:0.7.1
 - com.google.flogger:google-extensions:0.7.1
+- com.google.guava:guava:jar:31.1-jre
+- com.google.guava:failureaccess:jar:1.0.1
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.http-client:google-http-client-apache-v2:1.42.3
 - com.google.http-client:google-http-client-appengine:1.42.3
@@ -63,8 +65,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opencensus:opencensus-contrib-resource-util:0.31.0
 - io.opencensus:opencensus-exporter-metrics-util:0.31.0
 - io.opencensus:opencensus-exporter-stats-stackdriver:0.31.0
-- io.opencensus:opencensus-impl:0.31.0
 - io.opencensus:opencensus-impl-core:0.31.0
+- io.opencensus:opencensus-impl:0.31.0
 - io.opencensus:opencensus-proto:0.2.0
 - io.perfmark:perfmark-api:0.25.0
 - org.apache.httpcomponents:httpclient:4.5.13


### PR DESCRIPTION
## What is the purpose of the change

* Resolve FLINK-33793 `java.lang.NoSuchMethodError when checkpointing in Google Cloud Storage`

## Brief change log

* Make sure that Guava is bundled for GCS connector

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
