### PR TITLE
[FLINK-33907][ci] Makes copying test jars being done later

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -157,7 +157,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
-						<phase>process-test-resources</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>


### PR DESCRIPTION
Based on the following PR(s):
* https://github.com/apache/flink/pull/23961
* https://github.com/apache/flink/pull/23962
* === THIS PR ===
* https://github.com/apache/flink/pull/23964
* https://github.com/apache/flink/pull/23970
* https://github.com/apache/flink/pull/23971
* https://github.com/apache/flink/pull/23972

## What is the purpose of the change

See FLINK-33907 for further context.

## Brief change log

* Makes generating test jars happen earlier

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable