### PR TITLE
[FLINK-33681] Reuse input/output metrics of SourceOperator/SinkWriterOperator for task

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorIOMetricGroup.java
@@ -97,4 +97,16 @@ public class InternalOperatorIOMetricGroup extends ProxyMetricGroup<InternalOper
         TaskIOMetricGroup taskIO = parentMetricGroup.getTaskIOMetricGroup();
         taskIO.reuseRecordsOutputCounter(this.numRecordsOut);
     }
+
+    /** Causes the containing task to use this operators input bytes counter. */
+    public void reuseBytesInputMetricsForTask() {
+        TaskIOMetricGroup taskIO = parentMetricGroup.getTaskIOMetricGroup();
+        taskIO.reuseBytesInputCounter(this.numBytesIn);
+    }
+
+    /** Causes the containing task to use this operators output bytes counter. */
+    public void reuseBytesOutputMetricsForTask() {
+        TaskIOMetricGroup taskIO = parentMetricGroup.getTaskIOMetricGroup();
+        taskIO.reuseBytesOutputCounter(this.numBytesOut);
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -50,8 +50,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
     private final Clock clock;
 
-    private final Counter numBytesIn;
-    private final Counter numBytesOut;
+    private final SumCounter numBytesIn;
+    private final SumCounter numBytesOut;
     private final SumCounter numRecordsIn;
     private final SumCounter numRecordsOut;
     private final Counter numBuffersOut;
@@ -95,8 +95,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     public TaskIOMetricGroup(TaskMetricGroup parent, Clock clock) {
         super(parent);
         this.clock = clock;
-        this.numBytesIn = counter(MetricNames.IO_NUM_BYTES_IN);
-        this.numBytesOut = counter(MetricNames.IO_NUM_BYTES_OUT);
+        this.numBytesIn = counter(MetricNames.IO_NUM_BYTES_IN, new SumCounter());
+        this.numBytesOut = counter(MetricNames.IO_NUM_BYTES_OUT, new SumCounter());
         this.numBytesInRate = meter(MetricNames.IO_NUM_BYTES_IN_RATE, new MeterView(numBytesIn));
         this.numBytesOutRate = meter(MetricNames.IO_NUM_BYTES_OUT_RATE, new MeterView(numBytesOut));
 
@@ -315,6 +315,15 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     // ============================================================================================
     // Metric Reuse
     // ============================================================================================
+
+    public void reuseBytesInputCounter(Counter numBytesInCounter) {
+        this.numBytesIn.addCounter(numBytesInCounter);
+    }
+
+    public void reuseBytesOutputCounter(Counter numBytesOutCounter) {
+        this.numBytesOut.addCounter(numBytesOutCounter);
+    }
+
     public void reuseRecordsInputCounter(Counter numRecordsInCounter) {
         this.numRecordsIn.addCounter(numRecordsInCounter);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -230,6 +230,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             Output<StreamRecord<OUT>> output) {
         super.setup(containingTask, config, output);
         initSourceMetricGroup();
+        // Metric "numRecordsIn" & "numBytesIn" is defined as the total number of records/bytes
+        // read from the external system in FLIP-33, reuse them for task to account for traffic
+        // with external system
+        this.metrics.getIOMetricGroup().reuseInputMetricsForTask();
+        this.metrics.getIOMetricGroup().reuseBytesInputMetricsForTask();
     }
 
     @VisibleForTesting

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2MetricsITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.testutils.InMemoryReporter;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -213,6 +214,25 @@ public class SinkV2MetricsITCase extends TestLogger {
                     .isEqualTo((processedRecordsPerSubtask - 1) * MetricWriter.BASE_SEND_TIME);
         }
         assertThat(subtaskWithMetrics, equalTo(numSplits));
+
+        // Test operator I/O metrics are reused by task metrics
+        List<TaskMetricGroup> taskMetricGroups =
+                reporter.findTaskMetricGroups(jobId, TEST_SINK_NAME);
+
+        int subtaskWithTaskMetrics = 0;
+        for (TaskMetricGroup taskMetricGroup : taskMetricGroups) {
+            // there are only 2 splits assigned; so two groups will not update metrics
+            if (taskMetricGroup.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
+                continue;
+            }
+
+            subtaskWithTaskMetrics++;
+            assertThatCounter(taskMetricGroup.getIOMetricGroup().getNumRecordsOutCounter())
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(taskMetricGroup.getIOMetricGroup().getNumBytesOutCounter())
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
+        }
+        assertThat(subtaskWithTaskMetrics, equalTo(numSplits));
     }
 
     private void assertSinkCommitterMetrics(JobID jobId, Map<String, Long> expected) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the numRecordsIn & numBytesIn metrics for sources and the numRecordsOut & numBytesOut metrics for sinks are always 0 on the Flink web dashboard.

[FLINK-11576](https://issues.apache.org/jira/browse/FLINK-11576) brings us these metrics on the opeartor level, but it does not integrate them on the task level. On the other hand, the summay metrics on the job overview page is based on the task level I/O metrics. As a result, even though new connectors supporting FLIP-33 metrics will report operator-level I/O metrics, we still cannot see the metrics on dashboard.

This MR attempts to reuse the operator-level source/sink I/O metrics for task so that they can be viewed on Flink web dashboard. 

## Brief change log

Reuse input/output metrics of SourceOperator/SinkWriterOperator for task. 

Since Flink only accounts for internal traffic for input/output bytes metrics before, the reuse won't cause duplication in the I/O bytes metrics. Also, as the output records metric is intentionally dropped for SinkWriterOperator in `OperatorChain#getOperatorRecordsOutCounter` and no input records metric is collected for `SourceOperatorStreamTask`, no duplication in the I/O records metrics will take place.

## Verifying this change

Manually run Kafka2Kafka job on a testing cluster on K8s, verified that the source/sink input/output metrics can be seen on the web dashboard.

![image](https://github.com/apache/flink/assets/22020529/4ed94730-cf21-4451-b662-de38faef87e2)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
