### PR TITLE
[FLINK-27082][ci] Disables tests that relies on disabling file permissions

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -236,6 +237,7 @@ public class LocalFileSystemTest extends TestLogger {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testRenameFileWithNoAccess() throws IOException {
         final FileSystem fs = FileSystem.getLocalFileSystem();
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -25,15 +25,16 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -237,7 +238,7 @@ public class LocalFileSystemTest extends TestLogger {
     }
 
     @Test
-    @Ignore("FLINK-27082: Fails in Docker with root user")
+    @Category(FailsInGHAContainerWithRootUser.class)
     public void testRenameFileWithNoAccess() throws IOException {
         final FileSystem fs = FileSystem.getLocalFileSystem();
 

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -120,13 +121,16 @@ public class FileUtilsTest {
     }
 
     @Test
-    void testDeleteDirectory() throws Exception {
-
+    void testDeleteNonExistentDirectory() throws Exception {
         // deleting a non-existent file should not cause an error
 
         File doesNotExist = TempDirUtils.newFolder(temporaryFolder, "abc");
         FileUtils.deleteDirectory(doesNotExist);
+    }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Test
+    void testDeleteProtectedDirectory() throws Exception {
         // deleting a write protected file should throw an error
 
         File cannotDeleteParent = TempDirUtils.newFolder(temporaryFolder);

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -128,7 +128,7 @@ public class FileUtilsTest {
         FileUtils.deleteDirectory(doesNotExist);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeleteProtectedDirectory() throws Exception {
         // deleting a write protected file should throw an error

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -103,6 +104,7 @@ class JarDeleteHandlerTest {
                         });
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testFailedDelete() throws Exception {
         makeJarDirReadOnly();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -104,7 +104,7 @@ class JarDeleteHandlerTest {
                         });
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testFailedDelete() throws Exception {
         makeJarDirReadOnly();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -193,11 +194,13 @@ class BlobCacheDeleteTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientLocalFailsNoJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(null);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientLocalFailsForJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -194,13 +194,13 @@ class BlobCacheDeleteTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeleteTransientLocalFailsNoJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(null);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeleteTransientLocalFailsForJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -169,16 +170,19 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingNoJob() throws IOException {
         testGetFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJob() throws IOException {
         testGetFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         testGetFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -264,16 +268,19 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientFailsStoreNoJob() throws IOException, InterruptedException {
         testGetFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetPermanentFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), PERMANENT_BLOB);
@@ -395,11 +402,13 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientRemoteDeleteFailsNoJob() throws IOException {
         testGetTransientRemoteDeleteFails(null);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientRemoteDeleteFailsForJob() throws IOException {
         testGetTransientRemoteDeleteFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -170,19 +170,19 @@ class BlobCacheGetTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetFailsIncomingNoJob() throws IOException {
         testGetFailsIncoming(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetFailsIncomingForJob() throws IOException {
         testGetFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         testGetFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -268,19 +268,19 @@ class BlobCacheGetTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetTransientFailsStoreNoJob() throws IOException, InterruptedException {
         testGetFailsStore(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetTransientFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetPermanentFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), PERMANENT_BLOB);
@@ -402,13 +402,13 @@ class BlobCacheGetTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetTransientRemoteDeleteFailsNoJob() throws IOException {
         testGetTransientRemoteDeleteFails(null);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetTransientRemoteDeleteFailsForJob() throws IOException {
         testGetTransientRemoteDeleteFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -520,16 +521,19 @@ class BlobCachePutTest {
 
     // --------------------------------------------------------------------------------------------
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -570,16 +574,19 @@ class BlobCachePutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -631,16 +638,19 @@ class BlobCachePutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -521,19 +521,19 @@ class BlobCachePutTest {
 
     // --------------------------------------------------------------------------------------------
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -574,19 +574,19 @@ class BlobCachePutTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -638,19 +638,19 @@ class BlobCachePutTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -188,16 +189,19 @@ class BlobServerDeleteTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientFailsNoJob() throws IOException {
         testDeleteBlobFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeletePermanentFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -189,19 +189,19 @@ class BlobServerDeleteTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeleteTransientFailsNoJob() throws IOException {
         testDeleteBlobFails(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeleteTransientFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testDeletePermanentFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.Reference;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -145,6 +146,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create incoming
      * files. File transfers should fail.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();
@@ -217,6 +219,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create the final
      * storage file. File transfers should fail.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsStoreForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.util.Reference;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -146,7 +146,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create incoming
      * files. File transfers should fail.
      */
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();
@@ -219,7 +219,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create the final
      * storage file. File transfers should fail.
      */
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testGetFailsStoreForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -402,16 +403,19 @@ class BlobServerPutTest {
 
     // --------------------------------------------------------------------------------------------
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -449,16 +453,19 @@ class BlobServerPutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -507,16 +514,19 @@ class BlobServerPutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -403,19 +403,19 @@ class BlobServerPutTest {
 
     // --------------------------------------------------------------------------------------------
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -453,19 +453,19 @@ class BlobServerPutTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -514,19 +514,19 @@ class BlobServerPutTest {
         }
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for {@link BlobUtils} working on non-writable directories. */
+@Disabled("FLINK-27082: Fails in Docker with root user")
 class BlobUtilsNonWritableTest {
 
     private static final String CANNOT_CREATE_THIS = "cannot-create-this";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for {@link BlobUtils} working on non-writable directories. */
-@Disabled("FLINK-27082: Fails in Docker with root user")
+@Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
 class BlobUtilsNonWritableTest {
 
     private static final String CANNOT_CREATE_THIS = "cannot-create-this";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.UserCodeClassLoader;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -323,6 +324,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testRegisterAndDownload() throws IOException {
         assumeTrue(!OperatingSystem.isWindows()); // setWritable doesn't work on Windows.
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -27,14 +27,15 @@ import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser;
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.UserCodeClassLoader;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -324,7 +325,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
     }
 
     @Test
-    @Ignore("FLINK-27082: Fails in Docker with root user")
+    @Category(FailsInGHAContainerWithRootUser.class)
     public void testRegisterAndDownload() throws IOException {
         assumeTrue(!OperatingSystem.isWindows()); // setWritable doesn't work on Windows.
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.helpers.NOPLogger;
@@ -72,6 +73,7 @@ class RestServerEndpointTest {
         assertThat(Files.exists(testUploadDir)).isTrue();
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testCreateUploadDirFails(@TempDir File file) throws Exception {
         assertThat(file.setWritable(false));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.rest;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.helpers.NOPLogger;
@@ -73,7 +73,7 @@ class RestServerEndpointTest {
         assertThat(Files.exists(testUploadDir)).isTrue();
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testCreateUploadDirFails(@TempDir File file) throws Exception {
         assertThat(file.setWritable(false));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -364,6 +365,7 @@ public class FsCheckpointStateOutputStreamTest {
      * This test checks that the stream does not check and clean the parent directory when
      * encountering a write error.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @TestTemplate
     void testStreamDoesNotTryToCleanUpParentOnError() throws Exception {
         final File directory = TempDirUtils.newFolder(tempDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -365,7 +365,7 @@ public class FsCheckpointStateOutputStreamTest {
      * This test checks that the stream does not check and clean the parent directory when
      * encountering a write error.
      */
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @TestTemplate
     void testStreamDoesNotTryToCleanUpParentOnError() throws Exception {
         final File directory = TempDirUtils.newFolder(tempDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -50,6 +50,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -113,6 +114,7 @@ class TaskManagerRunnerStartupTest {
      * Tests that the TaskManagerRunner startup fails synchronously when the I/O directories are not
      * writable.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testIODirectoryNotWritable() throws Exception {
         File nonWritable = TempDirUtils.newFolder(tempFolder);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -50,7 +50,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -114,7 +114,7 @@ class TaskManagerRunnerStartupTest {
      * Tests that the TaskManagerRunner startup fails synchronously when the I/O directories are not
      * writable.
      */
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testIODirectoryNotWritable() throws Exception {
         File nonWritable = TempDirUtils.newFolder(tempFolder);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.util.IOUtils;
 
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -407,6 +408,7 @@ public class RocksDBStateBackendConfigTest {
     // ------------------------------------------------------------------------
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testFailWhenNoLocalStorageDir() throws Exception {
         final File targetDir = tempFolder.newFolder();
         Assume.assumeTrue(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -42,13 +42,14 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser;
 import org.apache.flink.util.IOUtils;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
@@ -408,7 +409,7 @@ public class RocksDBStateBackendConfigTest {
     // ------------------------------------------------------------------------
 
     @Test
-    @Ignore("FLINK-27082: Fails in Docker with root user")
+    @Category(FailsInGHAContainerWithRootUser.class)
     public void testFailWhenNoLocalStorageDir() throws Exception {
         final File targetDir = tempFolder.newFolder();
         Assume.assumeTrue(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.util.OperatingSystem;
 
 import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -63,6 +64,7 @@ class FileCatalogStoreTest {
         assertCatalogStoreNotOpened(() -> catalogStore.removeCatalog(DUMMY, true));
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testCannotMakeStorePath() {
         assumeThat(OperatingSystem.isWindows())

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.util.OperatingSystem;
 
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -64,7 +64,7 @@ class FileCatalogStoreTest {
         assertCatalogStoreNotOpened(() -> catalogStore.removeCatalog(DUMMY, true));
     }
 
-    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Tag("org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser")
     @Test
     void testCannotMakeStorePath() {
         assumeThat(OperatingSystem.isWindows())

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsInGHAContainerWithRootUser.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/FailsInGHAContainerWithRootUser.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+/**
+ * Collects tests that fail in GitHub Actions workflows that execute the tests in containers as a
+ * root user.
+ *
+ * <p>See FLINK-27082/FLINK-33903
+ */
+public interface FailsInGHAContainerWithRootUser {}

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -41,6 +41,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -158,6 +159,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testDoNotCancelJobIfSavepointFails() throws Exception {
         setUpWithCheckpointInterval(10L);
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -38,12 +38,13 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
@@ -159,7 +160,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
     }
 
     @Test
-    @Ignore("FLINK-27082: Fails in Docker with root user")
+    @Category(FailsInGHAContainerWithRootUser.class)
     public void testDoNotCancelJobIfSavepointFails() throws Exception {
         setUpWithCheckpointInterval(10L);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1017,6 +1017,24 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>github-actions</id>
+
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-surefire-plugin</artifactId>
+							<configuration>
+								<excludedGroups>org.apache.flink.testutils.junit.FailsInGHAContainerWithRootUser</excludedGroups>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
+		<profile>
 			<id>java11</id>
 			<activation>
 				<jdk>[11,)</jdk>


### PR DESCRIPTION
Based on the following PR(s):
* https://github.com/apache/flink/pull/23961
* === THIS PR ===
* https://github.com/apache/flink/pull/23964
* https://github.com/apache/flink/pull/23965
* https://github.com/apache/flink/pull/23970
* https://github.com/apache/flink/pull/23971
* https://github.com/apache/flink/pull/23972

## What is the purpose of the change

See FLINK-27082 and FLINK-33903 for context

## Brief change log

* Disables/Ignores tests that rely on setting the file permissions to see that if the permissions are not granted will trigger error handling

## Verifying this change

Tests are disabled. No issue is expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable