### PR TITLE
[FLINK-33960][Scheduler] Fix the bug that Adaptive Scheduler doesn't respect the lowerBound when one flink job has more than 1 tasks

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -230,6 +230,27 @@ class SlotSharingSlotAllocatorTest {
     }
 
     @Test
+    void testDetermineParallelismWithLowerBoundsInsufficientSlotsForPartialVertices() {
+        final SlotSharingSlotAllocator slotAllocator =
+                SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
+                        TEST_RESERVE_SLOT_FUNCTION,
+                        TEST_FREE_SLOT_FUNCTION,
+                        TEST_IS_SLOT_FREE_FUNCTION);
+        SlotSharingGroup slotSharingGroup = new SlotSharingGroup();
+        final JobInformation.VertexInformation vertex1 =
+                new TestVertexInformation(new JobVertexID(), 2, 2, slotSharingGroup);
+        final JobInformation.VertexInformation vertex2 =
+                new TestVertexInformation(new JobVertexID(), 8, 8, slotSharingGroup);
+
+        final JobInformation jobInformation =
+                new TestJobInformation(Arrays.asList(vertex1, vertex2));
+        final Optional<VertexParallelism> vertexParallelism =
+                slotAllocator.determineParallelism(jobInformation, getSlots(5));
+
+        assertThat(vertexParallelism).isNotPresent();
+    }
+
+    @Test
     void testDetermineParallelismWithAllEqualLowerUpperBoundFreSlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.topology.VertexID;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -49,12 +48,9 @@ import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link SlotSharingSlotAllocator}. */
-public class SlotSharingSlotAllocatorTest extends TestLogger {
+class SlotSharingSlotAllocatorTest {
 
     private static final FreeSlotFunction TEST_FREE_SLOT_FUNCTION = (a, c, t) -> {};
     private static final ReserveSlotFunction TEST_RESERVE_SLOT_FUNCTION =
@@ -76,7 +72,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
             new TestVertexInformation(new JobVertexID(), 3, slotSharingGroup2);
 
     @Test
-    public void testCalculateRequiredSlots() {
+    void testCalculateRequiredSlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -94,7 +90,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testDetermineParallelismWithMinimumSlots() {
+    void testDetermineParallelismWithMinimumSlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -107,13 +103,13 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         final VertexParallelism vertexParallelism =
                 slotAllocator.determineParallelism(jobInformation, getSlots(2)).get();
 
-        assertThat(vertexParallelism.getParallelism(vertex1.getJobVertexID()), is(1));
-        assertThat(vertexParallelism.getParallelism(vertex2.getJobVertexID()), is(1));
-        assertThat(vertexParallelism.getParallelism(vertex3.getJobVertexID()), is(1));
+        assertThat(vertexParallelism.getParallelism(vertex1.getJobVertexID())).isOne();
+        assertThat(vertexParallelism.getParallelism(vertex2.getJobVertexID())).isOne();
+        assertThat(vertexParallelism.getParallelism(vertex3.getJobVertexID())).isOne();
     }
 
     @Test
-    public void testDetermineParallelismWithManySlots() {
+    void testDetermineParallelismWithManySlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -126,19 +122,16 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         final VertexParallelism vertexParallelism =
                 slotAllocator.determineParallelism(jobInformation, getSlots(50)).get();
 
-        assertThat(
-                vertexParallelism.getParallelism(vertex1.getJobVertexID()),
-                is(vertex1.getParallelism()));
-        assertThat(
-                vertexParallelism.getParallelism(vertex2.getJobVertexID()),
-                is(vertex2.getParallelism()));
-        assertThat(
-                vertexParallelism.getParallelism(vertex3.getJobVertexID()),
-                is(vertex3.getParallelism()));
+        assertThat(vertexParallelism.getParallelism(vertex1.getJobVertexID()))
+                .isEqualTo(vertex1.getParallelism());
+        assertThat(vertexParallelism.getParallelism(vertex2.getJobVertexID()))
+                .isEqualTo(vertex2.getParallelism());
+        assertThat(vertexParallelism.getParallelism(vertex3.getJobVertexID()))
+                .isEqualTo(vertex3.getParallelism());
     }
 
     @Test
-    public void testDetermineParallelismWithVariedParallelism() {
+    void testDetermineParallelismWithVariedParallelism() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -171,7 +164,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testDetermineParallelismUnsuccessfulWithLessSlotsThanSlotSharingGroups() {
+    void testDetermineParallelismUnsuccessfulWithLessSlotsThanSlotSharingGroups() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -184,11 +177,11 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         final Optional<VertexParallelism> vertexParallelism =
                 slotAllocator.determineParallelism(jobInformation, getSlots(1));
 
-        assertThat(vertexParallelism.isPresent(), is(false));
+        assertThat(vertexParallelism).isNotPresent();
     }
 
     @Test
-    public void testDetermineParallelismWithPartiallyEqualLowerUpperBound() {
+    void testDetermineParallelismWithPartiallyEqualLowerUpperBound() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -216,7 +209,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testDetermineParallelismWithLowerBoundsInsufficientSlots() {
+    void testDetermineParallelismWithLowerBoundsInsufficientSlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -237,7 +230,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testDetermineParallelismWithAllEqualLowerUpperBoundFreSlots() {
+    void testDetermineParallelismWithAllEqualLowerUpperBoundFreSlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -267,7 +260,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testDetermineParallelismWithAllEqualLowerUpperBoundManySlots() {
+    void testDetermineParallelismWithAllEqualLowerUpperBoundManySlots() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -297,7 +290,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
     }
 
     @Test
-    public void testReserveAvailableResources() {
+    void testReserveAvailableResources() {
         final SlotSharingSlotAllocator slotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION,
@@ -335,12 +328,12 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
 
             final SlotInfo backingSlot = expectedAssignment.getValue();
 
-            assertThat(assignedSlot.getAllocationId(), is(backingSlot.getAllocationId()));
+            assertThat(assignedSlot.getAllocationId()).isEqualTo(backingSlot.getAllocationId());
         }
     }
 
     @Test
-    public void testReserveUnavailableResources() {
+    void testReserveUnavailableResources() {
         final SlotSharingSlotAllocator slotSharingSlotAllocator =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                         TEST_RESERVE_SLOT_FUNCTION, TEST_FREE_SLOT_FUNCTION, ignored -> false);
@@ -357,7 +350,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         final Optional<? extends ReservedSlots> reservedSlots =
                 slotSharingSlotAllocator.tryReserveResources(jobSchedulingPlan);
 
-        assertFalse(reservedSlots.isPresent());
+        assertThat(reservedSlots).isNotPresent();
     }
 
     /**
@@ -365,7 +358,7 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
      * Local Recovery.
      */
     @Test
-    public void testStickyAllocation() {
+    void testStickyAllocation() {
         Map<JobVertexID, List<VertexAllocationInformation>> locality = new HashMap<>();
 
         // previous allocation allocation1: v1, v2
@@ -393,11 +386,6 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         IntStream.range(0, 10).forEach(i -> freeSlots.add(new TestSlotInfo(new AllocationID())));
         freeSlots.add(new TestSlotInfo(allocation1));
         freeSlots.add(new TestSlotInfo(allocation2));
-
-        Map<JobVertexID, Long> stateSizes = new HashMap<>();
-        stateSizes.put(vertex1.getJobVertexID(), 10L);
-        stateSizes.put(vertex2.getJobVertexID(), 10L);
-        stateSizes.put(vertex3.getJobVertexID(), 10L);
 
         JobSchedulingPlan schedulingPlan =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-33960][Scheduler] Fix the bug that Adaptive Scheduler doesn't respect the lowerBound when one flink job has more than 1 tasks

When we using the adaptive scheduler and the rescale api, users will set the lowerBound and upperBound for each job vertices. And users expect the parallelism of all vertices between lowerBound and upperBound.

But when one flink job  has more than 1 vertex, and resource isn't enough. Some of lowerBound won't be respect.
How to reproduce this bug:

One job has 2 job vertices, we set the resource requirements are:

    Vertex1: lowerBound=2, upperBound=2
    Vertex2: lowerBound=8, upperBound=8

They are same slotSharingGroup, and we only 5 available slots. This job shouldn't run due to the slots cannot meets the resource requiremnt for vertex2.

But the job can runs, and the parallelism of vertex2 is 5.

 
### Why does this  bug happen?

Flink calculates the minimumRequiredSlots for each slot sharing group, it should be the max lowerBound for all vertices of current slot sharing group.

But it's using the on the minimum lowerBound.


## Brief change log

- [FLINK-33960][JUnit5 migration] Migrate SlotSharingSlotAllocatorTest to Junit5 and Assertj
- [FLINK-33960][Scheduler] Fix the bug that Adaptive Scheduler doesn't respect the lowerBound when one flink job has more than 1 tasks


## Verifying this change

  - Added `SlotSharingSlotAllocatorTest#testDetermineParallelismWithLowerBoundsInsufficientSlotsForPartialVertices`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
