### PR TITLE
 [FLINK-33798][statebackend/rocksdb] automatically clean up rocksdb logs when the task exited.

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -486,7 +486,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
      * @param instanceRocksDBAbsolutePath The path where the rocksdb directory is located.
      * @return Resolved rocksdb log name prefix.
      */
-    public static String resolveRelocatedDbLogPrefix(String instanceRocksDBAbsolutePath) {
+    private String resolveRelocatedDbLogPrefix(String instanceRocksDBAbsolutePath) {
         if (!instanceRocksDBAbsolutePath.isEmpty()
                 && !instanceRocksDBAbsolutePath.matches("^[a-zA-Z0-9\\-._].*")) {
             instanceRocksDBAbsolutePath = instanceRocksDBAbsolutePath.substring(1);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainer.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -44,7 +45,11 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -59,8 +64,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public final class RocksDBResourceContainer implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(RocksDBResourceContainer.class);
 
+    private static final String ROCKSDB_RELOCATE_LOG_SUFFIX = "_LOG";
+
     // the filename length limit is 255 on most operating systems
-    private static final int INSTANCE_PATH_LENGTH_LIMIT = 255 - "_LOG".length();
+    private static final int INSTANCE_PATH_LENGTH_LIMIT =
+            255 - ROCKSDB_RELOCATE_LOG_SUFFIX.length();
 
     @Nullable private final File instanceRocksDBPath;
 
@@ -84,6 +92,8 @@ public final class RocksDBResourceContainer implements AutoCloseable {
 
     /** The handles to be closed when the container is closed. */
     private final ArrayList<AutoCloseable> handlesToClose;
+
+    @Nullable private Path relocatedDbLogBaseDir;
 
     @VisibleForTesting
     public RocksDBResourceContainer() {
@@ -267,6 +277,7 @@ public final class RocksDBResourceContainer implements AutoCloseable {
         if (sharedResources != null) {
             sharedResources.close();
         }
+        cleanRelocatedDbLogs();
     }
 
     /**
@@ -426,7 +437,9 @@ public final class RocksDBResourceContainer implements AutoCloseable {
         if (logFilePath != null) {
             File logFile = resolveFileLocation(logFilePath);
             if (logFile != null && resolveFileLocation(logFile.getParent()) != null) {
-                dbOptions.setDbLogDir(logFile.getParent());
+                String relocatedDbLogDir = logFile.getParent();
+                this.relocatedDbLogBaseDir = new File(relocatedDbLogDir).toPath();
+                dbOptions.setDbLogDir(relocatedDbLogDir);
             }
         }
     }
@@ -440,5 +453,45 @@ public final class RocksDBResourceContainer implements AutoCloseable {
     private File resolveFileLocation(String logFilePath) {
         File logFile = new File(logFilePath);
         return (logFile.exists() && logFile.canRead()) ? logFile : null;
+    }
+
+    /** Clean all relocated rocksdb logs. */
+    private void cleanRelocatedDbLogs() {
+        if (instanceRocksDBPath != null && relocatedDbLogBaseDir != null) {
+            LOG.info("Cleaning up relocated RocksDB logs: {}.", relocatedDbLogBaseDir);
+
+            String relocatedDbLogPrefix =
+                    resolveRelocatedDbLogPrefix(instanceRocksDBPath.getAbsolutePath());
+            try {
+                Arrays.stream(FileUtils.listDirectory(relocatedDbLogBaseDir))
+                        .filter(
+                                path ->
+                                        !Files.isDirectory(path)
+                                                && path.toFile()
+                                                        .getName()
+                                                        .startsWith(relocatedDbLogPrefix))
+                        .forEach(IOUtils::deleteFileQuietly);
+            } catch (IOException e) {
+                LOG.warn(
+                        "Could not list relocated RocksDB log directory: {}",
+                        relocatedDbLogBaseDir);
+            }
+        }
+    }
+
+    /**
+     * Resolve the prefix of rocksdb's log file name according to rocksdb's log file name rules. See
+     * https://github.com/ververica/frocksdb/blob/FRocksDB-6.20.3/file/filename.cc#L30.
+     *
+     * @param instanceRocksDBAbsolutePath The path where the rocksdb directory is located.
+     * @return Resolved rocksdb log name prefix.
+     */
+    public static String resolveRelocatedDbLogPrefix(String instanceRocksDBAbsolutePath) {
+        if (!instanceRocksDBAbsolutePath.isEmpty()
+                && !instanceRocksDBAbsolutePath.matches("^[a-zA-Z0-9\\-._].*")) {
+            instanceRocksDBAbsolutePath = instanceRocksDBAbsolutePath.substring(1);
+        }
+        return instanceRocksDBAbsolutePath.replaceAll("[^a-zA-Z0-9\\-._]", "_")
+                + ROCKSDB_RELOCATE_LOG_SUFFIX;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -394,8 +394,6 @@ public class RocksDBStateBackendConfigTest {
         final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
         RocksDBKeyedStateBackend<Integer> keyedBackend =
                 createKeyedStateBackend(rocksDbBackend, env, IntSerializer.INSTANCE);
-        // clear unused file
-        FileUtils.deleteFileOrDirectory(logFile);
 
         File instanceBasePath = keyedBackend.getInstanceBasePath();
         File instanceRocksDBPath =
@@ -407,7 +405,7 @@ public class RocksDBStateBackendConfigTest {
         java.nio.file.Path[] relocatedDbLogs;
         try {
             relocatedDbLogs = FileUtils.listDirectory(relocatedDBLogDir.toPath());
-            while (relocatedDbLogs.length <= 1) {
+            while (relocatedDbLogs.length <= 2) {
                 // If the default number of log files in rocksdb is not enough, add more logs.
                 try (FlushOptions flushOptions = new FlushOptions()) {
                     keyedBackend.db.put(RandomUtils.nextBytes(32), RandomUtils.nextBytes(512));
@@ -422,7 +420,8 @@ public class RocksDBStateBackendConfigTest {
         }
 
         relocatedDbLogs = FileUtils.listDirectory(relocatedDBLogDir.toPath());
-        assertEquals(0, relocatedDbLogs.length);
+        assertEquals(1, relocatedDbLogs.length);
+        assertEquals("taskManager.log", relocatedDbLogs[0].toFile().getName());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -70,8 +70,8 @@ import org.rocksdb.InfoLogLevel;
 import org.rocksdb.util.SizeUnit;
 
 import java.io.File;
-import java.util.Arrays;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

 [FLINK-33798][statebackend/rocksdb] automatically clean up rocksdb logs when the task exited.


## Brief change log

When the task exits, delete all rocksdb log files with the same prefix in the relocated directory.

## Verifying this change

This change added tests and can be verified as follows:

- org.apache.flink.contrib.streaming.state.RocksDBStateBackendConfigTest#testCleanRelocatedDbLogs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
