### PR TITLE
[FLINK-33817][flink-protobuf] Set ReadDefaultValues=False by default in proto3 for performance improvement

### DIFF
--- a/docs/content/docs/connectors/table/formats/protobuf.md
+++ b/docs/content/docs/connectors/table/formats/protobuf.md
@@ -149,9 +149,12 @@ Format Options
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>
-          This option only works if the generated class's version is proto2. If this value is set to true, the format will read empty values as the default values defined in the proto file.
+          If this value is set to true, the format will read empty values as the default values defined in the proto file.
           If the value is set to false, the format will generate null values if the data element does not exist in the binary protobuf message.
-          If the proto syntax is proto3, this value will forcibly be set to true, because proto3's standard is to use default values.
+          If proto syntax is proto3, users need to set this to true when using protobuf versions lower than 3.15 as older versions do not support 
+          checking for field presence which can cause runtime compilation issues. Additionally, primtive types will be set to default values 
+          instead of null as field presence cannot be checked for them. Please be aware that setting this to true will cause the deserialization 
+          performance to be much slower depending on schema complexity and message size.
       </td>
     </tr>
     <tr>

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatContext.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatContext.java
@@ -28,9 +28,12 @@ import java.util.List;
 public class PbFormatContext {
     private final PbFormatConfig pbFormatConfig;
     private final List<String> splitMethodStack = new ArrayList<>();
+    private final boolean readDefaultValuesForPrimitiveTypes;
 
-    public PbFormatContext(PbFormatConfig pbFormatConfig) {
+    public PbFormatContext(
+            PbFormatConfig pbFormatConfig, boolean readDefaultValuesForPrimitiveTypes) {
         this.pbFormatConfig = pbFormatConfig;
+        this.readDefaultValuesForPrimitiveTypes = readDefaultValuesForPrimitiveTypes;
     }
 
     private String createSplitMethod(
@@ -72,5 +75,9 @@ public class PbFormatContext {
 
     public PbFormatConfig getPbFormatConfig() {
         return pbFormatConfig;
+    }
+
+    public boolean getReadDefaultValuesForPrimitiveTypes() {
+        return readDefaultValuesForPrimitiveTypes;
     }
 }

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatOptions.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/PbFormatOptions.java
@@ -44,7 +44,10 @@ public class PbFormatOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Optional flag to read as default values instead of null when some field does not exist in deserialization; default to false."
-                                    + "If proto syntax is proto3, this value will be set true forcibly because proto3's standard is to use default values.");
+                                    + "If proto syntax is proto3, users need to set this to true when using protobuf versions lower than 3.15 as older versions "
+                                    + "do not support checking for field presence which can cause runtime compilation issues. Additionally, primtive types "
+                                    + "will be set to default values instead of null as field presence cannot be checked for them. Please be aware that setting this"
+                                    + " to true will cause the deserialization performance to be much slower depending on schema complexity and message size");
     public static final ConfigOption<String> WRITE_NULL_STRING_LITERAL =
             ConfigOptions.key("write-null-string-literal")
                     .stringType()

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
@@ -68,17 +68,14 @@ public class ProtoToRowConverter {
                             true,
                             Thread.currentThread().getContextClassLoader());
             String fullMessageClassName = PbFormatUtils.getFullJavaName(descriptor);
+            boolean readDefaultValuesForPrimitiveTypes = formatConfig.isReadDefaultValues();
             if (descriptor.getFile().getSyntax() == Syntax.PROTO3) {
-                // pb3 always read default values
-                formatConfig =
-                        new PbFormatConfig(
-                                formatConfig.getMessageClassName(),
-                                formatConfig.isIgnoreParseErrors(),
-                                true,
-                                formatConfig.getWriteNullStringLiterals());
+                // pb3 always read default values for primitive types
+                readDefaultValuesForPrimitiveTypes = true;
             }
             PbCodegenAppender codegenAppender = new PbCodegenAppender();
-            PbFormatContext pbFormatContext = new PbFormatContext(formatConfig);
+            PbFormatContext pbFormatContext =
+                    new PbFormatContext(formatConfig, readDefaultValuesForPrimitiveTypes);
             String uuid = UUID.randomUUID().toString().replaceAll("\\-", "");
             String generatedClassName = "GeneratedProtoToRow_" + uuid;
             String generatedPackageName = ProtoToRowConverter.class.getPackage().getName();

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
@@ -76,7 +76,7 @@ public class ProtoToRowConverter {
             PbCodegenAppender codegenAppender = new PbCodegenAppender();
             PbFormatContext pbFormatContext =
                     new PbFormatContext(formatConfig, readDefaultValuesForPrimitiveTypes);
-            String uuid = UUID.randomUUID().toString().replaceAll("\\-", "");
+            String uuid = UUID.randomUUID().toString().replace("-", "");
             String generatedClassName = "GeneratedProtoToRow_" + uuid;
             String generatedPackageName = ProtoToRowConverter.class.getPackage().getName();
             codegenAppender.appendLine("package " + generatedPackageName);

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
@@ -62,7 +62,7 @@ public class RowToProtoConverter {
             PbFormatContext formatContext = new PbFormatContext(formatConfig, false);
 
             PbCodegenAppender codegenAppender = new PbCodegenAppender(0);
-            String uuid = UUID.randomUUID().toString().replaceAll("\\-", "");
+            String uuid = UUID.randomUUID().toString().replace("-", "");
             String generatedClassName = "GeneratedRowToProto_" + uuid;
             String generatedPackageName = RowToProtoConverter.class.getPackage().getName();
             codegenAppender.appendLine("package " + generatedPackageName);

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
@@ -59,7 +59,7 @@ public class RowToProtoConverter {
         try {
             Descriptors.Descriptor descriptor =
                     PbFormatUtils.getDescriptor(formatConfig.getMessageClassName());
-            PbFormatContext formatContext = new PbFormatContext(formatConfig);
+            PbFormatContext formatContext = new PbFormatContext(formatConfig, false);
 
             PbCodegenAppender codegenAppender = new PbCodegenAppender(0);
             String uuid = UUID.randomUUID().toString().replaceAll("\\-", "");

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/Pb3ToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/Pb3ToRowTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test conversion of proto3 data to flink internal data. Default values after conversion is tested
@@ -92,17 +93,14 @@ public class Pb3ToRowTest {
         Pb3Test pb3Test = Pb3Test.newBuilder().build();
         RowData row = ProtobufTestHelper.pbBytesToRow(Pb3Test.class, pb3Test.toByteArray());
 
+        // primitive types should have default values
         assertFalse(row.isNullAt(0));
         assertFalse(row.isNullAt(1));
         assertFalse(row.isNullAt(2));
         assertFalse(row.isNullAt(3));
         assertFalse(row.isNullAt(4));
         assertFalse(row.isNullAt(5));
-        assertFalse(row.isNullAt(6));
-        assertFalse(row.isNullAt(7));
         assertFalse(row.isNullAt(8));
-        assertFalse(row.isNullAt(9));
-        assertFalse(row.isNullAt(10));
 
         assertEquals(0, row.getInt(0));
         assertEquals(0L, row.getLong(1));
@@ -110,16 +108,11 @@ public class Pb3ToRowTest {
         assertEquals(Float.valueOf(0.0f), Float.valueOf(row.getFloat(3)));
         assertEquals(Double.valueOf(0.0d), Double.valueOf(row.getDouble(4)));
         assertEquals("UNIVERSAL", row.getString(5).toString());
-
-        RowData rowData = row.getRow(6, 2);
-        assertEquals(0, rowData.getInt(0));
-        assertEquals(0L, rowData.getLong(1));
-
-        assertEquals(0, row.getArray(7).size());
-
         assertEquals(0, row.getBinary(8).length);
-
-        assertEquals(0, row.getMap(9).size());
-        assertEquals(0, row.getMap(10).size());
+        // non-primitive types should be null
+        assertTrue(row.isNullAt(6));
+        assertTrue(row.isNullAt(7));
+        assertTrue(row.isNullAt(9));
+        assertTrue(row.isNullAt(10));
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

**Background**

 

The current Protobuf format [implementation](https://github.com/apache/flink/blob/c3e2d163a637dca5f49522721109161bd7ebb723/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java) always sets ReadDefaultValues=True when using Proto3 version. This can cause severe performance degradation for large Protobuf schemas with OneOf fields as the entire generated code needs to be executed during deserialization even when certain fields are not present in the data to be deserialized and all the subsequent nested Fields can be skipped. Proto3 supports hasXXX() methods for checking field presence for non primitive types since Proto version [3.15](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0). In the internal performance benchmarks in our company, we've seen almost 10x difference in performance for one of our real production usecase when allowing to set ReadDefaultValues=False with proto3 version. The exact difference in performance depends on the schema complexity and data payload but we should allow user to set readDefaultValue=False in general.

 

**Solution**

 
Set Default value for ReadDefaultValues=False for both proto3 and proto2 versions. Add documentation for users to set this value to true when using older protobuf versions before 3.15 and the performance implications. Additionally, We need to be careful to check for field presence only on non-primitive types if ReadDefaultValues is false and version used is Proto3. 

**NOTE:** This is a breaking change as older SQL queries without proper null checking can fail after this change. The row contents after deserialization will be different before and after this change. @libenchao will be making a note about this as part of the release notes.


## Brief change log

  - *[FLINK-33817][flink-protobuf] update protobuf docs about readDefaultValues*
  - *[FLINK-33817][flink-protobuf] Set ReadDefaultValues=False by default in Proto3 for performance improvement*



## Verifying this change


This change is already covered by existing unit tests and e2e tests for the Protobuf format for correctness. The performance improvement is benchmarked on testing clusters in my company.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? Both JavaDocs and flink docs are updated
