### PR TITLE
[FLINK-20772][State] Make TtlValueState#update follow the description of interface about null values

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValueState.java
@@ -48,7 +48,7 @@ class TtlValueState<K, N, T>
     @Override
     public void update(T value) throws IOException {
         accessCallback.run();
-        original.update(wrapWithTs(value));
+        original.update(value == null ? null : wrapWithTs(value));
     }
 
     @Nullable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -188,6 +188,25 @@ public abstract class TtlStateTestBase {
     }
 
     @TestTemplate
+    void testValueSetNull() throws Exception {
+        // Only test this on value state
+        assumeThat(ctx()).isInstanceOf(TtlValueStateTestContext.class);
+
+        initTest(
+                StateTtlConfig.UpdateType.OnCreateAndWrite,
+                StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp);
+
+        ctx().update(ctx().updateUnexpired);
+        assertThat(ctx().get())
+                .withFailMessage(UPDATED_UNEXPIRED_AVAIL)
+                .isEqualTo(ctx().getUnexpired);
+
+        // Update null and we get empty.
+        ctx().update(null);
+        assertThat(ctx().get()).withFailMessage(EXPIRED_UNAVAIL).isEqualTo(ctx().emptyValue);
+    }
+
+    @TestTemplate
     void testExactExpirationOnWrite() throws Exception {
         initTest(
                 StateTtlConfig.UpdateType.OnCreateAndWrite,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlValueStateTestContext.java
@@ -21,14 +21,14 @@ package org.apache.flink.runtime.state.ttl;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 
 /** Test suite for {@link TtlValueState}. */
 class TtlValueStateTestContext
-        extends TtlStateTestContextBase<TtlValueState<?, String, String>, String, String> {
-    private static final String TEST_VAL1 = "test value1";
-    private static final String TEST_VAL2 = "test value2";
-    private static final String TEST_VAL3 = "test value3";
+        extends TtlStateTestContextBase<TtlValueState<?, String, Long>, Long, Long> {
+    private static final Long TEST_VAL1 = 11L;
+    private static final Long TEST_VAL2 = 21L;
+    private static final Long TEST_VAL3 = 31L;
 
     @Override
     void initTestValues() {
@@ -45,16 +45,16 @@ class TtlValueStateTestContext
     @Override
     public <US extends State, SV> StateDescriptor<US, SV> createStateDescriptor() {
         return (StateDescriptor<US, SV>)
-                new ValueStateDescriptor<>(getName(), StringSerializer.INSTANCE);
+                new ValueStateDescriptor<>(getName(), LongSerializer.INSTANCE);
     }
 
     @Override
-    public void update(String value) throws Exception {
+    public void update(Long value) throws Exception {
         ttlState.update(value);
     }
 
     @Override
-    public String get() throws Exception {
+    public Long get() throws Exception {
         return ttlState.value();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the TtlValueState#update will wrap the user value with timestamp and proxy request to the original value state. It does not check the null value, which violates the description of the base interface. This PR fixes this by enforcing null value check before wrapping.


## Brief change log

  - check the null value before wrapping in TtlValueState#update
 

## Verifying this change

This change added tests and can be verified as follows:
  - Added test case `testValueSetNull` in `TtlStateTestBase.java`, and make the value of `TtlValueStateTestContext` be `Long` to throw exception when serializing null.  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
