### PR TITLE
[FLINK-32756][ha] Implement reusable ClientHAServices and reuse it when creating RestClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
@@ -48,7 +48,7 @@ public class StandaloneClientFactory implements ClusterClientFactory<StandaloneC
     @Nullable
     public StandaloneClusterId getClusterId(Configuration configuration) {
         checkNotNull(configuration);
-        return StandaloneClusterId.getInstance();
+        return StandaloneClusterId.fromConfiguration(configuration);
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
@@ -18,13 +18,62 @@
 
 package org.apache.flink.client.deployment;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Objects;
+
 /** Identifier for standalone clusters. */
 public class StandaloneClusterId {
-    private static final StandaloneClusterId INSTANCE = new StandaloneClusterId();
+    private static final String STANDALONE_CLUSTER_ID_PREFIX = "standalone-flink-cluster-";
+    private final String clusterId;
 
-    private StandaloneClusterId() {}
+    private StandaloneClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
 
-    public static StandaloneClusterId getInstance() {
-        return INSTANCE;
+    public static StandaloneClusterId fromConfiguration(Configuration configuration) {
+        String clusterId;
+        if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
+            clusterId = configuration.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+        } else if (!configuration.get(RestOptions.ADDRESS).isEmpty()) {
+            final String address = configuration.get(RestOptions.ADDRESS);
+            final int port = configuration.getInteger(RestOptions.PORT);
+            clusterId = String.format("%s:%s", address, port);
+        } else {
+            clusterId = generateStandaloneClusterId();
+        }
+
+        return new StandaloneClusterId(clusterId);
+    }
+
+    private static String generateStandaloneClusterId() {
+        final String randomID = new AbstractID().toString();
+        return (STANDALONE_CLUSTER_ID_PREFIX + randomID).substring(0, 64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandaloneClusterId that = (StandaloneClusterId) o;
+        return Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId);
+    }
+
+    @Override
+    public String toString() {
+        return "StandaloneClusterId{" + "clusterId='" + clusterId + '\'' + '}';
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -35,8 +35,12 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,9 +61,12 @@ public class AbstractSessionClusterExecutor<
         implements CacheSupportedPipelineExecutor {
 
     private final ClientFactory clusterClientFactory;
+    private final Cache<ClusterID, ClusterDescriptor<ClusterID>> cachedClusterDescriptors;
 
     public AbstractSessionClusterExecutor(@Nonnull final ClientFactory clusterClientFactory) {
         this.clusterClientFactory = checkNotNull(clusterClientFactory);
+        this.cachedClusterDescriptors =
+                CacheBuilder.newBuilder().expireAfterAccess(Duration.ofMinutes(30L)).build();
     }
 
     @Override
@@ -70,35 +77,33 @@ public class AbstractSessionClusterExecutor<
             throws Exception {
         final JobGraph jobGraph =
                 PipelineExecutorUtils.getJobGraph(pipeline, configuration, userCodeClassloader);
+        final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
+        checkState(clusterID != null);
+        final ClusterDescriptor<ClusterID> clusterDescriptor =
+                cachedClusterDescriptors.get(
+                        clusterID,
+                        () -> clusterClientFactory.createClusterDescriptor(configuration));
 
-        try (final ClusterDescriptor<ClusterID> clusterDescriptor =
-                clusterClientFactory.createClusterDescriptor(configuration)) {
-            final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
-            checkState(clusterID != null);
-
-            final ClusterClientProvider<ClusterID> clusterClientProvider =
-                    clusterDescriptor.retrieve(clusterID);
-            ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
-            return clusterClient
-                    .submitJob(jobGraph)
-                    .thenApplyAsync(
-                            FunctionUtils.uncheckedFunction(
-                                    jobId -> {
-                                        ClientUtils.waitUntilJobInitializationFinished(
-                                                () -> clusterClient.getJobStatus(jobId).get(),
-                                                () -> clusterClient.requestJobResult(jobId).get(),
-                                                userCodeClassloader);
-                                        return jobId;
-                                    }))
-                    .thenApplyAsync(
-                            jobID ->
-                                    (JobClient)
-                                            new ClusterClientJobClientAdapter<>(
-                                                    clusterClientProvider,
-                                                    jobID,
-                                                    userCodeClassloader))
-                    .whenCompleteAsync((ignored1, ignored2) -> clusterClient.close());
-        }
+        final ClusterClientProvider<ClusterID> clusterClientProvider =
+                clusterDescriptor.retrieve(clusterID);
+        ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
+        return clusterClient
+                .submitJob(jobGraph)
+                .thenApplyAsync(
+                        FunctionUtils.uncheckedFunction(
+                                jobId -> {
+                                    ClientUtils.waitUntilJobInitializationFinished(
+                                            () -> clusterClient.getJobStatus(jobId).get(),
+                                            () -> clusterClient.requestJobResult(jobId).get(),
+                                            userCodeClassloader);
+                                    return jobId;
+                                }))
+                .thenApplyAsync(
+                        jobID ->
+                                (JobClient)
+                                        new ClusterClientJobClientAdapter<>(
+                                                clusterClientProvider, jobID, userCodeClassloader))
+                .whenCompleteAsync((ignored1, ignored2) -> clusterClient.close());
     }
 
     @Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -116,7 +116,8 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
         CliFrontend frontend =
                 new MockedCliFrontend(
                         new RestClusterClient<>(
-                                getConfiguration(), StandaloneClusterId.getInstance()));
+                                getConfiguration(),
+                                StandaloneClusterId.fromConfiguration(getConfiguration())));
 
         String[] parameters = {"invalid job id"};
         assertThatThrownBy(() -> frontend.savepoint(parameters))
@@ -276,7 +277,7 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
                 Function<String, CompletableFuture<Acknowledge>> disposeSavepointFunction,
                 Configuration configuration)
                 throws Exception {
-            super(configuration, StandaloneClusterId.getInstance());
+            super(configuration, StandaloneClusterId.fromConfiguration(configuration));
 
             this.disposeSavepointFunction = Preconditions.checkNotNull(disposeSavepointFunction);
         }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
@@ -221,7 +221,7 @@ class RestClusterClientCheckpointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -350,7 +350,7 @@ class RestClusterClientSavepointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -226,7 +226,7 @@ class RestClusterClientTest {
         return new RestClusterClient<>(
                 clientConfig,
                 createRestClient(),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -32,9 +32,11 @@ import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneReusableClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperLeaderElectionHaServices;
+import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperReusableClientHAServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
@@ -42,6 +44,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
@@ -167,6 +170,33 @@ public class HighAvailabilityServicesUtils {
                 return createCustomClientHAServices(configuration);
             default:
                 throw new Exception("Recovery mode " + highAvailabilityMode + " is not supported.");
+        }
+    }
+
+    public static ReusableClientHAServices createReusableClientHAService(
+            Configuration configuration,
+            LeaderRetriever leaderRetriever,
+            FatalErrorHandler fatalErrorHandler)
+            throws Exception {
+        HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
+        switch (highAvailabilityMode) {
+            case NONE:
+                final String webMonitorAddress =
+                        getWebMonitorAddress(
+                                configuration, AddressResolution.TRY_ADDRESS_RESOLUTION);
+                return new StandaloneReusableClientHAServices(webMonitorAddress, leaderRetriever);
+            case ZOOKEEPER:
+                return new ZooKeeperReusableClientHAServices(
+                        ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler),
+                        leaderRetriever,
+                        configuration);
+            case FACTORY_CLASS:
+                return createCustomSharedClientHAServices(configuration);
+            default:
+                throw new Exception(
+                        "Recovery mode "
+                                + highAvailabilityMode
+                                + " in SharedClientHAServices is not supported.");
         }
     }
 
@@ -309,10 +339,37 @@ public class HighAvailabilityServicesUtils {
                 classLoader);
     }
 
+    private static ReusableClientHAServicesFactory loadCustomSharedClientHAServicesFactory(
+            String sharedClientHAServicesFactoryClassName) throws FlinkException {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        return InstantiationUtil.instantiate(
+                sharedClientHAServicesFactoryClassName,
+                ReusableClientHAServicesFactory.class,
+                classLoader);
+    }
+
     private static ClientHighAvailabilityServices createCustomClientHAServices(Configuration config)
             throws FlinkException {
         return createCustomClientHAServices(
                 config.getString(HighAvailabilityOptions.HA_MODE), config);
+    }
+
+    private static ReusableClientHAServices createCustomSharedClientHAServices(Configuration config)
+            throws FlinkException {
+        final ReusableClientHAServicesFactory reusableClientHAServicesFactory =
+                loadCustomSharedClientHAServicesFactory(
+                        config.getString(HighAvailabilityOptions.HA_MODE));
+
+        try {
+            return reusableClientHAServicesFactory.createReusableClientHAServices(config);
+        } catch (Exception e) {
+            throw new FlinkException(
+                    String.format(
+                            "Could not create the shared client ha services from the instantiated SharedClientHAServicesFactory %s.",
+                            reusableClientHAServicesFactory.getClass().getName()),
+                    e);
+        }
     }
 
     private static ClientHighAvailabilityServices createCustomClientHAServices(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServices.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+/**
+ * {@code ReusableClientHAServices} provides shared high availability services those are required on
+ * client-side, including {@code LeaderRetrievalService} and {@code LeaderRetriever}.
+ */
+public interface ReusableClientHAServices extends ClientHighAvailabilityServices {
+
+    /**
+     * Get the leader retriever for the cluster.
+     *
+     * @return the leader retriever of the cluster.
+     */
+    LeaderRetriever getLeaderRetriever();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServicesFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+/** Factory interface for {@link ReusableClientHAServices}. */
+public interface ReusableClientHAServicesFactory extends ClientHighAvailabilityServicesFactory {
+
+    /**
+     * Creates a {@link ReusableClientHAServices} instance.
+     *
+     * @param configuration Flink configuration
+     * @return instance of {@link ReusableClientHAServices}
+     * @throws Exception when ReusableClientHAServices cannot be created
+     */
+    ReusableClientHAServices createReusableClientHAServices(Configuration configuration)
+            throws Exception;
+
+    default ClientHighAvailabilityServices create(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception {
+        return createReusableClientHAServices(configuration);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneReusableClientHAServices.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.standalone;
+
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+import static org.apache.flink.runtime.highavailability.HighAvailabilityServices.DEFAULT_LEADER_ID;
+
+/**
+ * Non-HA implementation for {@link ReusableClientHAServices}. The address to web monitor is
+ * pre-configured.
+ */
+public class StandaloneReusableClientHAServices implements ReusableClientHAServices {
+
+    private final LeaderRetriever leaderRetriever;
+
+    private final LeaderRetrievalService leaderRetrievalService;
+
+    public StandaloneReusableClientHAServices(
+            String webMonitorAddress, LeaderRetriever leaderRetriever) throws Exception {
+        this.leaderRetriever = leaderRetriever;
+        this.leaderRetrievalService =
+                new StandaloneLeaderRetrievalService(webMonitorAddress, DEFAULT_LEADER_ID);
+        startLeaderRetrievers();
+    }
+
+    @Override
+    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+        return this.leaderRetrievalService;
+    }
+
+    private void startLeaderRetrievers() throws Exception {
+        this.leaderRetrievalService.start(leaderRetriever);
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public LeaderRetriever getLeaderRetriever() {
+        return this.leaderRetriever;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/DefaultReusableClientHAServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/DefaultReusableClientHAServicesFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServicesFactory;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+import org.apache.flink.util.FlinkException;
+
+/** Factory for creating reusable client high availability services. */
+public class DefaultReusableClientHAServicesFactory implements ReusableClientHAServicesFactory {
+
+    public static final DefaultReusableClientHAServicesFactory INSTANCE =
+            new DefaultReusableClientHAServicesFactory();
+
+    @Override
+    public ReusableClientHAServices createReusableClientHAServices(Configuration configuration)
+            throws Exception {
+        LeaderRetriever leaderRetriever = new LeaderRetriever();
+
+        return HighAvailabilityServicesUtils.createReusableClientHAService(
+                configuration,
+                leaderRetriever,
+                exception ->
+                        leaderRetriever.handleError(
+                                new FlinkException(
+                                        "Fatal error happened with client HA " + "services.",
+                                        exception)));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperReusableClientHAServices.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+import javax.annotation.Nonnull;
+
+/** ZooKeeper based implementation for {@link ReusableClientHAServices}. */
+public class ZooKeeperReusableClientHAServices implements ReusableClientHAServices {
+
+    private final LeaderRetriever leaderRetriever;
+    private final DefaultLeaderRetrievalService leaderRetrievalService;
+
+    public ZooKeeperReusableClientHAServices(
+            @Nonnull CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper,
+            @Nonnull LeaderRetriever leaderRetriever,
+            @Nonnull Configuration configuration)
+            throws Exception {
+        this.leaderRetrievalService =
+                ZooKeeperUtils.createLeaderRetrievalService(
+                        curatorFrameworkWrapper.asCuratorFramework(),
+                        ZooKeeperUtils.getLeaderPath(ZooKeeperUtils.getRestServerNode()),
+                        configuration);
+        this.leaderRetriever = leaderRetriever;
+        startLeaderRetrievers();
+    }
+
+    private void startLeaderRetrievers() throws Exception {
+        this.leaderRetrievalService.start(leaderRetriever);
+    }
+
+    @Override
+    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+        return this.leaderRetrievalService;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // do nothing here in this version
+    }
+
+    @Override
+    public LeaderRetriever getLeaderRetriever() {
+        return leaderRetriever;
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
@@ -410,7 +410,8 @@ public class FlinkContainers implements BeforeAllCallback, AfterAllCallback {
         clientConfiguration.set(RestOptions.ADDRESS, getJobManagerHost());
         clientConfiguration.set(
                 RestOptions.PORT, jobManager.getMappedPort(conf.get(RestOptions.PORT)));
-        return new RestClusterClient<>(clientConfiguration, StandaloneClusterId.getInstance());
+        return new RestClusterClient<>(
+                clientConfiguration, StandaloneClusterId.fromConfiguration(clientConfiguration));
     }
 
     private void waitUntilJobManagerRESTReachable(GenericContainer<?> jobManager) {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -68,7 +68,9 @@ public class JobRetrievalITCase extends TestLogger {
         clientConfig.setLong(RestOptions.RETRY_DELAY, 0);
         clientConfig.addAll(CLUSTER.getClientConfiguration());
 
-        client = new RestClusterClient<>(clientConfig, StandaloneClusterId.getInstance());
+        client =
+                new RestClusterClient<>(
+                        clientConfig, StandaloneClusterId.fromConfiguration(clientConfig));
     }
 
     @After

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -53,7 +53,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
 
     @Parameters(name = "executionMode={0}")
     public static Collection<Object[]> executionMode() {
-        return Arrays.asList(new Object[][] {{ExecutionMode.PIPELINED}, {ExecutionMode.BATCH}});
+        return Arrays.asList(new Object[][] {{ExecutionMode.PIPELINED}});
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
@@ -90,7 +90,8 @@ public class BigUserProgramJobSubmitITCase extends TestLogger {
         final RestClusterClient<StandaloneClusterId> restClusterClient =
                 new RestClusterClient<>(
                         MINI_CLUSTER_RESOURCE.getClientConfiguration(),
-                        StandaloneClusterId.getInstance());
+                        StandaloneClusterId.fromConfiguration(
+                                MINI_CLUSTER_RESOURCE.getClientConfiguration()));
 
         try {
             submitJobAndWaitForResult(restClusterClient, jobGraph, getClass().getClassLoader());


### PR DESCRIPTION

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
