### PR TITLE
[FLINK-33877][streaming] Fix unstable test of CollectSinkFunctionTest.testConfiguredPortIsUsed

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
@@ -139,8 +139,6 @@ public class CollectSinkFunctionTest extends TestLogger {
                     .satisfies(
                             FlinkAssertions.anyCauseMatches(
                                     BindException.class, "Address already in use (Bind failed)"));
-        } finally {
-            functionWrapper.closeWrapper();
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33877][streaming] Fix unstable test of CollectSinkFunctionTest.testConfiguredPortIsUsed

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=55646&view=logs&j=0da23115-68bb-5dcd-192c-bd4c8adebde1&t=24c3384f-1bcb-57b3-224f-51bf973bbee8&l=9482
```
Dec 18 17:49:57 17:49:57.241 [ERROR] org.apache.flink.streaming.api.operators.collect.CollectSinkFunctionTest.testConfiguredPortIsUsed -- Time elapsed: 0.021 s <<< ERROR!
Dec 18 17:49:57 java.net.BindException: Address already in use (Bind failed)
Dec 18 17:49:57 	at java.net.PlainSocketImpl.socketBind(Native Method)
Dec 18 17:49:57 	at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:387)
Dec 18 17:49:57 	at java.net.ServerSocket.bind(ServerSocket.java:390)
Dec 18 17:49:57 	at java.net.ServerSocket.<init>(ServerSocket.java:252)
Dec 18 17:49:57 	at org.apache.flink.streaming.api.operators.collect.CollectSinkFunction$ServerThread.<init>(CollectSinkFunction.java:375)
Dec 18 17:49:57 	at org.apache.flink.streaming.api.operators.collect.CollectSinkFunction$ServerThread.<init>(CollectSinkFunction.java:362)
Dec 18 17:49:57 	at org.apache.flink.streaming.api.operators.collect.CollectSinkFunction.open(CollectSinkFunction.java:252)
Dec 18 17:49:57 	at org.apache.flink.streaming.api.operators.collect.utils.CollectSinkFunctionTestWrapper.openFunction(CollectSinkFunctionTestWrapper.java:103)
Dec 18 17:49:57 	at org.apache.flink.streaming.api.operators.collect.CollectSinkFunctionTest.testConfiguredPortIsUsed(CollectSinkFunctionTest.java:138)
Dec 18 17:49:57 	at java.lang.reflect.Method.invoke(Method.java:498)
Dec 18 17:49:57 	at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
Dec 18 17:49:57 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
Dec 18 17:49:57 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
Dec 18 17:49:57 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
Dec 18 17:49:57 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)
```

## Brief change log

Based on the exception stack trace, it is possible that port 50500 is being used by other test cases. 
To make this test more stable, we may need to use a random port.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
