### PR TITLE
[FLINK-33009][release] Disable binary compatibility check in master branch and only enable it in the release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2323,7 +2323,7 @@ under the License.
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>
-							<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+							<breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
 							<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
 							<onlyBinaryIncompatible>false</onlyBinaryIncompatible>
 							<includeSynthetic>true</includeSynthetic>

--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -59,6 +59,10 @@ function set_japicmp_reference_version() {
   perl -pi -e 's#(<japicmp.referenceVersion>).*(</japicmp.referenceVersion>)#${1}'${version}'${2}#' ${POM}
 }
 
+function enable_binary_incompatibility_check() {
+  perl -pi -e 's#<breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>#<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>#' ${POM}
+}
+
 function clear_exclusions() {
   exclusion_start=$(($(sed -n '/<!-- MARKER: start exclusions/=' ${POM}) + 1))
   exclusion_end=$(($(sed -n '/<!-- MARKER: end exclusions/=' ${POM}) - 1))
@@ -87,6 +91,7 @@ elif [[ ${current_branch} =~ ^release- ]]; then
   # snapshot branch
   set_japicmp_reference_version ${NEW_VERSION}
   enable_public_evolving_compatibility_checks
+  enable_binary_incompatibility_check
   clear_exclusions
 else
   echo "Script was called from unexpected branch ${current_branch}; should be rc/snapshot/master branch."


### PR DESCRIPTION
## What is the purpose of the change

*Disable binary compatibility check in master branch and only enable it in the release branch.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
