### PR TITLE
[FLINK-33784][table] Support Configuring CatalogStoreFactory via StreamExecutionEnvironment

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -118,11 +118,9 @@ public final class StreamTableEnvironmentImpl extends AbstractStreamTableEnviron
         final ModuleManager moduleManager = new ModuleManager();
 
         final CatalogStoreFactory catalogStoreFactory =
-                TableFactoryUtil.findAndCreateCatalogStoreFactory(
-                        settings.getConfiguration(), userClassLoader);
+                TableFactoryUtil.findAndCreateCatalogStoreFactory(tableConfig, userClassLoader);
         final CatalogStoreFactory.Context catalogStoreFactoryContext =
-                TableFactoryUtil.buildCatalogStoreFactoryContext(
-                        settings.getConfiguration(), userClassLoader);
+                TableFactoryUtil.buildCatalogStoreFactoryContext(tableConfig, userClassLoader);
         catalogStoreFactory.open(catalogStoreFactoryContext);
         final CatalogStore catalogStore =
                 settings.getCatalogStore() != null

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -242,22 +242,20 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         userClassLoader, ExecutorFactory.class, ExecutorFactory.DEFAULT_IDENTIFIER);
         final Executor executor = executorFactory.create(settings.getConfiguration());
 
+        // use configuration to init table config
+        final TableConfig tableConfig = TableConfig.getDefault();
+        tableConfig.setRootConfiguration(executor.getConfiguration());
+        tableConfig.addConfiguration(settings.getConfiguration());
+
         final CatalogStoreFactory catalogStoreFactory =
-                TableFactoryUtil.findAndCreateCatalogStoreFactory(
-                        settings.getConfiguration(), userClassLoader);
+                TableFactoryUtil.findAndCreateCatalogStoreFactory(tableConfig, userClassLoader);
         final CatalogStoreFactory.Context context =
-                TableFactoryUtil.buildCatalogStoreFactoryContext(
-                        settings.getConfiguration(), userClassLoader);
+                TableFactoryUtil.buildCatalogStoreFactoryContext(tableConfig, userClassLoader);
         catalogStoreFactory.open(context);
         final CatalogStore catalogStore =
                 settings.getCatalogStore() != null
                         ? settings.getCatalogStore()
                         : catalogStoreFactory.createCatalogStore();
-
-        // use configuration to init table config
-        final TableConfig tableConfig = TableConfig.getDefault();
-        tableConfig.setRootConfiguration(executor.getConfiguration());
-        tableConfig.addConfiguration(settings.getConfiguration());
 
         final ResourceManager resourceManager =
                 new ResourceManager(settings.getConfiguration(), userClassLoader);

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -311,9 +311,9 @@ object StreamTableEnvironmentImpl {
     val moduleManager = new ModuleManager
 
     val catalogStoreFactory =
-      TableFactoryUtil.findAndCreateCatalogStoreFactory(settings.getConfiguration, userClassLoader)
+      TableFactoryUtil.findAndCreateCatalogStoreFactory(tableConfig, userClassLoader)
     val catalogStoreFactoryContext =
-      TableFactoryUtil.buildCatalogStoreFactoryContext(settings.getConfiguration, userClassLoader)
+      TableFactoryUtil.buildCatalogStoreFactoryContext(tableConfig, userClassLoader)
     catalogStoreFactory.open(catalogStoreFactoryContext)
     val catalogStore =
       if (settings.getCatalogStore != null) settings.getCatalogStore

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
@@ -34,12 +34,16 @@ import org.apache.flink.table.catalog.listener.CatalogListener1;
 import org.apache.flink.table.catalog.listener.CatalogListener2;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_OPTION_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link TableEnvironment} that require a planner. */
@@ -153,6 +157,31 @@ class EnvironmentTest {
                         env2.getCatalogManager().getCatalogModificationListeners().stream()
                                 .map(c -> c.getClass().getName())
                                 .collect(Collectors.toList()));
+    }
+
+    @Test
+    void testRegisterCatalogStoreVarTableEnvironment(@TempDir File tempFolder) {
+        Configuration configuration = new Configuration();
+
+        configuration.setString(TABLE_CATALOG_STORE_KIND, "file");
+        configuration.setString(
+                TABLE_CATALOG_STORE_OPTION_PREFIX + "file.path", tempFolder.getAbsolutePath());
+        EnvironmentSettings settings =
+                EnvironmentSettings.newInstance().withConfiguration(configuration).build();
+
+        TableEnvironment env1 = TableEnvironment.create(settings);
+        Configuration catalogConfiguration = new Configuration();
+        catalogConfiguration.setString("type", "generic_in_memory");
+        env1.createCatalog(
+                "test_catalog", CatalogDescriptor.of("test_catalog", catalogConfiguration));
+
+        assertThat(env1.getCatalog("test_catalog").isPresent()).isTrue();
+
+        TableEnvironment env2 = TableEnvironment.create(settings);
+        assertThat(env2.getCatalog("test_catalog").isPresent()).isTrue();
+
+        TableEnvironment env3 = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+        assertThat(env3.getCatalog("test_catalog").isPresent()).isFalse();
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/EnvironmentTest.java
@@ -163,7 +163,7 @@ class EnvironmentTest {
     void testRegisterCatalogStoreVarTableEnvironment(@TempDir File tempFolder) {
         Configuration configuration = new Configuration();
 
-        configuration.setString(TABLE_CATALOG_STORE_KIND, "file");
+        configuration.set(TABLE_CATALOG_STORE_KIND, "file");
         configuration.setString(
                 TABLE_CATALOG_STORE_OPTION_PREFIX + "file.path", tempFolder.getAbsolutePath());
         EnvironmentSettings settings =
@@ -182,6 +182,11 @@ class EnvironmentTest {
 
         TableEnvironment env3 = TableEnvironment.create(EnvironmentSettings.newInstance().build());
         assertThat(env3.getCatalog("test_catalog").isPresent()).isFalse();
+
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        StreamTableEnvironment env4 = StreamTableEnvironment.create(env);
+        assertThat(env4.getCatalog("test_catalog").isPresent()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The initialization of CatalogStore is currently before flink-conf.yaml and StreamTableEnvironment, which causes the configuration in flink-conf.yaml to not take effect. We should move the initialization of CatalogStore after the configuration merging.


## Brief change log

* Postponed the discovery of CatalogStoreFactory until the final configuration is merged.
* Using map type options for get CatalogStore confs


## Verifying this change

Add unit test case in org.apache.flink.table.api.EnvironmentTest. Add CatalogStore Configuration in EnviromentSetting to verify if the discovery logic of CatalogStore can work properly, and whether other Enviroments can share the Catalog.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
