### PR TITLE
[FLINK-33902][ci] Adds -legacy to openssl command

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_ssl.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ssl.sh
@@ -67,8 +67,15 @@ function _set_conf_ssl_helper {
     keytool -importcert -keystore "${ssl_dir}/node.keystore" -storepass ${password} -file "${ssl_dir}/ca.cer" -alias ca -noprompt
     keytool -importcert -keystore "${ssl_dir}/node.keystore" -storepass ${password} -file "${ssl_dir}/node.cer" -alias node -noprompt
 
+    local additional_params
+    additional_params=""
+    if [[ ! "$(openssl version)" =~ OpenSSL\ 1 ]]; then
+        # OpenSSL 3.x doesn't enable PKCS12 by default - we need to enable legacy algorithms
+        additional_params="-legacy"
+    fi
+
     # keystore is converted into a pem format to use it as node.pem with curl in Flink REST API queries, see also $CURL_SSL_ARGS
-    openssl pkcs12 -passin pass:${password} -in "${ssl_dir}/node.keystore" -out "${ssl_dir}/node.pem" -nodes
+    openssl pkcs12 ${additional_params} -passin pass:${password} -in "${ssl_dir}/node.keystore" -out "${ssl_dir}/node.pem" -nodes
 
     if [ "${provider}" = "OPENSSL" -a "${provider_lib}" = "dynamic" ]; then
         cp $FLINK_DIR/opt/flink-shaded-netty-tcnative-dynamic-*.jar $FLINK_DIR/lib/


### PR DESCRIPTION
* === THIS PR ===
* https://github.com/apache/flink/pull/23962
* https://github.com/apache/flink/pull/23964
* https://github.com/apache/flink/pull/23965
* https://github.com/apache/flink/pull/23970
* https://github.com/apache/flink/pull/23971
* https://github.com/apache/flink/pull/23972

## What is the purpose of the change

See context of this change in FLINK-33902.

## Brief change log

* Utilizes `-legacy` parameter to support OpenSSL 3.0.0+

## Verifying this change

Azure CI should still not cause any errors. The GitHub Actions workflow part was tested in the context of FLINK-33550.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable