### PR TITLE
[FLINK-33877][streaming] Adjusting CollectSinkFunctionTest.testConfiguredPortIsUsed's assertion message to work with JDK 17 & 21

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.operators.collect;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.streaming.api.operators.collect.utils.CollectSinkFunctionTestWrapper;
 import org.apache.flink.streaming.api.operators.collect.utils.CollectTestUtils;
 import org.apache.flink.util.TestLogger;
@@ -136,9 +135,8 @@ public class CollectSinkFunctionTest extends TestLogger {
                     .getConfiguration()
                     .setInteger(TaskManagerOptions.COLLECT_PORT, socket.getLocalPort());
             assertThatThrownBy(() -> functionWrapper.openFunction())
-                    .satisfies(
-                            FlinkAssertions.anyCauseMatches(
-                                    BindException.class, "Address already in use (Bind failed)"));
+                    .isInstanceOf(BindException.class)
+                    .hasMessageContaining("Address already in use");
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-33877][streaming] Adjusting CollectSinkFunctionTest.testConfiguredPortIsUsed's assertion message to work with JDK 17 & 21

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=55700&view=logs&j=675bf62c-8558-587e-2555-dcad13acefb5&t=5878eed3-cc1e-5b12-1ed0-9e7139ce0992&l=9924

```
Dec 20 04:05:36 [Any cause is instance of class 'class java.net.BindException' and contains message 'Address already in use (Bind failed)'] 
Dec 20 04:05:36 Expecting any element of:
Dec 20 04:05:36   [java.net.BindException: Address already in use
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind0(Native Method)
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind(Net.java:555)
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind(Net.java:544)
Dec 20 04:05:36 	...(71 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)]
Dec 20 04:05:36 to satisfy the given assertions requirements but none did:
Dec 20 04:05:36 
Dec 20 04:05:36 java.net.BindException: Address already in use
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind0(Native Method)
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind(Net.java:555)
Dec 20 04:05:36 	at java.base/sun.nio.ch.Net.bind(Net.java:544)
Dec 20 04:05:36 	...(71 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
Dec 20 04:05:36 error: 
Dec 20 04:05:36 Expecting throwable message:
Dec 20 04:05:36   "Address already in use"
Dec 20 04:05:36 to contain:
Dec 20 04:05:36   "Address already in use (Bind failed)"
Dec 20 04:05:36 but did not.

```

## Verifying this change

This change is already covered by existing tests

```
jdk21
cd flink-streaming-java
mvn test -Dtest=org.apache.flink.streaming.api.operators.collect.CollectSinkFunctionTest
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
