### PR TITLE
[FLINK-33872] Retrieve checkpoint history for jobs in completed state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -905,29 +905,32 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
     @Override
     public CompletableFuture<ExecutionGraphInfo> requestExecutionGraphInfo(
             JobID jobId, Time timeout) {
-        Function<Throwable, ExecutionGraphInfo> checkExecutionGraphStoreOnException =
-                throwable -> {
-                    // check whether it is a completed job
-                    final ExecutionGraphInfo executionGraphInfo =
-                            executionGraphInfoStore.get(jobId);
-                    if (executionGraphInfo == null) {
-                        throw new CompletionException(
-                                ExceptionUtils.stripCompletionException(throwable));
-                    } else {
-                        return executionGraphInfo;
-                    }
-                };
         Optional<JobManagerRunner> maybeJob = getJobManagerRunner(jobId);
         return maybeJob.map(job -> job.requestJob(timeout))
                 .orElse(FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId)))
-                .exceptionally(checkExecutionGraphStoreOnException);
+                .exceptionally(t -> getExecutionGraphInfoFromStore(t, jobId));
+    }
+
+    private ExecutionGraphInfo getExecutionGraphInfoFromStore(Throwable t, JobID jobId) {
+        // check whether it is a completed job
+        final ExecutionGraphInfo executionGraphInfo = executionGraphInfoStore.get(jobId);
+        if (executionGraphInfo == null) {
+            throw new CompletionException(ExceptionUtils.stripCompletionException(t));
+        } else {
+            return executionGraphInfo;
+        }
     }
 
     @Override
     public CompletableFuture<CheckpointStatsSnapshot> requestCheckpointStats(
             JobID jobId, Time timeout) {
         return performOperationOnJobMasterGateway(
-                jobId, gateway -> gateway.requestCheckpointStats(timeout));
+                        jobId, gateway -> gateway.requestCheckpointStats(timeout))
+                .exceptionally(
+                        t ->
+                                getExecutionGraphInfoFromStore(t, jobId)
+                                        .getArchivedExecutionGraph()
+                                        .getCheckpointStatsSnapshot());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
@@ -75,6 +76,7 @@ import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.FlinkJobTerminatedWithoutCancellationException;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -681,6 +683,88 @@ public class DispatcherTest extends AbstractDispatcherTest {
                         () -> dispatcher.requestCheckpointStats(jobId, TIMEOUT));
         Assertions.assertThat(resultsFuture).succeedsWithin(Duration.ofSeconds(1));
         Assertions.assertThat(resultsFuture).isCompletedWithValue(snapshot);
+    }
+
+    @Test
+    public void testRetrieveCheckpointStatsOnFailedJob() throws Exception {
+        testRetrieveCheckpointStatsWithJobStatus(JobStatus.FAILED);
+    }
+
+    @Test
+    public void testRetrieveCheckpointStatsOnFinishedJob() throws Exception {
+        testRetrieveCheckpointStatsWithJobStatus(JobStatus.FINISHED);
+    }
+
+    @Test
+    public void testRetrieveCheckpointStatsOnCancelledJob() throws Exception {
+        testRetrieveCheckpointStatsWithJobStatus(JobStatus.CANCELED);
+    }
+
+    private void testRetrieveCheckpointStatsWithJobStatus(JobStatus jobStatus) throws Exception {
+        CheckpointStatsSnapshot snapshot = getTestCheckpointStatsSnapshotWithTwoFailedCheckpoints();
+        TestingJobMasterGateway testingJobMasterGateway =
+                new TestingJobMasterGatewayBuilder().build();
+
+        dispatcher =
+                createAndStartDispatcher(
+                        heartbeatServices,
+                        haServices,
+                        new TestingJobMasterGatewayJobManagerRunnerFactory(
+                                testingJobMasterGateway));
+
+        ErrorInfo failureCause =
+                jobStatus == JobStatus.FAILED
+                        ? new ErrorInfo(new RuntimeException("expected"), 1L)
+                        : null;
+
+        final ExecutionGraphInfo completedExecutionGraphInfo =
+                new ExecutionGraphInfo(
+                        new ArchivedExecutionGraphBuilder()
+                                .setJobID(jobId)
+                                .setState(jobStatus)
+                                .setCheckpointStatsSnapshot(snapshot)
+                                .setFailureCause(failureCause)
+                                .build());
+        dispatcher.completeJobExecution(completedExecutionGraphInfo);
+
+        CompletableFuture<CheckpointStatsSnapshot> resultsFuture =
+                dispatcher.callAsyncInMainThread(
+                        () -> dispatcher.requestCheckpointStats(jobId, TIMEOUT));
+        Assertions.assertThat(resultsFuture).succeedsWithin(Duration.ofSeconds(1));
+        Assertions.assertThat(resultsFuture).isCompletedWithValue(snapshot);
+    }
+
+    private CheckpointStatsSnapshot getTestCheckpointStatsSnapshotWithTwoFailedCheckpoints() {
+        CheckpointStatsTracker checkpointStatsTracker =
+                new CheckpointStatsTracker(
+                        10, UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup());
+        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress();
+        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress();
+        return checkpointStatsTracker.createSnapshot();
+    }
+
+    @Test
+    public void testRetrieveCheckpointStatsOnNonExistentJob() throws Exception {
+        TestingJobMasterGateway testingJobMasterGateway =
+                new TestingJobMasterGatewayBuilder().build();
+
+        dispatcher =
+                createAndStartDispatcher(
+                        heartbeatServices,
+                        haServices,
+                        new TestingJobMasterGatewayJobManagerRunnerFactory(
+                                testingJobMasterGateway));
+
+        CompletableFuture<CheckpointStatsSnapshot> resultsFuture =
+                dispatcher.callAsyncInMainThread(
+                        () -> dispatcher.requestCheckpointStats(jobId, TIMEOUT));
+
+        Assertions.assertThat(resultsFuture).failsWithin(Duration.ofSeconds(1));
+        Assertions.assertThat(resultsFuture).isCompletedExceptionally();
+
+        Assertions.assertThatThrownBy(resultsFuture::get)
+                .hasCauseInstanceOf(FlinkJobNotFoundException.class)
+                .hasMessageContaining("Could not find Flink job");
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
@@ -54,6 +55,7 @@ public class ArchivedExecutionGraphBuilder {
     private ArchivedExecutionConfig archivedExecutionConfig;
     private boolean isStoppable;
     private Map<String, SerializedValue<OptionalFailure<Object>>> serializedUserAccumulators;
+    private CheckpointStatsSnapshot checkpointStatsSnapshot;
 
     public ArchivedExecutionGraphBuilder setJobID(JobID jobID) {
         this.jobID = jobID;
@@ -121,6 +123,12 @@ public class ArchivedExecutionGraphBuilder {
         return this;
     }
 
+    public ArchivedExecutionGraphBuilder setCheckpointStatsSnapshot(
+            CheckpointStatsSnapshot checkpointStatsSnapshot) {
+        this.checkpointStatsSnapshot = checkpointStatsSnapshot;
+        return this;
+    }
+
     public ArchivedExecutionGraph build() {
         JobID jobID = this.jobID != null ? this.jobID : new JobID();
         String jobName = this.jobName != null ? this.jobName : "job_" + RANDOM.nextInt();
@@ -157,7 +165,7 @@ public class ArchivedExecutionGraphBuilder {
                         : new ArchivedExecutionConfigBuilder().build(),
                 isStoppable,
                 null,
-                null,
+                checkpointStatsSnapshot,
                 "stateBackendName",
                 "checkpointStorageName",
                 TernaryBoolean.UNDEFINED,


### PR DESCRIPTION
## What is the purpose of the change
* We fix the bug where checkpoint history does not show for completed jobs.

Backport of https://github.com/apache/flink/pull/23949

## Brief change log
* If job is not found when retrieving checkpoint stats snapshot, we first check the execution graph store, before throwing exception.
* Add unit tests for:
   * Retrieving checkpoint statistics for completed job
   * Retrieving checkpoint statistics for non-existent job (verify exception is thrown)


## Verifying this change

This change added tests and can be verified as follows:
- Added unit test to verify checkpoint statistics can be retrieved for FAILED job.
- Added unit test to verify non-existent job still throws `FlinkJobNotFoundException`
- Manually verified by spinning up local cluster.

Running job with checkpoint details:
![image](https://github.com/apache/flink/assets/35062175/f7d46864-fdfb-4f6f-a371-dea5b3580368)

Cancelled job with checkpoint details:
![image](https://github.com/apache/flink/assets/35062175/91f309e7-04eb-4c83-a13b-62e2a498740e)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

