### PR TITLE
[FLINK-33968][runtime] Advance the calculation of num of subpartitions to the time of initializing execution job vertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -43,8 +43,8 @@ public class IntermediateResultPartition {
 
     private final EdgeManager edgeManager;
 
-    /** Number of subpartitions. Initialized lazily and will not change once set. */
-    private int numberOfSubpartitions = NUM_SUBPARTITIONS_UNKNOWN;
+    /** Number of subpartitions for dynamic graph. */
+    private final int numberOfSubpartitionsForDynamicGraph;
 
     /** Whether this partition has produced all data. */
     private boolean dataAllProduced = false;
@@ -64,6 +64,17 @@ public class IntermediateResultPartition {
         this.producer = producer;
         this.partitionId = new IntermediateResultPartitionID(totalResult.getId(), partitionNumber);
         this.edgeManager = edgeManager;
+
+        if (!producer.getExecutionGraphAccessor().isDynamic()) {
+            this.numberOfSubpartitionsForDynamicGraph = NUM_SUBPARTITIONS_UNKNOWN;
+        } else {
+            this.numberOfSubpartitionsForDynamicGraph =
+                    computeNumberOfSubpartitionsForDynamicGraph();
+            checkState(
+                    numberOfSubpartitionsForDynamicGraph > 0,
+                    "Number of subpartitions is an unexpected value: "
+                            + numberOfSubpartitionsForDynamicGraph);
+        }
     }
 
     public void markPartitionGroupReleasable(ConsumedPartitionGroup partitionGroup) {
@@ -114,17 +125,6 @@ public class IntermediateResultPartition {
     }
 
     public int getNumberOfSubpartitions() {
-        if (numberOfSubpartitions == NUM_SUBPARTITIONS_UNKNOWN) {
-            numberOfSubpartitions = computeNumberOfSubpartitions();
-            checkState(
-                    numberOfSubpartitions > 0,
-                    "Number of subpartitions is an unexpected value: " + numberOfSubpartitions);
-        }
-
-        return numberOfSubpartitions;
-    }
-
-    private int computeNumberOfSubpartitions() {
         if (!getProducer().getExecutionGraphAccessor().isDynamic()) {
             List<ConsumerVertexGroup> consumerVertexGroups = getConsumerVertexGroups();
             checkState(!consumerVertexGroups.isEmpty());
@@ -134,13 +134,17 @@ public class IntermediateResultPartition {
             // for non-dynamic graph.
             return consumerVertexGroups.get(0).size();
         } else {
-            if (totalResult.isBroadcast()) {
-                // for dynamic graph and broadcast result, we only produced one subpartition,
-                // and all the downstream vertices should consume this subpartition.
-                return 1;
-            } else {
-                return computeNumberOfMaxPossiblePartitionConsumers();
-            }
+            return numberOfSubpartitionsForDynamicGraph;
+        }
+    }
+
+    private int computeNumberOfSubpartitionsForDynamicGraph() {
+        if (totalResult.isBroadcast()) {
+            // for dynamic graph and broadcast result, we only produced one subpartition,
+            // and all the downstream vertices should consume this subpartition.
+            return 1;
+        } else {
+            return computeNumberOfMaxPossiblePartitionConsumers();
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Solve FLINK-33968

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
