### PR TITLE
[FLINK-33909][ci] Adds custom action for selecting the release branch and commit hash

### DIFF
--- a/.github/actions/move_checkout/action.yml
+++ b/.github/actions/move_checkout/action.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: "Moves checkout"
+description: "Moves relevant checkout content"
+inputs:
+  source-directory:
+    description: "The directory the content is moved from."
+    required: true
+  target-directory:
+    description: "The directory the content is moved to."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: "Moves checkout content from ${{ inputs.source-directory }} to ${{ inputs.target-directory }}."
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.target-directory }}
+        
+        # .scalafmt.conf is needed for Scala format checks
+        # .mvn is needed to make the Maven wrapper accessible in test runs
+        mv ${{ inputs.source-directory }}/* \
+          ${{ inputs.source-directory }}/.scalafmt.conf \
+          ${{ inputs.source-directory }}/.mvn \
+          ${{ inputs.target-directory }}

--- a/.github/actions/select_release_branch/action.yml
+++ b/.github/actions/select_release_branch/action.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: "Release branch selection"
+description: "Selects the release branch."
+inputs:
+  release-branch-index:
+    description: "The index of the release branch: (1 - most-recent release; 2 - 2nd most-recent; ...)."
+    required: true
+outputs:
+  branch:
+    description: "The selected branch."
+    value: "${{ steps.branch-selection.outputs.branch }}"
+  commit-hash:
+    description: "The hash of the branches HEAD."
+    value: "${{ steps.extract-commit-hash.outputs.commit-hash }}"
+  commit-hash-short:
+    description: "The hash of the branches HEAD."
+    value: "${{ steps.extract-commit-hash.outputs.commit-hash-short }}"
+runs:
+  using: "composite"
+  steps:
+    - name: "Selects the release branch"
+      id: branch-selection
+      shell: bash
+      run: |
+        # actions/checkout only fetches one branch but we need all the branch information from origin
+        git fetch --no-tags --depth=1 origin
+
+        # filters the release branches and sorts by version
+        selected_branch="$(git branch --remotes | grep -o "release-[0-9]\{1,\}\.[0-9]\{1,\}" | sort -u -t'.' -k2,2V | tail -${{ inputs.release-branch-index }} | head -1)"
+        echo "INFO: Selected release branch: ${selected_branch}"
+        echo "branch=${selected_branch}" >> "$GITHUB_OUTPUT"
+    - name: "Extracts ${{ steps.branch-selection.outputs.branch }} HEAD commit hash"
+      id: extract-commit-hash
+      shell: bash
+      run: |
+        head_commit_hash="$(git show-ref --head --verify --hash refs/remotes/origin/${{ steps.branch-selection.outputs.branch }})"
+
+        echo "INFO: HEAD commit hash: ${head_commit_hash}"
+        echo "commit-hash=${head_commit_hash}" >> "$GITHUB_OUTPUT"
+        echo "commit-hash-short=${head_commit_hash:0:11}" >> "$GITHUB_OUTPUT"

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -157,7 +157,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
-						<phase>process-test-resources</phase>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -236,6 +237,7 @@ public class LocalFileSystemTest extends TestLogger {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testRenameFileWithNoAccess() throws IOException {
         final FileSystem fs = FileSystem.getLocalFileSystem();
 

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -120,13 +121,16 @@ public class FileUtilsTest {
     }
 
     @Test
-    void testDeleteDirectory() throws Exception {
-
+    void testDeleteNonExistentDirectory() throws Exception {
         // deleting a non-existent file should not cause an error
 
         File doesNotExist = TempDirUtils.newFolder(temporaryFolder, "abc");
         FileUtils.deleteDirectory(doesNotExist);
+    }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
+    @Test
+    void testDeleteProtectedDirectory() throws Exception {
         // deleting a write protected file should throw an error
 
         File cannotDeleteParent = TempDirUtils.newFolder(temporaryFolder);

--- a/flink-end-to-end-tests/test-scripts/common_ssl.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ssl.sh
@@ -68,7 +68,7 @@ function _set_conf_ssl_helper {
     keytool -importcert -keystore "${ssl_dir}/node.keystore" -storepass ${password} -file "${ssl_dir}/node.cer" -alias node -noprompt
 
     # keystore is converted into a pem format to use it as node.pem with curl in Flink REST API queries, see also $CURL_SSL_ARGS
-    openssl pkcs12 -passin pass:${password} -in "${ssl_dir}/node.keystore" -out "${ssl_dir}/node.pem" -nodes
+    openssl pkcs12 -legacy -passin pass:${password} -in "${ssl_dir}/node.keystore" -out "${ssl_dir}/node.pem" -nodes
 
     if [ "${provider}" = "OPENSSL" -a "${provider_lib}" = "dynamic" ]; then
         cp $FLINK_DIR/opt/flink-shaded-netty-tcnative-dynamic-*.jar $FLINK_DIR/lib/

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -104,6 +104,8 @@ cd dev
 
 rm -rf .conda/pkgs
 
+sudo apt-get -q install zip
+
 zip -q -r "${TEST_DATA_DIR}/venv.zip" .conda
 
 deactivate

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -103,6 +104,7 @@ class JarDeleteHandlerTest {
                         });
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testFailedDelete() throws Exception {
         makeJarDirReadOnly();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -193,11 +194,13 @@ class BlobCacheDeleteTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientLocalFailsNoJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(null);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientLocalFailsForJob() throws IOException, InterruptedException {
         testDeleteTransientLocalFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -169,16 +170,19 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingNoJob() throws IOException {
         testGetFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJob() throws IOException {
         testGetFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         testGetFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -264,16 +268,19 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientFailsStoreNoJob() throws IOException, InterruptedException {
         testGetFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetPermanentFailsStoreForJob() throws IOException, InterruptedException {
         testGetFailsStore(new JobID(), PERMANENT_BLOB);
@@ -395,11 +402,13 @@ class BlobCacheGetTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientRemoteDeleteFailsNoJob() throws IOException {
         testGetTransientRemoteDeleteFails(null);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetTransientRemoteDeleteFailsForJob() throws IOException {
         testGetTransientRemoteDeleteFails(new JobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -520,16 +521,19 @@ class BlobCachePutTest {
 
     // --------------------------------------------------------------------------------------------
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -570,16 +574,19 @@ class BlobCachePutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -631,16 +638,19 @@ class BlobCachePutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -188,16 +189,19 @@ class BlobServerDeleteTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientFailsNoJob() throws IOException {
         testDeleteBlobFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeleteTransientFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testDeletePermanentFailsForJob() throws IOException {
         testDeleteBlobFails(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.Reference;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -145,6 +146,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create incoming
      * files. File transfers should fail.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsIncomingForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();
@@ -217,6 +219,7 @@ class BlobServerGetTest {
      * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create the final
      * storage file. File transfers should fail.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testGetFailsStoreForJobHa() throws IOException {
         assumeThat(OperatingSystem.isWindows()).as("setWritable doesn't work on Windows").isFalse();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -402,16 +403,19 @@ class BlobServerPutTest {
 
     // --------------------------------------------------------------------------------------------
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsNoJob() throws IOException {
         testPutBufferFails(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJob() throws IOException {
         testPutBufferFails(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsForJobHa() throws IOException {
         testPutBufferFails(new JobID(), PERMANENT_BLOB);
@@ -449,16 +453,19 @@ class BlobServerPutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingNoJob() throws IOException {
         testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJob() throws IOException {
         testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsIncomingForJobHa() throws IOException {
         testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
@@ -507,16 +514,19 @@ class BlobServerPutTest {
         }
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreNoJob() throws IOException {
         testPutBufferFailsStore(null, TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJob() throws IOException {
         testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testPutBufferFailsStoreForJobHa() throws IOException {
         testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests for {@link BlobUtils} working on non-writable directories. */
