### PR TITLE
[FLINK-33534][runtime] Support configuring PARALLELISM_OVERRIDES during job submission

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/FlinkPipelineTranslationUtil.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/FlinkPipelineTranslationUtil.java
@@ -21,6 +21,7 @@ package org.apache.flink.client;
 
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
@@ -40,8 +41,18 @@ public final class FlinkPipelineTranslationUtil {
         FlinkPipelineTranslator pipelineTranslator =
                 getPipelineTranslator(userClassloader, pipeline);
 
-        return pipelineTranslator.translateToJobGraph(
-                pipeline, optimizerConfiguration, defaultParallelism);
+        JobGraph jobGraph =
+                pipelineTranslator.translateToJobGraph(
+                        pipeline, optimizerConfiguration, defaultParallelism);
+
+        optimizerConfiguration
+                .getOptional(PipelineOptions.PARALLELISM_OVERRIDES)
+                .ifPresent(
+                        map ->
+                                jobGraph.getJobConfiguration()
+                                        .set(PipelineOptions.PARALLELISM_OVERRIDES, map));
+
+        return jobGraph;
     }
 
     /**

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -85,7 +85,7 @@ abstract class JarHandlerParameterTest<
     static Time timeout = Time.seconds(10);
     static Map<String, String> responseHeaders = Collections.emptyMap();
 
-    private static Path jarWithManifest;
+    protected static Path jarWithManifest;
     private static Path jarWithoutManifest;
 
     static void init(File tmpDir) throws Exception {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -56,6 +57,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,7 +89,14 @@ class JarRunHandlerParameterTest
                     .set(CoreOptions.DEFAULT_PARALLELISM, 57)
                     .set(SavepointConfigOptions.SAVEPOINT_PATH, "/foo/bar/test")
                     .set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false)
-                    .set(SavepointConfigOptions.RESTORE_MODE, RESTORE_MODE);
+                    .set(SavepointConfigOptions.RESTORE_MODE, RESTORE_MODE)
+                    .set(
+                            PipelineOptions.PARALLELISM_OVERRIDES,
+                            new HashMap<String, String>() {
+                                {
+                                    put("v1", "10");
+                                }
+                            });
 
     @BeforeAll
     static void setup(@TempDir File tempDir) throws Exception {
@@ -275,6 +284,21 @@ class JarRunHandlerParameterTest
         JobGraph jobGraph = LAST_SUBMITTED_JOB_GRAPH_REFERENCE.get();
         assertThat(jobGraph.getSavepointRestoreSettings())
                 .isEqualTo(SavepointRestoreSettings.none());
+    }
+
+    @Test
+    void testConfigurationWithParallelismOverrides() throws Exception {
+        final JarRunRequestBody requestBody = getJarRequestWithConfiguration();
+        handleRequest(
+                createRequest(
+                        requestBody,
+                        getUnresolvedJarMessageParameters(),
+                        getUnresolvedJarMessageParameters(),
+                        jarWithManifest));
+        JobGraph jobGraph = LAST_SUBMITTED_JOB_GRAPH_REFERENCE.get();
+        assertThat(jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES))
+                .containsOnlyKeys("v1")
+                .containsEntry("v1", "10");
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -1557,7 +1557,9 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
     }
 
     private void applyParallelismOverrides(JobGraph jobGraph) {
-        Map<String, String> overrides = configuration.get(PipelineOptions.PARALLELISM_OVERRIDES);
+        Map<String, String> overrides = new HashMap<>();
+        overrides.putAll(configuration.get(PipelineOptions.PARALLELISM_OVERRIDES));
+        overrides.putAll(jobGraph.getJobConfiguration().get(PipelineOptions.PARALLELISM_OVERRIDES));
         for (JobVertex vertex : jobGraph.getVertices()) {
             String override = overrides.get(vertex.getID().toHexString());
             if (override != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1129,9 +1129,18 @@ public class DispatcherTest extends AbstractDispatcherTest {
                 ImmutableMap.of(
                         v1.getID().toHexString(), "10",
                         // v2 is omitted
-                        v3.getID().toHexString(), "42",
+                        v3.getID().toHexString(), "21",
                         // unknown vertex added
                         new JobVertexID().toHexString(), "23"));
+
+        jobGraph.getJobConfiguration()
+                .set(
+                        PipelineOptions.PARALLELISM_OVERRIDES,
+                        ImmutableMap.of(
+                                // verifies that job graph configuration has higher priority
+                                v3.getID().toHexString(), "42",
+                                // unknown vertex added
+                                new JobVertexID().toHexString(), "25"));
 
         dispatcher =
                 createAndStartDispatcher(


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports configuring the PARALLELISM_OVERRIDES configuration during the job submission process. Before this PR, Flink has currently only allowed configuring this parameter before the Dispatcher, or the cluster, starts.


## Brief change log

- Pass PARALLELISM_OVERRIDES from environment to job graph.
- Make dispatcher use PARALLELISM_OVERRIDES from job graph before submitting job.


## Verifying this change

This change is covered by modified and newly added tests in JarRunHandlerParameterTest and DispatcherTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
