### PR TITLE
[BP-1.18][FLINK-33588]Fix NullArgumentException of getQuantile method in DescriptiveStatisticsHistogramStatistics

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -174,6 +174,8 @@ public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistic
             }
             if (data != null) {
                 percentilesImpl.setData(data);
+            } else {
+                percentilesImpl.setData(new double[] {0.0});
             }
         }
     }


### PR DESCRIPTION
BP of #23931 with no change