+@Disabled("FLINK-27082: Fails in Docker with root user")
 class BlobUtilsNonWritableTest {
 
     private static final String CANNOT_CREATE_THIS = "cannot-create-this";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.UserCodeClassLoader;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -323,6 +324,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testRegisterAndDownload() throws IOException {
         assumeTrue(!OperatingSystem.isWindows()); // setWritable doesn't work on Windows.
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.helpers.NOPLogger;
@@ -72,6 +73,7 @@ class RestServerEndpointTest {
         assertThat(Files.exists(testUploadDir)).isTrue();
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testCreateUploadDirFails(@TempDir File file) throws Exception {
         assertThat(file.setWritable(false));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -364,6 +365,7 @@ public class FsCheckpointStateOutputStreamTest {
      * This test checks that the stream does not check and clean the parent directory when
      * encountering a write error.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @TestTemplate
     void testStreamDoesNotTryToCleanUpParentOnError() throws Exception {
         final File directory = TempDirUtils.newFolder(tempDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -50,6 +50,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -113,6 +114,7 @@ class TaskManagerRunnerStartupTest {
      * Tests that the TaskManagerRunner startup fails synchronously when the I/O directories are not
      * writable.
      */
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testIODirectoryNotWritable() throws Exception {
         File nonWritable = TempDirUtils.newFolder(tempFolder);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.util.IOUtils;
 
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -407,6 +408,7 @@ public class RocksDBStateBackendConfigTest {
     // ------------------------------------------------------------------------
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testFailWhenNoLocalStorageDir() throws Exception {
         final File targetDir = tempFolder.newFolder();
         Assume.assumeTrue(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.util.OperatingSystem;
 
 import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -63,6 +64,7 @@ class FileCatalogStoreTest {
         assertCatalogStoreNotOpened(() -> catalogStore.removeCatalog(DUMMY, true));
     }
 
+    @Disabled("FLINK-27082: Fails in Docker with root user")
     @Test
     void testCannotMakeStorePath() {
         assumeThat(OperatingSystem.isWindows())

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -41,6 +41,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -158,6 +159,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
     }
 
     @Test
+    @Ignore("FLINK-27082: Fails in Docker with root user")
     public void testDoNotCancelJobIfSavepointFails() throws Exception {
         setUpWithCheckpointInterval(10L);
 

--- a/tools/azure-pipelines/debug_files_utils.sh
+++ b/tools/azure-pipelines/debug_files_utils.sh
@@ -21,7 +21,11 @@ function prepare_debug_files {
 	MODULE=$@
 	export DEBUG_FILES_OUTPUT_DIR="$AGENT_TEMPDIRECTORY/debug_files"
 	export DEBUG_FILES_NAME="$(echo $MODULE | tr -c '[:alnum:]\n\r' '_')-$(date +%s)"
+	# make environment variables available in AzureCI workflow configurations
 	echo "##vso[task.setvariable variable=DEBUG_FILES_OUTPUT_DIR]$DEBUG_FILES_OUTPUT_DIR"
 	echo "##vso[task.setvariable variable=DEBUG_FILES_NAME]$DEBUG_FILES_NAME"
+	# make environment variables available in Github Actions workflow configuration
+	echo "debug-files-output-dir=${DEBUG_FILES_OUTPUT_DIR}" >> $GITHUB_OUTPUT
+	echo "debug-files-name=${DEBUG_FILES_NAME}" >> $GITHUB_OUTPUT
 	mkdir -p $DEBUG_FILES_OUTPUT_DIR || { echo "FAILURE: cannot create debug files directory '${DEBUG_FILES_OUTPUT_DIR}'." ; exit 1; }
 }


### PR DESCRIPTION
Based on the following PR(s):
* https://github.com/apache/flink/pull/23961
* https://github.com/apache/flink/pull/23962
* https://github.com/apache/flink/pull/23963
* https://github.com/apache/flink/pull/23964
* https://github.com/apache/flink/pull/23965
* https://github.com/apache/flink/pull/23966

## What is the purpose of the change

See FLINK-33909 for further context.

## Brief change log

* Adds custom action

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable