### PR TITLE
[FLINK-33941][table-planner] use field index instead of field name about window time column

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -84,7 +84,6 @@ import static org.apache.flink.table.planner.plan.utils.AggregateUtil.hasTimeInt
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.isProctimeAttribute;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.isRowtimeAttribute;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.isTableAggregate;
-import static org.apache.flink.table.planner.plan.utils.AggregateUtil.timeFieldIndex;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.toDuration;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.toLong;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.transformToStreamAggregateInfoList;
@@ -211,11 +210,7 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
 
         final int inputTimeFieldIndex;
         if (isRowtimeAttribute(window.timeAttribute())) {
-            inputTimeFieldIndex =
-                    timeFieldIndex(
-                            planner.getTypeFactory().buildRelNodeRowType(inputRowType),
-                            planner.createRelBuilder(),
-                            window.timeAttribute());
+            inputTimeFieldIndex = window.timeAttribute().getFieldIndex();
             if (inputTimeFieldIndex < 0) {
                 throw new TableException(
                         "Group window must defined on a time attribute, "

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -93,7 +93,6 @@ import static org.apache.flink.table.planner.plan.utils.AggregateUtil.hasRowInte
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.hasTimeIntervalType;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.isProctimeAttribute;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.isRowtimeAttribute;
-import static org.apache.flink.table.planner.plan.utils.AggregateUtil.timeFieldIndex;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.toDuration;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.toLong;
 import static org.apache.flink.table.planner.plan.utils.AggregateUtil.transformToStreamAggregateInfoList;
@@ -234,11 +233,7 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
 
         final int inputTimeFieldIndex;
         if (isRowtimeAttribute(window.timeAttribute())) {
-            inputTimeFieldIndex =
-                    timeFieldIndex(
-                            planner.getTypeFactory().buildRelNodeRowType(inputRowType),
-                            planner.createRelBuilder(),
-                            window.timeAttribute());
+            inputTimeFieldIndex = window.timeAttribute().getFieldIndex();
             if (inputTimeFieldIndex < 0) {
                 throw new TableException(
                         "Group window must defined on a time attribute, "

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateProjectMergeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateProjectMergeRule.java
@@ -56,7 +56,8 @@ import static java.util.Objects.requireNonNull;
  * <p>FLINK modifications are at lines
  *
  * <ol>
- *   <li>Should be removed after legacy groupWindowAggregate was removed: Lines 83 ~ 101
+ *   <li>Should be removed after legacy groupWindowAggregate was removed: Lines 85 ~ 105, Lines 136
+ *       ~ 156
  * </ol>
  */
 public class FlinkAggregateProjectMergeRule extends AggregateProjectMergeRule {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateProjectMergeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateProjectMergeRule.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.planner.plan.logical.LogicalWindow;
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
@@ -79,18 +81,19 @@ public class FlinkAggregateProjectMergeRule extends AggregateProjectMergeRule {
             RelOptRuleCall call, Aggregate aggregate, Project project) {
         // Find all fields which we need to be straightforward field projections.
         final Set<Integer> interestingFields = RelOptUtil.getAllFields(aggregate);
+        boolean isProctimeWindowAgg = false;
 
         // Should add the field of timeAttribute in a LogicalWindowAggregate node which uses rowTime
         if (aggregate instanceof LogicalWindowAggregate) {
             LogicalWindowAggregate winAgg = (LogicalWindowAggregate) aggregate;
             // isRowtimeAttribute can't be used here because the time_indicator phase comes later
-            boolean isProcTime =
+            isProctimeWindowAgg =
                     LogicalTypeChecks.isProctimeAttribute(
                             winAgg.getWindow()
                                     .timeAttribute()
                                     .getOutputDataType()
                                     .getLogicalType());
-            if (!isProcTime) {
+            if (!isProctimeWindowAgg) {
                 // no need to consider the inputIndex because LogicalWindowAggregate is single input
                 interestingFields.add(
                         ((LogicalWindowAggregate) aggregate)
@@ -127,13 +130,37 @@ public class FlinkAggregateProjectMergeRule extends AggregateProjectMergeRule {
             aggCalls.add(aggregateCall.transform(targetMapping));
         }
 
-        final Aggregate newAggregate =
-                aggregate.copy(
-                        aggregate.getTraitSet(),
-                        project.getInput(),
-                        newGroupSet,
-                        newGroupingSets,
-                        aggCalls.build());
+        final Aggregate newAggregate;
+
+        if (aggregate instanceof LogicalWindowAggregate && !isProctimeWindowAgg) {
+            // update the index of the time field in window
+            LogicalWindowAggregate winAgg = (LogicalWindowAggregate) aggregate;
+            LogicalWindow window = winAgg.getWindow();
+            int newTimeIndex = map.get(window.timeAttribute().getFieldIndex());
+            LogicalWindow newWindow =
+                    window.copy(
+                            new FieldReferenceExpression(
+                                    window.timeAttribute().getName(),
+                                    window.timeAttribute().getOutputDataType(),
+                                    window.timeAttribute().getInputIndex(),
+                                    newTimeIndex));
+            newAggregate =
+                    winAgg.copy(
+                            aggregate.getTraitSet(),
+                            project.getInput(),
+                            newGroupSet,
+                            newGroupingSets,
+                            aggCalls.build(),
+                            newWindow);
+        } else {
+            newAggregate =
+                    aggregate.copy(
+                            aggregate.getTraitSet(),
+                            project.getInput(),
+                            newGroupSet,
+                            newGroupingSets,
+                            aggCalls.build());
+        }
 
         // Add a project if the group set is not in the same order or
         // contains duplicates.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalPythonWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalPythonWindowAggregateRule.java
@@ -130,9 +130,7 @@ public class BatchPhysicalPythonWindowAggregateRule extends RelOptRule {
                         null);
         UserDefinedFunction[] aggFunctions = aggBufferTypesAndFunctions._3();
 
-        int inputTimeFieldIndex =
-                AggregateUtil.timeFieldIndex(
-                        input.getRowType(), call.builder(), window.timeAttribute());
+        int inputTimeFieldIndex = window.timeAttribute().getFieldIndex();
         RelDataType inputTimeFieldType =
                 input.getRowType().getFieldList().get(inputTimeFieldIndex).getType();
         boolean inputTimeIsDate = inputTimeFieldType.getSqlTypeName() == SqlTypeName.DATE;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
@@ -45,6 +45,8 @@ abstract class LogicalWindow(
     Objects.equals(timeAttribute, that.timeAttribute)
   }
 
+  def copy(newTimeAttribute: FieldReferenceExpression): LogicalWindow
+
   protected def isValueLiteralExpressionEqual(
       l1: ValueLiteralExpression,
       l2: ValueLiteralExpression): Boolean = {
@@ -90,6 +92,10 @@ case class TumblingGroupWindow(
     }
   }
 
+  override def copy(newTimeField: FieldReferenceExpression): LogicalWindow = {
+    TumblingGroupWindow(alias, newTimeField, size)
+  }
+
   override def toString: String = s"TumblingGroupWindow($alias, $timeField, $size)"
 }
 
@@ -113,6 +119,10 @@ case class SlidingGroupWindow(
     }
   }
 
+  override def copy(newTimeField: FieldReferenceExpression): LogicalWindow = {
+    SlidingGroupWindow(alias, newTimeField, size, slide)
+  }
+
   override def toString: String = s"SlidingGroupWindow($alias, $timeField, $size, $slide)"
 }
 
@@ -132,6 +142,10 @@ case class SessionGroupWindow(
     } else {
       false
     }
+  }
+
+  override def copy(newTimeField: FieldReferenceExpression): LogicalWindow = {
+    SessionGroupWindow(alias, newTimeField, gap)
   }
 
   override def toString: String = s"SessionGroupWindow($alias, $timeField, $gap)"

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWindowAggregate.scala
@@ -64,6 +64,24 @@ final class LogicalWindowAggregate(
       window,
       namedProperties)
   }
+
+  def copy(
+      traitSet: RelTraitSet,
+      input: RelNode,
+      groupSet: ImmutableBitSet,
+      // retain this to follow "Aggregate#copy"
+      groupSets: util.List[ImmutableBitSet],
+      aggCalls: util.List[AggregateCall],
+      window: LogicalWindow): Aggregate = {
+    new LogicalWindowAggregate(
+      cluster,
+      traitSet,
+      input,
+      groupSet,
+      aggCalls,
+      window,
+      namedProperties)
+  }
 }
 
 object LogicalWindowAggregate {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalWindowAggregateRule.scala
@@ -160,8 +160,7 @@ class BatchPhysicalWindowAggregateRule
     // TODO aggregate include projection now, so do not provide new trait will be safe
     val aggProvidedTraitSet = input.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
 
-    val inputTimeFieldIndex =
-      AggregateUtil.timeFieldIndex(input.getRowType, call.builder(), window.timeAttribute)
+    val inputTimeFieldIndex = window.timeAttribute.getFieldIndex
     val inputTimeFieldType = agg.getInput.getRowType.getFieldList.get(inputTimeFieldIndex).getType
     val inputTimeIsDate = inputTimeFieldType.getSqlTypeName == SqlTypeName.DATE
     // local-agg output order: groupSet | assignTs | auxGroupSet | aggCalls

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -1117,6 +1117,7 @@ object AggregateUtil extends Enumeration {
   }
 
   /** Compute field index of given timeField expression. */
+  @Deprecated
   def timeFieldIndex(
       inputType: RelDataType,
       relBuilder: RelBuilder,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -63,7 +63,6 @@ import org.apache.calcite.sql.`type`.{SqlTypeName, SqlTypeUtil}
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind, SqlRankFunction}
 import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.validate.SqlMonotonicity
-import org.apache.calcite.tools.RelBuilder
 
 import java.time.Duration
 import java.util
@@ -1114,15 +1113,6 @@ object AggregateUtil extends Enumeration {
         ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_SIZE + " must be > 0.")
     }
     new CountBundleTrigger[RowData](size)
-  }
-
-  /** Compute field index of given timeField expression. */
-  @Deprecated
-  def timeFieldIndex(
-      inputType: RelDataType,
-      relBuilder: RelBuilder,
-      timeField: FieldReferenceExpression): Int = {
-    relBuilder.values(inputType).field(timeField.getName).getIndex
   }
 
   /** Computes the positions of (window start, window end, row time). */


### PR DESCRIPTION
## What is the purpose of the change

In some exec nodes like StreamExecGroupWindowAggregate and some rules like BatchPhysicalWindowAggregateRule, planner uses "AggregateUtil#timeFieldIndex" to access the actual time field index, instead of using the time field index in LogicalWindow#timeAttribute directly. However, it would be more formal to use the field index instead of the column field.

## Brief change log

  - *Deprecate AggregateUtil#timeFieldIndex*
  - *Update the code using "AggregateUtil.timeFieldIndex(input.getRowType, call.builder(), window.timeAttribute)" before to use  "window.timeAttribute.getFieldIndex"*
  - *Fix the rule that doesn't update the index in window before while optimizing plan*

## Verifying this change

All existent tests can cover this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
