### PR TITLE
[FLINK-30535][Test] Customize TtlTimeProvider in state benchmarks

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
@@ -225,7 +225,7 @@ public class StateBackendBenchmarkUtils {
         return backendBuilder.build();
     }
 
-    private static File prepareDirectory(String prefix, File parentDir) throws IOException {
+    public static File prepareDirectory(String prefix, File parentDir) throws IOException {
         File target = File.createTempFile(prefix, "", parentDir);
         if (target.exists() && !target.delete()) {
             throw new IOException(


### PR DESCRIPTION
## What is the purpose of the change

In FLINK-30535, we provide benchmarks for ttl state. A customized `TtlTimeProvider` is needed for finely controlling a fixed size of expired keys per iteration. So in the `StateBackendBenchmarkUtils#createKeyedStateBackend`, a `TtlTimeProvider` should be added in parameters.

Also by the way, the `StateBackendBenchmarkUtils#prepareDirectory` is made public for the de-duplication of code in `RescalingBenchmarkBase` in state benchmarks.

## Brief change log

- add `TtlTimeProvider` in parameters of `StateBackendBenchmarkUtils#createKeyedStateBackend`.
- make `StateBackendBenchmarkUtils#prepareDirectory` public

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
