### PR TITLE
[FLINK-33565][Scheduler] ConcurrentExceptions works with exception merging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
@@ -157,10 +157,11 @@ public class ExecutionFailureHandler {
                     new JobException("The failure is not recoverable", cause),
                     timestamp,
                     failureLabels,
-                    globalFailure);
+                    globalFailure,
+                    true);
         }
 
-        restartBackoffTimeStrategy.notifyFailure(cause);
+        boolean isNewAttempt = restartBackoffTimeStrategy.notifyFailure(cause);
         if (restartBackoffTimeStrategy.canRestart()) {
             numberOfRestarts++;
 
@@ -171,7 +172,8 @@ public class ExecutionFailureHandler {
                     failureLabels,
                     verticesToRestart,
                     restartBackoffTimeStrategy.getBackoffTime(),
-                    globalFailure);
+                    globalFailure,
+                    isNewAttempt);
         } else {
             return FailureHandlingResult.unrecoverable(
                     failedExecution,
@@ -179,7 +181,8 @@ public class ExecutionFailureHandler {
                             "Recovery is suppressed by " + restartBackoffTimeStrategy, cause),
                     timestamp,
                     failureLabels,
-                    globalFailure);
+                    globalFailure,
+                    isNewAttempt);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
@@ -163,7 +163,9 @@ public class ExecutionFailureHandler {
 
         boolean isNewAttempt = restartBackoffTimeStrategy.notifyFailure(cause);
         if (restartBackoffTimeStrategy.canRestart()) {
-            numberOfRestarts++;
+            if (isNewAttempt) {
+                numberOfRestarts++;
+            }
 
             return FailureHandlingResult.restartable(
                     failedExecution,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExponentialDelayRestartBackoffTimeStrategy.java
@@ -109,12 +109,12 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
     }
 
     @Override
-    public void notifyFailure(Throwable cause) {
+    public boolean notifyFailure(Throwable cause) {
         long now = clock.absoluteTimeMillis();
 
         // Merge multiple failures into one attempt if there are tasks will be restarted later.
         if (now <= nextRestartTimestamp) {
-            return;
+            return false;
         }
 
         if ((now - nextRestartTimestamp) >= resetBackoffThresholdMS) {
@@ -122,6 +122,7 @@ public class ExponentialDelayRestartBackoffTimeStrategy implements RestartBackof
         }
         nextRestartTimestamp = now + calculateActualBackoffTime();
         currentRestartAttempt++;
+        return true;
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureHandlingResult.java
@@ -87,7 +87,7 @@ public class FailureHandlingResult {
             @Nullable Throwable cause,
             long timestamp,
             CompletableFuture<Map<String, String>> failureLabels,
-            @Nullable Set<ExecutionVertexID> verticesToRestart,
+            Set<ExecutionVertexID> verticesToRestart,
             long restartDelayMS,
             boolean globalFailure,
             boolean isRootCause) {
@@ -247,7 +247,7 @@ public class FailureHandlingResult {
             @Nullable Throwable cause,
             long timestamp,
             CompletableFuture<Map<String, String>> failureLabels,
-            @Nullable Set<ExecutionVertexID> verticesToRestart,
+            Set<ExecutionVertexID> verticesToRestart,
             long restartDelayMS,
             boolean globalFailure,
             boolean isRootCause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureRateRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureRateRestartBackoffTimeStrategy.java
@@ -79,11 +79,12 @@ public class FailureRateRestartBackoffTimeStrategy implements RestartBackoffTime
     }
 
     @Override
-    public void notifyFailure(Throwable cause) {
+    public boolean notifyFailure(Throwable cause) {
         if (isFailureTimestampsQueueFull()) {
             failureTimestamps.remove();
         }
         failureTimestamps.add(clock.absoluteTimeMillis());
+        return true;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FixedDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FixedDelayRestartBackoffTimeStrategy.java
@@ -61,8 +61,9 @@ public class FixedDelayRestartBackoffTimeStrategy implements RestartBackoffTimeS
     }
 
     @Override
-    public void notifyFailure(Throwable cause) {
+    public boolean notifyFailure(Throwable cause) {
         currentRestartAttempt++;
+        return true;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/NoRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/NoRestartBackoffTimeStrategy.java
@@ -33,8 +33,9 @@ public enum NoRestartBackoffTimeStrategy implements RestartBackoffTimeStrategy {
     }
 
     @Override
-    public void notifyFailure(final Throwable cause) {
+    public boolean notifyFailure(final Throwable cause) {
         // nothing to do
+        return true;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategy.java
@@ -38,8 +38,11 @@ public interface RestartBackoffTimeStrategy {
      * Notify the strategy about the task failure cause.
      *
      * @param cause of the task failure
+     * @return True means that the current failure is the first one after the most-recent failure
+     *     handling happened, false means that there has been a failure before that was not handled,
+     *     yet, and the current failure will be considered in a combined failure handling effort.
      */
-    void notifyFailure(Throwable cause);
+    boolean notifyFailure(Throwable cause);
 
     // ------------------------------------------------------------------------
     //  factory

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -359,17 +359,13 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
         final CompletableFuture<?> cancelFuture = cancelTasksAsync(verticesToRestart);
 
-        final FailureHandlingResultSnapshot failureHandlingResultSnapshot =
-                createFailureHandlingResultSnapshot(failureHandlingResult);
+        archiveFromFailureHandlingResult(
+                createFailureHandlingResultSnapshot(failureHandlingResult));
         delayExecutor.schedule(
                 () ->
                         FutureUtils.assertNoException(
                                 cancelFuture.thenRunAsync(
-                                        () -> {
-                                            archiveFromFailureHandlingResult(
-                                                    failureHandlingResultSnapshot);
-                                            restartTasks(executionVertexVersions, globalRecovery);
-                                        },
+                                        () -> restartTasks(executionVertexVersions, globalRecovery),
                                         getMainThreadExecutor())),
                 failureHandlingResult.getRestartDelayMS(),
                 TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -111,6 +111,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -128,6 +129,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Base class which can be used to implement {@link SchedulerNG}. */
 public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling {
@@ -165,6 +167,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
     private final ComponentMainThreadExecutor mainThreadExecutor;
 
     private final BoundedFIFOQueue<RootExceptionHistoryEntry> exceptionHistory;
+
+    private RootExceptionHistoryEntry latestRootExceptionEntry;
 
     private final ExecutionGraphFactory executionGraphFactory;
 
@@ -707,27 +711,40 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
             long timestamp,
             CompletableFuture<Map<String, String>> failureLabels,
             Iterable<Execution> executions) {
-        exceptionHistory.add(
+        latestRootExceptionEntry =
                 RootExceptionHistoryEntry.fromGlobalFailure(
-                        failure, timestamp, failureLabels, executions));
+                        failure, timestamp, failureLabels, executions);
+        exceptionHistory.add(latestRootExceptionEntry);
         log.debug("Archive global failure.", failure);
     }
 
     protected final void archiveFromFailureHandlingResult(
             FailureHandlingResultSnapshot failureHandlingResult) {
-        if (failureHandlingResult.getRootCauseExecution().isPresent()) {
+        if (!failureHandlingResult.isRootCause()) {
+            // Handle all subsequent exceptions as the concurrent exceptions when it's not a new
+            // attempt.
+            checkState(
+                    latestRootExceptionEntry != null,
+                    "A root exception entry should exist if failureHandlingResult wasn't "
+                            + "generated as part of a new error handling cycle.");
+            List<Execution> concurrentlyExecutions = new ArrayList<>();
+            failureHandlingResult.getRootCauseExecution().ifPresent(concurrentlyExecutions::add);
+            concurrentlyExecutions.addAll(failureHandlingResult.getConcurrentlyFailedExecution());
+
+            latestRootExceptionEntry.addConcurrentExceptions(concurrentlyExecutions);
+        } else if (failureHandlingResult.getRootCauseExecution().isPresent()) {
             final Execution rootCauseExecution =
                     failureHandlingResult.getRootCauseExecution().get();
 
-            final RootExceptionHistoryEntry rootEntry =
+            latestRootExceptionEntry =
                     RootExceptionHistoryEntry.fromFailureHandlingResultSnapshot(
                             failureHandlingResult);
-            exceptionHistory.add(rootEntry);
+            exceptionHistory.add(latestRootExceptionEntry);
 
             log.debug(
                     "Archive local failure causing attempt {} to fail: {}",
                     rootCauseExecution.getAttemptId(),
-                    rootEntry.getExceptionAsString());
+                    latestRootExceptionEntry.getExceptionAsString());
         } else {
             archiveGlobalFailure(
                     failureHandlingResult.getRootCause(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshot.java
@@ -48,6 +48,7 @@ public class FailureHandlingResultSnapshot {
     private final CompletableFuture<Map<String, String>> failureLabels;
     private final long timestamp;
     private final Set<Execution> concurrentlyFailedExecutions;
+    private final boolean isRootCause;
 
     /**
      * Creates a {@code FailureHandlingResultSnapshot} based on the passed {@link
@@ -84,7 +85,8 @@ public class FailureHandlingResultSnapshot {
                 ErrorInfo.handleMissingThrowable(failureHandlingResult.getError()),
                 failureHandlingResult.getTimestamp(),
                 failureHandlingResult.getFailureLabels(),
-                concurrentlyFailedExecutions);
+                concurrentlyFailedExecutions,
+                failureHandlingResult.isRootCause());
     }
 
     @VisibleForTesting
@@ -93,7 +95,8 @@ public class FailureHandlingResultSnapshot {
             Throwable rootCause,
             long timestamp,
             CompletableFuture<Map<String, String>> failureLabels,
-            Set<Execution> concurrentlyFailedExecutions) {
+            Set<Execution> concurrentlyFailedExecutions,
+            boolean isRootCause) {
         Preconditions.checkArgument(
                 rootCauseExecution == null
                         || !concurrentlyFailedExecutions.contains(rootCauseExecution),
@@ -105,6 +108,7 @@ public class FailureHandlingResultSnapshot {
         this.timestamp = timestamp;
         this.concurrentlyFailedExecutions =
                 Preconditions.checkNotNull(concurrentlyFailedExecutions);
+        this.isRootCause = isRootCause;
     }
 
     /**
@@ -150,7 +154,17 @@ public class FailureHandlingResultSnapshot {
      *
      * @return The concurrently failed {@code Executions}.
      */
-    public Iterable<Execution> getConcurrentlyFailedExecution() {
+    public Set<Execution> getConcurrentlyFailedExecution() {
         return Collections.unmodifiableSet(concurrentlyFailedExecutions);
+    }
+
+    /**
+     * @return True means that the current failure is a new attempt, false means that there has been
+     *     a failure before and has not been tried yet, and the current failure will be merged into
+     *     the previous attempt, and these merged exceptions will be considered as the concurrent
+     *     exceptions.
+     */
+    public boolean isRootCause() {
+        return isRootCause;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/TestRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/TestRestartBackoffTimeStrategy.java
@@ -42,8 +42,9 @@ public class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrateg
     }
 
     @Override
-    public void notifyFailure(Throwable cause) {
+    public boolean notifyFailure(Throwable cause) {
         // ignore
+        return true;
     }
 
     public void setCanRestart(final boolean canRestart) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/TestRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/TestRestartBackoffTimeStrategy.java
@@ -19,6 +19,8 @@
 
 package org.apache.flink.runtime.executiongraph.failover;
 
+import java.util.function.Supplier;
+
 /** A RestartBackoffTimeStrategy implementation for tests. */
 public class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrategy {
 
@@ -26,9 +28,17 @@ public class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrateg
 
     private long backoffTime;
 
+    private Supplier<Boolean> isNewAttempt;
+
     public TestRestartBackoffTimeStrategy(boolean canRestart, long backoffTime) {
+        this(canRestart, backoffTime, () -> true);
+    }
+
+    public TestRestartBackoffTimeStrategy(
+            boolean canRestart, long backoffTime, Supplier<Boolean> isNewAttempt) {
         this.canRestart = canRestart;
         this.backoffTime = backoffTime;
+        this.isNewAttempt = isNewAttempt;
     }
 
     @Override
@@ -44,7 +54,7 @@ public class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrateg
     @Override
     public boolean notifyFailure(Throwable cause) {
         // ignore
-        return true;
+        return isNewAttempt.get();
     }
 
     public void setCanRestart(final boolean canRestart) {
@@ -53,5 +63,9 @@ public class TestRestartBackoffTimeStrategy implements RestartBackoffTimeStrateg
 
     public void setBackoffTime(final long backoffTime) {
         this.backoffTime = backoffTime;
+    }
+
+    public void setIsNewAttempt(Supplier<Boolean> isNewAttempt) {
+        this.isNewAttempt = isNewAttempt;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
@@ -96,7 +96,8 @@ class FailureHandlingResultSnapshotTest {
                                 .map(ExecutionVertex::getID)
                                 .collect(Collectors.toSet()),
                         0L,
-                        false);
+                        false,
+                        true);
 
         assertThatThrownBy(
                         () ->
@@ -124,7 +125,8 @@ class FailureHandlingResultSnapshotTest {
                                 .map(ExecutionVertex::getID)
                                 .collect(Collectors.toSet()),
                         0L,
-                        false);
+                        false,
+                        true);
 
         // FailedExecution with failure labels
         assertThat(failureHandlingResult.getFailureLabels().get())
@@ -145,6 +147,7 @@ class FailureHandlingResultSnapshotTest {
         assertThat(testInstance.getRootCauseExecution()).isPresent();
         assertThat(testInstance.getRootCauseExecution().get())
                 .isSameAs(rootCauseExecutionVertex.getCurrentExecutionAttempt());
+        assertThat(testInstance.isRootCause()).isTrue();
     }
 
     @Test
@@ -170,7 +173,8 @@ class FailureHandlingResultSnapshotTest {
                                 .map(ExecutionVertex::getID)
                                 .collect(Collectors.toSet()),
                         0L,
-                        false);
+                        false,
+                        true);
 
         final FailureHandlingResultSnapshot testInstance =
                 FailureHandlingResultSnapshot.create(
@@ -183,6 +187,7 @@ class FailureHandlingResultSnapshotTest {
                 .isSameAs(rootCauseExecutionVertex.getCurrentExecutionAttempt());
         assertThat(testInstance.getConcurrentlyFailedExecution())
                 .containsExactly(otherFailedExecutionVertex.getCurrentExecutionAttempt());
+        assertThat(testInstance.isRootCause()).isTrue();
     }
 
     @Test
@@ -196,7 +201,8 @@ class FailureHandlingResultSnapshotTest {
                                         new RuntimeException("Expected exception"),
                                         System.currentTimeMillis(),
                                         FailureEnricherUtils.EMPTY_FAILURE_LABELS,
-                                        Collections.singleton(rootCauseExecution)))
+                                        Collections.singleton(rootCauseExecution),
+                                        true))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -227,6 +233,7 @@ class FailureHandlingResultSnapshotTest {
                                 .map(ExecutionVertex::getID)
                                 .collect(Collectors.toSet()),
                         0L,
+                        true,
                         true);
 
         // FailedExecution with failure labels
@@ -244,6 +251,7 @@ class FailureHandlingResultSnapshotTest {
                 .containsExactlyInAnyOrder(
                         failedExecutionVertex0.getCurrentExecutionAttempt(),
                         failedExecutionVertex1.getCurrentExecutionAttempt());
+        assertThat(testInstance.isRootCause()).isTrue();
     }
 
     private Collection<Execution> getCurrentExecutions(ExecutionVertexID executionVertexId) {


### PR DESCRIPTION
## What is the purpose of the change

The concurrent exceptions doesn't work.


## Brief change log

- [FLINK-33565][Exception] Archive exceptions into the exception history immediately when they occur, instead of archiving them when restarting
  - The first commit is refactoring. 
  - Currently, archiving exception when restarting task instead of immediately. It means, when one task failure, we can see the exception history after flink restart this task. 
  - So the first commit is only a refactoring. It archives exceptions into the exception history immediately when they occur, instead of archiving them when restarting.
- [FLINK-33565][Exception] Restart strategy checks whether current failure is a new attempt
  - The second commit is related to restart strategy, adding a return value indicates whether current failure is a new attempt.
- [FLINK-33565][Scheduler] ConcurrentExceptions works with exception merging
  - The third commit is core solution of this JIRA:
  - If it's a new attempt, it's root exception. and it will be the latest root exception.
  - If it's not a new attempt, it will be a concurrentException and it will be added to the latest RootException.
- [FLINK-33565][Scheduler] Correct the numberOfRestarts metric
  - numberOfRestarts should be increased when exception is a new attempt
- [FLINK-33565][Scheduler][refactor] Remove the wrong `@Nullable` annotation of FailureHandlingResult due to the constructor checks `verticesToRestart` is not null




## Verifying this change

- Improve some tests of `ExecutionFailureHandlerTest`, and added new test: `testNewAttemptAndNumberOfRestarts`
- Improve some old tests of `ExponentialDelayRestartBackoffTimeStrategyTest` to check whether `isNewAttempt` is expected
- Improve some tests of `FailureHandlingResultTest` to test `isNewAttempt` are true and false
- Improve the `DefaultSchedulerTest#testExceptionHistoryConcurrentRestart`
- Check the `isNewAttempt` is expected in `FailureHandlingResultSnapshotTest`
- Test `addConcurrentExceptions` in `RootExceptionHistoryEntryTest`

### Test manually

I added a job demo with 6 regions, all tasks will fail when processing the first record, this demo job can be run directly. Here is the result, we can see all failed tasks in the WebUI.

![image](https://github.com/apache/flink/assets/38427477/8830b0eb-aaef-4ef6-b6dd-888f496aa229)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
