### PR TITLE
[FLINK-33927][table] Cleanup usage of deprecated ExecutionConfigOptions#(TABLE_EXEC_SHUFFLE_MODE, TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS)

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.table.api.Expressions.$;
-import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_UID_FORMAT;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_UID_GENERATION;
 import static org.apache.flink.table.api.config.ExecutionConfigOptions.UidGeneration.ALWAYS;
@@ -127,13 +126,6 @@ class TransformationsTest {
         checkUids(c -> c.set(TABLE_EXEC_UID_GENERATION, PLAN_ONLY), true, false);
         checkUids(c -> c.set(TABLE_EXEC_UID_GENERATION, ALWAYS), true, true);
         checkUids(c -> c.set(TABLE_EXEC_UID_GENERATION, DISABLED), false, false);
-        checkUids(
-                c -> {
-                    c.set(TABLE_EXEC_UID_GENERATION, PLAN_ONLY);
-                    c.set(TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS, true);
-                },
-                false,
-                false);
     }
 
     private static void checkUids(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
@@ -21,16 +21,12 @@ package org.apache.flink.table.planner.utils;
 import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
-import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.table.planner.utils.StreamExchangeModeUtils.getBatchStreamExchangeMode;
-import static org.apache.flink.table.planner.utils.StreamExchangeModeUtils.getGlobalStreamExchangeMode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link StreamExchangeModeUtils}. */
 class StreamExchangeModeUtilsTest {
@@ -67,75 +63,5 @@ class StreamExchangeModeUtilsTest {
                 ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
         assertThat(getBatchStreamExchangeMode(configuration, StreamExchangeMode.BATCH))
                 .isEqualTo(StreamExchangeMode.BATCH);
-    }
-
-    @Test
-    void testBatchStreamExchangeModeLegacyPrecedence() {
-        final Configuration configuration = new Configuration();
-
-        configuration.set(
-                ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());
-
-        assertThat(getBatchStreamExchangeMode(configuration, null))
-                .isEqualTo(StreamExchangeMode.BATCH);
-    }
-
-    @Test
-    void testLegacyShuffleMode() {
-        final Configuration configuration = new Configuration();
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED.toString());
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString());
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                StreamExchangeModeUtils.ALL_EDGES_BLOCKING_LEGACY);
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                StreamExchangeModeUtils.ALL_EDGES_PIPELINED_LEGACY);
-        assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
-
-        configuration.setString(
-                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Forward_edges_PIPELINED");
-        assertThat(
-                        StreamExchangeModeUtils.getGlobalStreamExchangeMode(configuration)
-                                .orElseThrow(AssertionError::new))
-                .isEqualTo(GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED);
-    }
-
-    @Test
-    void testInvalidLegacyShuffleMode() {
-        final Configuration configuration = new Configuration();
-        configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
-        assertThatThrownBy(() -> StreamExchangeModeUtils.getGlobalStreamExchangeMode(configuration))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Cleanup the usage of deprecated org.apache.flink.table.api.config.ExecutionConfigOptions#TABLE_EXEC_SHUFFLE_MODE, org.apache.flink.table.api.config.ExecutionConfigOptions#TABLE_EXEC_LEGACY_TRANSFORMATION_UIDS.

## Brief change log

cleanup deprecated usage.

## Verifying this change

no need additional verify besides CI

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no