### PR TITLE
[FLINK-33853][runtime][JUnit5 Migration] Migrate Junit5 for DeclarativeSlotPoolBridge test classes of runtime module

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
@@ -28,11 +28,9 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nonnull;
 
@@ -44,7 +42,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(TestLoggerExtension.class)
 class DeclarativeSlotPoolBridgePreferredAllocationsTest {
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgePreferredAllocationsTest.java
@@ -45,10 +45,10 @@ import java.util.concurrent.CompletableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(TestLoggerExtension.class)
-public class DeclarativeSlotPoolBridgePreferredAllocationsTest {
+class DeclarativeSlotPoolBridgePreferredAllocationsTest {
 
     @Test
-    public void testDeclarativeSlotPoolTakesPreferredAllocationsIntoAccount() throws Exception {
+    void testDeclarativeSlotPoolTakesPreferredAllocationsIntoAccount() throws Exception {
         final DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
                 new DeclarativeSlotPoolBridge(
                         new JobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeRequestCompletionTest.java
@@ -28,11 +28,12 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.function.CheckedSupplier;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -43,27 +44,24 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests how the {@link DeclarativeSlotPoolBridge} completes slot requests. */
-public class DeclarativeSlotPoolBridgeRequestCompletionTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class DeclarativeSlotPoolBridgeRequestCompletionTest {
 
     private static final Time TIMEOUT = SlotPoolUtils.TIMEOUT;
 
     private TestingResourceManagerGateway resourceManagerGateway;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         resourceManagerGateway = new TestingResourceManagerGateway();
     }
 
     /** Tests that the {@link DeclarativeSlotPoolBridge} completes slots in request order. */
     @Test
-    public void testRequestsAreCompletedInRequestOrder() {
+    void testRequestsAreCompletedInRequestOrder() {
         runSlotRequestCompletionTest(
                 CheckedSupplier.unchecked(this::createAndSetUpSlotPool), slotPool -> {});
     }
@@ -73,7 +71,7 @@ public class DeclarativeSlotPoolBridgeRequestCompletionTest extends TestLogger {
      * order.
      */
     @Test
-    public void testStashOrderMaintainsRequestOrder() {
+    void testStashOrderMaintainsRequestOrder() {
         runSlotRequestCompletionTest(
                 CheckedSupplier.unchecked(this::createAndSetUpSlotPoolWithoutResourceManager),
                 this::connectToResourceManager);
@@ -113,7 +111,7 @@ public class DeclarativeSlotPoolBridgeRequestCompletionTest extends TestLogger {
                             new SimpleAckingTaskManagerGateway(),
                             Collections.singleton(slotOffer));
 
-            assertThat(acceptedSlots, containsInAnyOrder(slotOffer));
+            assertThat(acceptedSlots).contains(slotOffer);
 
             final FlinkException testingReleaseException =
                     new FlinkException("Testing release exception");
@@ -121,7 +119,7 @@ public class DeclarativeSlotPoolBridgeRequestCompletionTest extends TestLogger {
             // check that the slot requests get completed in sequential order
             for (int i = 0; i < slotRequestIds.size(); i++) {
                 final CompletableFuture<PhysicalSlot> slotRequestFuture = slotRequests.get(i);
-                assertThat(slotRequestFuture.getNow(null), is(not(nullValue())));
+                assertThat(slotRequestFuture.getNow(null)).isNotNull();
                 slotPool.releaseSlot(slotRequestIds.get(i), testingReleaseException);
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeRequestCompletionTest.java
@@ -28,12 +28,10 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,7 +45,6 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests how the {@link DeclarativeSlotPoolBridge} completes slot requests. */
-@ExtendWith(TestLoggerExtension.class)
 class DeclarativeSlotPoolBridgeRequestCompletionTest {
 
     private static final Time TIMEOUT = SlotPoolUtils.TIMEOUT;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -27,13 +26,15 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -44,37 +45,33 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeTest.createAllocatedSlot;
 import static org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeTest.createDeclarativeSlotPoolBridge;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DeclarativeSlotPoolBridge}. */
-@RunWith(Parameterized.class)
-public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger {
+@ExtendWith({TestLoggerExtension.class, ParameterizedTestExtension.class})
+class DeclarativeSlotPoolBridgeResourceDeclarationTest {
 
     private static final JobMasterId jobMasterId = JobMasterId.generate();
     private final ComponentMainThreadExecutor mainThreadExecutor =
             ComponentMainThreadExecutorServiceAdapter.forMainThread();
-    private final RequestSlotMatchingStrategy requestSlotMatchingStrategy;
+
+    @Parameter private RequestSlotMatchingStrategy requestSlotMatchingStrategy;
 
     private RequirementListener requirementListener;
     private DeclarativeSlotPoolBridge declarativeSlotPoolBridge;
 
-    @Parameterized.Parameters(name = "RequestSlotMatchingStrategy: {0}")
+    @Parameters(name = "RequestSlotMatchingStrategy: {0}")
     public static Collection<RequestSlotMatchingStrategy> data() throws IOException {
         return Arrays.asList(
                 SimpleRequestSlotMatchingStrategy.INSTANCE,
                 PreferredAllocationRequestSlotMatchingStrategy.INSTANCE);
     }
 
-    public DeclarativeSlotPoolBridgeResourceDeclarationTest(
-            RequestSlotMatchingStrategy requestSlotMatchingStrategy) {
-        this.requestSlotMatchingStrategy = requestSlotMatchingStrategy;
-    }
-
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() {
         requirementListener = new RequirementListener();
 
         final TestingDeclarativeSlotPoolBuilder slotPoolBuilder =
@@ -100,27 +97,26 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
                         declarativeSlotPoolFactory, requestSlotMatchingStrategy);
     }
 
-    @After
-    public void teardown() throws Exception {
+    @AfterEach
+    void teardown() {
         if (declarativeSlotPoolBridge != null) {
             declarativeSlotPoolBridge.close();
         }
     }
 
-    @Test
-    public void testRequirementsIncreasedOnNewAllocation() throws Exception {
+    @TestTemplate
+    void testRequirementsIncreasedOnNewAllocation() throws Exception {
         declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
 
         // requesting the allocation of a new slot should increase the requirements
         declarativeSlotPoolBridge.requestNewAllocatedSlot(
                 new SlotRequestId(), ResourceProfile.UNKNOWN, Time.minutes(5));
-        assertThat(
-                requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN),
-                is(1));
+        assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN))
+                .isOne();
     }
 
-    @Test
-    public void testRequirementsDecreasedOnAllocationTimeout() throws Exception {
+    @TestTemplate
+    void testRequirementsDecreasedOnAllocationTimeout() throws Exception {
         final ScheduledExecutorService scheduledExecutorService =
                 Executors.newSingleThreadScheduledExecutor();
         try {
@@ -141,19 +137,18 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
                             .get();
 
             // waiting for the timeout
-            assertThat(
-                    allocationFuture,
-                    FlinkMatchers.futureWillCompleteExceptionally(Duration.ofMinutes(1)));
-
+            assertThatFuture(allocationFuture).failsWithin(Duration.ofMinutes(1));
+            Thread.sleep(5L);
             // when the allocation fails the requirements should be reduced (it is the users
             // responsibility to retry)
             CompletableFuture.runAsync(
                             () ->
                                     assertThat(
-                                            requirementListener
-                                                    .getRequirements()
-                                                    .getResourceCount(ResourceProfile.UNKNOWN),
-                                            is(0)),
+                                                    requirementListener
+                                                            .getRequirements()
+                                                            .getResourceCount(
+                                                                    ResourceProfile.UNKNOWN))
+                                            .isZero(),
                             mainThreadExecutor)
                     .join();
         } finally {
@@ -161,20 +156,19 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
         }
     }
 
-    @Test
-    public void testRequirementsUnchangedOnNewSlotsNotification() throws Exception {
+    @TestTemplate
+    void testRequirementsUnchangedOnNewSlotsNotification() throws Exception {
         declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
 
         // notifications about new slots should not affect requirements
         final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
         declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(newSlot));
-        assertThat(
-                requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN),
-                is(0));
+        assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN))
+                .isZero();
     }
 
-    @Test
-    public void testRequirementsIncreasedOnSlotReservation() throws Exception {
+    @TestTemplate
+    void testRequirementsIncreasedOnSlotReservation() throws Exception {
         declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
 
         final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
@@ -184,13 +178,12 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
         final SlotRequestId slotRequestId = new SlotRequestId();
         declarativeSlotPoolBridge.allocateAvailableSlot(
                 slotRequestId, newSlot.getAllocationId(), ResourceProfile.UNKNOWN);
-        assertThat(
-                requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN),
-                is(1));
+        assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN))
+                .isOne();
     }
 
-    @Test
-    public void testRequirementsDecreasedOnSlotFreeing() throws Exception {
+    @TestTemplate
+    void testRequirementsDecreasedOnSlotFreeing() throws Exception {
         declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
 
         final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
@@ -203,13 +196,12 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
         // releasing (==freeing) a [reserved] slot should decrease the requirements
         declarativeSlotPoolBridge.releaseSlot(
                 slotRequestId, new RuntimeException("Test exception"));
-        assertThat(
-                requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN),
-                is(0));
+        assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN))
+                .isZero();
     }
 
-    @Test
-    public void testRequirementsDecreasedOnSlotAllocationFailure() throws Exception {
+    @TestTemplate
+    void testRequirementsDecreasedOnSlotAllocationFailure() throws Exception {
         declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
 
         final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
@@ -223,9 +215,8 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
                 newSlot.getTaskManagerLocation().getResourceID(),
                 newSlot.getAllocationId(),
                 new RuntimeException("Test exception"));
-        assertThat(
-                requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN),
-                is(0));
+        assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN))
+                .isZero();
     }
 
     private static final class RequirementListener {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
-import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +50,7 @@ import static org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBri
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DeclarativeSlotPoolBridge}. */
-@ExtendWith({TestLoggerExtension.class, ParameterizedTestExtension.class})
+@ExtendWith(ParameterizedTestExtension.class)
 class DeclarativeSlotPoolBridgeResourceDeclarationTest {
 
     private static final JobMasterId jobMasterId = JobMasterId.generate();
@@ -138,7 +137,6 @@ class DeclarativeSlotPoolBridgeResourceDeclarationTest {
 
             // waiting for the timeout
             assertThatFuture(allocationFuture).failsWithin(Duration.ofMinutes(1));
-            Thread.sleep(5L);
             // when the allocation fails the requirements should be reduced (it is the users
             // responsibility to retry)
             CompletableFuture.runAsync(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
-import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 
@@ -60,7 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link DeclarativeSlotPoolBridge}. */
-@ExtendWith({TestLoggerExtension.class, ParameterizedTestExtension.class})
+@ExtendWith(ParameterizedTestExtension.class)
 class DeclarativeSlotPoolBridgeTest {
 
     private static final Time rpcTimeout = Time.seconds(20);
@@ -201,10 +200,7 @@ class DeclarativeSlotPoolBridgeTest {
 
             declarativeSlotPoolBridge.close();
 
-            assertThatThrownBy(
-                            () -> {
-                                FutureUtils.waitForAll(slotFutures).get();
-                            })
+            assertThatThrownBy(() -> FutureUtils.waitForAll(slotFutures).get())
                     .as("The slot futures should be completed exceptionally.")
                     .isInstanceOf(ExecutionException.class);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -20,13 +20,11 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
@@ -34,13 +32,15 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nonnull;
 
@@ -55,34 +55,30 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link DeclarativeSlotPoolBridge}. */
-@RunWith(Parameterized.class)
-public class DeclarativeSlotPoolBridgeTest extends TestLogger {
+@ExtendWith({TestLoggerExtension.class, ParameterizedTestExtension.class})
+class DeclarativeSlotPoolBridgeTest {
 
     private static final Time rpcTimeout = Time.seconds(20);
     private static final JobID jobId = new JobID();
     private static final JobMasterId jobMasterId = JobMasterId.generate();
     private final ComponentMainThreadExecutor mainThreadExecutor =
             ComponentMainThreadExecutorServiceAdapter.forMainThread();
-    private final RequestSlotMatchingStrategy requestSlotMatchingStrategy;
+    @Parameter private RequestSlotMatchingStrategy requestSlotMatchingStrategy;
 
-    @Parameterized.Parameters(name = "RequestSlotMatchingStrategy: {0}")
+    @Parameters(name = "RequestSlotMatchingStrategy: {0}")
     public static Collection<RequestSlotMatchingStrategy> data() throws IOException {
         return Arrays.asList(
                 SimpleRequestSlotMatchingStrategy.INSTANCE,
                 PreferredAllocationRequestSlotMatchingStrategy.INSTANCE);
     }
 
-    public DeclarativeSlotPoolBridgeTest(RequestSlotMatchingStrategy requestSlotMatchingStrategy) {
-        this.requestSlotMatchingStrategy = requestSlotMatchingStrategy;
-    }
-
-    @Test
-    public void testSlotOffer() throws Exception {
+    @TestTemplate
+    void testSlotOffer() throws Exception {
         final SlotRequestId slotRequestId = new SlotRequestId();
         final AllocationID expectedAllocationId = new AllocationID();
         final PhysicalSlot allocatedSlot = createAllocatedSlot(expectedAllocationId);
@@ -105,8 +101,8 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
         }
     }
 
-    @Test
-    public void testNotEnoughResourcesAvailableFailsPendingRequests() throws Exception {
+    @TestTemplate
+    void testNotEnoughResourcesAvailableFailsPendingRequests() throws Exception {
         final SlotRequestId slotRequestId = new SlotRequestId();
 
         final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory =
@@ -132,15 +128,12 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
                             declarativeSlotPoolBridge.notifyNotEnoughResourcesAvailable(
                                     Collections.emptyList()));
 
-            assertThat(
-                    slotAllocationFuture,
-                    FlinkMatchers.futureWillCompleteExceptionally(
-                            NoResourceAvailableException.class, Duration.ofSeconds(10)));
+            assertThatFuture(slotAllocationFuture).failsWithin(Duration.ofSeconds(10));
         }
     }
 
-    @Test
-    public void testReleasingAllocatedSlot() throws Exception {
+    @TestTemplate
+    void testReleasingAllocatedSlot() throws Exception {
         final CompletableFuture<AllocationID> releaseSlotFuture = new CompletableFuture<>();
         final AllocationID expectedAllocationId = new AllocationID();
         final PhysicalSlot allocatedSlot = createAllocatedSlot(expectedAllocationId);
@@ -149,7 +142,7 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
                 TestingDeclarativeSlotPool.builder()
                         .setReserveFreeSlotFunction(
                                 (allocationId, resourceProfile) -> {
-                                    assertThat(allocationId, is(expectedAllocationId));
+                                    assertThat(allocationId).isSameAs(expectedAllocationId);
                                     return allocatedSlot;
                                 })
                         .setFreeReservedSlotFunction(
@@ -171,12 +164,12 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
                     slotRequestId, expectedAllocationId, allocatedSlot.getResourceProfile());
             declarativeSlotPoolBridge.releaseSlot(slotRequestId, null);
 
-            assertThat(releaseSlotFuture.join(), is(expectedAllocationId));
+            assertThat(releaseSlotFuture.join()).isSameAs(expectedAllocationId);
         }
     }
 
-    @Test
-    public void testNoConcurrentModificationWhenSuspendingAndReleasingSlot() throws Exception {
+    @TestTemplate
+    void testNoConcurrentModificationWhenSuspendingAndReleasingSlot() throws Exception {
         try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
                 createDeclarativeSlotPoolBridge(
                         new DefaultDeclarativeSlotPoolFactory(), requestSlotMatchingStrategy)) {
@@ -208,17 +201,17 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
 
             declarativeSlotPoolBridge.close();
 
-            try {
-                FutureUtils.waitForAll(slotFutures).get();
-                fail("The slot futures should be completed exceptionally.");
-            } catch (ExecutionException expected) {
-                // expected
-            }
+            assertThatThrownBy(
+                            () -> {
+                                FutureUtils.waitForAll(slotFutures).get();
+                            })
+                    .as("The slot futures should be completed exceptionally.")
+                    .isInstanceOf(ExecutionException.class);
         }
     }
 
-    @Test
-    public void testAcceptingOfferedSlotsWithoutResourceManagerConnected() throws Exception {
+    @TestTemplate
+    void testAcceptingOfferedSlotsWithoutResourceManagerConnected() throws Exception {
         try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
                 createDeclarativeSlotPoolBridge(
                         new DefaultDeclarativeSlotPoolFactory(), requestSlotMatchingStrategy)) {
@@ -239,12 +232,12 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
                     new SimpleAckingTaskManagerGateway(),
                     Collections.singleton(new SlotOffer(allocationId, 0, ResourceProfile.ANY)));
 
-            assertThat(slotFuture.join().getAllocationId(), is(allocationId));
+            assertThat(slotFuture.join().getAllocationId()).isSameAs(allocationId);
         }
     }
 
-    @Test
-    public void testIfJobIsRestartingAllOfferedSlotsWillBeRegistered() throws Exception {
+    @TestTemplate
+    void testIfJobIsRestartingAllOfferedSlotsWillBeRegistered() throws Exception {
         final CompletableFuture<Void> registerSlotsCalledFuture = new CompletableFuture<>();
         final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory =
                 new TestingDeclarativeSlotPoolFactory(


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33853][runtime][JUnit5 Migration] Migrate Junit5 for DeclarativeSlotPoolBridge test classes of runtime module


## Brief change log

- DeclarativeSlotPoolBridgeRequestCompletionTest
- DeclarativeSlotPoolBridgeResourceDeclarationTest
- DeclarativeSlotPoolBridgePreferredAllocationsTest
- DeclarativeSlotPoolBridgeTest

## Verifying this change

N.A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
