### PR TITLE
[FLINK-33882] UT/IT for checkpointing statistics

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatisticsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DescriptiveStatisticsHistogramStatistics} and {@link
+ * DescriptiveStatisticsHistogramStatistics.CommonMetricsSnapshot}.
+ */
+class DescriptiveStatisticsHistogramStatisticsTest {
+
+    /** Tests the getPercentile functionality of the DescriptiveStatisticsHistogramStatistics. */
+    @Test
+    void testDescriptiveStatisticsHistogramStatistics() {
+        double data = 0.20;
+        double percentileValue =
+                new DescriptiveStatisticsHistogramStatistics.CommonMetricsSnapshot()
+                        .getPercentile(data);
+        assertThat(percentileValue).isEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

UT/IT for checkpointing statistics for FLINK-33588(Fix Flink Checkpointing Statistics Bug)


## Brief change log

1、add a DescriptiveStatisticsHistogramStatisticsTest.java file 


## Verifying this change

1、add a DescriptiveStatisticsHistogramStatisticsTest.java file for testing UT/IT for checkpointing statistics of FLINK-33588.
2、When the value of data is null, call DescriptiveStatisticsHistogramStatistics CommonMetricsSnapshot does not report errors or throw exceptions when static internal classes are present.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
