### PR TITLE
[BP-1.18][FLINK-33531][python] Remove cython upper bounds

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -16,7 +16,7 @@ pip>=20.3
 setuptools>=18.0
 wheel
 apache-beam>=2.43.0,<2.49.0
-cython>=0.29.24,<3
+cython>=0.29.24
 py4j==0.10.9.7
 python-dateutil>=2.8.0,<3
 cloudpickle~=2.2.0

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -22,7 +22,7 @@ requires = [
     "setuptools>=18.0",
     "wheel",
     "apache-beam>=2.43.0,<2.49.0",
-    "cython>=0.29.24,<3",
+    "cython>=0.29.24",
     "fastavro>=1.1.0,!=1.8.0"
 ]
 


### PR DESCRIPTION
This is a cherry pick backport of https://github.com/apache/flink/pull/23755 to 1.18
