### PR TITLE
[FLINK-34001][docs][table] Fix ambiguous document description towards the default value for configuring operator-level state TTL

### DIFF
--- a/docs/content/docs/dev/table/concepts/overview.md
+++ b/docs/content/docs/dev/table/concepts/overview.md
@@ -508,7 +508,7 @@ It performs a regular inner join with different state TTL for left and right sid
       ]
     ```
     The `"index"` indicates the current state is the i-th input the operator, and the index starts from zero.
-The current TTL value for both left and right side is `"0 ms"`, which means the state retention is not enabled. 
+The current TTL value for both left and right side is `"0 ms"`, which means the state never expires.
 Now change the value of left state to `"3000 ms"` and right state to `"9000 ms"`.
     ```json
     "state": [


### PR DESCRIPTION
## What is the purpose of the change

This is a trivial PR to eliminate the ambiguous description about the meaning of 0ms when configuring operator-level state TTL for SQL/TableAPI using compiled plan.


## Brief change log

Change "state retention is not enabled" to "state never expires"


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
