### PR TITLE
[FLINK-33611] [flink-protobuf] Support Large Protobuf Schemas

### DIFF
--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenRowDeserializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenRowDeserializer.java
@@ -109,10 +109,7 @@ public class PbCodegenRowDeserializer implements PbCodegenDeserializer {
             index += 1;
         }
         if (!splitAppender.code().isEmpty()) {
-            String splitMethod =
-                    formatContext.splitDeserializerRowTypeMethod(
-                            flinkRowDataVar, pbMessageTypeStr, pbMessageVar, splitAppender.code());
-            appender.appendSegment(splitMethod);
+            appender.appendSegment(splitAppender.code());
         }
         appender.appendLine(resultVar + " = " + flinkRowDataVar);
         return appender.code();

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenRowSerializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenRowSerializer.java
@@ -130,13 +130,7 @@ public class PbCodegenRowSerializer implements PbCodegenSerializer {
             index += 1;
         }
         if (!splitAppender.code().isEmpty()) {
-            String splitMethod =
-                    formatContext.splitSerializerRowTypeMethod(
-                            flinkRowDataVar,
-                            pbMessageTypeStr + ".Builder",
-                            messageBuilderVar,
-                            splitAppender.code());
-            appender.appendSegment(splitMethod);
+            appender.appendSegment(splitAppender.code());
         }
         appender.appendLine(resultVar + " = " + messageBuilderVar + ".build()");
         return appender.code();

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbProtoToRowTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.VeryBigPbClass;
+
+import org.junit.Test;
+
+/**
+ * Test for very huge proto definition, which may trigger some special optimizations such as code
+ * splitting and java constant pool size optimization.
+ */
+public class VeryBigPbProtoToRowTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        VeryBigPbClass.VeryBigPbMessage veryBigPbMessage =
+                VeryBigPbClass.VeryBigPbMessage.newBuilder().build();
+        // test generated code can be compiled
+        ProtobufTestHelper.pbBytesToRow(
+                VeryBigPbClass.VeryBigPbMessage.class, veryBigPbMessage.toByteArray());
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbRowToProtoTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbRowToProtoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.VeryBigPbClass;
+import org.apache.flink.table.data.GenericRowData;
+
+import org.junit.Test;
+
+/**
+ * Test for very huge proto definition, which may trigger some special optimizations such as code
+ * splitting and java constant pool size optimization.
+ */
+public class VeryBigPbRowToProtoTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        GenericRowData rowData = new GenericRowData(4);
+
+        // test generated code can be compiled
+        ProtobufTestHelper.rowToPbBytes(rowData, VeryBigPbClass.VeryBigPbMessage.class);
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_very_big_pb.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_very_big_pb.proto
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package org.apache.flink.formats.protobuf.testproto;
+
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_outer_classname = "VeryBigPbClass";
+
+message VeryBigPbMessage {
+  NestedType1 nested_field1 = 1;
+  NestedType1 nested_field2 = 2;
+}
+
+message NestedType1 {
+  NestedType2 nested_field1 = 1;
+  NestedType2 nested_field2 = 2;
+}
+
+message NestedType2 {
+  NestedType3 nested_field1 = 1;
+  NestedType3 nested_field2 = 2;
+}
+
+message NestedType3 {
+  NestedType4 nested_field1 = 1;
+  NestedType4 nested_field2 = 2;
+}
+
+message NestedType4 {
+  NestedType5 nested_field1 = 1;
+  NestedType5 nested_field2 = 2;
+}
+
+message NestedType5 {
+  NestedType6 nested_field1 = 1;
+  NestedType6 nested_field2 = 2;
+}
+
+message NestedType6 {
+  NestedType7 nested_field1 = 1;
+  NestedType7 nested_field2 = 2;
+}
+
+message NestedType7 {
+  NestedType8 nested_field1 = 1;
+  NestedType8 nested_field2 = 2;
+}
+
+message NestedType8 {
+  NestedType9 nested_field1 = 1;
+  NestedType9 nested_field2 = 2;
+}
+
+message NestedType9 {
+  NestedType10 nested_field1 = 1;
+  NestedType10 nested_field2 = 2;
+}
+
+message NestedType10 {
+  NestedType11 nested_field1 = 1;
+  NestedType11 nested_field2 = 2;
+}
+
+message NestedType11 {
+  NestedType12 nested_field1 = 1;
+  NestedType12 nested_field2 = 2;
+}
+
+message NestedType12 {
+  NestedType13 nested_field1 = 1;
+  NestedType13 nested_field2 = 2;
+}
+
+message NestedType13 {
+  NestedType14 nested_field1 = 1;
+  NestedType14 nested_field2 = 2;
+}
+
+message NestedType14 {
+  int32 nested_field1 = 1;
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

**Background**

Flink serializes and deserializes protobuf format data by calling the decode or encode method in GeneratedProtoToRow_XXX.java generated by codegen to parse byte[] data into Protobuf Java objects. [FLINK-32650](https://issues.apache.org/jira/browse/FLINK-32650) has introduced the ability to split the generated code to improve the performance for large Protobuf schemas. However, this is still not sufficient to support some larger protobuf schemas as the generated code exceeds the java constant pool size [limit](https://en.wikipedia.org/wiki/Java_class_file#The_constant_pool) and we can see errors like "Too many constants" when trying to compile the generated code. We have run into these issues while doing a POC with some of our real production schemas at UBER

**Solution**

Split the last code segment also only when the size exceeds split threshold limit. Currently, the last segment of the generated code is always being split which can lead to too many split methods and thus exceed the constant pool size limit

**Implementation**

Add check for split size before splitting last segment

## Brief change log


-     [FLINK-33611] [flink-protobuf] Add VeryBigProtobuf testcases
-     [FLINK-33611] [flink-protobuf] Split last segment only when size exceeds split threshold limit in serializer
-     [FLINK-33611] [flink-protobuf] Split last segment only when size exceeds split threshold limit in deserializer


## Verifying this change

This change is already covered by existing tests, such as existing Unit Tests and Integration tests for Protobuf format Including the `BigProtoBufCodeSpiltterTest`. Additionally, I have added a new test with very big protobuf schemas which would fail without the optimizations made in this pull request

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? Not Applicable as the feature is fully transparent to users
