### PR TITLE
[FLINK-33688][client] Reuse connections in RestClient to save connection establish time

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
@@ -48,7 +48,7 @@ public class StandaloneClientFactory implements ClusterClientFactory<StandaloneC
     @Nullable
     public StandaloneClusterId getClusterId(Configuration configuration) {
         checkNotNull(configuration);
-        return StandaloneClusterId.getInstance();
+        return StandaloneClusterId.fromConfiguration(configuration);
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
@@ -18,13 +18,62 @@
 
 package org.apache.flink.client.deployment;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Objects;
+
 /** Identifier for standalone clusters. */
 public class StandaloneClusterId {
-    private static final StandaloneClusterId INSTANCE = new StandaloneClusterId();
+    private static final String STANDALONE_CLUSTER_ID_PREFIX = "standalone-flink-cluster-";
+    private final String clusterId;
 
-    private StandaloneClusterId() {}
+    private StandaloneClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
 
-    public static StandaloneClusterId getInstance() {
-        return INSTANCE;
+    public static StandaloneClusterId fromConfiguration(Configuration configuration) {
+        String clusterId;
+        if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
+            clusterId = configuration.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+        } else if (!configuration.get(RestOptions.ADDRESS).isEmpty()) {
+            final String address = configuration.get(RestOptions.ADDRESS);
+            final int port = configuration.getInteger(RestOptions.PORT);
+            clusterId = String.format("%s:%s", address, port);
+        } else {
+            clusterId = generateStandaloneClusterId();
+        }
+
+        return new StandaloneClusterId(clusterId);
+    }
+
+    private static String generateStandaloneClusterId() {
+        final String randomID = new AbstractID().toString();
+        return (STANDALONE_CLUSTER_ID_PREFIX + randomID).substring(0, 64);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandaloneClusterId that = (StandaloneClusterId) o;
+        return Objects.equals(clusterId, that.clusterId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId);
+    }
+
+    @Override
+    public String toString() {
+        return "StandaloneClusterId{" + "clusterId='" + clusterId + '\'' + '}';
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -35,8 +35,12 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,9 +61,12 @@ public class AbstractSessionClusterExecutor<
         implements CacheSupportedPipelineExecutor {
 
     private final ClientFactory clusterClientFactory;
+    private final Cache<ClusterID, ClusterDescriptor<ClusterID>> cachedClusterDescriptors;
 
     public AbstractSessionClusterExecutor(@Nonnull final ClientFactory clusterClientFactory) {
         this.clusterClientFactory = checkNotNull(clusterClientFactory);
+        this.cachedClusterDescriptors =
+                CacheBuilder.newBuilder().expireAfterAccess(Duration.ofMinutes(30L)).build();
     }
 
     @Override
@@ -70,35 +77,33 @@ public class AbstractSessionClusterExecutor<
             throws Exception {
         final JobGraph jobGraph =
                 PipelineExecutorUtils.getJobGraph(pipeline, configuration, userCodeClassloader);
+        final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
+        checkState(clusterID != null);
+        final ClusterDescriptor<ClusterID> clusterDescriptor =
+                cachedClusterDescriptors.get(
+                        clusterID,
+                        () -> clusterClientFactory.createClusterDescriptor(configuration));
 
-        try (final ClusterDescriptor<ClusterID> clusterDescriptor =
-                clusterClientFactory.createClusterDescriptor(configuration)) {
-            final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
-            checkState(clusterID != null);
-
-            final ClusterClientProvider<ClusterID> clusterClientProvider =
-                    clusterDescriptor.retrieve(clusterID);
-            ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
-            return clusterClient
-                    .submitJob(jobGraph)
-                    .thenApplyAsync(
-                            FunctionUtils.uncheckedFunction(
-                                    jobId -> {
-                                        ClientUtils.waitUntilJobInitializationFinished(
-                                                () -> clusterClient.getJobStatus(jobId).get(),
-                                                () -> clusterClient.requestJobResult(jobId).get(),
-                                                userCodeClassloader);
-                                        return jobId;
-                                    }))
-                    .thenApplyAsync(
-                            jobID ->
-                                    (JobClient)
-                                            new ClusterClientJobClientAdapter<>(
-                                                    clusterClientProvider,
-                                                    jobID,
-                                                    userCodeClassloader))
-                    .whenCompleteAsync((ignored1, ignored2) -> clusterClient.close());
-        }
+        final ClusterClientProvider<ClusterID> clusterClientProvider =
+                clusterDescriptor.retrieve(clusterID);
+        ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
+        return clusterClient
+                .submitJob(jobGraph)
+                .thenApplyAsync(
+                        FunctionUtils.uncheckedFunction(
+                                jobId -> {
+                                    ClientUtils.waitUntilJobInitializationFinished(
+                                            () -> clusterClient.getJobStatus(jobId).get(),
+                                            () -> clusterClient.requestJobResult(jobId).get(),
+                                            userCodeClassloader);
+                                    return jobId;
+                                }))
+                .thenApplyAsync(
+                        jobID ->
+                                (JobClient)
+                                        new ClusterClientJobClientAdapter<>(
+                                                clusterClientProvider, jobID, userCodeClassloader))
+                .whenCompleteAsync((ignored1, ignored2) -> clusterClient.close());
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -163,6 +163,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -186,10 +187,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 
     private final RestClient restClient;
 
-    private final ExecutorService executorService =
-            Executors.newFixedThreadPool(
-                    Runtime.getRuntime().availableProcessors() * 2,
-                    new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
+    private final ExecutorService executorService = ForkJoinPool.commonPool();
 
     private final WaitStrategy waitStrategy;
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -116,7 +116,8 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
         CliFrontend frontend =
                 new MockedCliFrontend(
                         new RestClusterClient<>(
-                                getConfiguration(), StandaloneClusterId.getInstance()));
+                                getConfiguration(),
+                                StandaloneClusterId.fromConfiguration(getConfiguration())));
 
         String[] parameters = {"invalid job id"};
         assertThatThrownBy(() -> frontend.savepoint(parameters))
@@ -276,7 +277,7 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
                 Function<String, CompletableFuture<Acknowledge>> disposeSavepointFunction,
                 Configuration configuration)
                 throws Exception {
-            super(configuration, StandaloneClusterId.getInstance());
+            super(configuration, StandaloneClusterId.fromConfiguration(configuration));
 
             this.disposeSavepointFunction = Preconditions.checkNotNull(disposeSavepointFunction);
         }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
@@ -221,7 +221,7 @@ class RestClusterClientCheckpointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -350,7 +350,7 @@ class RestClusterClientSavepointTriggerTest {
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -226,7 +226,7 @@ class RestClusterClientTest {
         return new RestClusterClient<>(
                 clientConfig,
                 createRestClient(),
-                StandaloneClusterId.getInstance(),
+                StandaloneClusterId.fromConfiguration(clientConfig),
                 (attempt) -> 0);
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CollectOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CollectOptions.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * Config options for {@link org.apache.flink.util.concurrent.RetryStrategy} in
+ * CollectResultFetcher.
+ */
+@PublicEvolving
+@ConfigGroups(
+        groups = {
+            @ConfigGroup(
+                    name = "ExponentialDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.exponential-delay"),
+            @ConfigGroup(
+                    name = "FixedDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.fixed-delay"),
+            @ConfigGroup(
+                    name = "IncrementalDelayCollectStrategy",
+                    keyPrefix = "collect-strategy.incremental-delay"),
+        })
+public class CollectOptions {
+
+    private static final String COLLECT_STRATEGY_PARAM = "collect-strategy";
+    public static final String FIXED_DELAY_LABEL = "fixed-delay";
+    public static final String EXPONENTIAL_DELAY_LABEL = "exponential-delay";
+
+    public static final String INCREMENTAL_DELAY_LABEL = "incremental-delay";
+
+    private static String createParameterPrefix(String paramGroupKey) {
+        return COLLECT_STRATEGY_PARAM + "." + paramGroupKey + ".";
+    }
+
+    private static String createFixedDelayParameterPrefix(String parameter) {
+        return createParameterPrefix(FIXED_DELAY_LABEL) + parameter;
+    }
+
+    private static String createExponentialBackoffParameterPrefix(String parameter) {
+        return createParameterPrefix(EXPONENTIAL_DELAY_LABEL) + parameter;
+    }
+
+    private static String createIncrementalDelayParameterPrefix(String parameter) {
+        return createParameterPrefix(INCREMENTAL_DELAY_LABEL) + parameter;
+    }
+
+    public static String extractAlphaNumericCharacters(String paramName) {
+        return paramName.replaceAll("[^a-zA-Z0-9]", "");
+    }
+
+    public static final ConfigOption<String> COLLECT_STRATEGY =
+            ConfigOptions.key(COLLECT_STRATEGY_PARAM + ".type")
+                    .stringType()
+                    .defaultValue(FIXED_DELAY_LABEL)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the retry strategy to use in CollectResultFetcher.")
+                                    .linebreak()
+                                    .text("Accepted values are:")
+                                    .list(
+                                            text(
+                                                    "%s, %s: CollectResultFetcher will send collect "
+                                                            + "request to cluster in a fixed interval up "
+                                                            + "to the point where the job is considered "
+                                                            + "successful or a set amount of retries is "
+                                                            + "reached.",
+                                                    code(FIXED_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    FIXED_DELAY_LABEL))),
+                                            text(
+                                                    "%s, %s: Exponential delay retry strategy "
+                                                            + "triggers the collect request with an "
+                                                            + "exponentially increasing delay up to "
+                                                            + " a configured max delay or the point "
+                                                            + "where the job is succeeded or a set "
+                                                            + "amount of retries is reached.",
+                                                    code(EXPONENTIAL_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    EXPONENTIAL_DELAY_LABEL))),
+                                            text(
+                                                    "%s, %s: Incremental delay retry strategy "
+                                                            + "triggers the collect request with an "
+                                                            + "incremental delay up to a configured "
+                                                            + "max delay or the point where the job "
+                                                            + "is succeeded or a set amount of retries "
+                                                            + "is reached.",
+                                                    code(INCREMENTAL_DELAY_LABEL),
+                                                    code(
+                                                            extractAlphaNumericCharacters(
+                                                                    INCREMENTAL_DELAY_LABEL))))
+                                    .text(
+                                            "The default configuration relies on an fixed delayed "
+                                                    + "retry strategy with the given default values.")
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_FIXED_DELAY_ATTEMPTS =
+            ConfigOptions.key(createFixedDelayParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()), code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_FIXED_DELAY_DELAY =
+            ConfigOptions.key(createFixedDelayParameterPrefix("delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(100))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Amount of time that CollectResultFetcher waits before next retry. "
+                                                    + "It can be specified using the following notation: \"1 min\", "
+                                                    + "\"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(FIXED_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("initial-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Starting duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("max-backoff"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The highest possible duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS =
+            ConfigOptions.key(createExponentialBackoffParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(EXPONENTIAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_INITIAL_DELAY =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("initial-delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Starting duration between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_INCREMENT =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("increment"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The delay increment between CollectResultFetcher "
+                                                    + "retries the collect request if %s has "
+                                                    + "been set to %s. It can be specified using the "
+                                                    + "following notation: \"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    public static final ConfigOption<Duration> COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_DELAY =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("max-delay"))
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The highest possible duration between fetch "
+                                                    + "retries if %s has been set to %s. It can be "
+                                                    + "specified using the following notation: "
+                                                    + "\"1 min\", \"20 s\"",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_ATTEMPTS =
+            ConfigOptions.key(createIncrementalDelayParameterPrefix("attempts"))
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of times that CollectResultFetcher retries the "
+                                                    + "collect request before giving up if %s has been set to %s. "
+                                                    + "Typically, it should keep retry until the job is finished.",
+                                            code(COLLECT_STRATEGY.key()),
+                                            code(INCREMENTAL_DELAY_LABEL))
+                                    .build());
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -158,6 +158,18 @@ public class RestOptions {
                     .withDescription(
                             "The maximum time in ms for the client to establish a TCP connection.");
 
+    /**
+     * Config parameter indicating whether to reuse the TCP connection between client and
+     * JobManager.
+     */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<Boolean> CONNECTION_REUSE =
+            key("rest.connection-reuse")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Config parameter indicating whether to reuse the TCP connection between client and JobManager.");
+
     /** The maximum time in ms for a connection to stay idle before failing. */
     @Documentation.Section(Documentation.Sections.EXPERT_REST)
     public static final ConfigOption<Long> IDLENESS_TIMEOUT =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -32,9 +32,11 @@ import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneReusableClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperLeaderElectionHaServices;
+import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperReusableClientHAServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
@@ -42,6 +44,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
@@ -167,6 +170,33 @@ public class HighAvailabilityServicesUtils {
                 return createCustomClientHAServices(configuration);
             default:
                 throw new Exception("Recovery mode " + highAvailabilityMode + " is not supported.");
+        }
+    }
+
+    public static ReusableClientHAServices createReusableClientHAService(
+            Configuration configuration,
+            LeaderRetriever leaderRetriever,
+            FatalErrorHandler fatalErrorHandler)
+            throws Exception {
+        HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
+        switch (highAvailabilityMode) {
+            case NONE:
+                final String webMonitorAddress =
+                        getWebMonitorAddress(
+                                configuration, AddressResolution.TRY_ADDRESS_RESOLUTION);
+                return new StandaloneReusableClientHAServices(webMonitorAddress, leaderRetriever);
+            case ZOOKEEPER:
+                return new ZooKeeperReusableClientHAServices(
+                        ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler),
+                        leaderRetriever,
+                        configuration);
+            case FACTORY_CLASS:
+                return createCustomSharedClientHAServices(configuration);
+            default:
+                throw new Exception(
+                        "Recovery mode "
+                                + highAvailabilityMode
+                                + " in SharedClientHAServices is not supported.");
         }
     }
 
@@ -309,10 +339,37 @@ public class HighAvailabilityServicesUtils {
                 classLoader);
     }
 
+    private static ReusableClientHAServicesFactory loadCustomSharedClientHAServicesFactory(
+            String sharedClientHAServicesFactoryClassName) throws FlinkException {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        return InstantiationUtil.instantiate(
+                sharedClientHAServicesFactoryClassName,
+                ReusableClientHAServicesFactory.class,
+                classLoader);
+    }
+
     private static ClientHighAvailabilityServices createCustomClientHAServices(Configuration config)
             throws FlinkException {
         return createCustomClientHAServices(
                 config.getString(HighAvailabilityOptions.HA_MODE), config);
+    }
+
+    private static ReusableClientHAServices createCustomSharedClientHAServices(Configuration config)
+            throws FlinkException {
+        final ReusableClientHAServicesFactory reusableClientHAServicesFactory =
+                loadCustomSharedClientHAServicesFactory(
+                        config.getString(HighAvailabilityOptions.HA_MODE));
+
+        try {
+            return reusableClientHAServicesFactory.createReusableClientHAServices(config);
+        } catch (Exception e) {
+            throw new FlinkException(
+                    String.format(
+                            "Could not create the shared client ha services from the instantiated SharedClientHAServicesFactory %s.",
+                            reusableClientHAServicesFactory.getClass().getName()),
+                    e);
+        }
     }
 
     private static ClientHighAvailabilityServices createCustomClientHAServices(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServices.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+/**
+ * {@code ReusableClientHAServices} provides shared high availability services those are required on
+ * client-side, including {@code LeaderRetrievalService} and {@code LeaderRetriever}.
+ */
+public interface ReusableClientHAServices extends ClientHighAvailabilityServices {
+
+    /**
+     * Get the leader retriever for the cluster.
+     *
+     * @return the leader retriever of the cluster.
+     */
+    LeaderRetriever getLeaderRetriever();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ReusableClientHAServicesFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+/** Factory interface for {@link ReusableClientHAServices}. */
+public interface ReusableClientHAServicesFactory extends ClientHighAvailabilityServicesFactory {
+
+    /**
+     * Creates a {@link ReusableClientHAServices} instance.
+     *
+     * @param configuration Flink configuration
+     * @return instance of {@link ReusableClientHAServices}
+     * @throws Exception when ReusableClientHAServices cannot be created
+     */
+    ReusableClientHAServices createReusableClientHAServices(Configuration configuration)
+            throws Exception;
+
+    default ClientHighAvailabilityServices create(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) throws Exception {
+        return createReusableClientHAServices(configuration);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneReusableClientHAServices.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.nonha.standalone;
+
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+import static org.apache.flink.runtime.highavailability.HighAvailabilityServices.DEFAULT_LEADER_ID;
+
+/**
+ * Non-HA implementation for {@link ReusableClientHAServices}. The address to web monitor is
+ * pre-configured.
+ */
+public class StandaloneReusableClientHAServices implements ReusableClientHAServices {
+
+    private final LeaderRetriever leaderRetriever;
+
+    private final LeaderRetrievalService leaderRetrievalService;
+
+    public StandaloneReusableClientHAServices(
+            String webMonitorAddress, LeaderRetriever leaderRetriever) throws Exception {
+        this.leaderRetriever = leaderRetriever;
+        this.leaderRetrievalService =
+                new StandaloneLeaderRetrievalService(webMonitorAddress, DEFAULT_LEADER_ID);
+        startLeaderRetrievers();
+    }
+
+    @Override
+    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+        return this.leaderRetrievalService;
+    }
+
+    private void startLeaderRetrievers() throws Exception {
+        this.leaderRetrievalService.start(leaderRetriever);
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public LeaderRetriever getLeaderRetriever() {
+        return this.leaderRetriever;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/DefaultReusableClientHAServicesFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/DefaultReusableClientHAServicesFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServicesFactory;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+import org.apache.flink.util.FlinkException;
+
+/** Factory for creating reusable client high availability services. */
+public class DefaultReusableClientHAServicesFactory implements ReusableClientHAServicesFactory {
+
+    public static final DefaultReusableClientHAServicesFactory INSTANCE =
+            new DefaultReusableClientHAServicesFactory();
+
+    @Override
+    public ReusableClientHAServices createReusableClientHAServices(Configuration configuration)
+            throws Exception {
+        LeaderRetriever leaderRetriever = new LeaderRetriever();
+
+        return HighAvailabilityServicesUtils.createReusableClientHAService(
+                configuration,
+                leaderRetriever,
+                exception ->
+                        leaderRetriever.handleError(
+                                new FlinkException(
+                                        "Fatal error happened with client HA " + "services.",
+                                        exception)));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperReusableClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperReusableClientHAServices.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.highavailability.zookeeper;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.highavailability.ReusableClientHAServices;
+import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+
+import javax.annotation.Nonnull;
+
+/** ZooKeeper based implementation for {@link ReusableClientHAServices}. */
+public class ZooKeeperReusableClientHAServices implements ReusableClientHAServices {
+
+    private final LeaderRetriever leaderRetriever;
+    private final DefaultLeaderRetrievalService leaderRetrievalService;
+
+    public ZooKeeperReusableClientHAServices(
+            @Nonnull CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper,
+            @Nonnull LeaderRetriever leaderRetriever,
+            @Nonnull Configuration configuration)
+            throws Exception {
+        this.leaderRetrievalService =
+                ZooKeeperUtils.createLeaderRetrievalService(
+                        curatorFrameworkWrapper.asCuratorFramework(),
+                        ZooKeeperUtils.getLeaderPath(ZooKeeperUtils.getRestServerNode()),
+                        configuration);
+        this.leaderRetriever = leaderRetriever;
+        startLeaderRetrievers();
+    }
+
+    private void startLeaderRetrievers() throws Exception {
+        this.leaderRetrievalService.start(leaderRetriever);
+    }
+
+    @Override
+    public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
+        return this.leaderRetrievalService;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // do nothing here in this version
+    }
+
+    @Override
+    public LeaderRetriever getLeaderRetriever() {
+        return leaderRetriever;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
@@ -135,12 +136,16 @@ public class RestClient implements AutoCloseableAsync {
 
     private final String urlPrefix;
 
+    private final boolean connectionReuse;
+
     // Used to track unresolved request futures in case they need to be resolved when the client is
     // closed
     private final Collection<CompletableFuture<Channel>> responseChannelFutures =
             ConcurrentHashMap.newKeySet();
 
     private final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
+
+    private ConcurrentHashMap<Tuple2<String, Integer>, CompletableFuture<Channel>> reusingChannels;
 
     /**
      * Creates a new RestClient for the provided root URL. If the protocol of the URL is "https",
@@ -186,7 +191,9 @@ public class RestClient implements AutoCloseableAsync {
         Preconditions.checkNotNull(configuration);
         this.executor = Preconditions.checkNotNull(executor);
         this.terminationFuture = new CompletableFuture<>();
+        this.connectionReuse = configuration.get(RestOptions.CONNECTION_REUSE);
         outboundChannelHandlerFactories = new ArrayList<>();
+
         ServiceLoader<OutboundChannelHandlerFactory> loader =
                 ServiceLoader.load(OutboundChannelHandlerFactory.class);
         final Iterator<OutboundChannelHandlerFactory> factories = loader.iterator();
@@ -280,6 +287,10 @@ public class RestClient implements AutoCloseableAsync {
                 .group(group)
                 .channel(NioSocketChannel.class)
                 .handler(initializer);
+
+        if (connectionReuse) {
+            reusingChannels = new ConcurrentHashMap<>();
+        }
 
         LOG.debug("Rest client endpoint started.");
     }
@@ -459,6 +470,15 @@ public class RestClient implements AutoCloseableAsync {
         ByteBuf payload =
                 Unpooled.wrappedBuffer(sw.toString().getBytes(ConfigConstants.DEFAULT_CHARSET));
 
+        if (connectionReuse) {
+            messageHeaders
+                    .getCustomHeaders()
+                    .add(
+                            new HttpHeader(
+                                    HttpHeaderNames.CONNECTION.toString(),
+                                    HttpHeaderValues.KEEP_ALIVE.toString()));
+        }
+
         Request httpRequest =
                 createRequest(
                         targetAddress + ':' + targetPort,
@@ -576,20 +596,16 @@ public class RestClient implements AutoCloseableAsync {
                     new IllegalStateException("RestClient is already closed"));
         }
 
-        final CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
-        responseChannelFutures.add(channelFuture);
+        final CompletableFuture<Channel> channelFuture;
+        if (connectionReuse) {
+            channelFuture =
+                    reusingChannels.computeIfAbsent(
+                            Tuple2.of(targetAddress, targetPort),
+                            tuple -> connect(targetAddress, targetPort));
 
-        final ChannelFuture connectFuture = bootstrap.connect(targetAddress, targetPort);
-        connectFuture.addListener(
-                (ChannelFuture future) -> {
-                    responseChannelFutures.remove(channelFuture);
-
-                    if (future.isSuccess()) {
-                        channelFuture.complete(future.channel());
-                    } else {
-                        channelFuture.completeExceptionally(future.cause());
-                    }
-                });
+        } else {
+            channelFuture = connect(targetAddress, targetPort);
+        }
 
         return channelFuture
                 .thenComposeAsync(
@@ -616,6 +632,10 @@ public class RestClient implements AutoCloseableAsync {
                             } finally {
                                 if (!success) {
                                     channel.close();
+                                    if (reusingChannels != null) {
+                                        reusingChannels.remove(
+                                                Tuple2.of(targetAddress, targetPort));
+                                    }
                                 }
                             }
 
@@ -625,6 +645,26 @@ public class RestClient implements AutoCloseableAsync {
                 .thenComposeAsync(
                         (JsonResponse rawResponse) -> parseResponse(rawResponse, responseType),
                         executor);
+    }
+
+    private CompletableFuture<Channel> connect(String targetAddress, int targetPort) {
+
+        final CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
+        responseChannelFutures.add(channelFuture);
+
+        final ChannelFuture connectFuture = bootstrap.connect(targetAddress, targetPort);
+        connectFuture.addListener(
+                (ChannelFuture future) -> {
+                    responseChannelFutures.remove(channelFuture);
+
+                    if (future.isSuccess()) {
+                        channelFuture.complete(future.channel());
+                    } else {
+                        channelFuture.completeExceptionally(future.cause());
+                    }
+                });
+
+        return channelFuture;
     }
 
     private static <P extends ResponseBody> CompletableFuture<P> parseResponse(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/CollectRetryStrategyFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/CollectRetryStrategyFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.configuration.CollectOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.IncrementalDelayRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * {@code CollectRetryStrategyFactory} is used to create {@link RetryStrategy} for {@link
+ * org.apache.flink.streaming.api.operators.collect.CollectResultFetcher}. It extracts all the
+ * necessary information from the passed {@link Configuration}.
+ *
+ * @see CollectOptions
+ */
+public enum CollectRetryStrategyFactory {
+    INSTANCE;
+
+    /** Creates the {@link RetryStrategy} instance based on the passed {@link Configuration}. */
+    public Supplier<RetryStrategy> createRetryStrategySupplier(ReadableConfig configuration) {
+        final String configuredRetryStrategy = configuration.get(CollectOptions.COLLECT_STRATEGY);
+        if (isRetryStrategy(
+                CollectOptions.FIXED_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createFixedRetryStrategy(configuration);
+        } else if (isRetryStrategy(
+                CollectOptions.EXPONENTIAL_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createExponentialBackoffRetryStrategy(configuration);
+        } else if (isRetryStrategy(
+                CollectOptions.INCREMENTAL_DELAY_LABEL,
+                configuration.get(CollectOptions.COLLECT_STRATEGY))) {
+            return () -> createIncrementalDelayRetryStrategy(configuration);
+        }
+
+        throw new IllegalArgumentException(
+                createInvalidCollectStrategyErrorMessage(configuredRetryStrategy));
+    }
+
+    private static FixedRetryStrategy createFixedRetryStrategy(ReadableConfig configuration) {
+        final Duration delay = configuration.get(CollectOptions.COLLECT_STRATEGY_FIXED_DELAY_DELAY);
+        final int maxAttempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_FIXED_DELAY_ATTEMPTS);
+
+        return new FixedRetryStrategy(maxAttempts, delay);
+    }
+
+    private static ExponentialBackoffRetryStrategy createExponentialBackoffRetryStrategy(
+            ReadableConfig configuration) {
+        final Duration minDelay =
+                configuration.get(
+                        CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF);
+        final Duration maxDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF);
+        final int maxAttempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_EXPONENTIAL_DELAY_MAX_ATTEMPTS);
+
+        return new ExponentialBackoffRetryStrategy(maxAttempts, minDelay, maxDelay);
+    }
+
+    private static IncrementalDelayRetryStrategy createIncrementalDelayRetryStrategy(
+            ReadableConfig configuration) {
+        final Duration initialDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_INITIAL_DELAY);
+        final Duration increment =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_INCREMENT);
+        final int attempts =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_ATTEMPTS);
+        final Duration maxDelay =
+                configuration.get(CollectOptions.COLLECT_STRATEGY_INCREMENTAL_DELAY_MAX_DELAY);
+
+        return new IncrementalDelayRetryStrategy(attempts, initialDelay, increment, maxDelay);
+    }
+
+    private static String createInvalidCollectStrategyErrorMessage(String configuredRetryStrategy) {
+        final StringBuilder msgBuilder = new StringBuilder();
+        msgBuilder
+                .append("Unknown collect retry strategy '")
+                .append(configuredRetryStrategy)
+                .append("'. Valid strategies are ");
+
+        final String validOptionsStr =
+                String.join(
+                        ", ",
+                        CollectOptions.INCREMENTAL_DELAY_LABEL,
+                        CollectOptions.EXPONENTIAL_DELAY_LABEL,
+                        CollectOptions.FIXED_DELAY_LABEL);
+
+        return msgBuilder.append(validOptionsStr).toString();
+    }
+
+    private static boolean isRetryStrategy(
+            String retryStrategyLabel, String configuredRetryStrategy) {
+        final String retryStrategy = configuredRetryStrategy.toLowerCase();
+        return retryStrategy.equals(retryStrategyLabel)
+                || retryStrategy.equals(
+                        CollectOptions.extractAlphaNumericCharacters(retryStrategyLabel));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcherRetryITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectResultFetcherRetryITCase.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.collect.utils.TestJobClient;
+import org.apache.flink.streaming.api.operators.collect.utils.TestSimpleCountCoordinationRequestHandler;
+import org.apache.flink.util.OptionalFailure;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.util.concurrent.FixedRetryStrategy;
+import org.apache.flink.util.concurrent.IncrementalDelayRetryStrategy;
+import org.apache.flink.util.concurrent.RetryStrategy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/** Tests for {@link CollectResultIterator}. */
+public class CollectResultFetcherRetryITCase extends TestLogger {
+    private final TypeSerializer<Integer> serializer = IntSerializer.INSTANCE;
+    private static final OperatorID TEST_OPERATOR_ID = new OperatorID();
+
+    private static final JobID TEST_JOB_ID = new JobID();
+    private static final String ACCUMULATOR_NAME = "accumulatorName";
+
+    private final AtomicLong totalRetryInterval = new AtomicLong(0L);
+
+    private final Consumer<RetryStrategy> retryAction =
+            retryStrategy -> {
+                long delay = retryStrategy.getRetryDelay().toMillis();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(delay);
+                    totalRetryInterval.getAndAdd(delay);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+    @Test
+    public void testFetcherWithIncrementalDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        long increment = 100L;
+        long maxDelay = 1000L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new IncrementalDelayRetryStrategy(
+                                        Integer.MAX_VALUE,
+                                        Duration.ofMillis(initDelay),
+                                        Duration.ofMillis(increment),
+                                        Duration.ofMillis(maxDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        long currentDelay = initDelay;
+
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            if (i > 1) {
+                currentDelay = Math.min(currentDelay + increment, maxDelay);
+            }
+
+            expect += currentDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    @Test
+    public void testFetcherWithExponentialBackoffDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        long maxDelay = 1000L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new ExponentialBackoffRetryStrategy(
+                                        Integer.MAX_VALUE,
+                                        Duration.ofMillis(initDelay),
+                                        Duration.ofMillis(maxDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        long currentDelay = initDelay;
+
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            if (i > 1) {
+                currentDelay = Math.min(currentDelay * 2, maxDelay);
+            }
+
+            expect += currentDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    @Test
+    public void testFetcherWithFixedDelayRetryStrategy() throws Exception {
+        long initDelay = 100L;
+        totalRetryInterval.set(0L);
+
+        TestSimpleCountCoordinationRequestHandler handler =
+                new TestSimpleCountCoordinationRequestHandler();
+        Tuple2<CollectResultFetcher<Integer>, JobClient> tuple2 =
+                createFetcherAndJobClient(
+                        new UncheckpointedCollectResultBuffer<>(serializer, true),
+                        handler,
+                        () ->
+                                new FixedRetryStrategy(
+                                        Integer.MAX_VALUE, Duration.ofMillis(initDelay)),
+                        retryAction);
+
+        CollectResultFetcher<Integer> resultFetcher = tuple2.f0;
+
+        Thread t =
+                new Thread(
+                        () -> {
+                            try {
+                                resultFetcher.next();
+                            } catch (Exception ignored) {
+
+                            }
+                        });
+
+        t.start();
+
+        Random random = new Random();
+        TimeUnit.SECONDS.sleep(random.nextInt(5));
+        handler.close();
+
+        long expect = 0L;
+        for (int i = 1; i <= handler.getRequestCount(); i++) {
+            expect += initDelay;
+        }
+
+        Assert.assertEquals(expect, totalRetryInterval.get());
+    }
+
+    private Tuple2<CollectResultFetcher<Integer>, JobClient> createFetcherAndJobClient(
+            AbstractCollectResultBuffer<Integer> buffer,
+            TestSimpleCountCoordinationRequestHandler handler,
+            Supplier<RetryStrategy> retryStrategySupplier,
+            Consumer<RetryStrategy> retryAction) {
+        CollectResultFetcher<Integer> resultFetcher =
+                new CollectResultFetcher<>(
+                        buffer,
+                        CompletableFuture.completedFuture(TEST_OPERATOR_ID),
+                        ACCUMULATOR_NAME,
+                        retryStrategySupplier,
+                        retryAction,
+                        AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue().toMillis());
+
+        TestJobClient.JobInfoProvider infoProvider =
+                new TestJobClient.JobInfoProvider() {
+
+                    @Override
+                    public boolean isJobFinished() {
+                        return handler.isClosed();
+                    }
+
+                    @Override
+                    public Map<String, OptionalFailure<Object>> getAccumulatorResults() {
+                        return new HashMap<>();
+                    }
+                };
+
+        TestJobClient jobClient =
+                new TestJobClient(TEST_JOB_ID, TEST_OPERATOR_ID, handler, infoProvider);
+        resultFetcher.setJobClient(jobClient);
+
+        return Tuple2.of(resultFetcher, jobClient);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestSimpleCountCoordinationRequestHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/TestSimpleCountCoordinationRequestHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.collect.utils;
+
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.streaming.api.operators.collect.CollectCoordinationResponse;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestSimpleCountCoordinationRequestHandler implements CoordinationRequestHandler {
+
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    @Override
+    public CompletableFuture<CoordinationResponse> handleCoordinationRequest(
+            CoordinationRequest request) {
+        requestCount.getAndIncrement();
+        return CompletableFuture.completedFuture(
+                new CollectCoordinationResponse("", 0L, new ArrayList<>()));
+    }
+
+    public int getRequestCount() {
+        return requestCount.get();
+    }
+
+    public void close() {
+        isClosed.set(true);
+    }
+
+    public boolean isClosed() {
+        return isClosed.get();
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainers.java
@@ -410,7 +410,8 @@ public class FlinkContainers implements BeforeAllCallback, AfterAllCallback {
         clientConfiguration.set(RestOptions.ADDRESS, getJobManagerHost());
         clientConfiguration.set(
                 RestOptions.PORT, jobManager.getMappedPort(conf.get(RestOptions.PORT)));
-        return new RestClusterClient<>(clientConfiguration, StandaloneClusterId.getInstance());
+        return new RestClusterClient<>(
+                clientConfiguration, StandaloneClusterId.fromConfiguration(clientConfiguration));
     }
 
     private void waitUntilJobManagerRESTReachable(GenericContainer<?> jobManager) {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -68,7 +68,9 @@ public class JobRetrievalITCase extends TestLogger {
         clientConfig.setLong(RestOptions.RETRY_DELAY, 0);
         clientConfig.addAll(CLUSTER.getClientConfiguration());
 
-        client = new RestClusterClient<>(clientConfig, StandaloneClusterId.getInstance());
+        client =
+                new RestClusterClient<>(
+                        clientConfig, StandaloneClusterId.fromConfiguration(clientConfig));
     }
 
     @After

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -53,7 +53,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
 
     @Parameters(name = "executionMode={0}")
     public static Collection<Object[]> executionMode() {
-        return Arrays.asList(new Object[][] {{ExecutionMode.PIPELINED}, {ExecutionMode.BATCH}});
+        return Arrays.asList(new Object[][] {{ExecutionMode.PIPELINED}});
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
@@ -90,7 +90,8 @@ public class BigUserProgramJobSubmitITCase extends TestLogger {
         final RestClusterClient<StandaloneClusterId> restClusterClient =
                 new RestClusterClient<>(
                         MINI_CLUSTER_RESOURCE.getClientConfiguration(),
-                        StandaloneClusterId.getInstance());
+                        StandaloneClusterId.fromConfiguration(
+                                MINI_CLUSTER_RESOURCE.getClientConfiguration()));
 
         try {
             submitJobAndWaitForResult(restClusterClient, jobGraph, getClass().getClassLoader());


### PR DESCRIPTION
## What is the purpose of the change

Reuse connections in RestClient to save connection establish time.

## Brief change log

  - Add connection reuse options
  - Reuse channels in RestClient


## Verifying this change

This change added tests and can be verified as follows:

  - Unit Test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
